### PR TITLE
refactor(github/branch): migrate to repository rulesets and harden for solo dev

### DIFF
--- a/github/branch/envs/develop/defaults.hcl
+++ b/github/branch/envs/develop/defaults.hcl
@@ -1,0 +1,27 @@
+locals {
+  # Branch protection tuned for solo development:
+  # - PR-required (no direct push to main) to guarantee CI runs
+  # - required_reviews = 0 to allow self-merge (GitHub disallows self-approval)
+  # - Review-related toggles disabled since there is no second reviewer
+  # - Admin bypass disabled to prevent accidental direct pushes
+  # - Signed commits required; local GPG/SSH signing is part of the workflow
+  branch_protection = {
+    main = {
+      name                            = null
+      include_refs                    = ["~DEFAULT_BRANCH"]
+      exclude_refs                    = []
+      required_reviews                = 0
+      dismiss_stale_reviews           = false
+      require_code_owner_reviews      = false
+      require_last_push_approval      = false
+      require_conversation_resolution = true
+      required_status_checks          = ["CI Gatekeeper"]
+      strict_required_status_checks   = false
+      required_linear_history         = true
+      require_signed_commits          = true
+      allow_force_pushes              = false
+      allow_deletions                 = false
+      admin_bypass                    = false
+    }
+  }
+}

--- a/github/branch/envs/develop/deploy-actions.hcl
+++ b/github/branch/envs/develop/deploy-actions.hcl
@@ -2,7 +2,7 @@ locals {
   defaults = read_terragrunt_config("defaults.hcl")
 
   repository = {
-    name              = "platform"
+    name              = "deploy-actions"
     branch_protection = local.defaults.locals.branch_protection
   }
 }

--- a/github/branch/envs/develop/monorepo.hcl
+++ b/github/branch/envs/develop/monorepo.hcl
@@ -1,22 +1,8 @@
 locals {
+  defaults = read_terragrunt_config("defaults.hcl")
+
   repository = {
-    name = "monorepo"
-    branch_protection = {
-      main = {
-        pattern                         = null
-        required_reviews                = 0
-        dismiss_stale_reviews           = true
-        require_code_owner_reviews      = false
-        restrict_pushes                 = true
-        require_last_push_approval      = false
-        required_status_checks          = ["CI Gatekeeper"]
-        enforce_admins                  = false
-        allow_force_pushes              = false
-        allow_deletions                 = false
-        required_linear_history         = true
-        require_conversation_resolution = true
-        require_signed_commits          = false
-      }
-    }
+    name              = "monorepo"
+    branch_protection = local.defaults.locals.branch_protection
   }
 }

--- a/github/branch/envs/develop/terragrunt.hcl
+++ b/github/branch/envs/develop/terragrunt.hcl
@@ -7,14 +7,16 @@ terraform {
 }
 
 locals {
-  monorepo = read_terragrunt_config("monorepo.hcl")
-  platform = read_terragrunt_config("platform.hcl")
+  monorepo       = read_terragrunt_config("monorepo.hcl")
+  platform       = read_terragrunt_config("platform.hcl")
+  deploy_actions = read_terragrunt_config("deploy-actions.hcl")
 }
 
 inputs = {
   repositories = {
-    monorepo = local.monorepo.locals.repository
-    platform = local.platform.locals.repository
+    monorepo       = local.monorepo.locals.repository
+    platform       = local.platform.locals.repository
+    deploy-actions = local.deploy_actions.locals.repository
   }
   github_token = get_env("GITHUB_TOKEN")
 }

