### PR TITLE
chore(github/branch): disable required_signatures on main

### DIFF
--- a/github/branch/envs/develop/defaults.hcl
+++ b/github/branch/envs/develop/defaults.hcl
@@ -4,7 +4,7 @@ locals {
   # - required_reviews = 0 to allow self-merge (GitHub disallows self-approval)
   # - Review-related toggles disabled since there is no second reviewer
   # - Admin bypass disabled to prevent accidental direct pushes
-  # - Signed commits required; local GPG/SSH signing is part of the workflow
+  # - Signed commits not required; revisit once SSH/GPG signing is set up locally
   branch_protection = {
     main = {
       name                            = null
@@ -18,7 +18,7 @@ locals {
       required_status_checks          = ["CI Gatekeeper"]
       strict_required_status_checks   = false
       required_linear_history         = true
-      require_signed_commits          = true
+      require_signed_commits          = false
       allow_force_pushes              = false
       allow_deletions                 = false
       admin_bypass                    = false


### PR DESCRIPTION
## Summary

- Set `require_signed_commits = false` in `github/branch/envs/develop/defaults.hcl`
- Reverts a piece of #202 because local SSH/GPG signing is not yet configured on the workstation

## Why

After #202 was applied, `required_signatures = true` is enforced on all three managed repositories (monorepo / platform / deploy-actions). The local environment uses `git commit -s` (DCO sign-off) but no cryptographic signing — every commit is `Unverified`. This blocks every future PR merge, including:

- Manual PRs from this workstation
- Renovate auto-merges (Renovate's default git CLI commits are unsigned)
- Claude Code Action commits, depending on token type

Until SSH signing is set up (`gpg.format = ssh` + `user.signingkey` + `commit.gpgsign = true`) and the SSH key is registered on GitHub as a Signing key, this requirement creates more pain than protection.

## Caveat about merging this PR

This very PR's commit is unsigned, so the existing rule may block its merge. Workarounds, in order of preference:

1. **Squash-merge via GitHub Web UI** — GitHub creates a fresh squash commit signed by GitHub, which satisfies the rule
2. If that's blocked: temporarily edit the `monorepo-main` ruleset on github.com, add yourself to bypass actors, merge, then remove the bypass
3. Alternatively: re-edit `defaults.hcl` directly via the GitHub Web UI (web edits are auto-Verified)

## Test plan

- [x] `terragrunt run -- validate` passes locally
- [ ] CI `terragrunt plan` shows only `require_signed_commits: true → false` and `required_signatures: true → false` on the three rulesets
- [ ] After apply: `gh api repos/panicboat/<repo>/rulesets/<id>` shows `required_signatures` rule is gone

## Follow-up

- Set up SSH signing locally and re-enable `require_signed_commits = true` in a future PR