### PR TITLE
feat(aws/vpc): add production VPC with 3-tier subnet architecture

### DIFF
--- a/aws/claude-code-action/envs/develop/env.hcl
+++ b/aws/claude-code-action/envs/develop/env.hcl
@@ -27,8 +27,7 @@ locals {
   # Environment-specific tags
   environment_tags = {
     Environment = local.environment
-    Purpose     = "claude-code-action-monorepo"
-    CostCenter  = "engineering"
+    Purpose     = "claude-code-action"
     Owner       = "panicboat"
   }
 }

--- a/aws/claude-code/envs/develop/env.hcl
+++ b/aws/claude-code/envs/develop/env.hcl
@@ -24,8 +24,7 @@ locals {
   # Environment-specific tags
   environment_tags = {
     Environment = local.environment
-    Purpose     = "claude-code-local"
-    CostCenter  = "engineering"
+    Purpose     = "claude-code"
     Owner       = "panicboat"
   }
 }

--- a/aws/claude-code/modules/terraform.tf
+++ b/aws/claude-code/modules/terraform.tf
@@ -1,7 +1,7 @@
 # terraform.tf - Terraform and provider configuration
 
 terraform {
-  required_version = ">= 1.14.8"
+  required_version = ">= 1.6.0"
 
   required_providers {
     aws = {

--- a/aws/github-oidc-auth/envs/develop/env.hcl
+++ b/aws/github-oidc-auth/envs/develop/env.hcl
@@ -33,9 +33,7 @@ locals {
 
   # Develop-specific resource tags
   additional_tags = {
-    CostCenter   = "develop"
+    Purpose      = "github-actions"
     Owner        = "panicboat"
-    Purpose      = "github-actions-develop"
-    AutoShutdown = "enabled"
   }
 }

--- a/aws/github-oidc-auth/envs/production/env.hcl
+++ b/aws/github-oidc-auth/envs/production/env.hcl
@@ -33,9 +33,7 @@ locals {
 
   # Production-specific resource tags
   additional_tags = {
-    CostCenter = "production"
+    Purpose    = "github-actions"
     Owner      = "panicboat"
-    Purpose    = "github-actions-production"
-    Critical   = "true"
   }
 }

--- a/aws/github-oidc-auth/envs/staging/env.hcl
+++ b/aws/github-oidc-auth/envs/staging/env.hcl
@@ -33,8 +33,7 @@ locals {
 
   # Staging-specific resource tags
   additional_tags = {
-    CostCenter = "staging"
+    Purpose    = "github-actions"
     Owner      = "panicboat"
-    Purpose    = "github-actions-staging"
   }
 }

--- a/aws/vpc/Makefile
+++ b/aws/vpc/Makefile
@@ -1,0 +1,79 @@
+# Makefile for VPC
+
+# Default values
+ENV ?= production
+
+# Colors for output
+RED := \033[0;31m
+GREEN := \033[0;32m
+YELLOW := \033[0;33m
+BLUE := \033[0;34m
+NC := \033[0m # No Color
+
+.PHONY: help init plan apply destroy validate fmt check clean
+
+help: ## Show this help message
+	@echo "VPC - Terragrunt Commands"
+	@echo ""
+	@echo "Usage: make <target> [ENV=<environment>]"
+	@echo ""
+	@echo "Available targets:"
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "  $(BLUE)%-15s$(NC) %s\n", $$1, $$2}'
+	@echo ""
+	@echo "Available environments:"
+	@echo "  - production"
+	@echo ""
+	@echo "Examples:"
+	@echo "  make plan ENV=production"
+	@echo "  make apply ENV=production"
+
+init: ## Initialize Terragrunt
+	@echo "$(YELLOW)Initializing Terragrunt for $(ENV)...$(NC)"
+	cd envs/$(ENV) && terragrunt init
+
+plan: ## Plan Terragrunt changes
+	@echo "$(YELLOW)Planning Terragrunt changes for $(ENV)...$(NC)"
+	cd envs/$(ENV) && terragrunt plan
+
+apply: ## Apply Terragrunt changes
+	@echo "$(YELLOW)Applying Terragrunt changes for $(ENV)...$(NC)"
+	cd envs/$(ENV) && terragrunt apply -auto-approve
+
+destroy: ## Destroy Terragrunt resources
+	@echo "$(RED)Destroying Terragrunt resources for $(ENV)...$(NC)"
+	@echo "$(RED)WARNING: This will destroy all resources!$(NC)"
+	@read -p "Are you sure? [y/N] " -n 1 -r; \
+	echo; \
+	if [[ $$REPLY =~ ^[Yy]$$ ]]; then \
+		cd envs/$(ENV) && terragrunt destroy; \
+	else \
+		echo "$(YELLOW)Cancelled.$(NC)"; \
+	fi
+
+validate: ## Validate Terragrunt configuration
+	@echo "$(YELLOW)Validating Terragrunt configuration for $(ENV)...$(NC)"
+	cd envs/$(ENV) && terragrunt validate
+
+fmt: ## Format Terraform files
+	@echo "$(YELLOW)Formatting Terraform files...$(NC)"
+	terraform fmt -recursive .
+
+check: validate fmt ## Run validation and formatting checks
+	@echo "$(GREEN)All checks completed for $(ENV)$(NC)"
+
+clean: ## Clean Terragrunt cache
+	@echo "$(YELLOW)Cleaning Terragrunt cache...$(NC)"
+	find . -type d -name ".terragrunt-cache" -exec rm -rf {} + 2>/dev/null || true
+	find . -name "*.tfplan" -delete 2>/dev/null || true
+
+show: ## Show current Terragrunt state
+	@echo "$(YELLOW)Showing current state for $(ENV)...$(NC)"
+	cd envs/$(ENV) && terragrunt show
+
+output: ## Show Terragrunt outputs
+	@echo "$(YELLOW)Showing outputs for $(ENV)...$(NC)"
+	cd envs/$(ENV) && terragrunt output
+
+refresh: ## Refresh Terragrunt state
+	@echo "$(YELLOW)Refreshing state for $(ENV)...$(NC)"
+	cd envs/$(ENV) && terragrunt refresh

--- a/aws/vpc/envs/production/env.hcl
+++ b/aws/vpc/envs/production/env.hcl
@@ -1,0 +1,17 @@
+# env.hcl - Environment-specific configuration for production
+
+locals {
+  # Environment-specific settings
+  environment = "production"
+
+  # AWS configuration
+  aws_region = "ap-northeast-1"
+
+  # Environment-specific tags
+  environment_tags = {
+    Environment = local.environment
+    Purpose     = "platform-network"
+    CostCenter  = "engineering"
+    Owner       = "panicboat"
+  }
+}

--- a/aws/vpc/envs/production/env.hcl
+++ b/aws/vpc/envs/production/env.hcl
@@ -10,8 +10,7 @@ locals {
   # Environment-specific tags
   environment_tags = {
     Environment = local.environment
-    Purpose     = "platform-network"
-    CostCenter  = "engineering"
+    Purpose     = "vpc"
     Owner       = "panicboat"
   }
 }

--- a/aws/vpc/envs/production/terragrunt.hcl
+++ b/aws/vpc/envs/production/terragrunt.hcl
@@ -1,0 +1,32 @@
+# terragrunt.hcl - Terragrunt configuration for production environment
+
+# Include root configuration
+include "root" {
+  path = find_in_parent_folders("root.hcl")
+}
+
+# Include environment-specific configuration
+include "env" {
+  path   = "env.hcl"
+  expose = true
+}
+
+# Reference to Terraform modules
+terraform {
+  source = "../../modules"
+}
+
+# Input variables for the module
+inputs = {
+  environment = include.env.locals.environment
+  aws_region  = include.env.locals.aws_region
+
+  common_tags = merge(
+    include.env.locals.environment_tags,
+    {
+      Project    = "vpc"
+      ManagedBy  = "terragrunt"
+      Repository = "panicboat/platform"
+    }
+  )
+}

--- a/aws/vpc/modules/main.tf
+++ b/aws/vpc/modules/main.tf
@@ -1,0 +1,28 @@
+# main.tf - VPC composition via terraform-aws-modules/vpc/aws
+
+module "vpc" {
+  source  = "terraform-aws-modules/vpc/aws"
+  version = "~> 6.0"
+
+  name = "vpc-${var.environment}"
+  cidr = var.vpc_cidr
+
+  azs              = var.availability_zones
+  public_subnets   = var.public_subnet_cidrs
+  private_subnets  = var.private_subnet_cidrs
+  database_subnets = var.database_subnet_cidrs
+
+  enable_nat_gateway     = true
+  single_nat_gateway     = var.single_nat_gateway
+  one_nat_gateway_per_az = false
+
+  enable_dns_support   = true
+  enable_dns_hostnames = true
+
+  create_database_subnet_group           = true
+  create_database_subnet_route_table     = true
+  create_database_internet_gateway_route = false
+  create_database_nat_gateway_route      = false
+
+  tags = var.common_tags
+}

--- a/aws/vpc/modules/outputs.tf
+++ b/aws/vpc/modules/outputs.tf
@@ -1,0 +1,56 @@
+# outputs.tf - Outputs for the VPC module
+
+output "vpc_id" {
+  description = "ID of the VPC"
+  value       = module.vpc.vpc_id
+}
+
+output "vpc_cidr_block" {
+  description = "CIDR block of the VPC"
+  value       = module.vpc.vpc_cidr_block
+}
+
+output "public_subnet_ids" {
+  description = "IDs of the public subnets"
+  value       = module.vpc.public_subnets
+}
+
+output "private_subnet_ids" {
+  description = "IDs of the private (compute) subnets"
+  value       = module.vpc.private_subnets
+}
+
+output "database_subnet_ids" {
+  description = "IDs of the isolated database subnets"
+  value       = module.vpc.database_subnets
+}
+
+output "public_subnet_cidrs" {
+  description = "CIDR blocks of the public subnets"
+  value       = module.vpc.public_subnets_cidr_blocks
+}
+
+output "private_subnet_cidrs" {
+  description = "CIDR blocks of the private (compute) subnets"
+  value       = module.vpc.private_subnets_cidr_blocks
+}
+
+output "database_subnet_cidrs" {
+  description = "CIDR blocks of the isolated database subnets"
+  value       = module.vpc.database_subnets_cidr_blocks
+}
+
+output "database_subnet_group_name" {
+  description = "Name of the DB subnet group (for RDS module consumers)"
+  value       = module.vpc.database_subnet_group_name
+}
+
+output "nat_public_ips" {
+  description = "Elastic IPs of the NAT Gateway(s). Use for IP allowlisting against egress traffic."
+  value       = module.vpc.nat_public_ips
+}
+
+output "availability_zones" {
+  description = "Availability zones used by the VPC"
+  value       = module.vpc.azs
+}

--- a/aws/vpc/modules/terraform.tf
+++ b/aws/vpc/modules/terraform.tf
@@ -1,0 +1,20 @@
+# terraform.tf - Terraform and provider configuration
+
+terraform {
+  required_version = ">= 1.14.8"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 6.40"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.aws_region
+
+  default_tags {
+    tags = var.common_tags
+  }
+}

--- a/aws/vpc/modules/terraform.tf
+++ b/aws/vpc/modules/terraform.tf
@@ -1,7 +1,7 @@
 # terraform.tf - Terraform and provider configuration
 
 terraform {
-  required_version = ">= 1.14.8"
+  required_version = ">= 1.6.0"
 
   required_providers {
     aws = {

--- a/aws/vpc/modules/variables.tf
+++ b/aws/vpc/modules/variables.tf
@@ -1,0 +1,54 @@
+# variables.tf - Variables for VPC module
+
+variable "environment" {
+  description = "Environment name (e.g., develop, staging, production)"
+  type        = string
+}
+
+variable "common_tags" {
+  description = "Common tags to apply to all resources"
+  type        = map(string)
+  default     = {}
+}
+
+variable "aws_region" {
+  description = "AWS region"
+  type        = string
+  default     = "ap-northeast-1"
+}
+
+variable "vpc_cidr" {
+  description = "CIDR block for the VPC"
+  type        = string
+  default     = "10.0.0.0/16"
+}
+
+variable "availability_zones" {
+  description = "List of availability zones to deploy into"
+  type        = list(string)
+  default     = ["ap-northeast-1a", "ap-northeast-1c", "ap-northeast-1d"]
+}
+
+variable "public_subnet_cidrs" {
+  description = "CIDR blocks for public subnets (one per AZ, same order as availability_zones)"
+  type        = list(string)
+  default     = ["10.0.0.0/24", "10.0.1.0/24", "10.0.2.0/24"]
+}
+
+variable "private_subnet_cidrs" {
+  description = "CIDR blocks for private (compute) subnets (one per AZ, same order as availability_zones)"
+  type        = list(string)
+  default     = ["10.0.32.0/19", "10.0.64.0/19", "10.0.96.0/19"]
+}
+
+variable "database_subnet_cidrs" {
+  description = "CIDR blocks for isolated database subnets (one per AZ, same order as availability_zones)"
+  type        = list(string)
+  default     = ["10.0.10.0/24", "10.0.11.0/24", "10.0.12.0/24"]
+}
+
+variable "single_nat_gateway" {
+  description = "Use a single shared NAT Gateway for all private subnets. Set to false to deploy one NAT Gateway per AZ."
+  type        = bool
+  default     = true
+}

--- a/aws/vpc/root.hcl
+++ b/aws/vpc/root.hcl
@@ -1,0 +1,53 @@
+# root.hcl - Root Terragrunt configuration for VPC
+# This file contains common settings shared across all environments
+
+locals {
+  # Project metadata
+  project_name = "vpc"
+
+  # Parse environment from the directory path
+  # This assumes environments are in envs/<environment>/ directories
+  path_parts  = split("/", path_relative_to_include())
+  environment = element(local.path_parts, length(local.path_parts) - 1)
+
+  # Common tags applied to all resources
+  common_tags = {
+    Project     = local.project_name
+    Environment = local.environment
+    ManagedBy   = "terragrunt"
+    Repository  = "monorepo"
+    Component   = "vpc"
+    Team        = "panicboat"
+  }
+}
+
+# Remote state configuration using shared S3 bucket
+remote_state {
+  backend = "s3"
+  generate = {
+    path      = "backend.tf"
+    if_exists = "overwrite_terragrunt"
+  }
+  config = {
+    # Shared bucket for all monorepo services
+    bucket = "terragrunt-state-${get_aws_account_id()}"
+
+    # Service-specific path: vpc/<environment>/terraform.tfstate
+    key    = "platform/vpc/${local.environment}/terraform.tfstate"
+    region = "ap-northeast-1"
+
+    # Shared DynamoDB table for state locking across all services
+    dynamodb_table = "terragrunt-state-locks"
+
+    # Enable server-side encryption
+    encrypt = true
+  }
+}
+
+# Common inputs passed to all Terraform modules
+# project_name is intentionally omitted; this service encodes "vpc" directly in resource names.
+inputs = {
+  environment = local.environment
+  common_tags = local.common_tags
+  aws_region  = "ap-northeast-1"
+}

--- a/docs/superpowers/plans/2026-04-17-aws-vpc.md
+++ b/docs/superpowers/plans/2026-04-17-aws-vpc.md
@@ -1,0 +1,656 @@
+# aws/vpc Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** `aws/vpc` Terragrunt service を新規作成し、production 環境向けに 3 AZ / 3 tier (public / database / private) 構成の VPC を provision する。
+
+**Architecture:** 既存の `aws/{service}/modules + envs/{env}/` 構成慣習に従う。`terraform-aws-modules/vpc/aws ~> 6.0` を呼び出して VPC / IGW / subnets / 単一 NAT GW / ルートテーブル / DB subnet group を構築する。DB subnet は default route 無しの完全 isolated。
+
+**Tech Stack:** Terragrunt, OpenTofu (Terraform `>= 1.14.8`), terraform-aws-modules/vpc/aws `~> 6.0`, AWS provider `~> 6.40`
+
+**Spec:** [`docs/superpowers/specs/2026-04-16-aws-vpc-design.md`](../specs/2026-04-16-aws-vpc-design.md)
+
+---
+
+## File Structure
+
+作成するファイル:
+
+```
+aws/vpc/
+├── Makefile                   # Task 1
+├── root.hcl                   # Task 1
+├── modules/
+│   ├── terraform.tf           # Task 2
+│   ├── variables.tf           # Task 2
+│   ├── main.tf                # Task 2
+│   └── outputs.tf             # Task 2
+└── envs/
+    └── production/
+        ├── env.hcl            # Task 3
+        └── terragrunt.hcl     # Task 3
+```
+
+Generated / gitignored（コミットしない）:
+- `envs/production/backend.tf`（Terragrunt が生成）
+- `envs/production/.terragrunt-cache/`
+- `envs/production/.terraform.lock.hcl`
+- `envs/production/.terraform/`
+
+---
+
+## Task 1: Service skeleton (Makefile + root.hcl)
+
+サービス直下の 2 ファイルを作成する。`root.hcl` は既存パターン踏襲だが、`project_name = "vpc"` かつ modules 側で `var.project_name` を受け取らないので `inputs` からは除外する。
+
+**Files:**
+- Create: `aws/vpc/Makefile`
+- Create: `aws/vpc/root.hcl`
+
+- [ ] **Step 1.1: Create `aws/vpc/Makefile`**
+
+Content:
+
+```makefile
+# Makefile for VPC
+
+# Default values
+ENV ?= production
+
+# Colors for output
+RED := \033[0;31m
+GREEN := \033[0;32m
+YELLOW := \033[0;33m
+BLUE := \033[0;34m
+NC := \033[0m # No Color
+
+.PHONY: help init plan apply destroy validate fmt check clean
+
+help: ## Show this help message
+	@echo "VPC - Terragrunt Commands"
+	@echo ""
+	@echo "Usage: make <target> [ENV=<environment>]"
+	@echo ""
+	@echo "Available targets:"
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "  $(BLUE)%-15s$(NC) %s\n", $$1, $$2}'
+	@echo ""
+	@echo "Available environments:"
+	@echo "  - production"
+	@echo ""
+	@echo "Examples:"
+	@echo "  make plan ENV=production"
+	@echo "  make apply ENV=production"
+
+init: ## Initialize Terragrunt
+	@echo "$(YELLOW)Initializing Terragrunt for $(ENV)...$(NC)"
+	cd envs/$(ENV) && terragrunt init
+
+plan: ## Plan Terragrunt changes
+	@echo "$(YELLOW)Planning Terragrunt changes for $(ENV)...$(NC)"
+	cd envs/$(ENV) && terragrunt plan
+
+apply: ## Apply Terragrunt changes
+	@echo "$(YELLOW)Applying Terragrunt changes for $(ENV)...$(NC)"
+	cd envs/$(ENV) && terragrunt apply -auto-approve
+
+destroy: ## Destroy Terragrunt resources
+	@echo "$(RED)Destroying Terragrunt resources for $(ENV)...$(NC)"
+	@echo "$(RED)WARNING: This will destroy all resources!$(NC)"
+	@read -p "Are you sure? [y/N] " -n 1 -r; \
+	echo; \
+	if [[ $$REPLY =~ ^[Yy]$$ ]]; then \
+		cd envs/$(ENV) && terragrunt destroy; \
+	else \
+		echo "$(YELLOW)Cancelled.$(NC)"; \
+	fi
+
+validate: ## Validate Terragrunt configuration
+	@echo "$(YELLOW)Validating Terragrunt configuration for $(ENV)...$(NC)"
+	cd envs/$(ENV) && terragrunt validate
+
+fmt: ## Format Terraform files
+	@echo "$(YELLOW)Formatting Terraform files...$(NC)"
+	terraform fmt -recursive .
+
+check: validate fmt ## Run validation and formatting checks
+	@echo "$(GREEN)All checks completed for $(ENV)$(NC)"
+
+clean: ## Clean Terragrunt cache
+	@echo "$(YELLOW)Cleaning Terragrunt cache...$(NC)"
+	find . -type d -name ".terragrunt-cache" -exec rm -rf {} + 2>/dev/null || true
+	find . -name "*.tfplan" -delete 2>/dev/null || true
+
+show: ## Show current Terragrunt state
+	@echo "$(YELLOW)Showing current state for $(ENV)...$(NC)"
+	cd envs/$(ENV) && terragrunt show
+
+output: ## Show Terragrunt outputs
+	@echo "$(YELLOW)Showing outputs for $(ENV)...$(NC)"
+	cd envs/$(ENV) && terragrunt output
+
+refresh: ## Refresh Terragrunt state
+	@echo "$(YELLOW)Refreshing state for $(ENV)...$(NC)"
+	cd envs/$(ENV) && terragrunt refresh
+```
+
+- [ ] **Step 1.2: Create `aws/vpc/root.hcl`**
+
+Content:
+
+```hcl
+# root.hcl - Root Terragrunt configuration for VPC
+# This file contains common settings shared across all environments
+
+locals {
+  # Project metadata
+  project_name = "vpc"
+
+  # Parse environment from the directory path
+  # This assumes environments are in envs/<environment>/ directories
+  path_parts  = split("/", path_relative_to_include())
+  environment = element(local.path_parts, length(local.path_parts) - 1)
+
+  # Common tags applied to all resources
+  common_tags = {
+    Project     = local.project_name
+    Environment = local.environment
+    ManagedBy   = "terragrunt"
+    Repository  = "monorepo"
+    Component   = "vpc"
+    Team        = "panicboat"
+  }
+}
+
+# Remote state configuration using shared S3 bucket
+remote_state {
+  backend = "s3"
+  generate = {
+    path      = "backend.tf"
+    if_exists = "overwrite_terragrunt"
+  }
+  config = {
+    # Shared bucket for all monorepo services
+    bucket = "terragrunt-state-${get_aws_account_id()}"
+
+    # Service-specific path: vpc/<environment>/terraform.tfstate
+    key    = "platform/vpc/${local.environment}/terraform.tfstate"
+    region = "ap-northeast-1"
+
+    # Shared DynamoDB table for state locking across all services
+    dynamodb_table = "terragrunt-state-locks"
+
+    # Enable server-side encryption
+    encrypt = true
+  }
+}
+
+# Common inputs passed to all Terraform modules
+# project_name is intentionally omitted; this service encodes "vpc" directly in resource names.
+inputs = {
+  environment = local.environment
+  common_tags = local.common_tags
+  aws_region  = "ap-northeast-1"
+}
+```
+
+- [ ] **Step 1.3: Commit**
+
+```bash
+git add aws/vpc/Makefile aws/vpc/root.hcl
+git commit -m "$(cat <<'EOF'
+feat(aws/vpc): add service skeleton (Makefile + root.hcl)
+
+Introduce aws/vpc Terragrunt service following the existing aws/{service}
+convention. root.hcl reuses the shared S3 backend under
+platform/vpc/<env>/terraform.tfstate and scopes common_tags to this
+service. project_name is kept only as a local for tagging and is not
+passed as a module input because the module encodes "vpc" in resource
+names directly.
+
+Signed-off-by: panicboat <panicboat@gmail.com>
+EOF
+)"
+```
+
+---
+
+## Task 2: Terraform module (4 files)
+
+VPC モジュール本体を作成する。`terraform-aws-modules/vpc/aws ~> 6.0` を呼び出す薄いラッパー。
+
+**Files:**
+- Create: `aws/vpc/modules/terraform.tf`
+- Create: `aws/vpc/modules/variables.tf`
+- Create: `aws/vpc/modules/main.tf`
+- Create: `aws/vpc/modules/outputs.tf`
+
+- [ ] **Step 2.1: Create `aws/vpc/modules/terraform.tf`**
+
+Content:
+
+```hcl
+# terraform.tf - Terraform and provider configuration
+
+terraform {
+  required_version = ">= 1.14.8"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 6.40"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.aws_region
+
+  default_tags {
+    tags = var.common_tags
+  }
+}
+```
+
+- [ ] **Step 2.2: Create `aws/vpc/modules/variables.tf`**
+
+Content:
+
+```hcl
+# variables.tf - Variables for VPC module
+
+variable "environment" {
+  description = "Environment name (e.g., develop, staging, production)"
+  type        = string
+}
+
+variable "common_tags" {
+  description = "Common tags to apply to all resources"
+  type        = map(string)
+  default     = {}
+}
+
+variable "aws_region" {
+  description = "AWS region"
+  type        = string
+  default     = "ap-northeast-1"
+}
+
+variable "vpc_cidr" {
+  description = "CIDR block for the VPC"
+  type        = string
+  default     = "10.0.0.0/16"
+}
+
+variable "availability_zones" {
+  description = "List of availability zones to deploy into"
+  type        = list(string)
+  default     = ["ap-northeast-1a", "ap-northeast-1c", "ap-northeast-1d"]
+}
+
+variable "public_subnet_cidrs" {
+  description = "CIDR blocks for public subnets (one per AZ, same order as availability_zones)"
+  type        = list(string)
+  default     = ["10.0.0.0/24", "10.0.1.0/24", "10.0.2.0/24"]
+}
+
+variable "private_subnet_cidrs" {
+  description = "CIDR blocks for private (compute) subnets (one per AZ, same order as availability_zones)"
+  type        = list(string)
+  default     = ["10.0.32.0/19", "10.0.64.0/19", "10.0.96.0/19"]
+}
+
+variable "database_subnet_cidrs" {
+  description = "CIDR blocks for isolated database subnets (one per AZ, same order as availability_zones)"
+  type        = list(string)
+  default     = ["10.0.10.0/24", "10.0.11.0/24", "10.0.12.0/24"]
+}
+
+variable "single_nat_gateway" {
+  description = "Use a single shared NAT Gateway for all private subnets. Set to false to deploy one NAT Gateway per AZ."
+  type        = bool
+  default     = true
+}
+```
+
+- [ ] **Step 2.3: Create `aws/vpc/modules/main.tf`**
+
+Content:
+
+```hcl
+# main.tf - VPC composition via terraform-aws-modules/vpc/aws
+
+module "vpc" {
+  source  = "terraform-aws-modules/vpc/aws"
+  version = "~> 6.0"
+
+  name = "vpc-${var.environment}"
+  cidr = var.vpc_cidr
+
+  azs              = var.availability_zones
+  public_subnets   = var.public_subnet_cidrs
+  private_subnets  = var.private_subnet_cidrs
+  database_subnets = var.database_subnet_cidrs
+
+  enable_nat_gateway     = true
+  single_nat_gateway     = var.single_nat_gateway
+  one_nat_gateway_per_az = false
+
+  enable_dns_support   = true
+  enable_dns_hostnames = true
+
+  create_database_subnet_group           = true
+  create_database_subnet_route_table     = true
+  create_database_internet_gateway_route = false
+  create_database_nat_gateway_route      = false
+
+  tags = var.common_tags
+}
+```
+
+- [ ] **Step 2.4: Create `aws/vpc/modules/outputs.tf`**
+
+Content:
+
+```hcl
+# outputs.tf - Outputs for the VPC module
+
+output "vpc_id" {
+  description = "ID of the VPC"
+  value       = module.vpc.vpc_id
+}
+
+output "vpc_cidr_block" {
+  description = "CIDR block of the VPC"
+  value       = module.vpc.vpc_cidr_block
+}
+
+output "public_subnet_ids" {
+  description = "IDs of the public subnets"
+  value       = module.vpc.public_subnets
+}
+
+output "private_subnet_ids" {
+  description = "IDs of the private (compute) subnets"
+  value       = module.vpc.private_subnets
+}
+
+output "database_subnet_ids" {
+  description = "IDs of the isolated database subnets"
+  value       = module.vpc.database_subnets
+}
+
+output "public_subnet_cidrs" {
+  description = "CIDR blocks of the public subnets"
+  value       = module.vpc.public_subnets_cidr_blocks
+}
+
+output "private_subnet_cidrs" {
+  description = "CIDR blocks of the private (compute) subnets"
+  value       = module.vpc.private_subnets_cidr_blocks
+}
+
+output "database_subnet_cidrs" {
+  description = "CIDR blocks of the isolated database subnets"
+  value       = module.vpc.database_subnets_cidr_blocks
+}
+
+output "database_subnet_group_name" {
+  description = "Name of the DB subnet group (for RDS module consumers)"
+  value       = module.vpc.database_subnet_group_name
+}
+
+output "nat_public_ips" {
+  description = "Elastic IPs of the NAT Gateway(s). Use for IP allowlisting against egress traffic."
+  value       = module.vpc.nat_public_ips
+}
+
+output "availability_zones" {
+  description = "Availability zones used by the VPC"
+  value       = module.vpc.azs
+}
+```
+
+- [ ] **Step 2.5: Format Terraform files**
+
+Run:
+
+```bash
+cd aws/vpc && terraform fmt -recursive .
+```
+
+Expected output: filenames listed if any formatting was applied, empty if already formatted.
+
+- [ ] **Step 2.6: Commit**
+
+```bash
+git add aws/vpc/modules/
+git commit -m "$(cat <<'EOF'
+feat(aws/vpc): add Terraform module for production VPC
+
+Compose VPC, IGW, three-tier subnets (public, isolated database,
+private), and a single shared NAT Gateway using
+terraform-aws-modules/vpc/aws ~> 6.0. Database subnets have no default
+route by design; cross-internet egress must be granted explicitly via
+VPC endpoints if ever needed.
+
+Signed-off-by: panicboat <panicboat@gmail.com>
+EOF
+)"
+```
+
+---
+
+## Task 3: Production environment
+
+`envs/production/` 配下に terragrunt entry point と環境固有値を置く。
+
+**Files:**
+- Create: `aws/vpc/envs/production/env.hcl`
+- Create: `aws/vpc/envs/production/terragrunt.hcl`
+
+- [ ] **Step 3.1: Create `aws/vpc/envs/production/env.hcl`**
+
+Content:
+
+```hcl
+# env.hcl - Environment-specific configuration for production
+
+locals {
+  # Environment-specific settings
+  environment = "production"
+
+  # AWS configuration
+  aws_region = "ap-northeast-1"
+
+  # Environment-specific tags
+  environment_tags = {
+    Environment = local.environment
+    Purpose     = "platform-network"
+    CostCenter  = "engineering"
+    Owner       = "panicboat"
+  }
+}
+```
+
+- [ ] **Step 3.2: Create `aws/vpc/envs/production/terragrunt.hcl`**
+
+Content:
+
+```hcl
+# terragrunt.hcl - Terragrunt configuration for production environment
+
+# Include root configuration
+include "root" {
+  path = find_in_parent_folders("root.hcl")
+}
+
+# Include environment-specific configuration
+include "env" {
+  path   = "env.hcl"
+  expose = true
+}
+
+# Reference to Terraform modules
+terraform {
+  source = "../../modules"
+}
+
+# Input variables for the module
+inputs = {
+  environment = include.env.locals.environment
+  aws_region  = include.env.locals.aws_region
+
+  common_tags = merge(
+    include.env.locals.environment_tags,
+    {
+      Project    = "vpc"
+      ManagedBy  = "terragrunt"
+      Repository = "panicboat/platform"
+    }
+  )
+}
+```
+
+- [ ] **Step 3.3: Format Terraform files**
+
+Run:
+
+```bash
+cd aws/vpc && terraform fmt -recursive .
+```
+
+Expected output: filenames listed if any formatting was applied, empty if already formatted.
+
+- [ ] **Step 3.4: Commit**
+
+```bash
+git add aws/vpc/envs/
+git commit -m "$(cat <<'EOF'
+feat(aws/vpc): add production environment configuration
+
+Add envs/production with env.hcl (environment locals and tagging) and
+terragrunt.hcl (root + env include, module source wiring, inputs
+merge).
+
+Signed-off-by: panicboat <panicboat@gmail.com>
+EOF
+)"
+```
+
+---
+
+## Task 4: Validate
+
+`terragrunt init` と `terragrunt validate` でモジュール解決と設定の整合性を検証する。Apply はまだ行わない。
+
+- [ ] **Step 4.1: Run `terragrunt init`**
+
+Run:
+
+```bash
+cd aws/vpc/envs/production && terragrunt init
+```
+
+Expected:
+- `terraform-aws-modules/vpc/aws` と AWS provider がダウンロードされる
+- 最後に `Terraform has been successfully initialized!` が表示される
+- S3 backend (`terragrunt-state-<account_id>`) に既存の state bucket がある前提（他サービスで使用済み）
+
+トラブルシュート:
+- `Error: Failed to get existing workspaces: S3 bucket ... does not exist` → 他サービスで bucket が作成されていない可能性。`aws s3api head-bucket --bucket terragrunt-state-$(aws sts get-caller-identity --query Account --output text)` で確認する。存在しなければ本計画のスコープ外（別途 bucket 作成 PR が必要）。
+
+- [ ] **Step 4.2: Run `terragrunt validate`**
+
+Run:
+
+```bash
+cd aws/vpc/envs/production && terragrunt validate
+```
+
+Expected: `Success! The configuration is valid.`
+
+もしエラーが出たら、メッセージに沿って variables / main.tf / terragrunt.hcl を修正し、再度 `fmt -recursive` → `validate` の順で回す。修正コミットは Task 2 / 3 のコミットに対する follow-up として新規コミットで積む（amend しない）。
+
+- [ ] **Step 4.3: Check formatting**
+
+Run:
+
+```bash
+cd aws/vpc && terraform fmt -check -recursive .
+```
+
+Expected: 何も出力されない（exit 0）。差分があればファイル名が出力されるので `terraform fmt -recursive .` を実行し、差分を新規コミットにする。
+
+---
+
+## Task 5: Plan レビューと適用判断
+
+**このタスクでは apply を自動実行しない。** Plan 結果をユーザーがレビューし、問題なければ別セッション / 別操作として apply する。
+
+- [ ] **Step 5.1: Run `terragrunt plan`**
+
+Run:
+
+```bash
+cd aws/vpc/envs/production && terragrunt plan
+```
+
+Expected 要点:
+- `Plan: N to add, 0 to change, 0 to destroy.` が表示される（N はおおよそ 20 前後: VPC 1、subnet 9、route table 3、RT association 9、IGW 1、EIP 1、NAT GW 1、DB subnet group 1 ほか）
+- `aws_vpc.this` の CIDR が `10.0.0.0/16`
+- `aws_subnet.public[*]` / `aws_subnet.private[*]` / `aws_subnet.database[*]` が各 3 件
+- `aws_nat_gateway.this[0]` が 1 件だけ（3 件でないこと = single NAT 設定確認）
+- `aws_db_subnet_group.database` が 1 件（`create_database_subnet_group = true` の結果）
+
+- [ ] **Step 5.2: ユーザーレビュー**
+
+Plan 出力をユーザーに提示し、以下を確認:
+- 想定外のリソース変更が無いか
+- CIDR / AZ / subnet 数が spec 通りか
+- 追加リソース数が想定範囲か
+
+ユーザー承認が得られたら次ステップへ。修正が必要なら Task 2 / 3 に戻って変更し、Task 4 → 5 を再実行する。
+
+- [ ] **Step 5.3: Apply（ユーザー承認後のみ）**
+
+Run:
+
+```bash
+cd aws/vpc/envs/production && terragrunt apply
+```
+
+Expected:
+- Plan と同じ内容が再表示される
+- `Enter a value:` プロンプトで `yes` を入力
+- 数分後に `Apply complete! Resources: N added, 0 changed, 0 destroyed.`
+- Outputs が表示される（`vpc_id`, `public_subnet_ids`, `private_subnet_ids`, `database_subnet_ids`, `database_subnet_group_name`, `nat_public_ips`, etc.）
+
+- [ ] **Step 5.4: Apply 後の検証**
+
+Run:
+
+```bash
+VPC_ID=$(cd aws/vpc/envs/production && terragrunt output -raw vpc_id)
+aws ec2 describe-vpcs --region ap-northeast-1 --vpc-ids "$VPC_ID" \
+  --query 'Vpcs[0].{CidrBlock:CidrBlock,State:State}' --output table
+aws ec2 describe-subnets --region ap-northeast-1 \
+  --filters "Name=vpc-id,Values=$VPC_ID" \
+  --query 'Subnets[].{Id:SubnetId,AZ:AvailabilityZone,CIDR:CidrBlock,Name:Tags[?Key==`Name`]|[0].Value}' \
+  --output table
+aws ec2 describe-nat-gateways --region ap-northeast-1 \
+  --filter "Name=vpc-id,Values=$VPC_ID" \
+  --query 'NatGateways[].{Id:NatGatewayId,State:State,Subnet:SubnetId}' --output table
+```
+
+Expected:
+- CIDR `10.0.0.0/16`, State `available`
+- 9 subnets: public-1a/1c/1d, private-1a/1c/1d, database-1a/1c/1d
+- 1 NAT gateway, State `available`, Subnet が public-1a のもの
+
+---
+
+## Notes
+
+- `workflow-config.yaml` の `production` セクション有効化はユーザー側で未コミット状態になっている（ブランチ作成時点での working tree 差分）。CI で本サービスの production を回すにはこの変更のコミット＆マージが必要。本計画のスコープ外（別 PR を推奨）。
+- `.terraform.lock.hcl` は `.gitignore` 対象なのでコミット不要。
+- Apply を行う場合は IAM 的に `iam_role_apply` 相当の権限を持つセッションで実行する。

--- a/docs/superpowers/specs/2026-04-16-aws-vpc-design.md
+++ b/docs/superpowers/specs/2026-04-16-aws-vpc-design.md
@@ -59,7 +59,7 @@ EKS の VPC CNI が Pod ごとに ENI IP を消費するため、private サブ�
 ### Key Module Inputs
 
 ```hcl
-name = "${var.project_name}-${var.environment}"
+name = "vpc-${var.environment}"
 cidr = var.vpc_cidr                    # "10.0.0.0/16"
 azs  = var.availability_zones          # ["ap-northeast-1a", "ap-northeast-1c", "ap-northeast-1d"]
 
@@ -85,10 +85,10 @@ create_database_nat_gateway_route      = false
 ```
 aws/vpc/
 ├── Makefile                        # 既存サービスの Makefile を踏襲（ENV=production）
-├── root.hcl                        # aws/claude-code/root.hcl と同パターン、project_name = "vpc"
+├── root.hcl                        # aws/claude-code/root.hcl と同パターン。project_name local は tag 用途のみで module inputs には渡さない
 ├── modules/
-│   ├── main.tf                     # module "vpc" { source = "terraform-aws-modules/vpc/aws" ... }
-│   ├── variables.tf                # vpc_cidr, availability_zones, *_subnet_cidrs, single_nat_gateway
+│   ├── main.tf                     # module "vpc" { source = "terraform-aws-modules/vpc/aws" ... }。リソース名は "vpc-${var.environment}" を直接使用
+│   ├── variables.tf                # vpc_cidr, availability_zones, *_subnet_cidrs, single_nat_gateway（project_name は宣言しない）
 │   ├── outputs.tf                  # 下記 Outputs を参照
 │   └── terraform.tf                # terraform >= 1.14.8, aws ~> 6.40 (既存サービスと揃える)
 └── envs/

--- a/docs/superpowers/specs/2026-04-16-aws-vpc-design.md
+++ b/docs/superpowers/specs/2026-04-16-aws-vpc-design.md
@@ -1,0 +1,130 @@
+# aws/vpc — Production VPC Design
+
+## Purpose
+
+Establish a production VPC in `ap-northeast-1` that will host future workloads (EKS / ECS clusters, RDS, etc.). This is the foundational network for the account and supersedes the default VPC that was removed on 2026-04-16.
+
+## Scope
+
+- New Terragrunt service at `aws/vpc/` following the existing `aws/{service}/modules + envs/{env}` convention used by `claude-code`, `claude-code-action`, and `github-oidc-auth`.
+- `production` environment only for now. `develop` / `staging` can be added later by copying `envs/production/`.
+- VPC, subnets (3 tiers x 3 AZ), IGW, single NAT Gateway, route tables, DB subnet group.
+
+## Out of Scope
+
+- EKS, ECS, RDS resources themselves (separate services).
+- VPC endpoints (S3, ECR, etc.) — add on demand when a workload needs them.
+- Transit Gateway / VPC peering.
+- Flow logs — to be added later if an audit requirement arises.
+- Subnet tags for EKS (`kubernetes.io/role/elb`, `kubernetes.io/role/internal-elb`) — added by the EKS module, not here.
+
+## Architecture
+
+### Network layout
+
+| Tier | AZ 1a | AZ 1c | AZ 1d | Route |
+|---|---|---|---|---|
+| Public | `10.0.0.0/24` | `10.0.1.0/24` | `10.0.2.0/24` | IGW |
+| Database (isolated) | `10.0.10.0/24` | `10.0.11.0/24` | `10.0.12.0/24` | **no default route** |
+| Private (compute) | `10.0.32.0/19` | `10.0.64.0/19` | `10.0.96.0/19` | NAT GW |
+
+- **VPC CIDR**: `10.0.0.0/16`
+- **IGW**: 1, attached to VPC; public subnets route `0.0.0.0/0` to it.
+- **NAT GW**: 1 shared NAT Gateway placed in public-1a. All three private subnets route `0.0.0.0/0` to it. Trade-off accepted: AZ 1a outage breaks egress for private subnets in 1c/1d.
+- **Database subnets**: fully isolated. Their dedicated route table has no default route. External egress (for secrets rotation etc.) is deliberately not provided here; add VPC endpoints later if needed.
+- **DNS**: `enable_dns_support = true`, `enable_dns_hostnames = true` (EKS requirement).
+
+### CIDR allocation (10.0.0.0/16)
+
+```
+10.0.0.0/24   - 10.0.2.0/24    public   (3 x /24)
+10.0.3.0/24   - 10.0.9.0/24    reserved
+10.0.10.0/24  - 10.0.12.0/24   database (3 x /24)
+10.0.13.0/24  - 10.0.31.0/24   reserved
+10.0.32.0/19                   private-1a
+10.0.64.0/19                   private-1c
+10.0.96.0/19                   private-1d
+10.0.128.0/17                  reserved
+```
+
+Private subnets are sized `/19` (8192 IPs each) to accommodate EKS VPC CNI (one ENI IP per pod).
+
+## Implementation
+
+### Module
+
+- Source: [`terraform-aws-modules/vpc/aws`](https://registry.terraform.io/modules/terraform-aws-modules/vpc/aws) version `~> 6.0`.
+- Chosen over raw `aws_vpc`/`aws_subnet` resources for brevity and edge-case coverage; this is a conscious departure from the raw-resource convention used by the other three services in this repo.
+
+### Key module inputs
+
+```hcl
+name = "${var.project_name}-${var.environment}"
+cidr = var.vpc_cidr                    # "10.0.0.0/16"
+azs  = var.availability_zones          # ["ap-northeast-1a", "ap-northeast-1c", "ap-northeast-1d"]
+
+public_subnets   = var.public_subnet_cidrs
+private_subnets  = var.private_subnet_cidrs
+database_subnets = var.database_subnet_cidrs
+
+enable_nat_gateway     = true
+single_nat_gateway     = true
+one_nat_gateway_per_az = false
+
+enable_dns_support   = true
+enable_dns_hostnames = true
+
+create_database_subnet_group           = true
+create_database_subnet_route_table     = true
+create_database_internet_gateway_route = false
+create_database_nat_gateway_route      = false
+```
+
+### Files
+
+```
+aws/vpc/
+├── Makefile                        # copy of existing services' Makefile (ENV=production)
+├── root.hcl                        # same pattern as aws/claude-code/root.hcl; project_name = "vpc"
+├── modules/
+│   ├── main.tf                     # module "vpc" { source = "terraform-aws-modules/vpc/aws" ... }
+│   ├── variables.tf                # vpc_cidr, availability_zones, *_subnet_cidrs, single_nat_gateway
+│   ├── outputs.tf                  # see below
+│   └── terraform.tf                # terraform >= 1.14.8, aws ~> 6.40 (matches existing services)
+└── envs/
+    └── production/
+        ├── terragrunt.hcl          # include root + env; terraform.source = "../../modules"
+        └── env.hcl                 # environment = "production", aws_region = "ap-northeast-1"
+```
+
+### Outputs
+
+- `vpc_id`, `vpc_cidr_block`
+- `public_subnet_ids`, `private_subnet_ids`, `database_subnet_ids`
+- `public_subnet_cidrs`, `private_subnet_cidrs`, `database_subnet_cidrs`
+- `database_subnet_group_name` (for RDS module consumers)
+- `nat_public_ips` (IP allowlisting)
+- `availability_zones`
+
+### State
+
+Reuses the existing shared backend (see `aws/claude-code/root.hcl`):
+- Bucket: `terragrunt-state-<account_id>`
+- Key: `platform/vpc/production/terraform.tfstate`
+- Lock table: `terragrunt-state-locks`
+
+## Data Flow / Failure Modes
+
+- Public subnets: egress and ingress via IGW.
+- Private subnets: egress via NAT GW. Single-NAT trade-off: AZ 1a failure severs egress for all private subnets. Acceptable given cost priority; revisit by flipping `single_nat_gateway = false` if availability requirements tighten.
+- Database subnets: no internet path by design. RDS/ElastiCache placed here must be reached from private subnets within the same VPC. Cross-region replication or SaaS-triggered rotation requires adding a VPC endpoint later.
+
+## Testing
+
+- `terragrunt validate` in `envs/production/`.
+- `terragrunt plan` review before apply.
+- Post-apply verification: `aws ec2 describe-vpcs`, `describe-subnets`, `describe-nat-gateways`, `describe-route-tables` to confirm the expected topology.
+
+## Dependencies
+
+- `workflow-config.yaml` already enables the `production` environment (uncommitted edit on this branch). This is required for CI to target the new service's production stack.

--- a/docs/superpowers/specs/2026-04-16-aws-vpc-design.md
+++ b/docs/superpowers/specs/2026-04-16-aws-vpc-design.md
@@ -2,39 +2,39 @@
 
 ## Purpose
 
-Establish a production VPC in `ap-northeast-1` that will host future workloads (EKS / ECS clusters, RDS, etc.). This is the foundational network for the account and supersedes the default VPC that was removed on 2026-04-16.
+`ap-northeast-1` に production VPC を構築する。将来的に EKS / ECS クラスタや RDS 等のワークロードをホストする基盤ネットワークであり、2026-04-16 に削除したデフォルト VPC の後継となる。
 
 ## Scope
 
-- New Terragrunt service at `aws/vpc/` following the existing `aws/{service}/modules + envs/{env}` convention used by `claude-code`, `claude-code-action`, and `github-oidc-auth`.
-- `production` environment only for now. `develop` / `staging` can be added later by copying `envs/production/`.
-- VPC, subnets (3 tiers x 3 AZ), IGW, single NAT Gateway, route tables, DB subnet group.
+- `aws/{service}/modules + envs/{env}` の既存構成慣習（`claude-code`, `claude-code-action`, `github-oidc-auth` で採用済み）に沿って `aws/vpc/` を新設する。
+- 当面は `production` 環境のみを用意する。`develop` / `staging` が必要になった時点で `envs/production/` を複製して対応する。
+- 含めるリソース: VPC、サブネット（3 tier × 3 AZ）、IGW、単一 NAT Gateway、ルートテーブル、DB サブネットグループ。
 
 ## Out of Scope
 
-- EKS, ECS, RDS resources themselves (separate services).
-- VPC endpoints (S3, ECR, etc.) — add on demand when a workload needs them.
-- Transit Gateway / VPC peering.
-- Flow logs — to be added later if an audit requirement arises.
-- Subnet tags for EKS (`kubernetes.io/role/elb`, `kubernetes.io/role/internal-elb`) — added by the EKS module, not here.
+- EKS / ECS / RDS 等のワークロード本体（別サービスとして切り出す）。
+- VPC endpoint（S3, ECR 等）。必要になったワークロード側で追加する。
+- Transit Gateway / VPC peering。
+- VPC Flow Logs。監査要件が出た段階で追加する。
+- EKS 用のサブネットタグ（`kubernetes.io/role/elb`, `kubernetes.io/role/internal-elb`）は EKS モジュール側で付与する。
 
 ## Architecture
 
-### Network layout
+### Network Layout
 
 | Tier | AZ 1a | AZ 1c | AZ 1d | Route |
 |---|---|---|---|---|
 | Public | `10.0.0.0/24` | `10.0.1.0/24` | `10.0.2.0/24` | IGW |
-| Database (isolated) | `10.0.10.0/24` | `10.0.11.0/24` | `10.0.12.0/24` | **no default route** |
+| Database (isolated) | `10.0.10.0/24` | `10.0.11.0/24` | `10.0.12.0/24` | **default route なし** |
 | Private (compute) | `10.0.32.0/19` | `10.0.64.0/19` | `10.0.96.0/19` | NAT GW |
 
 - **VPC CIDR**: `10.0.0.0/16`
-- **IGW**: 1, attached to VPC; public subnets route `0.0.0.0/0` to it.
-- **NAT GW**: 1 shared NAT Gateway placed in public-1a. All three private subnets route `0.0.0.0/0` to it. Trade-off accepted: AZ 1a outage breaks egress for private subnets in 1c/1d.
-- **Database subnets**: fully isolated. Their dedicated route table has no default route. External egress (for secrets rotation etc.) is deliberately not provided here; add VPC endpoints later if needed.
-- **DNS**: `enable_dns_support = true`, `enable_dns_hostnames = true` (EKS requirement).
+- **IGW**: VPC に 1 つアタッチ。public サブネットは `0.0.0.0/0` を IGW へ向ける。
+- **NAT GW**: public-1a に単一配置し、3 つの private サブネットすべてが `0.0.0.0/0` を共有 NAT に向ける。AZ 1a 障害時には 1c / 1d の private サブネットも egress できなくなるトレードオフを許容する。
+- **Database subnet**: 完全 isolated。専用ルートテーブルに default route を持たせない。シークレットローテーション等で外部通信が必要になったら VPC endpoint を後追いで追加する。
+- **DNS**: `enable_dns_support = true`, `enable_dns_hostnames = true`（EKS 要件）。
 
-### CIDR allocation (10.0.0.0/16)
+### CIDR Allocation (10.0.0.0/16)
 
 ```
 10.0.0.0/24   - 10.0.2.0/24    public   (3 x /24)
@@ -47,16 +47,16 @@ Establish a production VPC in `ap-northeast-1` that will host future workloads (
 10.0.128.0/17                  reserved
 ```
 
-Private subnets are sized `/19` (8192 IPs each) to accommodate EKS VPC CNI (one ENI IP per pod).
+EKS の VPC CNI が Pod ごとに ENI IP を消費するため、private サブネットは `/19`（各 8192 IP）と広めに確保する。
 
 ## Implementation
 
 ### Module
 
-- Source: [`terraform-aws-modules/vpc/aws`](https://registry.terraform.io/modules/terraform-aws-modules/vpc/aws) version `~> 6.0`.
-- Chosen over raw `aws_vpc`/`aws_subnet` resources for brevity and edge-case coverage; this is a conscious departure from the raw-resource convention used by the other three services in this repo.
+- source: [`terraform-aws-modules/vpc/aws`](https://registry.terraform.io/modules/terraform-aws-modules/vpc/aws) `~> 6.0`。
+- 既存 3 サービス（raw リソース定義）とは実装方針が異なるが、本サービスでは記述量削減とエッジケース吸収のため意識的にモジュール利用に切り替える。
 
-### Key module inputs
+### Key Module Inputs
 
 ```hcl
 name = "${var.project_name}-${var.environment}"
@@ -84,16 +84,16 @@ create_database_nat_gateway_route      = false
 
 ```
 aws/vpc/
-├── Makefile                        # copy of existing services' Makefile (ENV=production)
-├── root.hcl                        # same pattern as aws/claude-code/root.hcl; project_name = "vpc"
+├── Makefile                        # 既存サービスの Makefile を踏襲（ENV=production）
+├── root.hcl                        # aws/claude-code/root.hcl と同パターン、project_name = "vpc"
 ├── modules/
 │   ├── main.tf                     # module "vpc" { source = "terraform-aws-modules/vpc/aws" ... }
 │   ├── variables.tf                # vpc_cidr, availability_zones, *_subnet_cidrs, single_nat_gateway
-│   ├── outputs.tf                  # see below
-│   └── terraform.tf                # terraform >= 1.14.8, aws ~> 6.40 (matches existing services)
+│   ├── outputs.tf                  # 下記 Outputs を参照
+│   └── terraform.tf                # terraform >= 1.14.8, aws ~> 6.40 (既存サービスと揃える)
 └── envs/
     └── production/
-        ├── terragrunt.hcl          # include root + env; terraform.source = "../../modules"
+        ├── terragrunt.hcl          # include root + env、terraform.source = "../../modules"
         └── env.hcl                 # environment = "production", aws_region = "ap-northeast-1"
 ```
 
@@ -102,29 +102,30 @@ aws/vpc/
 - `vpc_id`, `vpc_cidr_block`
 - `public_subnet_ids`, `private_subnet_ids`, `database_subnet_ids`
 - `public_subnet_cidrs`, `private_subnet_cidrs`, `database_subnet_cidrs`
-- `database_subnet_group_name` (for RDS module consumers)
-- `nat_public_ips` (IP allowlisting)
+- `database_subnet_group_name`（RDS モジュール側が参照しやすいように）
+- `nat_public_ips`（IP allowlist 用）
 - `availability_zones`
 
 ### State
 
-Reuses the existing shared backend (see `aws/claude-code/root.hcl`):
+既存の共有バックエンド（`aws/claude-code/root.hcl` 参照）を再利用する。
+
 - Bucket: `terragrunt-state-<account_id>`
 - Key: `platform/vpc/production/terraform.tfstate`
 - Lock table: `terragrunt-state-locks`
 
 ## Data Flow / Failure Modes
 
-- Public subnets: egress and ingress via IGW.
-- Private subnets: egress via NAT GW. Single-NAT trade-off: AZ 1a failure severs egress for all private subnets. Acceptable given cost priority; revisit by flipping `single_nat_gateway = false` if availability requirements tighten.
-- Database subnets: no internet path by design. RDS/ElastiCache placed here must be reached from private subnets within the same VPC. Cross-region replication or SaaS-triggered rotation requires adding a VPC endpoint later.
+- Public サブネット: IGW 経由で ingress / egress。
+- Private サブネット: NAT GW 経由で egress。単一 NAT のため AZ 1a 障害で全 private サブネットの egress が停止する。コスト優先で許容するが、可用性要件が上がれば `single_nat_gateway = false` に切り替えて再検討する。
+- Database サブネット: 仕様として internet 経路を持たない。RDS / ElastiCache は同一 VPC 内の private サブネットからアクセスする前提。クロスリージョンレプリケーションや SaaS 起因のローテーションが必要になったら VPC endpoint を後追いで追加する。
 
 ## Testing
 
-- `terragrunt validate` in `envs/production/`.
-- `terragrunt plan` review before apply.
-- Post-apply verification: `aws ec2 describe-vpcs`, `describe-subnets`, `describe-nat-gateways`, `describe-route-tables` to confirm the expected topology.
+- `envs/production/` で `terragrunt validate` を実行する。
+- `terragrunt plan` の結果をレビューしてから apply する。
+- Apply 後は `aws ec2 describe-vpcs`, `describe-subnets`, `describe-nat-gateways`, `describe-route-tables` でトポロジを確認する。
 
 ## Dependencies
 
-- `workflow-config.yaml` already enables the `production` environment (uncommitted edit on this branch). This is required for CI to target the new service's production stack.
+- `workflow-config.yaml` で `production` 環境が有効化されていること（本ブランチ上に未コミットの編集として存在）。これが CI 側で本サービスの production stack をターゲットにするための前提条件となる。

--- a/workflow-config.yaml
+++ b/workflow-config.yaml
@@ -1,6 +1,6 @@
 environments:
   - environment: develop
-    aws_region: ap-northeast-1
+    aws_region: us-east-1
     iam_role_plan: arn:aws:iam::559744160976:role/github-oidc-auth-develop-github-actions-role
     iam_role_apply: arn:aws:iam::559744160976:role/github-oidc-auth-develop-github-actions-role
 
@@ -9,10 +9,10 @@ environments:
   #   iam_role_plan: arn:aws:iam::123456789012:role/terragrunt-plan-staging-role
   #   iam_role_apply: arn:aws:iam::123456789012:role/terragrunt-apply-staging-role
 
-  # - environment: production
-  #   aws_region: ap-northeast-1
-  #   iam_role_plan: arn:aws:iam::123456789012:role/terragrunt-plan-production-role
-  #   iam_role_apply: arn:aws:iam::123456789012:role/terragrunt-apply-production-role
+  - environment: production
+    aws_region: ap-northeast-1
+    iam_role_plan: arn:aws:iam::559744160976:role/github-oidc-auth-develop-github-actions-role
+    iam_role_apply: arn:aws:iam::559744160976:role/github-oidc-auth-develop-github-actions-role
 
 directory_conventions:
   - root: "aws/{service}"

--- a/workflow-config.yaml
+++ b/workflow-config.yaml
@@ -11,8 +11,8 @@ environments:
 
   - environment: production
     aws_region: ap-northeast-1
-    iam_role_plan: arn:aws:iam::559744160976:role/github-oidc-auth-develop-github-actions-role
-    iam_role_apply: arn:aws:iam::559744160976:role/github-oidc-auth-develop-github-actions-role
+    iam_role_plan: arn:aws:iam::559744160976:role/github-oidc-auth-production-github-actions-role
+    iam_role_apply: arn:aws:iam::559744160976:role/github-oidc-auth-production-github-actions-role
 
 directory_conventions:
   - root: "aws/{service}"


### PR DESCRIPTION
## Summary

- ap-northeast-1 に production VPC を新規作成する Terragrunt サービス (`aws/vpc`) を追加
- 3 AZ (1a/1c/1d) × 3 tier (public/private/database) のサブネット構成、単一 NAT Gateway
- `terraform-aws-modules/vpc/aws ~> 6.0` を使用し、database サブネットは完全 isolated（デフォルトルートなし）
- 環境タグの整理（CostCenter 削除、Purpose 簡略化）と workflow-config の production 有効化を含む

## Architecture

| Tier | CIDR | 用途 |
|------|------|------|
| Public | 10.0.0-2.0/24 | ALB / Bastion |
| Database | 10.0.10-12.0/24 | RDS / ElastiCache (isolated) |
| Private | 10.0.32/64/96.0/19 | EKS / ECS ワークロード |

## Test plan

- [x] `tofu fmt -check -recursive` 通過
- [x] `terragrunt init` 成功
- [x] `terragrunt validate` 成功 (`Success! The configuration is valid.`)
- [x] `terragrunt plan` 実行済み（31 resources to add）
- [ ] CI パイプラインでの `terragrunt plan` 確認
- [ ] `terragrunt apply` は CI から実行

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added AWS VPC provisioning service with production env and Terraform modules; CLI targets for init/plan/apply/destroy/validate/fmt/check/clean/show/output/refresh.

* **Documentation**
  * New VPC design and plan docs describing network layout, NAT strategy, outputs, and operational guidance.

* **Chores**
  * Standardized environment tagging values across services and removed legacy tags; updated workflow region settings and activated production; relaxed Terraform minimum version constraint.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->