### PR TITLE
fix(makefile): use printf to render ANSI color escapes

### DIFF
--- a/aws/github-oidc-auth/Makefile
+++ b/aws/github-oidc-auth/Makefile
@@ -30,52 +30,52 @@ help: ## Show this help message
 	@echo "  make apply ENV=production"
 
 init: ## Initialize Terragrunt
-	@echo "$(YELLOW)Initializing Terragrunt for $(ENV)...$(NC)"
+	@printf "$(YELLOW)Initializing Terragrunt for $(ENV)...$(NC)\n"
 	cd envs/$(ENV) && terragrunt init
 
 plan: ## Plan Terragrunt changes
-	@echo "$(YELLOW)Planning Terragrunt changes for $(ENV)...$(NC)"
+	@printf "$(YELLOW)Planning Terragrunt changes for $(ENV)...$(NC)\n"
 	cd envs/$(ENV) && terragrunt plan
 
 apply: ## Apply Terragrunt changes
-	@echo "$(YELLOW)Applying Terragrunt changes for $(ENV)...$(NC)"
+	@printf "$(YELLOW)Applying Terragrunt changes for $(ENV)...$(NC)\n"
 	cd envs/$(ENV) && terragrunt apply -auto-approve
 
 destroy: ## Destroy Terragrunt resources
-	@echo "$(RED)Destroying Terragrunt resources for $(ENV)...$(NC)"
-	@echo "$(RED)WARNING: This will destroy all resources!$(NC)"
+	@printf "$(RED)Destroying Terragrunt resources for $(ENV)...$(NC)\n"
+	@printf "$(RED)WARNING: This will destroy all resources!$(NC)\n"
 	@read -p "Are you sure? [y/N] " -n 1 -r; \
 	echo; \
 	if [[ $$REPLY =~ ^[Yy]$$ ]]; then \
 		cd envs/$(ENV) && terragrunt destroy; \
 	else \
-		echo "$(YELLOW)Cancelled.$(NC)"; \
+		printf "$(YELLOW)Cancelled.$(NC)\n"; \
 	fi
 
 validate: ## Validate Terragrunt configuration
-	@echo "$(YELLOW)Validating Terragrunt configuration for $(ENV)...$(NC)"
+	@printf "$(YELLOW)Validating Terragrunt configuration for $(ENV)...$(NC)\n"
 	cd envs/$(ENV) && terragrunt validate
 
 fmt: ## Format Terraform files
-	@echo "$(YELLOW)Formatting Terraform files...$(NC)"
+	@printf "$(YELLOW)Formatting Terraform files...$(NC)\n"
 	terraform fmt -recursive .
 
 check: validate fmt ## Run validation and formatting checks
-	@echo "$(GREEN)All checks completed for $(ENV)$(NC)"
+	@printf "$(GREEN)All checks completed for $(ENV)$(NC)\n"
 
 clean: ## Clean Terragrunt cache
-	@echo "$(YELLOW)Cleaning Terragrunt cache...$(NC)"
+	@printf "$(YELLOW)Cleaning Terragrunt cache...$(NC)\n"
 	find . -type d -name ".terragrunt-cache" -exec rm -rf {} + 2>/dev/null || true
 	find . -name "*.tfplan" -delete 2>/dev/null || true
 
 show: ## Show current Terragrunt state
-	@echo "$(YELLOW)Showing current state for $(ENV)...$(NC)"
+	@printf "$(YELLOW)Showing current state for $(ENV)...$(NC)\n"
 	cd envs/$(ENV) && terragrunt show
 
 output: ## Show Terragrunt outputs
-	@echo "$(YELLOW)Showing outputs for $(ENV)...$(NC)"
+	@printf "$(YELLOW)Showing outputs for $(ENV)...$(NC)\n"
 	cd envs/$(ENV) && terragrunt output
 
 refresh: ## Refresh Terragrunt state
-	@echo "$(YELLOW)Refreshing state for $(ENV)...$(NC)"
+	@printf "$(YELLOW)Refreshing state for $(ENV)...$(NC)\n"
 	cd envs/$(ENV) && terragrunt refresh

--- a/aws/vpc/Makefile
+++ b/aws/vpc/Makefile
@@ -28,52 +28,52 @@ help: ## Show this help message
 	@echo "  make apply ENV=production"
 
 init: ## Initialize Terragrunt
