### PR TITLE
refactor(.github/workflows): use deploy-actions/kubernetes for kustomize diff

### DIFF
--- a/.github/workflows/auto-label--deploy-trigger.yaml
+++ b/.github/workflows/auto-label--deploy-trigger.yaml
@@ -88,6 +88,7 @@ jobs:
       fail-fast: false
     uses: ./.github/workflows/reusable--kubernetes-builder.yaml
     with:
+      service-name: ${{ matrix.target.service }}
       environment: ${{ matrix.target.environment }}
       app-id: ${{ vars.APP_ID }}
     secrets:

--- a/.github/workflows/reusable--kubernetes-builder.yaml
+++ b/.github/workflows/reusable--kubernetes-builder.yaml
@@ -3,6 +3,10 @@ name: 'Reusable - Kubernetes Builder'
 on:
   workflow_call:
     inputs:
+      service-name:
+        required: true
+        type: string
+        description: 'Service name for identification'
       environment:
         required: true
         type: string
@@ -67,33 +71,11 @@ jobs:
           commit_user_name: 'github-actions[bot]'
           commit_user_email: 'github-actions[bot]@users.noreply.github.com'
 
-      - name: Extract base manifests
-        run: |
-          BASE_DIR=/tmp/base
-          SRC=kubernetes/manifests/${{ inputs.environment }}
-          mkdir -p "$BASE_DIR"
-          git rev-parse --verify "origin/main:${SRC}" >/dev/null 2>&1 || exit 0
-          while IFS= read -r file; do
-            rel="${file#"${SRC}/"}"
-            mkdir -p "$BASE_DIR/$(dirname "$rel")"
-            git show "origin/main:${file}" > "$BASE_DIR/${rel}"
-          done < <(git ls-tree -r --name-only origin/main "${SRC}/")
-
-      - name: Generate diff
-        id: diff
-        uses: int128/diff-action@v2
+      - name: Kubernetes Diff
+        uses: panicboat/deploy-actions/kubernetes@main
         with:
-          base: /tmp/base
-          head: kubernetes/manifests/${{ inputs.environment }}
-          token: ${{ steps.app-token.outputs.token }}
-
-      - name: Post PR comment
-        if: steps.pr-info.outputs.number != ''
-        uses: marocchino/sticky-pull-request-comment@v2
-        with:
-          number: ${{ steps.pr-info.outputs.number }}
-          header: kubernetes-diff-${{ inputs.environment }}
-          message: |
-            ## Kubernetes Manifests Diff (`${{ inputs.environment }}`)
-            ${{ steps.diff.outputs.comment-body || '**No manifest changes**' }}
-          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+          github-token: ${{ steps.app-token.outputs.token }}
+          service-name: ${{ inputs.service-name }}
+          environment: ${{ inputs.environment }}
+          path: kubernetes/manifests/${{ inputs.environment }}
+          pr-number: ${{ steps.pr-info.outputs.number }}


### PR DESCRIPTION
## Summary

- `reusable--kubernetes-builder.yaml` の diff + コメント部分を `panicboat/deploy-actions/kubernetes@main` に置き換え
- hydrate + auto-commit のフローはそのまま維持
- `service-name` input を追加（deploy-trigger から `matrix.target.service` を渡す）

## Test plan

- [ ] PR で kubernetes manifest に変更を加え、hydrate → commit → diff コメントが正しく投稿されることを確認
- [ ] diff コメントのフォーマットが従来と同等であることを確認