### PR TITLE
Switch panicboat-actions references to renamed actions

### DIFF
--- a/.github/workflows/auto-approve.yaml
+++ b/.github/workflows/auto-approve.yaml
@@ -20,8 +20,7 @@ jobs:
           app-id: ${{ vars.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
 
-      - name: Auto-approve PRs
-        uses: panicboat/panicboat-actions/auto-approve@main
+      - name: Auto-approve
+        uses: hmarr/auto-approve-action@v4.0.0
         with:
-          token: ${{ steps.app-token.outputs.token }}
-          auto-merge-label: 'automerge'
+          github-token: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/claude-code-action.yaml
+++ b/.github/workflows/claude-code-action.yaml
@@ -34,6 +34,6 @@ jobs:
           owner: ${{ github.repository_owner }}
 
       - name: Run Claude Code
-        uses: panicboat/panicboat-actions/claude-code-action@main
+        uses: panicboat/panicboat-actions/claude-run@main
         with:
           token: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/reusable--kubernetes-builder.yaml
+++ b/.github/workflows/reusable--kubernetes-builder.yaml
@@ -52,10 +52,10 @@ jobs:
           ref: ${{ github.head_ref }}
           fetch-depth: 0
 
-      - name: Kubernetes Diff
-        uses: panicboat/panicboat-actions/kubernetes@main
+      - name: Kustomize Diff
+        uses: panicboat/panicboat-actions/kustomize-diff@main
         with:
-          github-token: ${{ steps.app-token.outputs.token }}
+          token: ${{ steps.app-token.outputs.token }}
           service-name: ${{ inputs.service-name }}
           environment: ${{ inputs.environment }}
           path: kubernetes/manifests/${{ inputs.environment }}/${{ inputs.service-name }}

--- a/.github/workflows/reusable--terragrunt-executor.yaml
+++ b/.github/workflows/reusable--terragrunt-executor.yaml
@@ -59,14 +59,13 @@ jobs:
         continue-on-error: true
 
       - name: Execute Terragrunt
-        uses: panicboat/panicboat-actions/terragrunt@main
+        uses: panicboat/panicboat-actions/terragrunt-run@main
         with:
-          github-token: ${{ steps.app-token.outputs.token }}
+          token: ${{ steps.app-token.outputs.token }}
           service-name: ${{ inputs.service-name }}
           environment: ${{ inputs.environment }}
           action-type: ${{ inputs.action-type }}
           iam-role: ${{ inputs.iam-role }}
           aws-region: ${{ inputs.aws-region }}
           working-directory: ${{ inputs.working-directory }}
-          repository: ${{ github.repository }}
           pr-number: ${{ steps.pr-info.outputs.number }}


### PR DESCRIPTION
## Summary
- `auto-approve.yaml`: call `hmarr/auto-approve-action@v4.0.0` directly, drop auto-merge.
- `claude-code-action.yaml`: switch reference to `panicboat-actions/claude-run@main`.
- `reusable--kubernetes-builder.yaml`: switch to `kustomize-diff@main`, rename `github-token` → `token`.
- `reusable--terragrunt-executor.yaml`: switch to `terragrunt-run@main`, rename `github-token` → `token`, drop `repository`.

Depends on: panicboat-actions PR (Phase 1) merged ✓.

## Test plan
- [ ] Trigger a bot PR to verify `auto-approve.yaml` (approve only, no merge)
- [ ] Comment `@claude` on a PR/issue to verify `claude-code-action.yaml`
- [ ] Open a PR touching kubernetes overlays to verify `reusable--kubernetes-builder.yaml`
- [ ] Open a PR touching terragrunt configs to verify `reusable--terragrunt-executor.yaml`