-	@echo "$(YELLOW)Initializing Terragrunt for $(ENV)...$(NC)"
+	@printf "$(YELLOW)Initializing Terragrunt for $(ENV)...$(NC)\n"
 	cd envs/$(ENV) && terragrunt init
 
 plan: ## Plan Terragrunt changes
-	@echo "$(YELLOW)Planning Terragrunt changes for $(ENV)...$(NC)"
+	@printf "$(YELLOW)Planning Terragrunt changes for $(ENV)...$(NC)\n"
 	cd envs/$(ENV) && terragrunt plan
 
 apply: ## Apply Terragrunt changes
-	@echo "$(YELLOW)Applying Terragrunt changes for $(ENV)...$(NC)"
+	@printf "$(YELLOW)Applying Terragrunt changes for $(ENV)...$(NC)\n"
 	cd envs/$(ENV) && terragrunt apply -auto-approve
 
 destroy: ## Destroy Terragrunt resources
-	@echo "$(RED)Destroying Terragrunt resources for $(ENV)...$(NC)"
-	@echo "$(RED)WARNING: This will destroy all resources!$(NC)"
+	@printf "$(RED)Destroying Terragrunt resources for $(ENV)...$(NC)\n"
+	@printf "$(RED)WARNING: This will destroy all resources!$(NC)\n"
 	@read -p "Are you sure? [y/N] " -n 1 -r; \
 	echo; \
 	if [[ $$REPLY =~ ^[Yy]$$ ]]; then \
 		cd envs/$(ENV) && terragrunt destroy; \
 	else \
-		echo "$(YELLOW)Cancelled.$(NC)"; \
+		printf "$(YELLOW)Cancelled.$(NC)\n"; \
 	fi
 
 validate: ## Validate Terragrunt configuration
-	@echo "$(YELLOW)Validating Terragrunt configuration for $(ENV)...$(NC)"
+	@printf "$(YELLOW)Validating Terragrunt configuration for $(ENV)...$(NC)\n"
 	cd envs/$(ENV) && terragrunt validate
 
 fmt: ## Format Terraform files
-	@echo "$(YELLOW)Formatting Terraform files...$(NC)"
+	@printf "$(YELLOW)Formatting Terraform files...$(NC)\n"
 	terraform fmt -recursive .
 
 check: validate fmt ## Run validation and formatting checks
-	@echo "$(GREEN)All checks completed for $(ENV)$(NC)"
+	@printf "$(GREEN)All checks completed for $(ENV)$(NC)\n"
 
 clean: ## Clean Terragrunt cache
-	@echo "$(YELLOW)Cleaning Terragrunt cache...$(NC)"
+	@printf "$(YELLOW)Cleaning Terragrunt cache...$(NC)\n"
 	find . -type d -name ".terragrunt-cache" -exec rm -rf {} + 2>/dev/null || true
 	find . -name "*.tfplan" -delete 2>/dev/null || true
 
 show: ## Show current Terragrunt state
-	@echo "$(YELLOW)Showing current state for $(ENV)...$(NC)"
+	@printf "$(YELLOW)Showing current state for $(ENV)...$(NC)\n"
 	cd envs/$(ENV) && terragrunt show
 
 output: ## Show Terragrunt outputs
-	@echo "$(YELLOW)Showing outputs for $(ENV)...$(NC)"
+	@printf "$(YELLOW)Showing outputs for $(ENV)...$(NC)\n"
 	cd envs/$(ENV) && terragrunt output
 
 refresh: ## Refresh Terragrunt state
-	@echo "$(YELLOW)Refreshing state for $(ENV)...$(NC)"
+	@printf "$(YELLOW)Refreshing state for $(ENV)...$(NC)\n"
 	cd envs/$(ENV) && terragrunt refresh

--- a/github/branch/Makefile
+++ b/github/branch/Makefile
@@ -18,52 +18,52 @@ help:
 	@echo "Available environments: develop"
 
 init: ## Initialize Terragrunt
-	@echo "$(YELLOW)Initializing Terragrunt for $(ENV)...$(NC)"
+	@printf "$(YELLOW)Initializing Terragrunt for $(ENV)...$(NC)\n"
 	cd envs/$(ENV) && terragrunt init
 
 plan: ## Plan Terragrunt changes
