### PR TITLE
chore: migrate workflow-config to stack-grouped schema

### DIFF
--- a/workflow-config.yaml
+++ b/workflow-config.yaml
@@ -1,30 +1,41 @@
 environments:
   - environment: local
     # local environment is kubernetes-only; AWS fields are placeholders
-    aws_region: ""
-    iam_role_plan: ""
-    iam_role_apply: ""
+    stacks:
+      terragrunt:
+        aws_region: ""
+        iam_role_plan: ""
+        iam_role_apply: ""
+      kubernetes: {}
 
   - environment: develop
-    aws_region: us-east-1
-    iam_role_plan: arn:aws:iam::559744160976:role/github-oidc-auth-develop-github-actions-role
-    iam_role_apply: arn:aws:iam::559744160976:role/github-oidc-auth-develop-github-actions-role
+    stacks:
+      terragrunt:
+        aws_region: us-east-1
+        iam_role_plan: arn:aws:iam::559744160976:role/github-oidc-auth-develop-github-actions-role
+        iam_role_apply: arn:aws:iam::559744160976:role/github-oidc-auth-develop-github-actions-role
+      kubernetes: {}
 
   - environment: production
-    aws_region: ap-northeast-1
-    iam_role_plan: arn:aws:iam::559744160976:role/github-oidc-auth-production-github-actions-role
-    iam_role_apply: arn:aws:iam::559744160976:role/github-oidc-auth-production-github-actions-role
+    stacks:
+      terragrunt:
+        aws_region: ap-northeast-1
+        iam_role_plan: arn:aws:iam::559744160976:role/github-oidc-auth-production-github-actions-role
+        iam_role_apply: arn:aws:iam::559744160976:role/github-oidc-auth-production-github-actions-role
+      kubernetes: {}
 
-directory_conventions:
+stack_conventions:
   - root: "aws/{service}"
     stacks:
       - name: terragrunt
         directory: "envs/{environment}"
+        required_attributes: [aws_region, iam_role_plan, iam_role_apply]
 
   - root: "github/{service}"
     stacks:
       - name: terragrunt
         directory: "envs/{environment}"
+        required_attributes: [aws_region, iam_role_plan, iam_role_apply]
 
   - root: "kubernetes/components/{service}"
     stacks:


### PR DESCRIPTION
## Summary

- `environments[]` 直下のフラット属性 (`aws_region` / `iam_role_*`) を `environments[].stacks.<name>.<attr>` の stack-grouped 構造に移行。
- `directory_conventions` セクションを `stack_conventions` にリネームし、`terragrunt` stack に `required_attributes: [aws_region, iam_role_plan, iam_role_apply]` を宣言。`kubernetes` stack は AWS 不要のため required_attributes なし。
- `local` environment は kubernetes-only で AWS 非依存だが、`required_attributes` 検証はキー存在のみ確認するため、旧 yaml と同様に terragrunt の AWS attribute を空文字 (`""`) で残してある。

## Context

`panicboat/deploy-actions` の `feat/stack-grouped-attributes` (PR #202) で action-scripts 側のスキーマ移行が完了したため、本 PR で利用側の `workflow-config.yaml` を追従。`auto-label--deploy-trigger.yaml` 等が参照する matrix item のキー名は維持されるため、workflow ファイル自体への変更は不要。

## Test plan

- [ ] `config-manager validate` で新 YAML が valid と判定される（手元で確認済み）
- [ ] `auto-label--label-dispatcher` / `auto-label--deploy-trigger` の動作確認（PR レビュー時に GitHub Actions 上で確認）