### PR TITLE
feat(github/repository): disable forking on monorepo and platform

### DIFF
--- a/docs/superpowers/plans/2026-04-29-disable-forking.md
+++ b/docs/superpowers/plans/2026-04-29-disable-forking.md
@@ -1,0 +1,246 @@
+# Disable Forking on Selected Public Repositories Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** `github_repository` モジュールに `allow_forking` を追加し、`monorepo` と `platform` リポジトリで fork を禁止する。
+
+**Architecture:** `repository` モジュールの `repositories` 変数のスキーマに optional な `allow_forking`（デフォルト `true`）を追加し、`github_repository` リソースに渡す。fork を禁止したいリポジトリの `.hcl` で `allow_forking = false` を明示する。
+
+**Tech Stack:** Terraform >= 1.14.8, Terragrunt, GitHub Provider ~> 6.11
+
+**Spec:** `docs/superpowers/specs/2026-04-28-disable-forking-design.md`
+
+---
+
+## File Map
+
+**Modify:**
+- `github/repository/modules/variables.tf` — `repositories` の object 型に `allow_forking = optional(bool, true)` を追加
+- `github/repository/modules/main.tf` — `github_repository` リソースに `allow_forking = each.value.allow_forking` を追加
+- `github/repository/envs/develop/monorepo.hcl` — `allow_forking = false` を追加
+- `github/repository/envs/develop/platform.hcl` — `allow_forking = false` を追加
+
+**Unchanged:**
+- `github/repository/envs/develop/deploy-actions.hcl`
+- `github/repository/envs/develop/panicboat-actions.hcl`
+- `github/repository/envs/develop/ansible.hcl`
+- `github/repository/envs/develop/dotfiles.hcl`
+
+---
+
+## Task 1: モジュールスキーマに `allow_forking` を追加する
+
+**Files:**
+- Modify: `github/repository/modules/variables.tf:34-46`
+
+- [ ] **Step 1: `repositories` 変数の object 型に `allow_forking` を追加する**
+
+`github/repository/modules/variables.tf` の `repositories` 変数を以下に置き換える。
+
+```hcl
+variable "repositories" {
+  description = "Map of repository configurations. visibility must be one of: public, private, internal"
+  type = map(object({
+    name          = string
+    description   = string
+    visibility    = string
+    allow_forking = optional(bool, true)
+    features = object({
+      issues   = bool
+      wiki     = bool
+      projects = bool
+    })
+  }))
+}
+```
+
+- [ ] **Step 2: `terraform fmt` でフォーマットする**
+
+Run: `cd github/repository && make fmt`
+Expected: 終了コード 0、整形差分があれば適用される。
+
+- [ ] **Step 3: コミット**
+
+```bash
+git add github/repository/modules/variables.tf
+git commit -s -m "feat(github/repository): add allow_forking field to repositories variable"
+```
+
+---
+
+## Task 2: リソースに `allow_forking` を渡す
+
+**Files:**
+- Modify: `github/repository/modules/main.tf:12`
+
+- [ ] **Step 1: `github_repository` リソースに `allow_forking` を追加する**
+
+`github/repository/modules/main.tf` の `vulnerability_alerts = true` の直後に `allow_forking = each.value.allow_forking` を追加する。差分は以下の通り。
+
+```hcl
+  vulnerability_alerts = true
+  allow_forking        = each.value.allow_forking
+
+  allow_merge_commit     = false
+```
+
+変更後の該当部分:
+
+```hcl
+resource "github_repository" "repository" {
+  for_each = var.repositories
+
+  name        = each.value.name
+  description = each.value.description
+  visibility  = each.value.visibility
+
+  has_issues   = each.value.features.issues
+  has_wiki     = each.value.features.wiki
+  has_projects = each.value.features.projects
+
+  vulnerability_alerts = true
+  allow_forking        = each.value.allow_forking
+
+  allow_merge_commit     = false
+  allow_squash_merge     = true
+  allow_rebase_merge     = true
+  allow_update_branch    = true
+  allow_auto_merge       = true
+  delete_branch_on_merge = true
+
+  squash_merge_commit_message = "BLANK"
+  squash_merge_commit_title   = "PR_TITLE"
+
+  archived = false
+}
+```
+
+- [ ] **Step 2: `terraform fmt` でフォーマットする**
+
+Run: `cd github/repository && make fmt`
+Expected: 終了コード 0。
+
+- [ ] **Step 3: `terragrunt validate` で構文確認する**
+
+Run: `cd github/repository && make validate ENV=develop`
+Expected: 終了コード 0、`Success!` が表示される。
+
+- [ ] **Step 4: コミット**
+
+```bash
+git add github/repository/modules/main.tf
+git commit -s -m "feat(github/repository): wire allow_forking through to github_repository resource"
+```
+
+---
+
+## Task 3: `monorepo` と `platform` で fork を禁止する
+
+**Files:**
+- Modify: `github/repository/envs/develop/monorepo.hcl`
+- Modify: `github/repository/envs/develop/platform.hcl`
+
+- [ ] **Step 1: `monorepo.hcl` に `allow_forking = false` を追加する**
+
+`github/repository/envs/develop/monorepo.hcl` を以下に置き換える。
+
+```hcl
+locals {
+  repository = {
+    name          = "monorepo"
+    description   = "Monorepo for multiple services and infrastructure configurations."
+    visibility    = "public"
+    allow_forking = false
+    features = {
+      issues   = true
+      wiki     = false
+      projects = true
+    }
+  }
+}
+```
+
+- [ ] **Step 2: `platform.hcl` に `allow_forking = false` を追加する**
+
+`github/repository/envs/develop/platform.hcl` を以下に置き換える。
+
+```hcl
+locals {
+  repository = {
+    name          = "platform"
+    description   = "Platform for multiple services and infrastructure configurations"
+    visibility    = "public"
+    allow_forking = false
+    features = {
+      issues   = true
+      wiki     = false
+      projects = true
+    }
+  }
+}
+```
+
+- [ ] **Step 3: `terraform fmt` でフォーマットする**
+
+Run: `cd github/repository && make fmt`
+Expected: 終了コード 0。
+
+- [ ] **Step 4: `terragrunt plan` で差分を確認する**
+
+Run: `cd github/repository && make plan ENV=develop`
+Expected:
+- `github_repository.repository["monorepo"]` で `allow_forking: true -> false` の差分が出る。
+- `github_repository.repository["platform"]` で `allow_forking: true -> false` の差分が出る。
+- `deploy-actions`, `panicboat-actions`, `ansible`, `dotfiles` の 4 リポジトリで `allow_forking` の差分が出ない（リフレッシュ差分以外）。
+- `Plan: 0 to add, 2 to change, 0 to destroy.` と表示される（他に未適用の差分が無い前提）。
+
+差分が想定外（4 リポジトリのいずれかで `allow_forking` が変化した、あるいは `monorepo`/`platform` で変化しなかった）の場合は、Task 1〜2 のスキーマ・リソース定義を見直す。
+
+- [ ] **Step 5: コミット**
+
+```bash
+git add github/repository/envs/develop/monorepo.hcl github/repository/envs/develop/platform.hcl
+git commit -s -m "feat(github/repository): disable forking on monorepo and platform"
+```
+
+---
+
+## Task 4: 適用と検証
+
+**Files:** （変更なし、運用作業のみ）
+
+- [ ] **Step 1: `terragrunt apply` を実行する**
+
+Run: `cd github/repository && make apply ENV=develop`
+Expected: `Apply complete! Resources: 0 added, 2 changed, 0 destroyed.`
+
+- [ ] **Step 2: GitHub UI で確認する**
+
+ブラウザで以下を確認する。
+- `https://github.com/panicboat/monorepo/settings` の "Features" セクションで "Allow forking" がオフになっている。
+- `https://github.com/panicboat/platform/settings` の "Features" セクションで "Allow forking" がオフになっている。
+- `deploy-actions`, `panicboat-actions`, `ansible`, `dotfiles` の "Allow forking" は変更されていない（オン）。
+
+差分が想定通りでない場合は revert + 再適用で `allow_forking = true` に戻す。
+
+- [ ] **Step 3: PR を作成する**
+
+`feat/disable-forking` を origin に push し、Draft PR を作成する。
+
+```bash
+git push -u origin HEAD
+gh pr create --draft --title "feat(github/repository): disable forking on monorepo and platform" --body "$(cat <<'EOF'
+## Summary
+- `repositories` 変数に `allow_forking`（optional, default true）を追加
+- `monorepo` と `platform` で `allow_forking = false` に設定
+
+## Spec
+docs/superpowers/specs/2026-04-28-disable-forking-design.md
+
+## Test plan
+- [ ] `make plan ENV=develop` で `monorepo` / `platform` のみ `allow_forking: true -> false`
+- [ ] `make apply ENV=develop` 後、GitHub UI で 2 リポジトリの "Allow forking" がオフ
+- [ ] 他 4 リポジトリの "Allow forking" は変化なし
+EOF
+)"
+```