-	@echo "$(YELLOW)Planning Terragrunt changes for $(ENV)...$(NC)"
+	@printf "$(YELLOW)Planning Terragrunt changes for $(ENV)...$(NC)\n"
 	cd envs/$(ENV) && terragrunt plan
 
 apply: ## Apply Terragrunt changes
-	@echo "$(YELLOW)Applying Terragrunt changes for $(ENV)...$(NC)"
+	@printf "$(YELLOW)Applying Terragrunt changes for $(ENV)...$(NC)\n"
 	cd envs/$(ENV) && terragrunt apply -auto-approve
 
 destroy: ## Destroy Terragrunt resources
-	@echo "$(RED)Destroying Terragrunt resources for $(ENV)...$(NC)"
-	@echo "$(RED)WARNING: This will destroy all resources!$(NC)"
+	@printf "$(RED)Destroying Terragrunt resources for $(ENV)...$(NC)\n"
+	@printf "$(RED)WARNING: This will destroy all resources!$(NC)\n"
 	@read -p "Are you sure? [y/N] " -n 1 -r; \
 	echo; \
 	if [[ $$REPLY =~ ^[Yy]$$ ]]; then \
 		cd envs/$(ENV) && terragrunt destroy; \
 	else \
-		echo "$(YELLOW)Cancelled.$(NC)"; \
+		printf "$(YELLOW)Cancelled.$(NC)\n"; \
 	fi
 
 validate: ## Validate Terragrunt configuration
-	@echo "$(YELLOW)Validating Terragrunt configuration for $(ENV)...$(NC)"
+	@printf "$(YELLOW)Validating Terragrunt configuration for $(ENV)...$(NC)\n"
 	cd envs/$(ENV) && terragrunt validate
 
 fmt: ## Format Terraform files
-	@echo "$(YELLOW)Formatting Terraform files...$(NC)"
+	@printf "$(YELLOW)Formatting Terraform files...$(NC)\n"
 	terraform fmt -recursive .
 
 check: validate fmt ## Run validation and formatting checks
-	@echo "$(GREEN)All checks completed for $(ENV)$(NC)"
+	@printf "$(GREEN)All checks completed for $(ENV)$(NC)\n"
 
 clean: ## Clean Terragrunt cache
-	@echo "$(YELLOW)Cleaning Terragrunt cache...$(NC)"
+	@printf "$(YELLOW)Cleaning Terragrunt cache...$(NC)\n"
 	find . -type d -name ".terragrunt-cache" -exec rm -rf {} + 2>/dev/null || true
 	find . -name "*.tfplan" -delete 2>/dev/null || true
 
 show: ## Show current Terragrunt state
-	@echo "$(YELLOW)Showing current state for $(ENV)...$(NC)"
+	@printf "$(YELLOW)Showing current state for $(ENV)...$(NC)\n"
 	cd envs/$(ENV) && terragrunt show
 
 output: ## Show Terragrunt outputs
-	@echo "$(YELLOW)Showing outputs for $(ENV)...$(NC)"
+	@printf "$(YELLOW)Showing outputs for $(ENV)...$(NC)\n"
 	cd envs/$(ENV) && terragrunt output
 
 refresh: ## Refresh Terragrunt state
-	@echo "$(YELLOW)Refreshing state for $(ENV)...$(NC)"
+	@printf "$(YELLOW)Refreshing state for $(ENV)...$(NC)\n"
 	cd envs/$(ENV) && terragrunt refresh

--- a/github/repository/Makefile
+++ b/github/repository/Makefile
@@ -18,52 +18,52 @@ help:
 	@echo "Available environments: develop"
 
 init: ## Initialize Terragrunt
-	@echo "$(YELLOW)Initializing Terragrunt for $(ENV)...$(NC)"
+	@printf "$(YELLOW)Initializing Terragrunt for $(ENV)...$(NC)\n"
 	cd envs/$(ENV) && terragrunt init
 
 plan: ## Plan Terragrunt changes
-	@echo "$(YELLOW)Planning Terragrunt changes for $(ENV)...$(NC)"
+	@printf "$(YELLOW)Planning Terragrunt changes for $(ENV)...$(NC)\n"
 	cd envs/$(ENV) && terragrunt plan
 
 apply: ## Apply Terragrunt changes
-	@echo "$(YELLOW)Applying Terragrunt changes for $(ENV)...$(NC)"
+	@printf "$(YELLOW)Applying Terragrunt changes for $(ENV)...$(NC)\n"
 	cd envs/$(ENV) && terragrunt apply -auto-approve
 
 destroy: ## Destroy Terragrunt resources
