### PR TITLE
feat(workflow-config): add github/{service} directory convention

### DIFF
--- a/README-ja.md
+++ b/README-ja.md
@@ -18,7 +18,7 @@
 │   ├── clusters/k3d/          # Flux bootstrap (flux-system, repositories)
 │   ├── components/            # Cilium, Prometheus, Loki, Tempo, OTel, Beyla, etc.
 │   └── manifests/k3d/         # Rendered manifests for the k3d cluster
-├── github/github-repository/  # Terraform for GitHub repo settings
+├── github/repository/         # Terraform for GitHub repo settings
 ├── docs/
 └── workflow-config.yaml       # Environments and deployment targets
 ```
@@ -36,7 +36,7 @@
 |-------|-----------------|---------|
 | AWS Infrastructure | `aws/{service}/envs/{environment}` | Terragrunt 0.83.2 + OpenTofu 1.6.0 (`gruntwork-io/terragrunt-action@v3.2.0`) |
 | Kubernetes Platform | `kubernetes/components/{service}/{environment}` | Helmfile + Kustomize hydration (`reusable--kubernetes-builder.yaml`) / Flux CD |
-| GitHub Repo Settings | `github/github-repository` | Terraform |
+| GitHub Repo Settings | `github/repository` | Terraform |
 
 ### Environments
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 │   ├── clusters/k3d/          # Flux bootstrap (flux-system, repositories)
 │   ├── components/            # Cilium, Prometheus, Loki, Tempo, OTel, Beyla, etc.
 │   └── manifests/k3d/         # Rendered manifests for the k3d cluster
-├── github/github-repository/  # Terraform for GitHub repo settings
+├── github/repository/         # Terraform for GitHub repo settings
 ├── docs/
 └── workflow-config.yaml       # Environments and deployment targets
 ```
@@ -36,7 +36,7 @@
 |-------|-----------------|---------|
 | AWS Infrastructure | `aws/{service}/envs/{environment}` | Terragrunt 0.83.2 + OpenTofu 1.6.0 (`gruntwork-io/terragrunt-action@v3.2.0`) |
 | Kubernetes Platform | `kubernetes/components/{service}/{environment}` | Helmfile + Kustomize hydration (`reusable--kubernetes-builder.yaml`) / Flux CD |
-| GitHub Repo Settings | `github/github-repository` | Terraform |
+| GitHub Repo Settings | `github/repository` | Terraform |
 
 ### Environments
 

--- a/workflow-config.yaml
+++ b/workflow-config.yaml
@@ -20,6 +20,11 @@ directory_conventions:
       - name: terragrunt
         directory: "envs/{environment}"
 
+  - root: "github/{service}"
+    stacks:
+      - name: terragrunt
+        directory: "envs/{environment}"
+
   - root: "kubernetes/components/{service}"
     stacks:
       - name: kubernetes


### PR DESCRIPTION
## Summary
- `workflow-config.yaml` の `directory_conventions` に `github/{service}` (terragrunt, `envs/{environment}`) を追加
- これにより `github/repository` / `github/branch` 配下の変更が label-dispatcher に検出され、既存の reusable terragrunt executor 経由で CI 上の plan/apply が回るようになる
- 併せて README / README-ja から `github/github-repository` の旧名残を `github/repository` に更新

## Background
既存の directory_conventions は `aws/{service}` と `kubernetes/components/{service}` のみを認識しており、`github/` 配下の Terragrunt スタックは label-dispatcher / label-resolver の対象外だった。

label-dispatcher は `deploy-actions/action-scripts/label-dispatcher/use_cases/detect_changed_services.rb:97-110` で directory_conventions のパターンを正規表現に変換し changed_files にマッチさせるため、パターンに無いパスは deploy ラベル付与の対象にならない。今回の追加で `github/{service}/envs/{environment}` がマッチ対象になる。

GitHub App 側の権限（Repository: Administration Write, Organization: Administration Write 等）は付与済み。

## Test plan
- [ ] この PR に対して label-dispatcher が `deploy:repository` / `deploy:branch` いずれかのラベルを付けるか確認（workflow-config.yaml 以外の github/* 配下変更がないので付かない想定）
- [ ] `github/repository/envs/develop/*.hcl` を弄るフォローアップ PR を起こし、deploy label 自動付与 → `plan` コメント投稿まで通ることを確認
- [ ] apply 後に state migration 済みの既存リソースで差分が出ないことを確認

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated documentation to reflect simplified directory structure naming conventions for GitHub repository settings across all language versions.

* **Chores**
  * Added new workflow configuration convention to support service-based directory routing with environment-based stack management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->