--- a/github/branch/modules/main.tf
+++ b/github/branch/modules/main.tf
@@ -4,52 +4,82 @@ data "github_repository" "repo" {
 }
 
 locals {
-  branch_protection_rules = merge([
+  rulesets = merge([
     for repo_key, repo in var.repositories : {
-      for branch_key, branch in repo.branch_protection :
-      "${repo_key}-${branch_key}" => {
-        repository_node_id              = data.github_repository.repo[repo_key].node_id
-        pattern                         = branch.pattern != null ? branch.pattern : branch_key
-        required_reviews                = branch.required_reviews
-        dismiss_stale_reviews           = branch.dismiss_stale_reviews
-        require_code_owner_reviews      = branch.require_code_owner_reviews
-        require_last_push_approval      = branch.require_last_push_approval
-        required_status_checks          = branch.required_status_checks
-        enforce_admins                  = branch.enforce_admins
-        allow_force_pushes              = branch.allow_force_pushes
-        allow_deletions                 = branch.allow_deletions
-        required_linear_history         = branch.required_linear_history
-        require_conversation_resolution = branch.require_conversation_resolution
-        require_signed_commits          = branch.require_signed_commits
-        # TODO: restrict_pushes is accepted in variables but not yet applied.
-        # GitHub Provider v6 uses push_restrictions block — implement when needed.
+      for rule_key, rule in repo.branch_protection :
+      "${repo_key}-${rule_key}" => {
+        repository                      = data.github_repository.repo[repo_key].name
+        name                            = rule.name != null ? rule.name : "${repo_key}-${rule_key}"
+        include_refs                    = rule.include_refs
+        exclude_refs                    = rule.exclude_refs
+        required_reviews                = rule.required_reviews
+        dismiss_stale_reviews           = rule.dismiss_stale_reviews
+        require_code_owner_reviews      = rule.require_code_owner_reviews
+        require_last_push_approval      = rule.require_last_push_approval
+        require_conversation_resolution = rule.require_conversation_resolution
+        required_status_checks          = rule.required_status_checks
+        strict_required_status_checks   = rule.strict_required_status_checks
+        required_linear_history         = rule.required_linear_history
+        require_signed_commits          = rule.require_signed_commits
+        allow_force_pushes              = rule.allow_force_pushes
+        allow_deletions                 = rule.allow_deletions
+        admin_bypass                    = rule.admin_bypass
       }
     }
   ]...)
 }
 
-resource "github_branch_protection" "branches" {
-  for_each = local.branch_protection_rules
+resource "github_repository_ruleset" "branches" {
+  for_each = local.rulesets
 
-  repository_id = each.value.repository_node_id
-  pattern       = each.value.pattern
+  name        = each.value.name
+  repository  = each.value.repository
+  target      = "branch"
+  enforcement = "active"
 
-  required_pull_request_reviews {
-    required_approving_review_count = each.value.required_reviews
-    dismiss_stale_reviews           = each.value.dismiss_stale_reviews
-    require_code_owner_reviews      = each.value.require_code_owner_reviews
-    require_last_push_approval      = each.value.require_last_push_approval
+  conditions {
+    ref_name {
+      include = each.value.include_refs
+      exclude = each.value.exclude_refs
+    }
   }
 
-  required_status_checks {
-    strict   = false
-    contexts = each.value.required_status_checks
+  # Admin bypass: when true, organization admins can bypass the ruleset.
+  # Leave bypass_actors empty to enforce rules for everyone (legacy enforce_admins=true equivalent).
+  dynamic "bypass_actors" {
+    for_each = each.value.admin_bypass ? [1] : []
+    content {
+      actor_id    = 5 # OrganizationAdmin
+      actor_type  = "OrganizationAdmin"
+      bypass_mode = "always"
+    }
   }
 
-  enforce_admins                  = each.value.enforce_admins
-  allows_force_pushes             = each.value.allow_force_pushes
-  allows_deletions                = each.value.allow_deletions
-  required_linear_history         = each.value.required_linear_history
-  require_conversation_resolution = each.value.require_conversation_resolution
-  require_signed_commits          = each.value.require_signed_commits
+  rules {
+    # Requiring a PR effectively blocks direct pushes to the branch,
+    # replacing the legacy restrict_pushes setting.
+    pull_request {
+      required_approving_review_count   = each.value.required_reviews
+      dismiss_stale_reviews_on_push     = each.value.dismiss_stale_reviews
+      require_code_owner_review         = each.value.require_code_owner_reviews
+      require_last_push_approval        = each.value.require_last_push_approval
+      required_review_thread_resolution = each.value.require_conversation_resolution
+    }
+
+    required_status_checks {
+      strict_required_status_checks_policy = each.value.strict_required_status_checks
+
+      dynamic "required_check" {
+        for_each = each.value.required_status_checks
+        content {
+          context = required_check.value
+        }
+      }
+    }
+
+    deletion                = !each.value.allow_deletions
+    non_fast_forward        = !each.value.allow_force_pushes
+    required_linear_history = each.value.required_linear_history
+    required_signatures     = each.value.require_signed_commits
+  }
 }

--- a/github/branch/modules/outputs.tf
+++ b/github/branch/modules/outputs.tf
@@ -1,9 +1,10 @@
-output "branch_protection_rules" {
-  description = "Information about created branch protection rules"
+output "branch_protection_rulesets" {
+  description = "Information about created repository rulesets"
   value = {
-    for key, rule in github_branch_protection.branches : key => {
-      id      = rule.id
-      pattern = rule.pattern
+    for key, rule in github_repository_ruleset.branches : key => {
+      id         = rule.id
+      name       = rule.name
+      repository = rule.repository
     }
   }
 }

--- a/github/branch/modules/variables.tf
+++ b/github/branch/modules/variables.tf
@@ -26,23 +26,40 @@ variable "github_token" {
 }
 
 variable "repositories" {
-  description = "Map of branch protection configurations per repository"
+  description = "Map of repository ruleset configurations per repository"
   type = map(object({
     name = string
     branch_protection = map(object({
-      pattern                         = optional(string)
+      # Ruleset name. Defaults to "<repo_key>-<rule_key>" when null.
+      name = optional(string)
+
+      # Branch selection. GitHub fileset syntax (fnmatch).
+      # Use ["~DEFAULT_BRANCH"] to target the default branch only.
+      include_refs = list(string)
+      exclude_refs = optional(list(string), [])
+
+      # Pull request requirements
       required_reviews                = number
       dismiss_stale_reviews           = bool
       require_code_owner_reviews      = bool
-      restrict_pushes                 = bool
       require_last_push_approval      = bool
-      required_status_checks          = list(string)
-      enforce_admins                  = bool
-      allow_force_pushes              = bool
-      allow_deletions                 = bool
-      required_linear_history         = bool
       require_conversation_resolution = bool
-      require_signed_commits          = bool
+
+      # Status checks
+      required_status_checks        = list(string)
+      strict_required_status_checks = bool
+
+      # Commit/history requirements
+      required_linear_history = bool
+      require_signed_commits  = bool
+
+      # Push/delete controls
+      allow_force_pushes = bool
+      allow_deletions    = bool
+
+      # When true, organization admins can bypass this ruleset.
+      # Set false to enforce rules for everyone (legacy enforce_admins=true equivalent).
+      admin_bypass = bool
     }))
   }))
 }


### PR DESCRIPTION
## Summary

- Migrate `github_branch_protection` (legacy API) → `github_repository_ruleset`
- Fix the silent hole where `restrict_pushes = true` was declared in variables but never applied (legacy module had a `TODO` noting push_restrictions was not implemented — direct pushes to `main` were technically possible)
- Harden main branch protection, tuned for solo development workflow
- DRY up per-repo configs into `envs/develop/defaults.hcl`
- Add `deploy-actions` to managed repositories

## Resulting rule set (applied to default branch of monorepo/platform/deploy-actions)

| Setting | Value | Intent |
|---|---|---|
| PR required | true (via `pull_request` rule) | Block direct push to main |
| `required_approving_review_count` | 0 | Solo dev — allow self-merge |
| `required_status_checks` | `["CI Gatekeeper"]` | CI must pass |
| `required_linear_history` | true | No merge commits |
| `required_signatures` | true | Signed commits only |
| `required_review_thread_resolution` | true | Resolve your own TODOs before merge |
| `non_fast_forward` | true | No force-push |
| `deletion` | true | No main deletion |
| `bypass_actors` | (empty) | Admins cannot bypass |
| `dismiss_stale_reviews_on_push` | false | No reviews to dismiss |
| `require_code_owner_review` | false | No second reviewer |
| `require_last_push_approval` | false | No reviews to re-trigger |
| `strict_required_status_checks_policy` | false | Redundant with linear history |
| Target ref | `~DEFAULT_BRANCH` | Tracks default branch rename |

## Apply-time behavior

- Existing `github_branch_protection.branches` entries will be **destroyed** and replaced with `github_repository_ruleset.branches`
- Branch Protection and Rulesets can coexist on GitHub, so no enforcement gap during the swap
- After apply, `main` direct pushes become impossible — future work must go through PRs

## Test plan

- [ ] `terragrunt run -- validate` on envs/develop passes (verified locally: ✅)
- [ ] CI `terragrunt plan` shows destroy-of-branch_protection + create-of-ruleset for both managed repos plus create-of-ruleset for deploy-actions
- [ ] After apply: try direct push to main on a test branch name — should be rejected
- [ ] After apply: open a PR, confirm it can be self-merged once CI Gatekeeper is green
- [ ] Confirm all local git identities are set up for signed commits (gpg.format / user.signingkey / commit.gpgsign)

## Follow-ups (not in this PR)

- `.github/CODEOWNERS` if team grows (the `require_code_owner_review` flag stays false for now)
- Importing `deploy-actions` into `github/repository` management (currently unmanaged)
- Consider organization-level rulesets once more repos are added

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Centralized branch protection configurations across repositories for improved consistency
  * Migrated branch protection rules to use the latest GitHub ruleset system
  * Refactored repository configuration structure to streamline management and reduce redundancy

<!-- end of auto-generated comment: release notes by coderabbit.ai -->