### PR TITLE
fix(aws/claude-code-action): unbreak apply by using '+' in GitHubRepos tag

### DIFF
--- a/aws/claude-code-action/modules/main.tf
+++ b/aws/claude-code-action/modules/main.tf
@@ -57,7 +57,7 @@ resource "aws_iam_role" "claude_code_action_role" {
   tags = merge(var.common_tags, {
     Name        = "${var.project_name}-${var.environment}-github-actions-role"
     GitHubOrg   = var.github_org
-    GitHubRepos = join(",", var.github_repos)
+    GitHubRepos = join("+", var.github_repos)
     Purpose     = "claude-code-action-bedrock"
   })
 }


### PR DESCRIPTION
## Summary
Follow-up fix for #143. The merged apply failed on `TagRole`:

```
Value at 'tags.1.member.value' failed to satisfy constraint:
Member must satisfy regular expression pattern: [\p{L}\p{Z}\p{N}_.:/=+\-@]*
```

`modules/main.tf` builds the `GitHubRepos` tag with `join(",", var.github_repos)`. IAM tag values do not permit `,`, and with `github_repos` recently expanded to `["monorepo","platform","deploy-actions"]` the join produces `monorepo,platform,deploy-actions` which is rejected. With a single-element list (`["monorepo"]`) the comma never appeared, so this was a latent bug.

Switch the separator to `+`, which is in the allowed IAM tag value character set.

## Test plan
- [ ] `terragrunt apply` in `envs/develop` succeeds and updates the IAM role tags/assume-role-policy without validation error

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal infrastructure configuration formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->