-	@echo "$(RED)Destroying Terragrunt resources for $(ENV)...$(NC)"
-	@echo "$(RED)WARNING: This will destroy all resources!$(NC)"
+	@printf "$(RED)Destroying Terragrunt resources for $(ENV)...$(NC)\n"
+	@printf "$(RED)WARNING: This will destroy all resources!$(NC)\n"
 	@read -p "Are you sure? [y/N] " -n 1 -r; \
 	echo; \
 	if [[ $$REPLY =~ ^[Yy]$$ ]]; then \
 		cd envs/$(ENV) && terragrunt destroy; \
 	else \
-		echo "$(YELLOW)Cancelled.$(NC)"; \
+		printf "$(YELLOW)Cancelled.$(NC)\n"; \
 	fi
 
 validate: ## Validate Terragrunt configuration
-	@echo "$(YELLOW)Validating Terragrunt configuration for $(ENV)...$(NC)"
+	@printf "$(YELLOW)Validating Terragrunt configuration for $(ENV)...$(NC)\n"
 	cd envs/$(ENV) && terragrunt validate
 
 fmt: ## Format Terraform files
-	@echo "$(YELLOW)Formatting Terraform files...$(NC)"
+	@printf "$(YELLOW)Formatting Terraform files...$(NC)\n"
 	terraform fmt -recursive .
 
 check: validate fmt ## Run validation and formatting checks
-	@echo "$(GREEN)All checks completed for $(ENV)$(NC)"
+	@printf "$(GREEN)All checks completed for $(ENV)$(NC)\n"
 
 clean: ## Clean Terragrunt cache
-	@echo "$(YELLOW)Cleaning Terragrunt cache...$(NC)"
+	@printf "$(YELLOW)Cleaning Terragrunt cache...$(NC)\n"
 	find . -type d -name ".terragrunt-cache" -exec rm -rf {} + 2>/dev/null || true
 	find . -name "*.tfplan" -delete 2>/dev/null || true
 
 show: ## Show current Terragrunt state
-	@echo "$(YELLOW)Showing current state for $(ENV)...$(NC)"
+	@printf "$(YELLOW)Showing current state for $(ENV)...$(NC)\n"
 	cd envs/$(ENV) && terragrunt show
 
 output: ## Show Terragrunt outputs
-	@echo "$(YELLOW)Showing outputs for $(ENV)...$(NC)"
+	@printf "$(YELLOW)Showing outputs for $(ENV)...$(NC)\n"
 	cd envs/$(ENV) && terragrunt output
 
 refresh: ## Refresh Terragrunt state
-	@echo "$(YELLOW)Refreshing state for $(ENV)...$(NC)"
+	@printf "$(YELLOW)Refreshing state for $(ENV)...$(NC)\n"
 	cd envs/$(ENV) && terragrunt refresh


### PR DESCRIPTION
## Summary

- PR #211 で `kubernetes/Makefile` の echo → printf 置換を行ったが、同種の Terragrunt 用 Makefile 4 ファイル (`aws/github-oidc-auth/Makefile`, `aws/vpc/Makefile`, `github/branch/Makefile`, `github/repository/Makefile`) にも同じ問題 (ターミナルに `\033[0;33m...` がそのまま表示される) が残っていたため、同じ手法でまとめて修正
- `echo` は既定でバックスラッシュエスケープを解釈しないため、色付き出力箇所を `printf "...\n"` に置換
- 色を使わない `echo` (空行、ヘルプ本文など) はそのまま維持
- `awk 'BEGIN{...}{printf "  $(BLUE)%-15s$(NC) %s\n", ...}'` の awk printf は元から ESC を解釈するため変更不要

## Test plan

- [ ] `cd aws/github-oidc-auth && make plan ENV=develop` の見出し行が黄色で表示される（`\033[0;33m` がそのまま表示されない）
- [ ] `cd aws/vpc && make plan ENV=production` の見出し行が黄色で表示される
- [ ] `cd github/branch && make plan ENV=develop` の見出し行が黄色で表示される
- [ ] `cd github/repository && make plan ENV=develop` の見出し行が黄色で表示される
- [ ] `make help` のヘルプ一覧 (awk 経由の出力) が引き続き青色で表示される