### PR TITLE
chore(github/repository): verify CI terragrunt plan/apply for github stack

### DIFF
--- a/github/repository/envs/develop/monorepo.hcl
+++ b/github/repository/envs/develop/monorepo.hcl
@@ -1,7 +1,7 @@
 locals {
   repository = {
     name        = "monorepo"
-    description = "Monorepo for multiple services and infrastructure configurations"
+    description = "Monorepo for multiple services and infrastructure configurations."
     visibility  = "public"
     features = {
       issues   = true


### PR DESCRIPTION
## Summary
- `github/repository/envs/develop/monorepo.hcl` の description に末尾ピリオドを追加
- 目的は #200 で追加した `github/{service}` directory convention が、label-dispatcher → label-resolver → reusable terragrunt executor まで通しで機能することの確認

## Expected CI behavior
- [ ] `auto-label--label-dispatcher` が `deploy:repository:develop` 相当のラベルを自動付与
- [ ] `auto-label--deploy-trigger` が matrix に `service=repository, environment=develop, stack=terragrunt` を展開
- [ ] `reusable--terragrunt-executor` が `working-directory=github/repository/envs/develop` で plan 実行
- [ ] GitHub App トークンの Repository: Administration Write が効き、terragrunt plan で `github_repository.repository["monorepo"]` の description のみ差分になる
- [ ] plan 結果が PR にコメントとして投稿される

## Notes
- この PR は検証目的。plan 結果を確認後、description 変更を採用するなら merge、採用しないなら close で OK
- apply は main へのマージ時に走る（`auto-label--deploy-trigger.yaml:68`）。マージする場合は description がそのまま実リポジトリに反映される点に注意