### PR TITLE
refactor(workflows): switch personal wrappers to panicboat-actions

### DIFF
--- a/.github/workflows/auto-approve.yaml
+++ b/.github/workflows/auto-approve.yaml
@@ -21,7 +21,7 @@ jobs:
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
 
       - name: Auto-approve PRs
-        uses: panicboat/deploy-actions/auto-approve@main
+        uses: panicboat/panicboat-actions/auto-approve@main
         with:
           token: ${{ steps.app-token.outputs.token }}
           auto-merge-label: 'automerge'

--- a/.github/workflows/claude-code-action.yaml
+++ b/.github/workflows/claude-code-action.yaml
@@ -34,6 +34,6 @@ jobs:
           owner: ${{ github.repository_owner }}
 
       - name: Run Claude Code
-        uses: panicboat/deploy-actions/claude-code-action@main
+        uses: panicboat/panicboat-actions/claude-code-action@main
         with:
           token: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/reusable--kubernetes-builder.yaml
+++ b/.github/workflows/reusable--kubernetes-builder.yaml
@@ -53,7 +53,7 @@ jobs:
           fetch-depth: 0
 
       - name: Kubernetes Diff
-        uses: panicboat/deploy-actions/kubernetes@main
+        uses: panicboat/panicboat-actions/kubernetes@main
         with:
           github-token: ${{ steps.app-token.outputs.token }}
           service-name: ${{ inputs.service-name }}

--- a/.github/workflows/reusable--terragrunt-executor.yaml
+++ b/.github/workflows/reusable--terragrunt-executor.yaml
@@ -59,7 +59,7 @@ jobs:
         continue-on-error: true
 
       - name: Execute Terragrunt
-        uses: panicboat/deploy-actions/terragrunt@main
+        uses: panicboat/panicboat-actions/terragrunt@main
         with:
           github-token: ${{ steps.app-token.outputs.token }}
           service-name: ${{ inputs.service-name }}


### PR DESCRIPTION
## Summary

terragrunt / kubernetes / claude-code-action / auto-approve の \`uses:\` を \`panicboat/panicboat-actions/...@main\` に切り替え。

## Test plan

- [ ] PR 上で全 workflow の CI が通ることを確認
- [ ] \`grep -rn panicboat/deploy-actions/ .github/workflows\` で label-dispatcher / label-resolver のみ残ることを確認

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow configurations to use updated action repositories across multiple pipeline workflows. All existing input parameters and functionality are preserved. No user-facing impact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->