### PR TITLE
chore: drop terragrunt placeholder from local environment

### DIFF
--- a/workflow-config.yaml
+++ b/workflow-config.yaml
@@ -1,11 +1,7 @@
 environments:
   - environment: local
-    # local environment is kubernetes-only; AWS fields are placeholders
+    # local environment is kubernetes-only
     stacks:
-      terragrunt:
-        aws_region: ""
-        iam_role_plan: ""
-        iam_role_apply: ""
       kubernetes: {}
 
   - environment: develop

--- a/workflow-config.yaml
+++ b/workflow-config.yaml
@@ -1,30 +1,41 @@
 environments:
   - environment: local
     # local environment is kubernetes-only; AWS fields are placeholders
-    aws_region: ""
-    iam_role_plan: ""
-    iam_role_apply: ""
+    stacks:
+      terragrunt:
+        aws_region: ""
+        iam_role_plan: ""
+        iam_role_apply: ""
+      kubernetes: {}
 
   - environment: develop
-    aws_region: us-east-1
-    iam_role_plan: arn:aws:iam::559744160976:role/github-oidc-auth-develop-github-actions-role
-    iam_role_apply: arn:aws:iam::559744160976:role/github-oidc-auth-develop-github-actions-role
+    stacks:
+      terragrunt:
+        aws_region: us-east-1
+        iam_role_plan: arn:aws:iam::559744160976:role/github-oidc-auth-develop-github-actions-role
+        iam_role_apply: arn:aws:iam::559744160976:role/github-oidc-auth-develop-github-actions-role
+      kubernetes: {}
 
   - environment: production
-    aws_region: ap-northeast-1
-    iam_role_plan: arn:aws:iam::559744160976:role/github-oidc-auth-production-github-actions-role
-    iam_role_apply: arn:aws:iam::559744160976:role/github-oidc-auth-production-github-actions-role
+    stacks:
+      terragrunt:
+        aws_region: ap-northeast-1
+        iam_role_plan: arn:aws:iam::559744160976:role/github-oidc-auth-production-github-actions-role
+        iam_role_apply: arn:aws:iam::559744160976:role/github-oidc-auth-production-github-actions-role
+      kubernetes: {}
 
-directory_conventions:
+stack_conventions:
   - root: "aws/{service}"
     stacks:
       - name: terragrunt
         directory: "envs/{environment}"
+        required_attributes: [aws_region, iam_role_plan, iam_role_apply]
 
   - root: "github/{service}"
     stacks:
       - name: terragrunt
         directory: "envs/{environment}"
+        required_attributes: [aws_region, iam_role_plan, iam_role_apply]
 
   - root: "kubernetes/components/{service}"
     stacks:


### PR DESCRIPTION
## Summary

`workflow-config.yaml` の `local` 環境から `stacks.terragrunt` の空文字 placeholder を削除する。

`local` 環境は kubernetes-only であり、`panicboat/deploy-actions` PR #203 で `ValidateConfig` が「`environments[].stacks` に未宣言の stack は `required_attributes` 検証をスキップ」する挙動になったため、placeholder は不要になった。

## Context

旧スキーマでは `aws_region: ""` 等を入れることで「`local` 環境では terragrunt を使わない」を表現していたが、新しい挙動では `stacks.terragrunt` 自体を省略するだけで意図が伝わるため、より簡潔な記述になる。

## Test plan

- [x] `config-manager validate` で valid 判定（手元で確認済み）