### PR TITLE
fix(aws/vpc/modules): track OpenTofu releases for required_version

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -51,6 +51,13 @@
       "matchManagers": ["helmv3", "helm-values", "helmfile"],
       "allowedVersions": "< 1.19.0",
       "enabled": false
+    },
+
+    {
+      "description": "Track OpenTofu releases instead of Terraform for required_version",
+      "matchDepTypes": ["required_version"],
+      "matchDepNames": ["hashicorp/terraform"],
+      "overridePackageName": "opentofu/opentofu"
     }
   ]
 }

--- a/aws/vpc/modules/terraform.tf
+++ b/aws/vpc/modules/terraform.tf
@@ -1,7 +1,7 @@
-# terraform.tf - Terraform and provider configuration
+# terraform.tf - OpenTofu and provider configuration
 
 terraform {
-  required_version = ">= 1.14.8"
+  required_version = ">= 1.11.6"
 
   required_providers {
     aws = {


### PR DESCRIPTION
## Summary
- `required_version` を Terraform 体系 (`>= 1.14.8`) から OpenTofu 体系 (`>= 1.11.6`) に修正
- Renovate の `packageRules` に `overridePackageName` を追加し、`required_version` の参照先を `hashicorp/terraform` → `opentofu/opentofu` にリマップ

## Why
Renovate の terraform manager は `required_version` を検出すると `hashicorp/terraform` の GitHub releases を参照してバージョンを bump する。OpenTofu を使用しているため、Terraform のバージョン体系に引き上げられると `tofu init` が失敗する。

## Test plan
- [x] `tofu init -backend=false` が正常に完了することを確認済み
- [ ] Renovate の Dependency Dashboard で `required_version` が `opentofu/opentofu` を参照していることを確認

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated infrastructure tooling configuration to use OpenTofu instead of Terraform.
  * Adjusted module's minimum version requirement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->