### PR TITLE
fix(ci): dedupe deploy-trigger runs with PR-scoped concurrency

### DIFF
--- a/.github/workflows/auto-label--deploy-trigger.yaml
+++ b/.github/workflows/auto-label--deploy-trigger.yaml
@@ -15,8 +15,8 @@ permissions:
   pull-requests: write
 
 concurrency:
-  group: deploy-trigger-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
+  group: deploy-trigger-${{ github.event_name }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   deploy-trigger:

--- a/.github/workflows/auto-label--deploy-trigger.yaml
+++ b/.github/workflows/auto-label--deploy-trigger.yaml
@@ -14,6 +14,10 @@ permissions:
   contents: read
   pull-requests: write
 
+concurrency:
+  group: deploy-trigger-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   deploy-trigger:
     name: 'Deployment Trigger'


### PR DESCRIPTION
## Summary
- Add a PR-scoped `concurrency` group with `cancel-in-progress: true` to `auto-label--deploy-trigger.yaml`
- Prevents duplicate Terragrunt plan runs and DynamoDB tfstate lock contention when a PR touches multiple services

## Background
The Label Dispatcher adds one `deploy:<service>` label per modified service. Each label fires its own `pull_request.labeled` event, so a PR touching N services triggers N runs of the Resolver workflow. Each run resolves the full target list and plans every service in its matrix, which:

1. Runs the same `service × environment` plan N times (CI waste)
2. Races N workflow runs against the same tfstate DynamoDB lock, so the losers fail with `ConditionalCheckFailedException`

Observed on panicboat/platform#146 where two labels (`deploy:claude-code`, `deploy:claude-code-action`) triggered two parallel runs 1 second apart, and the second run failed to acquire the `claude-code-action/develop` tfstate lock.

## Test plan
- [ ] Open a PR that modifies two or more services and confirm only one Resolver run completes (earlier runs are cancelled)
- [ ] Confirm no more `Error acquiring the state lock` failures on Terragrunt plan comments

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Deployment workflow updated to enforce controlled concurrent runs: new logic groups runs and allows automatic cancellation of in-progress runs for pull request triggers while leaving non-pull-request runs unaffected, reducing overlapping deployment executions and improving run predictability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->