### PR TITLE
chore(github): manage ansible and dotfiles via terragrunt

### DIFF
--- a/github/branch/envs/develop/ansible.hcl
+++ b/github/branch/envs/develop/ansible.hcl
@@ -1,0 +1,13 @@
+locals {
+  defaults = read_terragrunt_config("defaults.hcl")
+
+  repository = {
+    name = "ansible"
+    branch_protection = {
+      main = merge(
+        local.defaults.locals.branch_protection.main,
+        {}
+      )
+    }
+  }
+}

--- a/github/branch/envs/develop/defaults.hcl
+++ b/github/branch/envs/develop/defaults.hcl
@@ -14,8 +14,8 @@ locals {
       dismiss_stale_reviews           = false
       require_code_owner_reviews      = false
       require_last_push_approval      = false
-      require_conversation_resolution = true
-      required_status_checks          = ["CI Gatekeeper"]
+      require_conversation_resolution = false
+      required_status_checks          = []
       strict_required_status_checks   = false
       required_linear_history         = true
       require_signed_commits          = false

--- a/github/branch/envs/develop/deploy-actions.hcl
+++ b/github/branch/envs/develop/deploy-actions.hcl
@@ -3,6 +3,11 @@ locals {
 
   repository = {
     name              = "deploy-actions"
-    branch_protection = local.defaults.locals.branch_protection
+    branch_protection = {
+      main = merge(
+        local.defaults.locals.branch_protection.main,
+        {}
+      )
+    }
   }
 }

--- a/github/branch/envs/develop/dotfiles.hcl
+++ b/github/branch/envs/develop/dotfiles.hcl
@@ -1,0 +1,13 @@
+locals {
+  defaults = read_terragrunt_config("defaults.hcl")
+
+  repository = {
+    name              = "dotfiles"
+    branch_protection = {
+      main = merge(
+        local.defaults.locals.branch_protection.main,
+        {}
+      )
+    }
+  }
+}

--- a/github/branch/envs/develop/monorepo.hcl
+++ b/github/branch/envs/develop/monorepo.hcl
@@ -3,6 +3,13 @@ locals {
 
   repository = {
     name              = "monorepo"
-    branch_protection = local.defaults.locals.branch_protection
+    branch_protection = {
+      main = merge(
+        local.defaults.locals.branch_protection.main,
+        {
+          required_status_checks = ["CI Gatekeeper"]
+        }
+      )
+    }
   }
 }

--- a/github/branch/envs/develop/panicboat-actions.hcl
+++ b/github/branch/envs/develop/panicboat-actions.hcl
@@ -3,6 +3,11 @@ locals {
 
   repository = {
     name              = "panicboat-actions"
-    branch_protection = local.defaults.locals.branch_protection
+    branch_protection = {
+      main = merge(
+        local.defaults.locals.branch_protection.main,
+        {}
+      )
+    }
   }
 }

--- a/github/branch/envs/develop/platform.hcl
+++ b/github/branch/envs/develop/platform.hcl
@@ -3,6 +3,13 @@ locals {
 
   repository = {
     name              = "platform"
-    branch_protection = local.defaults.locals.branch_protection
+    branch_protection = {
+      main = merge(
+        local.defaults.locals.branch_protection.main,
+        {
+          required_status_checks = ["CI Gatekeeper"]
+        }
+      )
+    }
   }
 }

--- a/github/branch/envs/develop/terragrunt.hcl
+++ b/github/branch/envs/develop/terragrunt.hcl
@@ -11,6 +11,8 @@ locals {
   platform          = read_terragrunt_config("platform.hcl")
   deploy_actions    = read_terragrunt_config("deploy-actions.hcl")
   panicboat_actions = read_terragrunt_config("panicboat-actions.hcl")
+  ansible           = read_terragrunt_config("ansible.hcl")
+  dotfiles          = read_terragrunt_config("dotfiles.hcl")
 }
 
 inputs = {
@@ -19,6 +21,8 @@ inputs = {
     platform          = local.platform.locals.repository
     deploy-actions    = local.deploy_actions.locals.repository
     panicboat-actions = local.panicboat_actions.locals.repository
+    ansible           = local.ansible.locals.repository
+    dotfiles          = local.dotfiles.locals.repository
   }
   github_token = get_env("GITHUB_TOKEN")
 }

--- a/github/branch/modules/main.tf
+++ b/github/branch/modules/main.tf
@@ -66,13 +66,16 @@ resource "github_repository_ruleset" "branches" {
       required_review_thread_resolution = each.value.require_conversation_resolution
     }
 
-    required_status_checks {
-      strict_required_status_checks_policy = each.value.strict_required_status_checks
+    dynamic "required_status_checks" {
+      for_each = length(each.value.required_status_checks) > 0 ? [1] : []
+      content {
+        strict_required_status_checks_policy = each.value.strict_required_status_checks
 
-      dynamic "required_check" {
-        for_each = each.value.required_status_checks
-        content {
-          context = required_check.value
+        dynamic "required_check" {
+          for_each = each.value.required_status_checks
+          content {
+            context = required_check.value
+          }
         }
       }
     }

--- a/github/repository/envs/develop/ansible.hcl
+++ b/github/repository/envs/develop/ansible.hcl
@@ -1,0 +1,12 @@
+locals {
+  repository = {
+    name        = "ansible"
+    description = ""
+    visibility  = "public"
+    features = {
+      issues   = true
+      wiki     = false
+      projects = true
+    }
+  }
+}

--- a/github/repository/envs/develop/dotfiles.hcl
+++ b/github/repository/envs/develop/dotfiles.hcl
@@ -1,0 +1,12 @@
+locals {
+  repository = {
+    name        = "dotfiles"
+    description = ""
+    visibility  = "public"
+    features = {
+      issues   = true
+      wiki     = false
+      projects = true
+    }
+  }
+}

--- a/github/repository/envs/develop/terragrunt.hcl
+++ b/github/repository/envs/develop/terragrunt.hcl
@@ -11,6 +11,8 @@ locals {
   platform          = read_terragrunt_config("platform.hcl")
   deploy_actions    = read_terragrunt_config("deploy-actions.hcl")
   panicboat_actions = read_terragrunt_config("panicboat-actions.hcl")
+  ansible           = read_terragrunt_config("ansible.hcl")
+  dotfiles          = read_terragrunt_config("dotfiles.hcl")
 }
 
 inputs = {
@@ -19,6 +21,8 @@ inputs = {
     platform          = local.platform.locals.repository
     deploy-actions    = local.deploy_actions.locals.repository
     panicboat-actions = local.panicboat_actions.locals.repository
+    ansible           = local.ansible.locals.repository
+    dotfiles          = local.dotfiles.locals.repository
   }
   github_token = get_env("GITHUB_TOKEN")
 }

--- a/github/repository/root.hcl
+++ b/github/repository/root.hcl
@@ -8,8 +8,6 @@ locals {
     Project     = local.project_name
     Environment = local.environment
     ManagedBy   = "terragrunt"
-    Repository  = "monorepo"
-    Component   = "repository-management"
     Team        = "panicboat"
   }
 }


### PR DESCRIPTION
## Summary

- Bring existing `panicboat/ansible` and `panicboat/dotfiles` repositories under terragrunt management (repository + branch protection)
- Refactor branch protection to make `required_status_checks` opt-in per repo via dynamic block
- Drop redundant `Repository`/`Component` common tags from `github/repository/root.hcl`

## Plan summary

| Env | Outcome |
|---|---|
| `github/repository/envs/develop` | 2 add (CloudWatch Log Group for ansible/dotfiles), 2 update (ansible/dotfiles repo settings — wiki=false, merge defaults, etc.), 4 update (log group tag cleanup) |
| `github/branch/envs/develop` | 2 add (ansible/dotfiles rulesets), 4 update (per-repo refactor reflecting on existing repos) |

`github_repository.repository["ansible"]` and `["dotfiles"]` were imported into state prior to plan verification.

## Test plan

- [x] `terragrunt plan` (repository env) shows only expected diffs
- [x] `terragrunt plan` (branch env) shows only expected diffs
- [ ] `terragrunt apply` (repository env)
- [ ] `terragrunt apply` (branch env)
- [ ] Confirm ansible/dotfiles repo settings on GitHub reflect the new state

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `ansible` and `dotfiles` repositories to configuration management.

* **Chores**
  * Updated branch protection rules for the `main` branch, removing conversation resolution requirement and adjusting CI status check policies across repositories.
  * Removed repository and component tags from common tagging configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->