### PR TITLE
feat(kubernetes): revert cert-only noise after hydrate

### DIFF
--- a/kubernetes/Makefile
+++ b/kubernetes/Makefile
@@ -93,6 +93,14 @@ hydrate: ## Hydrate manifests from Helmfile and Kustomize (usage: make hydrate E
 		echo "- $$component.yaml" >> manifests/$(ENV)/kustomization.yaml; \
 	done
 	@echo "- 00-namespaces.yaml" >> manifests/$(ENV)/kustomization.yaml
+	@echo "$(BLUE)💧 Reverting cert-only changes (helm regenerates these on each run)...$(NC)"
+	@for f in manifests/$(ENV)/*.yaml; do \
+		[ "$$(basename $$f)" = "kustomization.yaml" ] && continue; \
+		git ls-files --error-unmatch "$$f" >/dev/null 2>&1 || continue; \
+		if git diff --quiet -I '^[[:space:]]*(ca\.crt|ca\.key|tls\.crt|tls\.key|caBundle):' -- "$$f"; then \
+			git checkout -- "$$f"; \
+		fi; \
+	done
 	@echo "$(GREEN)✅ Manifests hydrated$(NC)"
 
 # =============================================================================


### PR DESCRIPTION
## Summary
- `make hydrate` 実行のたびに helm が自己署名証明書 / webhook caBundle を再生成し、実質変更のない差分が積み上がる問題を解消
- hydrate の最後で各マニフェストを `git diff -I '<cert pattern>'` で判定し、証明書系フィールドのみの変更のファイルは `git checkout` で HEAD に戻す
- 証明書本体は git 管理したまま（空にすると hubble-relay / opentelemetry-operator が CrashLoop するため）

## Test plan
- [x] 実質変更なしで `make hydrate` → working tree clean
- [x] `components/loki/k3d/values.yaml` を改変 → 該当ファイルの差分は保持される（リバートされない）
- [ ] CI で `make hydrate` を自動化する workflow は別 PR で対応

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the deployment hydration process to prevent certificate-only changes from appearing in manifest diffs. Certificates are now automatically reverted to repository versions during hydration, ensuring cleaner and more focused deployment changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->