--- a/docs/superpowers/specs/2026-04-28-disable-forking-design.md
+++ b/docs/superpowers/specs/2026-04-28-disable-forking-design.md
@@ -2,21 +2,21 @@
 
 ## Background
 
-Terraform/Terragrunt manages our GitHub repositories under `github/repository/`. The `github_repository` resource currently does not configure `allow_forking`, so all repositories implicitly allow forks (relevant for public repositories; private/internal forking is governed at the org level).
+GitHub リポジトリは Terraform / Terragrunt（`github/repository/` 配下）で管理している。現状の `github_repository` リソースでは `allow_forking` を明示しておらず、すべてのリポジトリで fork が暗黙的に許可されている（public リポジトリにおいて意味を持つ。private/internal の fork 可否は org 設定で制御される）。
 
-We want to disable forking on specific public repositories while keeping the option open per repository.
+特定の public リポジトリで fork を禁止しつつ、リポジトリごとに切り替えられるようにしたい。
 
 ## Goals
 
-- Allow each repository to opt out of forking via its per-repository `.hcl` configuration.
-- Disable forking for `monorepo` and `platform` in this change.
-- Keep existing behavior (fork allowed) for all other repositories.
+- 各リポジトリの `.hcl` で fork 可否を個別に指定できるようにする。
+- 今回の変更で `monorepo` と `platform` の fork を禁止する。
+- それ以外のリポジトリは現状の挙動（fork 許可）を維持する。
 
 ## Non-Goals
 
