### PR TITLE
feat(aws/claude-code): add Terragrunt module for local Claude Code Bedrock access

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,6 @@ pids
 # Kubernetes and Helm files
 Chart.lock
 charts/
+
+# Git worktrees
+.worktrees/

--- a/aws/claude-code-action/modules/main.tf
+++ b/aws/claude-code-action/modules/main.tf
@@ -57,7 +57,7 @@ resource "aws_iam_role" "claude_code_action_role" {
   tags = merge(var.common_tags, {
     Name        = "${var.project_name}-${var.environment}-github-actions-role"
     GitHubOrg   = var.github_org
-    GitHubRepos = join(",", var.github_repos)
+    GitHubRepos = join("+", var.github_repos)
     Purpose     = "claude-code-action-bedrock"
   })
 }

--- a/aws/claude-code/Makefile
+++ b/aws/claude-code/Makefile
@@ -1,0 +1,81 @@
+# Makefile for Claude Code
+
+# Default values
+ENV ?= develop
+
+# Colors for output
+RED := \033[0;31m
+GREEN := \033[0;32m
+YELLOW := \033[0;33m
+BLUE := \033[0;34m
+NC := \033[0m # No Color
+
+.PHONY: help init plan apply destroy validate fmt check clean
+
+help: ## Show this help message
+	@echo "Claude Code - Terragrunt Commands"
+	@echo ""
+	@echo "Usage: make <target> [ENV=<repository>]"
+	@echo ""
+	@echo "Available targets:"
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "  $(BLUE)%-15s$(NC) %s\n", $$1, $$2}'
+	@echo ""
+	@echo "Available environments:"
+	@echo "  - develop"
+	@echo "  - staging"
+	@echo "  - production"
+	@echo ""
+	@echo "Examples:"
+	@echo "  make plan ENV=staging"
+	@echo "  make apply ENV=production"
+
+init: ## Initialize Terragrunt
+	@echo "$(YELLOW)Initializing Terragrunt for $(ENV)...$(NC)"
+	cd envs/$(ENV) && terragrunt init
+
+plan: ## Plan Terragrunt changes
+	@echo "$(YELLOW)Planning Terragrunt changes for $(ENV)...$(NC)"
+	cd envs/$(ENV) && terragrunt plan
+
+apply: ## Apply Terragrunt changes
+	@echo "$(YELLOW)Applying Terragrunt changes for $(ENV)...$(NC)"
+	cd envs/$(ENV) && terragrunt apply -auto-approve
+
+destroy: ## Destroy Terragrunt resources
+	@echo "$(RED)Destroying Terragrunt resources for $(ENV)...$(NC)"
+	@echo "$(RED)WARNING: This will destroy all resources!$(NC)"
+	@read -p "Are you sure? [y/N] " -n 1 -r; \
+	echo; \
+	if [[ $$REPLY =~ ^[Yy]$$ ]]; then \
+		cd envs/$(ENV) && terragrunt destroy; \
+	else \
+		echo "$(YELLOW)Cancelled.$(NC)"; \
+	fi
+
+validate: ## Validate Terragrunt configuration
+	@echo "$(YELLOW)Validating Terragrunt configuration for $(ENV)...$(NC)"
+	cd envs/$(ENV) && terragrunt validate
+
+fmt: ## Format Terraform files
+	@echo "$(YELLOW)Formatting Terraform files...$(NC)"
+	terraform fmt -recursive .
+
+check: validate fmt ## Run validation and formatting checks
+	@echo "$(GREEN)All checks completed for $(ENV)$(NC)"
+
+clean: ## Clean Terragrunt cache
+	@echo "$(YELLOW)Cleaning Terragrunt cache...$(NC)"
+	find . -type d -name ".terragrunt-cache" -exec rm -rf {} + 2>/dev/null || true
+	find . -name "*.tfplan" -delete 2>/dev/null || true
+
+show: ## Show current Terragrunt state
+	@echo "$(YELLOW)Showing current state for $(ENV)...$(NC)"
+	cd envs/$(ENV) && terragrunt show
+
+output: ## Show Terragrunt outputs
+	@echo "$(YELLOW)Showing outputs for $(ENV)...$(NC)"
+	cd envs/$(ENV) && terragrunt output
+
+refresh: ## Refresh Terragrunt state
+	@echo "$(YELLOW)Refreshing state for $(ENV)...$(NC)"
+	cd envs/$(ENV) && terragrunt refresh

--- a/aws/claude-code/envs/develop/env.hcl
+++ b/aws/claude-code/envs/develop/env.hcl
@@ -1,0 +1,31 @@
+# env.hcl - Environment-specific configuration for develop
+
+locals {
+  # Environment-specific settings
+  environment = "develop"
+
+  # AWS configuration
+  aws_region          = "ap-northeast-1"
+  claude_model_region = "us-west-2" # Claude models are available in us-west-2
+
+  # Principals allowed to assume the Claude Code role
+  trusted_principal_arns = [
+    "arn:aws:iam::559744160976:user/panicboat",
+  ]
+
+  # IAM configuration
+  max_session_duration = 7200 # 2 hours for development work
+
+  # Additional IAM policies (if needed)
+  additional_iam_policies = [
+    # Add any additional policy ARNs here if needed
+  ]
+
+  # Environment-specific tags
+  environment_tags = {
+    Environment = local.environment
+    Purpose     = "claude-code-local"
+    CostCenter  = "engineering"
+    Owner       = "panicboat"
+  }
+}

--- a/aws/claude-code/envs/develop/terragrunt.hcl
+++ b/aws/claude-code/envs/develop/terragrunt.hcl
@@ -1,0 +1,45 @@
+# terragrunt.hcl - Terragrunt configuration for develop environment
+
+# Include root configuration
+include "root" {
+  path = find_in_parent_folders("root.hcl")
+}
+
+# Include environment-specific configuration
+include "env" {
+  path   = "env.hcl"
+  expose = true
+}
+
+# Reference to Terraform modules
+terraform {
+  source = "../../modules"
+}
+
+# Input variables for the module
+inputs = {
+  # Project configuration
+  project_name = "claude-code"
+  environment  = include.env.locals.environment
+
+  # AWS configuration
+  aws_region          = include.env.locals.aws_region
+  claude_model_region = include.env.locals.claude_model_region
+
+  # Trust configuration
+  trusted_principal_arns = include.env.locals.trusted_principal_arns
+
+  # IAM configuration
+  max_session_duration    = include.env.locals.max_session_duration
+  additional_iam_policies = include.env.locals.additional_iam_policies
+
+  # Tags
+  common_tags = merge(
+    include.env.locals.environment_tags,
+    {
+      Project    = "claude-code"
+      ManagedBy  = "terragrunt"
+      Repository = "panicboat/platform"
+    }
+  )
+}

--- a/aws/claude-code/modules/main.tf
+++ b/aws/claude-code/modules/main.tf
@@ -1,0 +1,115 @@
+# main.tf - Claude Code IAM Role and Bedrock Permissions
+
+# Get current AWS account information
+data "aws_caller_identity" "current" {}
+
+locals {
+  # ARNs of the cross-region inference profiles (created in claude_model_region)
+  inference_profile_arns = [
+    for p in var.bedrock_inference_profiles :
+    "arn:aws:bedrock:${var.claude_model_region}:${data.aws_caller_identity.current.account_id}:inference-profile/${p.profile_id}"
+  ]
+
+  # ARNs of the underlying foundation models in every source region the profile
+  # may route to. Both the profile ARN and the FM ARNs must be allowed or
+  # InvokeModel returns AccessDenied, but the FM ARNs are only granted when the
+  # request is routed through an approved inference profile (see the
+  # bedrock:InferenceProfileArn condition below).
+  foundation_model_arns = flatten([
+    for p in var.bedrock_inference_profiles : [
+      for r in p.source_regions :
+      "arn:aws:bedrock:${r}::foundation-model/${p.model_id}"
+    ]
+  ])
+}
+
+# IAM Role for Claude Code (local CLI)
+resource "aws_iam_role" "claude_code_role" {
+  name                 = "${var.project_name}-${var.environment}-role"
+  max_session_duration = var.max_session_duration
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Principal = {
+          AWS = var.trusted_principal_arns
+        }
+        Action = "sts:AssumeRole"
+      }
+    ]
+  })
+
+  tags = merge(var.common_tags, {
+    Name    = "${var.project_name}-${var.environment}-role"
+    Purpose = "claude-code-bedrock"
+  })
+}
+
+# Custom IAM Policy for Bedrock Claude Access
+resource "aws_iam_policy" "bedrock_claude_policy" {
+  name        = "${var.project_name}-${var.environment}-bedrock-claude-policy"
+  description = "Policy for Claude Code to access Amazon Bedrock Claude models"
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "bedrock:InvokeModel",
+          "bedrock:InvokeModelWithResponseStream"
+        ]
+        Resource = local.inference_profile_arns
+      },
+      {
+        Effect = "Allow"
+        Action = [
+          "bedrock:InvokeModel",
+          "bedrock:InvokeModelWithResponseStream"
+        ]
+        Resource = local.foundation_model_arns
+        Condition = {
+          StringEquals = {
+            "bedrock:InferenceProfileArn" = local.inference_profile_arns
+          }
+        }
+      },
+      {
+        Effect = "Allow"
+        Action = [
+          "bedrock:ListFoundationModels",
+          "bedrock:GetFoundationModel"
+        ]
+        Resource = "*"
+      },
+      {
+        Effect = "Allow"
+        Action = [
+          "aws-marketplace:ViewSubscriptions",
+          "aws-marketplace:Subscribe"
+        ]
+        Resource = "*"
+      }
+    ]
+  })
+
+  tags = merge(var.common_tags, {
+    Name    = "${var.project_name}-${var.environment}-bedrock-claude-policy"
+    Purpose = "bedrock-claude-access"
+  })
+}
+
+# Attach Bedrock Claude policy to the role
+resource "aws_iam_role_policy_attachment" "bedrock_claude_policy_attachment" {
+  role       = aws_iam_role.claude_code_role.name
+  policy_arn = aws_iam_policy.bedrock_claude_policy.arn
+}
+
+# Attach any additional policies specified
+resource "aws_iam_role_policy_attachment" "additional_policies" {
+  count      = length(var.additional_iam_policies)
+  role       = aws_iam_role.claude_code_role.name
+  policy_arn = var.additional_iam_policies[count.index]
+}

