### PR TITLE
feat(aws/claude-code,claude-code-action): allow Bedrock Haiku 4.5 access

### DIFF
--- a/aws/claude-code-action/modules/variables.tf
+++ b/aws/claude-code-action/modules/variables.tf
@@ -86,6 +86,18 @@ variable "bedrock_inference_profiles" {
         "us-west-2",
       ]
     },
+    {
+      profile_id = "us.anthropic.claude-haiku-4-5-20251001-v1:0"
+      model_id   = "anthropic.claude-haiku-4-5-20251001-v1:0"
+      source_regions = [
+        "ca-central-1",
+        "ca-west-1",
+        "us-east-1",
+        "us-east-2",
+        "us-west-1",
+        "us-west-2",
+      ]
+    },
   ]
 }
 

--- a/aws/claude-code/modules/variables.tf
+++ b/aws/claude-code/modules/variables.tf
@@ -75,6 +75,18 @@ variable "bedrock_inference_profiles" {
         "us-west-2",
       ]
     },
+    {
+      profile_id = "us.anthropic.claude-haiku-4-5-20251001-v1:0"
+      model_id   = "anthropic.claude-haiku-4-5-20251001-v1:0"
+      source_regions = [
+        "ca-central-1",
+        "ca-west-1",
+        "us-east-1",
+        "us-east-2",
+        "us-west-1",
+        "us-west-2",
+      ]
+    },
   ]
 }
 


### PR DESCRIPTION
## Summary
- Add `us.anthropic.claude-haiku-4-5-20251001-v1:0` to the default `bedrock_inference_profiles` in both `aws/claude-code` and `aws/claude-code-action` modules
- Claude Code invokes Haiku for lightweight tasks (conversation summaries, title generation) alongside the main Sonnet/Opus model, so the IAM policy must grant access to the Haiku 4.5 CRIS profile too

## Test plan
- [ ] `terragrunt plan` in `aws/claude-code/envs/develop` shows the Haiku profile/FM ARNs added to the IAM policy
- [ ] `terragrunt plan` in `aws/claude-code-action/envs/develop` shows the same
- [ ] After apply, running `claude` via Bedrock no longer fails on Haiku AccessDenied

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added support for Claude Haiku model inference profile across multiple AWS regions (Canada Central, Canada West, US East, US West).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->