-- Changing organization-level fork policies.
-- Changing visibility, branch protection, or any other repository setting.
-- Restructuring how per-repository configuration is wired through `terragrunt.hcl`.
+- 組織レベルの fork ポリシーは変更しない。
+- 可視性、ブランチ保護、その他のリポジトリ設定は変更しない。
+- per-repo 設定を `terragrunt.hcl` に渡す経路の構造は変えない。
 
 ## Design
 
@@ -24,7 +24,7 @@ We want to disable forking on specific public repositories while keeping the opt
 
 `github/repository/modules/variables.tf`
 
-Add `allow_forking` as an optional boolean field on the `repositories` map values, defaulting to `true` to preserve current behavior.
+`repositories` map の値オブジェクトに optional な `allow_forking` を追加し、デフォルト値を `true` として既存挙動を維持する。
 
 ```hcl
 variable "repositories" {
@@ -47,7 +47,7 @@ variable "repositories" {
 
 `github/repository/modules/main.tf`
 
-Pass `allow_forking` to the `github_repository` resource. Place it near `vulnerability_alerts` since both relate to repository-level access/security rather than collaboration features.
+`github_repository` リソースに `allow_forking` を渡す。collaboration 系の `features` ではなく、access / security 系の `vulnerability_alerts` の近くに配置する。
 
 ```hcl
 resource "github_repository" "repository" {
@@ -60,14 +60,14 @@ resource "github_repository" "repository" {
 
 ### Per-repository configuration
 
-Set `allow_forking = false` in the two `.hcl` files for repositories that should not be forkable:
+fork を禁止する 2 リポジトリの `.hcl` に `allow_forking = false` を追加する。
 
 - `github/repository/envs/develop/monorepo.hcl`
 - `github/repository/envs/develop/platform.hcl`
 
-Other `.hcl` files (`deploy-actions.hcl`, `panicboat-actions.hcl`, `ansible.hcl`, `dotfiles.hcl`) are left unchanged and inherit the default `true`.
+その他 4 ファイル（`deploy-actions.hcl`, `panicboat-actions.hcl`, `ansible.hcl`, `dotfiles.hcl`）は変更せず、デフォルトの `true` を継承する。
 
-Example after change:
+変更後の例:
 
 ```hcl
 locals {
@@ -87,11 +87,11 @@ locals {
 
 ## Verification
 
-1. `terragrunt plan` under `github/repository/envs/develop/`:
-   - `monorepo` and `platform` show `allow_forking: true -> false`.
-   - The other four repositories show no change for `allow_forking`.
-2. After `terragrunt apply`, confirm in the GitHub UI that the "Allow forking" setting is unchecked for `monorepo` and `platform` and unchanged elsewhere.
+1. `github/repository/envs/develop/` で `terragrunt plan` を実行し、以下を確認する。
+   - `monorepo` と `platform` で `allow_forking: true -> false` の差分が出ること。
+   - 他の 4 リポジトリで `allow_forking` の差分が出ないこと。
+2. `terragrunt apply` 後、GitHub UI で `monorepo` と `platform` の "Allow forking" がオフになっていること、それ以外のリポジトリで設定が変わっていないことを確認する。
 
 ## Rollback
 
-Revert the commit. `terragrunt apply` will restore `allow_forking = true` on the affected repositories.
+該当コミットを revert し、`terragrunt apply` を実行することで `allow_forking = true` に戻す。

--- a/docs/superpowers/specs/2026-04-28-disable-forking-design.md
+++ b/docs/superpowers/specs/2026-04-28-disable-forking-design.md
@@ -1,0 +1,97 @@
+# Disable Forking on Selected Public Repositories
+
+## Background
+
+Terraform/Terragrunt manages our GitHub repositories under `github/repository/`. The `github_repository` resource currently does not configure `allow_forking`, so all repositories implicitly allow forks (relevant for public repositories; private/internal forking is governed at the org level).
+
+We want to disable forking on specific public repositories while keeping the option open per repository.
+
+## Goals
+
+- Allow each repository to opt out of forking via its per-repository `.hcl` configuration.
+- Disable forking for `monorepo` and `platform` in this change.
+- Keep existing behavior (fork allowed) for all other repositories.
+
+## Non-Goals
+
+- Changing organization-level fork policies.
+- Changing visibility, branch protection, or any other repository setting.
+- Restructuring how per-repository configuration is wired through `terragrunt.hcl`.
+
+## Design
+
+### Module schema change
+
+`github/repository/modules/variables.tf`
+
+Add `allow_forking` as an optional boolean field on the `repositories` map values, defaulting to `true` to preserve current behavior.
+
+```hcl
+variable "repositories" {
+  description = "Map of repository configurations. visibility must be one of: public, private, internal"
+  type = map(object({
+    name          = string
+    description   = string
+    visibility    = string
+    allow_forking = optional(bool, true)
+    features = object({
+      issues   = bool
+      wiki     = bool
+      projects = bool
+    })
+  }))
+}
+```
+
+### Resource change
+
+`github/repository/modules/main.tf`
+
+Pass `allow_forking` to the `github_repository` resource. Place it near `vulnerability_alerts` since both relate to repository-level access/security rather than collaboration features.
+
+```hcl
+resource "github_repository" "repository" {
+  ...
+  vulnerability_alerts = true
+  allow_forking        = each.value.allow_forking
+  ...
+}
+```
+
+### Per-repository configuration
+
+Set `allow_forking = false` in the two `.hcl` files for repositories that should not be forkable:
+
+- `github/repository/envs/develop/monorepo.hcl`
+- `github/repository/envs/develop/platform.hcl`
+
+Other `.hcl` files (`deploy-actions.hcl`, `panicboat-actions.hcl`, `ansible.hcl`, `dotfiles.hcl`) are left unchanged and inherit the default `true`.
+
+Example after change:
+
+```hcl
+locals {
+  repository = {
+    name          = "monorepo"
+    description   = "Monorepo for multiple services and infrastructure configurations."
+    visibility    = "public"
+    allow_forking = false
+    features = {
+      issues   = true
+      wiki     = false
+      projects = true
+    }
+  }
+}
+```
+
+## Verification
+
+1. `terragrunt plan` under `github/repository/envs/develop/`:
+   - `monorepo` and `platform` show `allow_forking: true -> false`.
+   - The other four repositories show no change for `allow_forking`.
+2. After `terragrunt apply`, confirm in the GitHub UI that the "Allow forking" setting is unchecked for `monorepo` and `platform` and unchanged elsewhere.
+
+## Rollback
+
+Revert the commit. `terragrunt apply` will restore `allow_forking = true` on the affected repositories.

--- a/github/repository/envs/develop/monorepo.hcl
+++ b/github/repository/envs/develop/monorepo.hcl
@@ -1,8 +1,9 @@
 locals {
   repository = {
-    name        = "monorepo"
-    description = "Monorepo for multiple services and infrastructure configurations."
-    visibility  = "public"
+    name          = "monorepo"
+    description   = "Monorepo for multiple services and infrastructure configurations."
+    visibility    = "public"
+    allow_forking = false
     features = {
       issues   = true
       wiki     = false

--- a/github/repository/envs/develop/platform.hcl
+++ b/github/repository/envs/develop/platform.hcl
@@ -1,8 +1,9 @@
 locals {
   repository = {
-    name        = "platform"
-    description = "Platform for multiple services and infrastructure configurations"
-    visibility  = "public"
+    name          = "platform"
+    description   = "Platform for multiple services and infrastructure configurations"
+    visibility    = "public"
+    allow_forking = false
     features = {
       issues   = true
       wiki     = false

--- a/github/repository/modules/main.tf
+++ b/github/repository/modules/main.tf
@@ -10,6 +10,7 @@ resource "github_repository" "repository" {
   has_projects = each.value.features.projects
 
   vulnerability_alerts = true
+  allow_forking        = each.value.allow_forking
 
   allow_merge_commit     = false
   allow_squash_merge     = true

--- a/github/repository/modules/variables.tf
+++ b/github/repository/modules/variables.tf
@@ -34,9 +34,10 @@ variable "github_token" {
 variable "repositories" {
   description = "Map of repository configurations. visibility must be one of: public, private, internal"
   type = map(object({
-    name        = string
-    description = string
-    visibility  = string
+    name          = string
+    description   = string
+    visibility    = string
+    allow_forking = optional(bool, true)
     features = object({
       issues   = bool
       wiki     = bool


### PR DESCRIPTION
## Summary

- `repositories` 変数に `allow_forking`（`optional(bool, true)`）を追加
- `github_repository` リソースに `allow_forking` を配線
- `monorepo` / `platform` で `allow_forking = false` を設定

その他 4 リポジトリ（`deploy-actions`, `panicboat-actions`, `ansible`, `dotfiles`）はスキーマデフォルト `true` を継承し、挙動は変わりません。

## Spec / Plan

- Spec: `docs/superpowers/specs/2026-04-28-disable-forking-design.md`
- Plan: `docs/superpowers/plans/2026-04-29-disable-forking.md`

## Test plan

- [ ] `cd github/repository && make plan ENV=develop` で `monorepo` / `platform` のみ `allow_forking: true -> false`、他 4 リポジトリで該当差分が出ないこと
- [ ] `cd github/repository && make apply ENV=develop` 後、GitHub UI で `monorepo` / `platform` の "Allow forking" がオフになっていること
- [ ] 他 4 リポジトリの "Allow forking" は変化していないこと

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added per-repository GitHub forking control capability, with forking enabled by default.
  * Forking is now disabled for select repositories in the develop environment.

* **Documentation**
  * Added design specification and implementation guide for repository forking management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->