--- a/aws/claude-code/modules/outputs.tf
+++ b/aws/claude-code/modules/outputs.tf
@@ -1,0 +1,36 @@
+# outputs.tf - Outputs for Claude Code module
+
+output "iam_role_arn" {
+  description = "ARN of the IAM role for Claude Code"
+  value       = aws_iam_role.claude_code_role.arn
+}
+
+output "iam_role_name" {
+  description = "Name of the IAM role for Claude Code"
+  value       = aws_iam_role.claude_code_role.name
+}
+
+output "bedrock_policy_arn" {
+  description = "ARN of the Bedrock policy"
+  value       = aws_iam_policy.bedrock_claude_policy.arn
+}
+
+output "bedrock_inference_profiles" {
+  description = "List of allowed Bedrock cross-region inference profiles"
+  value       = var.bedrock_inference_profiles
+}
+
+output "claude_model_region" {
+  description = "AWS region where Claude models are available"
+  value       = var.claude_model_region
+}
+
+output "claude_code_configuration" {
+  description = "Configuration object for local Claude Code CLI"
+  value = {
+    role_arn                   = aws_iam_role.claude_code_role.arn
+    aws_region                 = var.aws_region
+    claude_model_region        = var.claude_model_region
+    bedrock_inference_profiles = var.bedrock_inference_profiles
+  }
+}

