### PR TITLE
docs(README): add platform deployment architecture

### DIFF
--- a/README-ja.md
+++ b/README-ja.md
@@ -1,0 +1,86 @@
+# Platform
+
+[🇺🇸 English](README.md) | **日本語**
+
+## 📖 Overview
+
+## 📂 Structure
+
+```
+.
+├── .github/workflows/         # GitHub Actions (Terragrunt executor, deploy trigger, etc.)
+├── aws/                       # Terragrunt stacks (module + envs/{environment})
+│   ├── claude-code/
+│   ├── claude-code-action/
+│   ├── github-oidc-auth/
+│   └── vpc/
+├── kubernetes/
+│   ├── clusters/k3d/          # Flux bootstrap (flux-system, repositories)
+│   ├── components/            # Cilium, Prometheus, Loki, Tempo, OTel, Beyla, etc.
+│   └── manifests/k3d/         # Rendered manifests for the k3d cluster
+├── github/github-repository/  # Terraform for GitHub repo settings
+├── docs/
+└── workflow-config.yaml       # Environments and deployment targets
+```
+
+## 🚢 Deployment
+
+### Trigger
+
+- `.github/workflows/auto-label--deploy-trigger.yaml` が PR ラベル / `main` への push で起動する。
+- `panicboat/deploy-actions/label-resolver` が `workflow-config.yaml` を参照してデプロイ対象 (`aws/{service}/envs/{environment}`) を解決する。
+
+### Stacks
+
+| Stack | Path Convention | Tooling |
+|-------|-----------------|---------|
+| AWS Infrastructure | `aws/{service}/envs/{environment}` | Terragrunt 0.83.2 + OpenTofu 1.6.0 (`gruntwork-io/terragrunt-action@v3.2.0`) |
+| Kubernetes Platform | `kubernetes/clusters/{cluster}`, `kubernetes/components/*` | Kustomize / Flux CD |
+| GitHub Repo Settings | `github/github-repository` | Terraform |
+
+### Environments
+
+`workflow-config.yaml` で定義。現状 `develop` と `production` が有効、`staging` は予約済み（コメントアウト）。
+
+| Environment | AWS Region | AWS Account | Status |
+|-------------|------------|-------------|--------|
+| develop | us-east-1 | 559744160976 | Active |
+| staging | - | - | Reserved |
+| production | ap-northeast-1 | 559744160976 | Active |
+
+Terragrunt の remote state は S3 bucket `terragrunt-state-559744160976` + DynamoDB lock table `terragrunt-state-locks` に集約される。
+
+### Pipeline Flow
+
+```mermaid
+flowchart LR
+  Trigger[PR / push main] --> Resolver[label-resolver<br/>workflow-config.yaml]
+  Resolver --> Executor[reusable--terragrunt-executor.yaml]
+  Executor -->|PR| Plan[terragrunt plan<br/>iam_role_plan]
+  Executor -->|merge to main| Apply[terragrunt apply<br/>iam_role_apply]
+  Plan --> PRComment[(PR comment)]
+  Apply --> AWS[(AWS)]
+  Apply --> OIDC[github-oidc-auth<br/>IAM roles]
+  OIDC -.->|AssumeRole| Executor
+```
+
+AWS 認証は GitHub OIDC 経由。`aws/github-oidc-auth/envs/{environment}` が各環境の IAM Role (plan / apply) を発行し、他の stack はそのロールを引いてデプロイする。
+
+### GitOps Sync (Flux CD)
+
+- `kubernetes/clusters/k3d/flux-system/gotk-sync.yaml` が Flux の bootstrap 構成。
+- 2 本の `GitRepository` を持つ（poll interval 1 分）:
+  - **platform repo**: `./kubernetes/clusters/k3d` を同期 → プラットフォーム共通コンポーネント（Cilium, CoreDNS, Prometheus-Operator, Grafana, Loki, Tempo, OpenTelemetry, Beyla など）を展開。
+  - **monorepo**: `./clusters/develop` を同期 → アプリケーションワークロードを展開（10 分間隔で reconcile）。
+- Platform と Monorepo は Flux を介して疎結合に接続される。
+
+### Claude Code Integration
+
+- `.github/workflows/claude-code-action.yaml` が `@claude` コメントで起動し、`claude-code-action` IAM ロール経由で AWS Bedrock の Claude を呼び出す。
+- `aws/claude-code-action/` と `aws/claude-code/` がそれぞれ Bedrock 呼び出し用 / 実行用 IAM を定義する。
+
+## 🔗 Related Repositories
+
+- [panicboat/monorepo](https://github.com/panicboat/monorepo) — アプリケーションソースと `clusters/{env}` マニフェスト（Flux 同期先）。
+- [panicboat/deploy-actions](https://github.com/panicboat/deploy-actions) — 再利用可能な GitHub Actions（`label-resolver`, `terragrunt`, `container-builder`, `auto-approve` など）。
+- [panicboat/ansible](https://github.com/panicboat/ansible) — 開発者ローカル環境のプロビジョニング（デプロイ系とは独立）。

--- a/README.md
+++ b/README.md
@@ -1,0 +1,86 @@
+# Platform
+
+**English** | [🇯🇵 日本語](README-ja.md)
+
+## 📖 Overview
+
+## 📂 Structure
+
+```
+.
+├── .github/workflows/         # GitHub Actions (Terragrunt executor, deploy trigger, etc.)
+├── aws/                       # Terragrunt stacks (module + envs/{environment})
+│   ├── claude-code/
+│   ├── claude-code-action/
+│   ├── github-oidc-auth/
+│   └── vpc/
+├── kubernetes/
+│   ├── clusters/k3d/          # Flux bootstrap (flux-system, repositories)
+│   ├── components/            # Cilium, Prometheus, Loki, Tempo, OTel, Beyla, etc.
+│   └── manifests/k3d/         # Rendered manifests for the k3d cluster
+├── github/github-repository/  # Terraform for GitHub repo settings
+├── docs/
+└── workflow-config.yaml       # Environments and deployment targets
+```
+
+## 🚢 Deployment
+
+### Trigger
+
+- `.github/workflows/auto-label--deploy-trigger.yaml` runs on PR labels or push to `main`.
+- `panicboat/deploy-actions/label-resolver` reads `workflow-config.yaml` to resolve deployment targets (`aws/{service}/envs/{environment}`).
+
+### Stacks
+
+| Stack | Path Convention | Tooling |
+|-------|-----------------|---------|
+| AWS Infrastructure | `aws/{service}/envs/{environment}` | Terragrunt 0.83.2 + OpenTofu 1.6.0 (`gruntwork-io/terragrunt-action@v3.2.0`) |
+| Kubernetes Platform | `kubernetes/clusters/{cluster}`, `kubernetes/components/*` | Kustomize / Flux CD |
+| GitHub Repo Settings | `github/github-repository` | Terraform |
+
+### Environments
+
+Defined in `workflow-config.yaml`. Currently `develop` and `production` are active; `staging` is reserved (commented out).
+
+| Environment | AWS Region | AWS Account | Status |
+|-------------|------------|-------------|--------|
+| develop | us-east-1 | 559744160976 | Active |
+| staging | - | - | Reserved |
+| production | ap-northeast-1 | 559744160976 | Active |
+
+Terragrunt remote state is consolidated in S3 bucket `terragrunt-state-559744160976` with DynamoDB lock table `terragrunt-state-locks`.
+
+### Pipeline Flow
+
+```mermaid
+flowchart LR
+  Trigger[PR / push main] --> Resolver[label-resolver<br/>workflow-config.yaml]
+  Resolver --> Executor[reusable--terragrunt-executor.yaml]
+  Executor -->|PR| Plan[terragrunt plan<br/>iam_role_plan]
+  Executor -->|merge to main| Apply[terragrunt apply<br/>iam_role_apply]
+  Plan --> PRComment[(PR comment)]
+  Apply --> AWS[(AWS)]
+  Apply --> OIDC[github-oidc-auth<br/>IAM roles]
+  OIDC -.->|AssumeRole| Executor
+```
+
+AWS authentication uses GitHub OIDC. `aws/github-oidc-auth/envs/{environment}` issues per-environment IAM roles (plan / apply), which other stacks assume to deploy.
+
+### GitOps Sync (Flux CD)
+
+- `kubernetes/clusters/k3d/flux-system/gotk-sync.yaml` defines the Flux bootstrap.
+- Two `GitRepository` sources (poll interval: 1 minute):
+  - **platform repo**: syncs `./kubernetes/clusters/k3d` — deploys shared platform components (Cilium, CoreDNS, Prometheus-Operator, Grafana, Loki, Tempo, OpenTelemetry, Beyla, etc.).
+  - **monorepo**: syncs `./clusters/develop` — deploys application workloads (reconciled every 10 minutes).
+- Platform and Monorepo are loosely coupled via Flux.
+
+### Claude Code Integration
+
+- `.github/workflows/claude-code-action.yaml` is triggered by `@claude` comments and invokes AWS Bedrock Claude via the `claude-code-action` IAM role.
+- `aws/claude-code-action/` and `aws/claude-code/` define the IAM roles for Bedrock invocation and execution respectively.
+
+## 🔗 Related Repositories
+
+- [panicboat/monorepo](https://github.com/panicboat/monorepo) — application source and `clusters/{env}` manifests (Flux sync target).
+- [panicboat/deploy-actions](https://github.com/panicboat/deploy-actions) — reusable GitHub Actions (`label-resolver`, `terragrunt`, `container-builder`, `auto-approve`, etc.).
+- [panicboat/ansible](https://github.com/panicboat/ansible) — developer local environment provisioning (independent from the deploy pipeline).


### PR DESCRIPTION
## Summary

- README.md と README-ja.md を新規作成（英語/日本語ペア）
- AWS (Terragrunt) と Kubernetes (Flux CD) のデプロイフローを記載
- Environments / Pipeline Flow (mermaid) / GitOps Sync / Claude Code Integration / Related Repositories を含む
- Flux が platform と monorepo の 2 本の GitRepository を watch する疎結合構成を明記

## Test plan

- [ ] GitHub 上で README.md と README-ja.md のレンダリングを目視確認
- [ ] mermaid 図が崩れていないか確認
- [ ] 英語版と日本語版の構造・セクション数が一致しているか確認
- [ ] Environments 表の region/account/status が `workflow-config.yaml` と整合しているか確認