### PR TITLE
chore(github): manage deploy-actions and panicboat-actions via terragrunt

### DIFF
--- a/github/branch/envs/develop/panicboat-actions.hcl
+++ b/github/branch/envs/develop/panicboat-actions.hcl
@@ -1,0 +1,8 @@
+locals {
+  defaults = read_terragrunt_config("defaults.hcl")
+
+  repository = {
+    name              = "panicboat-actions"
+    branch_protection = local.defaults.locals.branch_protection
+  }
+}

--- a/github/branch/envs/develop/terragrunt.hcl
+++ b/github/branch/envs/develop/terragrunt.hcl
@@ -7,16 +7,18 @@ terraform {
 }
 
 locals {
-  monorepo       = read_terragrunt_config("monorepo.hcl")
-  platform       = read_terragrunt_config("platform.hcl")
-  deploy_actions = read_terragrunt_config("deploy-actions.hcl")
+  monorepo          = read_terragrunt_config("monorepo.hcl")
+  platform          = read_terragrunt_config("platform.hcl")
+  deploy_actions    = read_terragrunt_config("deploy-actions.hcl")
+  panicboat_actions = read_terragrunt_config("panicboat-actions.hcl")
 }
 
 inputs = {
   repositories = {
-    monorepo       = local.monorepo.locals.repository
-    platform       = local.platform.locals.repository
-    deploy-actions = local.deploy_actions.locals.repository
+    monorepo          = local.monorepo.locals.repository
+    platform          = local.platform.locals.repository
+    deploy-actions    = local.deploy_actions.locals.repository
+    panicboat-actions = local.panicboat_actions.locals.repository
   }
   github_token = get_env("GITHUB_TOKEN")
 }

--- a/github/repository/envs/develop/deploy-actions.hcl
+++ b/github/repository/envs/develop/deploy-actions.hcl
@@ -1,0 +1,12 @@
+locals {
+  repository = {
+    name        = "deploy-actions"
+    description = "Generic deployment orchestration toolkit for multi-service GitHub Actions workflows."
+    visibility  = "public"
+    features = {
+      issues   = true
+      wiki     = false
+      projects = true
+    }
+  }
+}

--- a/github/repository/envs/develop/panicboat-actions.hcl
+++ b/github/repository/envs/develop/panicboat-actions.hcl
@@ -1,0 +1,12 @@
+locals {
+  repository = {
+    name        = "panicboat-actions"
+    description = "Personal-use GitHub Actions wrappers for panicboat infrastructure."
+    visibility  = "public"
+    features = {
+      issues   = true
+      wiki     = false
+      projects = true
+    }
+  }
+}

--- a/github/repository/envs/develop/terragrunt.hcl
+++ b/github/repository/envs/develop/terragrunt.hcl
@@ -7,14 +7,18 @@ terraform {
 }
 
 locals {
-  monorepo = read_terragrunt_config("monorepo.hcl")
-  platform = read_terragrunt_config("platform.hcl")
+  monorepo          = read_terragrunt_config("monorepo.hcl")
+  platform          = read_terragrunt_config("platform.hcl")
+  deploy_actions    = read_terragrunt_config("deploy-actions.hcl")
+  panicboat_actions = read_terragrunt_config("panicboat-actions.hcl")
 }
 
 inputs = {
   repositories = {
-    monorepo = local.monorepo.locals.repository
-    platform = local.platform.locals.repository
+    monorepo          = local.monorepo.locals.repository
+    platform          = local.platform.locals.repository
+    deploy-actions    = local.deploy_actions.locals.repository
+    panicboat-actions = local.panicboat_actions.locals.repository
   }
   github_token = get_env("GITHUB_TOKEN")
 }


### PR DESCRIPTION
## Summary

- 既存 \`deploy-actions\` と新規 \`panicboat-actions\` を \`github/repository/\` の Terragrunt 管理下に追加
- \`panicboat-actions\` を \`github/branch/\` の Terragrunt 管理下に追加

## Test plan

- [ ] \`make plan\`（repository, branch 両方）が想定どおりの diff を出すことを確認
- [ ] マージ後に \`terragrunt import\` で既存 deploy-actions を取り込み、\`make plan\` が clean になることを確認
- [ ] \`make apply\` で panicboat-actions が新規作成されることを確認

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added panicboat-actions repository with branch protection configuration.
  * Added deploy-actions repository with public visibility and enabled issues and projects features.

* **Configuration Updates**
  * Extended infrastructure configuration to manage two new repositories with corresponding settings and protections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->