--- a/aws/claude-code/modules/terraform.tf
+++ b/aws/claude-code/modules/terraform.tf
@@ -1,0 +1,20 @@
+# terraform.tf - Terraform and provider configuration
+
+terraform {
+  required_version = ">= 1.6.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 6.39"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.aws_region
+
+  default_tags {
+    tags = var.common_tags
+  }
+}

--- a/aws/claude-code/modules/variables.tf
+++ b/aws/claude-code/modules/variables.tf
@@ -1,0 +1,85 @@
+# variables.tf - Variables for Claude Code module
+
+variable "project_name" {
+  description = "Name of the project"
+  type        = string
+}
+
+variable "environment" {
+  description = "Environment name (e.g., develop, staging, production)"
+  type        = string
+}
+
+variable "common_tags" {
+  description = "Common tags to apply to all resources"
+  type        = map(string)
+  default     = {}
+}
+
+variable "aws_region" {
+  description = "AWS region"
+  type        = string
+  default     = "ap-northeast-1"
+}
+
+variable "trusted_principal_arns" {
+  description = "List of AWS principal ARNs allowed to assume the Claude Code role"
+  type        = list(string)
+}
+
+variable "max_session_duration" {
+  description = "Maximum session duration for the IAM role (in seconds)"
+  type        = number
+  default     = 3600
+  validation {
+    condition     = var.max_session_duration >= 3600 && var.max_session_duration <= 43200
+    error_message = "Max session duration must be between 3600 (1 hour) and 43200 (12 hours) seconds."
+  }
+}
+
+variable "additional_iam_policies" {
+  description = "List of additional IAM policy ARNs to attach to the role"
+  type        = list(string)
+  default     = []
+}
+
+variable "bedrock_inference_profiles" {
+  description = "List of Bedrock cross-region inference profiles to allow access to. Each entry defines the inference profile ID, the underlying foundation model ID, and the source regions the profile routes to."
+  type = list(object({
+    profile_id     = string
+    model_id       = string
+    source_regions = list(string)
+  }))
+  default = [
+    {
+      profile_id = "us.anthropic.claude-sonnet-4-6"
+      model_id   = "anthropic.claude-sonnet-4-6"
+      source_regions = [
+        "ca-central-1",
+        "ca-west-1",
+        "us-east-1",
+        "us-east-2",
+        "us-west-1",
+        "us-west-2",
+      ]
+    },
+    {
+      profile_id = "us.anthropic.claude-opus-4-6-v1"
+      model_id   = "anthropic.claude-opus-4-6-v1"
+      source_regions = [
+        "ca-central-1",
+        "ca-west-1",
+        "us-east-1",
+        "us-east-2",
+        "us-west-1",
+        "us-west-2",
+      ]
+    },
+  ]
+}
+
+variable "claude_model_region" {
+  description = "AWS region where Claude models are available (may differ from main region)"
+  type        = string
+  default     = "us-west-2"
+}

--- a/aws/claude-code/root.hcl
+++ b/aws/claude-code/root.hcl
@@ -1,0 +1,53 @@
+# root.hcl - Root Terragrunt configuration for Claude Code
+# This file contains common settings shared across all environments
+
+locals {
+  # Project metadata
+  project_name = "claude-code"
+
+  # Parse environment from the directory path
+  # This assumes environments are in envs/<environment>/ directories
+  path_parts  = split("/", path_relative_to_include())
+  environment = element(local.path_parts, length(local.path_parts) - 1)
+
+  # Common tags applied to all resources
+  common_tags = {
+    Project     = local.project_name
+    Environment = local.environment
+    ManagedBy   = "terragrunt"
+    Repository  = "monorepo"
+    Component   = "claude-code"
+    Team        = "panicboat"
+  }
+}
+
+# Remote state configuration using shared S3 bucket
+remote_state {
+  backend = "s3"
+  generate = {
+    path      = "backend.tf"
+    if_exists = "overwrite_terragrunt"
+  }
+  config = {
+    # Shared bucket for all monorepo services
+    bucket = "terragrunt-state-${get_aws_account_id()}"
+
+    # Service-specific path: claude-code/<environment>/terraform.tfstate
+    key    = "platform/claude-code/${local.environment}/terraform.tfstate"
+    region = "ap-northeast-1"
+
+    # Shared DynamoDB table for state locking across all services
+    dynamodb_table = "terragrunt-state-locks"
+
+    # Enable server-side encryption
+    encrypt = true
+  }
+}
+
+# Common inputs passed to all Terraform modules
+inputs = {
+  project_name = local.project_name
+  environment  = local.environment
+  common_tags  = local.common_tags
+  aws_region   = "ap-northeast-1"
+}


### PR DESCRIPTION
## Summary
- ローカル Claude Code CLI から Bedrock の Claude モデルを使うための AWS リソースを Terragrunt で管理
- `aws/claude-code-action` をベースに、信頼ポリシーを GitHub OIDC から IAM User (`sts:AssumeRole`) に差し替え
- develop 環境のみ。Sonnet/Opus 4.6 cross-region inference profile (us-west-2) を許可

## Usage
```sh
cd aws/claude-code && make apply ENV=develop
ROLE=$(cd envs/develop && terragrunt output -raw iam_role_arn)
aws sts assume-role --role-arn "$ROLE" --role-session-name claude-code
# 取得した一時クレデンシャルを環境変数にセット
export CLAUDE_CODE_USE_BEDROCK=1 AWS_REGION=us-west-2
claude
```

## Test plan
- [ ] `make plan ENV=develop` で意図した IAM Role / Policy が作成される
- [ ] `make apply` 後、`aws sts assume-role` で当該ロールを引き受けられる
- [ ] 一時クレデンシャルで `claude` 実行時に Bedrock Sonnet/Opus 4.6 が呼び出せる

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated repository ignore patterns to exclude additional directories.

* **New Features**
  * Added infrastructure-as-code configuration for AWS deployment with IAM role and Bedrock model integration.
  * Added Make-based development workflow commands for infrastructure management and automation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->