### PR TITLE
feat(oidc): tighten trust + split plan/apply roles

### DIFF
--- a/aws/github-oidc-auth/envs/develop/env.hcl
+++ b/aws/github-oidc-auth/envs/develop/env.hcl
@@ -8,11 +8,6 @@ locals {
   github_org  = "panicboat"
   github_repos = ["monorepo","platform"]
 
-  # GitHub branches that can assume the role in develop
-  github_branches = [
-    "*"
-  ]
-
   # GitHub environments that can assume the role
   github_environments = [
     "develop"

--- a/aws/github-oidc-auth/envs/develop/terragrunt.hcl
+++ b/aws/github-oidc-auth/envs/develop/terragrunt.hcl
@@ -22,7 +22,6 @@ inputs = {
   aws_region               = include.env.locals.aws_region
   github_org               = include.env.locals.github_org
   github_repos             = include.env.locals.github_repos
-  github_branches          = include.env.locals.github_branches
   github_environments      = include.env.locals.github_environments
   additional_iam_policies  = include.env.locals.additional_iam_policies
   create_oidc_provider     = include.env.locals.create_oidc_provider

--- a/aws/github-oidc-auth/envs/production/env.hcl
+++ b/aws/github-oidc-auth/envs/production/env.hcl
@@ -8,11 +8,6 @@ locals {
   github_org  = "panicboat"
   github_repos = ["monorepo","platform"]
 
-  # GitHub branches that can assume the role in production (service-specific)
-  github_branches = [
-    "*"
-  ]
-
   # GitHub environments that can assume the role
   github_environments = [
     "production"

--- a/aws/github-oidc-auth/envs/production/terragrunt.hcl
+++ b/aws/github-oidc-auth/envs/production/terragrunt.hcl
@@ -22,7 +22,6 @@ inputs = {
   aws_region               = include.env.locals.aws_region
   github_org               = include.env.locals.github_org
   github_repos             = include.env.locals.github_repos
-  github_branches          = include.env.locals.github_branches
   github_environments      = include.env.locals.github_environments
   additional_iam_policies  = include.env.locals.additional_iam_policies
   create_oidc_provider     = include.env.locals.create_oidc_provider

--- a/aws/github-oidc-auth/modules/main.tf
+++ b/aws/github-oidc-auth/modules/main.tf
@@ -34,34 +34,151 @@ locals {
 
 # Build trust policy conditions for GitHub Actions
 locals {
-  # Base conditions for repositories
-  repo_conditions = [
-    for repo in var.github_repos :
-    "repo:${var.github_org}/${repo}:*"
-  ]
-
-  # Conditions for specific branches
-  branch_conditions = flatten([
+  # plan-role: allow PR triggers and main-branch plan runs
+  plan_conditions = flatten([
     for repo in var.github_repos : [
-      for branch in var.github_branches :
-      "repo:${var.github_org}/${repo}:ref:refs/heads/${branch}"
+      "repo:${var.github_org}/${repo}:pull_request",
+      "repo:${var.github_org}/${repo}:ref:refs/heads/main",
     ]
   ])
 
-  # Conditions for specific environments
-  environment_conditions = flatten([
-    for repo in var.github_repos : [
-      for env in var.github_environments :
-      "repo:${var.github_org}/${repo}:environment:${env}"
-    ]
+  # apply-role: only main pushes or environment-gated runs
+  apply_conditions = flatten([
+    for repo in var.github_repos : concat(
+      ["repo:${var.github_org}/${repo}:ref:refs/heads/main"],
+      [for env in var.github_environments :
+      "repo:${var.github_org}/${repo}:environment:${env}"]
+    )
   ])
 
-  # Combine all conditions
-  all_conditions = concat(
-    local.repo_conditions,
-    local.branch_conditions,
-    local.environment_conditions
-  )
+  # Legacy trust conditions — preserved verbatim until aws_iam_role.github_actions_role
+  # is removed in Phase 3. Reproduces the previous concat(repo_wildcard, branch_wildcard,
+  # environment) construction exactly so that the in-flight trust policy is not changed
+  # by this plan. The branch wildcard is hard-coded because var.github_branches was ["*"]
+  # in both envs at the time it was removed; this entire local goes away with the legacy
+  # role, so the hard-code does not need to become a variable.
+  legacy_conditions = flatten([
+    for repo in var.github_repos : concat(
+      ["repo:${var.github_org}/${repo}:*"],
+      ["repo:${var.github_org}/${repo}:ref:refs/heads/*"],
+      [for env in var.github_environments :
+      "repo:${var.github_org}/${repo}:environment:${env}"]
+    )
+  ])
+}
+
+# Plan role: read-only AWS access + Terragrunt state lock RW
+resource "aws_iam_role" "plan" {
+  name                 = "${var.project_name}-${var.environment}-github-actions-plan-role"
+  max_session_duration = var.max_session_duration
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Principal = {
+          Federated = local.oidc_provider_arn
+        }
+        Action = "sts:AssumeRoleWithWebIdentity"
+        Condition = {
+          StringEquals = {
+            "token.actions.githubusercontent.com:aud" = "sts.amazonaws.com"
+          }
+          StringLike = {
+            "token.actions.githubusercontent.com:sub" = local.plan_conditions
+          }
+        }
+      }
+    ]
+  })
+
+  tags = merge(var.common_tags, {
+    Name    = "${var.project_name}-${var.environment}-github-actions-plan-role"
+    Purpose = "github-actions-oidc-plan"
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "plan_read_only" {
+  role       = aws_iam_role.plan.name
+  policy_arn = "arn:aws:iam::aws:policy/ReadOnlyAccess"
+}
+
+# DynamoDB lock table is shared across all environments and is always in
+# ap-northeast-1 — that is fixed in aws/github-oidc-auth/root.hcl
+# (remote_state.dynamodb_table region). It is intentionally NOT derived from
+# var.aws_region: the develop env uses us-east-1 as its primary region, but
+# the lock table lives in ap-northeast-1 regardless. If the lock table is
+# ever relocated, both this region and the value in root.hcl must change
+# together.
+resource "aws_iam_policy" "terragrunt_state_lock" {
+  name        = "${var.project_name}-${var.environment}-terragrunt-state-lock"
+  description = "DynamoDB lock table RW for Terragrunt state operations"
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "dynamodb:GetItem",
+          "dynamodb:PutItem",
+          "dynamodb:DeleteItem",
+        ]
+        Resource = "arn:aws:dynamodb:ap-northeast-1:${data.aws_caller_identity.current.account_id}:table/terragrunt-state-locks"
+      }
+    ]
+  })
+
+  tags = var.common_tags
+}
+
+resource "aws_iam_role_policy_attachment" "plan_state_lock" {
+  role       = aws_iam_role.plan.name
+  policy_arn = aws_iam_policy.terragrunt_state_lock.arn
+}
+
+# Apply role: AdministratorAccess gated by main push or environment
+resource "aws_iam_role" "apply" {
+  name                 = "${var.project_name}-${var.environment}-github-actions-apply-role"
+  max_session_duration = var.max_session_duration
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Principal = {
+          Federated = local.oidc_provider_arn
+        }
+        Action = "sts:AssumeRoleWithWebIdentity"
+        Condition = {
+          StringEquals = {
+            "token.actions.githubusercontent.com:aud" = "sts.amazonaws.com"
+          }
+          StringLike = {
+            "token.actions.githubusercontent.com:sub" = local.apply_conditions
+          }
+        }
+      }
+    ]
+  })
+
+  tags = merge(var.common_tags, {
+    Name    = "${var.project_name}-${var.environment}-github-actions-apply-role"
+    Purpose = "github-actions-oidc-apply"
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "apply_administrator_access" {
+  role       = aws_iam_role.apply.name
+  policy_arn = "arn:aws:iam::aws:policy/AdministratorAccess"
+}
+
+resource "aws_iam_role_policy_attachment" "apply_additional_policies" {
+  count      = length(var.additional_iam_policies)
+  role       = aws_iam_role.apply.name
+  policy_arn = var.additional_iam_policies[count.index]
 }
 
 # IAM Role for GitHub Actions OIDC
@@ -83,7 +200,7 @@ resource "aws_iam_role" "github_actions_role" {
             "token.actions.githubusercontent.com:aud" = "sts.amazonaws.com"
           }
           StringLike = {
-            "token.actions.githubusercontent.com:sub" = local.all_conditions
+            "token.actions.githubusercontent.com:sub" = local.legacy_conditions
           }
         }
       }
@@ -91,8 +208,8 @@ resource "aws_iam_role" "github_actions_role" {
   })
 
   tags = merge(var.common_tags, {
-    Name        = "${var.project_name}-${var.environment}-github-actions-role"
-    Purpose     = "github-actions-oidc"
+    Name    = "${var.project_name}-${var.environment}-github-actions-role"
+    Purpose = "github-actions-oidc"
   })
 }
 

--- a/aws/github-oidc-auth/modules/outputs.tf
+++ b/aws/github-oidc-auth/modules/outputs.tf
@@ -40,12 +40,27 @@ output "github_repos" {
   value       = var.github_repos
 }
 
-output "allowed_branches" {
-  description = "List of GitHub branches that can assume the role"
-  value       = var.github_branches
-}
-
 output "allowed_environments" {
   description = "List of GitHub environments that can assume the role"
   value       = var.github_environments
+}
+
+output "plan_role_arn" {
+  description = "ARN of the plan-only GitHub Actions IAM role"
+  value       = aws_iam_role.plan.arn
+}
+
+output "plan_role_name" {
+  description = "Name of the plan-only GitHub Actions IAM role"
+  value       = aws_iam_role.plan.name
+}
+
+output "apply_role_arn" {
+  description = "ARN of the apply GitHub Actions IAM role"
+  value       = aws_iam_role.apply.arn
+}
+
+output "apply_role_name" {
+  description = "Name of the apply GitHub Actions IAM role"
+  value       = aws_iam_role.apply.name
 }

--- a/aws/github-oidc-auth/modules/variables.tf
+++ b/aws/github-oidc-auth/modules/variables.tf
@@ -32,12 +32,6 @@ variable "github_repos" {
   type        = list(string)
 }
 
-variable "github_branches" {
-  description = "List of GitHub branches that can assume the role"
-  type        = list(string)
-  default     = ["main", "master"]
-}
-
 variable "github_environments" {
   description = "List of GitHub environments that can assume the role"
   type        = list(string)

--- a/docs/superpowers/plans/2026-04-30-oidc-hardening.md
+++ b/docs/superpowers/plans/2026-04-30-oidc-hardening.md
@@ -39,40 +39,30 @@ GitHub repository module:
 
 ---
 
-## Task 1: Verify github provider supports `default_workflow_permissions`
+## Task 1: Provider resource verification (already completed)
 
-**Files:** none (research only)
+**Files:** none (research only) — completed during planning
 
-This is a pre-condition for Task 9. If the installed `integrations/github ~> 6.12` does not support `default_workflow_permissions` on `github_actions_repository_permissions`, halt and update the spec (provider upgrade, replacement, or scope drop). Do not introduce a `null_resource` / `local-exec` workaround.
+The schema of `integrations/github` ~> 6.12 (locked to 6.12.0) was inspected and the result is:
 
-- [ ] **Step 1: Initialize the github/repository terragrunt-managed module to download the provider**
+- `github_actions_repository_permissions` has the attributes `enabled`, `allowed_actions`, `id`, `repository`, `sha_pinning_required`. It does NOT have `default_workflow_permissions`.
+- `github_workflow_repository_permissions` is a separate resource with attributes `repository`, `default_workflow_permissions`, `can_approve_pull_request_reviews`, `id`. This is the resource we will use.
 
-```bash
-cd github/repository/envs/develop
-terragrunt init
-```
+Subsequent tasks reference `github_workflow_repository_permissions` accordingly. No further action in Task 1.
 
-Expected: provider plugins are downloaded into `.terragrunt-cache/.../<some-hash>/.terraform/providers/registry.terraform.io/integrations/github/`.
-
-- [ ] **Step 2: Check whether `default_workflow_permissions` is in the resource schema**
+To re-verify the schema if needed:
 
 ```bash
 cd github/repository/envs/develop
-terragrunt providers schema -json 2>/dev/null \
+GITHUB_TOKEN=dummy terragrunt run -- providers schema -json 2>/dev/null \
   | jq '.provider_schemas
         | to_entries[]
         | select(.key | test("integrations/github"))
-        | .value.resource_schemas.github_actions_repository_permissions.block.attributes
-        | has("default_workflow_permissions")'
+        | .value.resource_schemas.github_workflow_repository_permissions.block.attributes
+        | keys'
 ```
 
-Expected: `true`.
-
-- [ ] **Step 3: Decide based on result**
-
-If the command prints `true` → proceed to Task 2.
-
-If `false` (or null) → STOP. Update `docs/superpowers/specs/2026-04-30-oidc-hardening-design.md` to either bump the github provider version, switch to a different provider, or remove the default-permissions requirement. Do not move on to subsequent tasks before the spec is revised and re-approved.
+Expected output: `["can_approve_pull_request_reviews", "default_workflow_permissions", "id", "repository"]`.
 
 ---
 
@@ -674,24 +664,24 @@ variable "repositories" {
 }
 ```
 
-- [ ] **Step 2: Add `github_actions_repository_permissions` resource**
+- [ ] **Step 2: Add `github_workflow_repository_permissions` resource**
 
 Edit `github/repository/modules/main.tf`. Append:
 
 ```hcl
-resource "github_actions_repository_permissions" "repository" {
+resource "github_workflow_repository_permissions" "repository" {
   for_each = {
     for k, v in var.repositories :
     k => v if v.actions_default_permissions_read
   }
 
-  repository                   = github_repository.repository[each.key].name
-  enabled                      = true
-  default_workflow_permissions = "read"
+  repository                       = github_repository.repository[each.key].name
+  default_workflow_permissions     = "read"
+  can_approve_pull_request_reviews = false
 }
 ```
 
-If Task 1 found that `default_workflow_permissions` is not supported, do NOT proceed — revisit the spec instead.
+The resource is `github_workflow_repository_permissions` (NOT `github_actions_repository_permissions` — the latter has different responsibilities and does not expose `default_workflow_permissions` in `integrations/github` ~> 6.12).
 
 - [ ] **Step 3: Format and validate**
 
@@ -760,8 +750,8 @@ cd github/repository && make plan ENV=develop
 ```
 
 Expected diff:
-- `module.monorepo.github_actions_repository_permissions.repository["monorepo"]` create
-- `module.platform.github_actions_repository_permissions.repository["platform"]` create
+- `module.monorepo.github_workflow_repository_permissions.repository["monorepo"]` create
+- `module.platform.github_workflow_repository_permissions.repository["platform"]` create
 - (No diffs for `deploy-actions`, `panicboat-actions`, `ansible`, `dotfiles`)
 
 If any other repository shows a diff, STOP and investigate.

--- a/docs/superpowers/plans/2026-04-30-oidc-hardening.md
+++ b/docs/superpowers/plans/2026-04-30-oidc-hardening.md
@@ -1,0 +1,900 @@
+# OIDC Trust Tightening and Plan/Apply Role Split Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Tighten OIDC trust policy, split plan/apply IAM roles, and set GitHub Actions default workflow permissions to read-only across `monorepo` and `platform` repos.
+
+**Architecture:** Three-stage IAM rollout (add new roles → switch consumers → delete old role) with separate stages for `ci-gatekeeper.yaml` permissions tweak and GitHub default workflow permissions. Terragrunt-managed AWS module changes plus Terraform-managed GitHub repository module additions. Verification by an explicit deny-test on the apply-role.
+
+**Tech Stack:** Terraform 1.11+, Terragrunt, hashicorp/aws ~> 6.42, integrations/github ~> 6.12, GitHub Actions, AWS IAM (OIDC).
+
+**Spec:** `docs/superpowers/specs/2026-04-30-oidc-hardening-design.md`
+
+---
+
+## Files Touched
+
+AWS module:
+- `aws/github-oidc-auth/modules/variables.tf` — drop `github_branches`
+- `aws/github-oidc-auth/modules/main.tf` — replace single role with plan-role and apply-role; add DynamoDB lock policy; eventually delete old role
+- `aws/github-oidc-auth/modules/outputs.tf` — add new outputs; eventually delete old outputs
+- `aws/github-oidc-auth/envs/develop/env.hcl` — drop `github_branches`
+- `aws/github-oidc-auth/envs/develop/terragrunt.hcl` — drop `github_branches` input
+- `aws/github-oidc-auth/envs/production/env.hcl` — drop `github_branches`
+- `aws/github-oidc-auth/envs/production/terragrunt.hcl` — drop `github_branches` input
+
+Workflow config:
+- `workflow-config.yaml` — switch `iam_role_plan` / `iam_role_apply` ARNs
+
+GitHub workflow:
+- `.github/workflows/ci-gatekeeper.yaml` — add `permissions: actions: read`
+
+GitHub repository module:
+- `github/repository/modules/variables.tf` — extend `repositories` schema
+- `github/repository/modules/main.tf` — add `github_actions_repository_permissions`
+- `github/repository/envs/develop/monorepo.hcl` — opt in to read default
+- `github/repository/envs/develop/platform.hcl` — opt in to read default
+
+`aws/github-oidc-auth/envs/staging/` is empty (no `env.hcl` / `terragrunt.hcl`) and is therefore out of scope.
+
+---
+
+## Task 1: Verify github provider supports `default_workflow_permissions`
+
+**Files:** none (research only)
+
+This is a pre-condition for Task 9. If the installed `integrations/github ~> 6.12` does not support `default_workflow_permissions` on `github_actions_repository_permissions`, halt and update the spec (provider upgrade, replacement, or scope drop). Do not introduce a `null_resource` / `local-exec` workaround.
+
+- [ ] **Step 1: Initialize the github/repository terragrunt-managed module to download the provider**
+
+```bash
+cd github/repository/envs/develop
+terragrunt init
+```
+
+Expected: provider plugins are downloaded into `.terragrunt-cache/.../<some-hash>/.terraform/providers/registry.terraform.io/integrations/github/`.
+
+- [ ] **Step 2: Check whether `default_workflow_permissions` is in the resource schema**
+
+```bash
+cd github/repository/envs/develop
+terragrunt providers schema -json 2>/dev/null \
+  | jq '.provider_schemas
+        | to_entries[]
+        | select(.key | test("integrations/github"))
+        | .value.resource_schemas.github_actions_repository_permissions.block.attributes
+        | has("default_workflow_permissions")'
+```
+
+Expected: `true`.
+
+- [ ] **Step 3: Decide based on result**
+
+If the command prints `true` → proceed to Task 2.
+
+If `false` (or null) → STOP. Update `docs/superpowers/specs/2026-04-30-oidc-hardening-design.md` to either bump the github provider version, switch to a different provider, or remove the default-permissions requirement. Do not move on to subsequent tasks before the spec is revised and re-approved.
+
+---
+
+## Task 2: Phase 1 — AWS module: variables and trust condition locals
+
+**Files:**
+- Modify: `aws/github-oidc-auth/modules/variables.tf`
+- Modify: `aws/github-oidc-auth/modules/main.tf`
+
+- [ ] **Step 1: Drop `github_branches` variable**
+
+Edit `aws/github-oidc-auth/modules/variables.tf`. Remove this block entirely:
+
+```hcl
+variable "github_branches" {
+  description = "List of GitHub branches that can assume the role"
+  type        = list(string)
+  default     = ["main", "master"]
+}
+```
+
+- [ ] **Step 2: Replace trust condition locals**
+
+Edit `aws/github-oidc-auth/modules/main.tf`. Locate the `locals` block that currently contains `repo_conditions`, `branch_conditions`, `environment_conditions`, and `all_conditions`. Replace that entire block with:
+
+```hcl
+locals {
+  # plan-role: PR トリガーと main 上での plan を許可
+  plan_conditions = flatten([
+    for repo in var.github_repos : [
+      "repo:${var.github_org}/${repo}:pull_request",
+      "repo:${var.github_org}/${repo}:ref:refs/heads/main",
+    ]
+  ])
+
+  # apply-role: main push と environment ゲート経由のみ
+  apply_conditions = flatten([
+    for repo in var.github_repos : concat(
+      ["repo:${var.github_org}/${repo}:ref:refs/heads/main"],
+      [for env in var.github_environments :
+        "repo:${var.github_org}/${repo}:environment:${env}"]
+    )
+  ])
+}
+```
+
+Leave the existing `oidc_provider_arn` local block untouched.
+
+- [ ] **Step 3: Format and validate**
+
+```bash
+cd aws/github-oidc-auth
+terraform fmt -recursive .
+make validate ENV=develop
+make validate ENV=production
+```
+
+Expected: `terraform fmt` exits silently or reformats; both `validate` calls pass.
+
+---
+
+## Task 3: Phase 1 — AWS module: add plan-role and DynamoDB lock policy
+
+**Files:**
+- Modify: `aws/github-oidc-auth/modules/main.tf`
+
+- [ ] **Step 1: Add plan-role and read-only attachment**
+
+Append to `aws/github-oidc-auth/modules/main.tf` (after the `locals` block from Task 2):
+
+```hcl
+# Plan role: read-only AWS access + Terragrunt state lock RW
+resource "aws_iam_role" "plan" {
+  name                 = "${var.project_name}-${var.environment}-github-actions-plan-role"
+  max_session_duration = var.max_session_duration
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Principal = {
+          Federated = local.oidc_provider_arn
+        }
+        Action = "sts:AssumeRoleWithWebIdentity"
+        Condition = {
+          StringEquals = {
+            "token.actions.githubusercontent.com:aud" = "sts.amazonaws.com"
+          }
+          StringLike = {
+            "token.actions.githubusercontent.com:sub" = local.plan_conditions
+          }
+        }
+      }
+    ]
+  })
+
+  tags = merge(var.common_tags, {
+    Name    = "${var.project_name}-${var.environment}-github-actions-plan-role"
+    Purpose = "github-actions-oidc-plan"
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "plan_read_only" {
+  role       = aws_iam_role.plan.name
+  policy_arn = "arn:aws:iam::aws:policy/ReadOnlyAccess"
+}
+```
+
+- [ ] **Step 2: Add Terragrunt state lock policy and attach to plan-role**
+
+Append to the same file:
+
+```hcl
+# DynamoDB lock table is shared across all envs and lives in ap-northeast-1
+# (see aws/github-oidc-auth/root.hcl remote_state.dynamodb_table).
+resource "aws_iam_policy" "terragrunt_state_lock" {
+  name        = "${var.project_name}-${var.environment}-terragrunt-state-lock"
+  description = "DynamoDB lock table RW for Terragrunt state operations"
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "dynamodb:GetItem",
+          "dynamodb:PutItem",
+          "dynamodb:DeleteItem",
+        ]
+        Resource = "arn:aws:dynamodb:ap-northeast-1:${data.aws_caller_identity.current.account_id}:table/terragrunt-state-locks"
+      }
+    ]
+  })
+
+  tags = var.common_tags
+}
+
+resource "aws_iam_role_policy_attachment" "plan_state_lock" {
+  role       = aws_iam_role.plan.name
+  policy_arn = aws_iam_policy.terragrunt_state_lock.arn
+}
+```
+
+- [ ] **Step 3: Format and validate**
+
+```bash
+cd aws/github-oidc-auth
+terraform fmt -recursive .
+make validate ENV=develop
+make validate ENV=production
+```
+
+Expected: pass.
+
+---
+
+## Task 4: Phase 1 — AWS module: add apply-role and outputs
+
+**Files:**
+- Modify: `aws/github-oidc-auth/modules/main.tf`
+- Modify: `aws/github-oidc-auth/modules/outputs.tf`
+
+- [ ] **Step 1: Add apply-role and policy attachments**
+
+Append to `aws/github-oidc-auth/modules/main.tf`:
+
+```hcl
+# Apply role: AdministratorAccess gated by main push or environment
+resource "aws_iam_role" "apply" {
+  name                 = "${var.project_name}-${var.environment}-github-actions-apply-role"
+  max_session_duration = var.max_session_duration
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Principal = {
+          Federated = local.oidc_provider_arn
+        }
+        Action = "sts:AssumeRoleWithWebIdentity"
+        Condition = {
+          StringEquals = {
+            "token.actions.githubusercontent.com:aud" = "sts.amazonaws.com"
+          }
+          StringLike = {
+            "token.actions.githubusercontent.com:sub" = local.apply_conditions
+          }
+        }
+      }
+    ]
+  })
+
+  tags = merge(var.common_tags, {
+    Name    = "${var.project_name}-${var.environment}-github-actions-apply-role"
+    Purpose = "github-actions-oidc-apply"
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "apply_administrator_access" {
+  role       = aws_iam_role.apply.name
+  policy_arn = "arn:aws:iam::aws:policy/AdministratorAccess"
+}
+
+resource "aws_iam_role_policy_attachment" "apply_additional_policies" {
+  count      = length(var.additional_iam_policies)
+  role       = aws_iam_role.apply.name
+  policy_arn = var.additional_iam_policies[count.index]
+}
+```
+
+The existing `aws_iam_role.github_actions_role` and its policy attachments (`administrator_access`, `additional_policies`) MUST remain in the file at this stage. They will be removed in Task 7.
+
+- [ ] **Step 2: Add new outputs**
+
+Edit `aws/github-oidc-auth/modules/outputs.tf`. Append:
+
+```hcl
+output "plan_role_arn" {
+  description = "ARN of the plan-only GitHub Actions IAM role"
+  value       = aws_iam_role.plan.arn
+}
+
+output "plan_role_name" {
+  description = "Name of the plan-only GitHub Actions IAM role"
+  value       = aws_iam_role.plan.name
+}
+
+output "apply_role_arn" {
+  description = "ARN of the apply GitHub Actions IAM role"
+  value       = aws_iam_role.apply.arn
+}
+
+output "apply_role_name" {
+  description = "Name of the apply GitHub Actions IAM role"
+  value       = aws_iam_role.apply.name
+}
+```
+
+Do NOT remove `github_actions_role_arn`, `github_actions_role_name`, or `allowed_branches` outputs yet — that happens in Task 7.
+
+- [ ] **Step 3: Format and validate**
+
+```bash
+cd aws/github-oidc-auth
+terraform fmt -recursive .
+make validate ENV=develop
+make validate ENV=production
+```
+
+Expected: pass.
+
+---
+
+## Task 5: Phase 1 — Drop `github_branches` from env configs
+
+**Files:**
+- Modify: `aws/github-oidc-auth/envs/develop/env.hcl`
+- Modify: `aws/github-oidc-auth/envs/develop/terragrunt.hcl`
+- Modify: `aws/github-oidc-auth/envs/production/env.hcl`
+- Modify: `aws/github-oidc-auth/envs/production/terragrunt.hcl`
+
+- [ ] **Step 1: Remove `github_branches` from develop/env.hcl**
+
+Edit `aws/github-oidc-auth/envs/develop/env.hcl`. Delete:
+
+```hcl
+  # GitHub branches that can assume the role in develop
+  github_branches = [
+    "*"
+  ]
+```
+
+- [ ] **Step 2: Remove `github_branches` from develop/terragrunt.hcl**
+
+Edit `aws/github-oidc-auth/envs/develop/terragrunt.hcl`. Delete this line from the `inputs` block:
+
+```hcl
+  github_branches          = include.env.locals.github_branches
+```
+
+- [ ] **Step 3: Remove `github_branches` from production/env.hcl**
+
+Edit `aws/github-oidc-auth/envs/production/env.hcl`. Delete:
+
+```hcl
+  # GitHub branches that can assume the role in production (service-specific)
+  github_branches = [
+    "*"
+  ]
+```
+
+- [ ] **Step 4: Remove `github_branches` from production/terragrunt.hcl**
+
+Edit `aws/github-oidc-auth/envs/production/terragrunt.hcl`. Delete the `github_branches` line from `inputs`.
+
+- [ ] **Step 5: Validate both envs**
+
+```bash
+cd aws/github-oidc-auth
+make validate ENV=develop
+make validate ENV=production
+```
+
+Expected: both pass.
+
+---
+
+## Task 6: Phase 1 — Plan, commit, apply
+
+**Files:** none (operational)
+
+- [ ] **Step 1: Plan develop**
+
+```bash
+cd aws/github-oidc-auth && make plan ENV=develop
+```
+
+Expected diff (creations only — no destroys):
+- `aws_iam_role.plan` create
+- `aws_iam_role_policy_attachment.plan_read_only` create
+- `aws_iam_policy.terragrunt_state_lock` create
+- `aws_iam_role_policy_attachment.plan_state_lock` create
+- `aws_iam_role.apply` create
+- `aws_iam_role_policy_attachment.apply_administrator_access` create
+- (no `aws_iam_role_policy_attachment.apply_additional_policies` since `var.additional_iam_policies` is empty)
+
+If the plan shows ANY destroy of `aws_iam_role.github_actions_role` or its attachments, STOP — Phase 1 is supposed to keep the legacy role intact (see Task 4 Step 1). Re-edit `main.tf` so the legacy resources are present, then re-plan.
+
+- [ ] **Step 2: Plan production**
+
+```bash
+cd aws/github-oidc-auth && make plan ENV=production
+```
+
+Expected: same shape as develop, with `production` in resource names and tags.
+
+- [ ] **Step 3: Commit Phase 1 changes**
+
+```bash
+cd .claude/worktrees/feat-oidc-hardening
+git add aws/github-oidc-auth/
+git commit -s -m "feat(aws/github-oidc-auth): add plan/apply roles alongside legacy role
+
+Introduce new plan-role (ReadOnlyAccess + Terragrunt state lock RW) and
+apply-role (AdministratorAccess) with tightened OIDC trust conditions.
+The legacy github_actions_role is left in place; a follow-up commit
+removes it once workflow-config.yaml has switched to the new ARNs.
+
+Refs: docs/superpowers/specs/2026-04-30-oidc-hardening-design.md"
+```
+
+- [ ] **Step 4: Apply develop**
+
+```bash
+cd aws/github-oidc-auth && make apply ENV=develop
+```
+
+Expected: apply completes without error. New roles and policies created.
+
+- [ ] **Step 5: Apply production**
+
+```bash
+cd aws/github-oidc-auth && make apply ENV=production
+```
+
+- [ ] **Step 6: Capture role ARNs for Task 7**
+
+```bash
+cd aws/github-oidc-auth
+make output ENV=develop | grep -E 'plan_role_arn|apply_role_arn'
+make output ENV=production | grep -E 'plan_role_arn|apply_role_arn'
+```
+
+Save the four ARNs locally — they are needed verbatim for Task 7.
+
+---
+
+## Task 7: Phase 2 — Switch `workflow-config.yaml` to new ARNs
+
+**Files:**
+- Modify: `workflow-config.yaml`
+
+- [ ] **Step 1: Update develop entry**
+
+Edit `workflow-config.yaml`. Replace the develop terragrunt block:
+
+```yaml
+  - environment: develop
+    stacks:
+      terragrunt:
+        aws_region: us-east-1
+        iam_role_plan: arn:aws:iam::559744160976:role/github-oidc-auth-develop-github-actions-role
+        iam_role_apply: arn:aws:iam::559744160976:role/github-oidc-auth-develop-github-actions-role
+      kubernetes: {}
+```
+
+with (use the exact `plan_role_arn` and `apply_role_arn` captured in Task 6 Step 6):
+
+```yaml
+  - environment: develop
+    stacks:
+      terragrunt:
+        aws_region: us-east-1
+        iam_role_plan: arn:aws:iam::559744160976:role/github-oidc-auth-develop-github-actions-plan-role
+        iam_role_apply: arn:aws:iam::559744160976:role/github-oidc-auth-develop-github-actions-apply-role
+      kubernetes: {}
+```
+
+- [ ] **Step 2: Update production entry**
+
+Same pattern for the `- environment: production` block. New ARNs:
+- `iam_role_plan: arn:aws:iam::559744160976:role/github-oidc-auth-production-github-actions-plan-role`
+- `iam_role_apply: arn:aws:iam::559744160976:role/github-oidc-auth-production-github-actions-apply-role`
+
+`local` environment is unchanged.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add workflow-config.yaml
+git commit -s -m "chore(workflow-config): switch terragrunt iam roles to new plan/apply ARNs"
+```
+
+- [ ] **Step 4: Verify in CI**
+
+After this commit reaches `main` (push the branch and merge per local PR workflow):
+
+1. Open a small no-op PR that touches a `terragrunt`-stacked path under `develop` scope (e.g., a comment in `aws/github-oidc-auth/envs/develop/env.hcl`).
+2. Confirm `auto-label--deploy-trigger.yaml` runs `terragrunt plan` using the new plan-role ARN and the job succeeds.
+3. After merging the no-op PR to main, confirm `terragrunt apply` runs using the new apply-role ARN and succeeds.
+
+If either step fails, do NOT proceed to Task 8. Fix the root cause first.
+
+---
+
+## Task 8: Phase 3 — Remove the legacy IAM role
+
+**Files:**
+- Modify: `aws/github-oidc-auth/modules/main.tf`
+- Modify: `aws/github-oidc-auth/modules/outputs.tf`
+
+- [ ] **Step 1: Remove `aws_iam_role.github_actions_role` and its attachments**
+
+Edit `aws/github-oidc-auth/modules/main.tf`. Delete these blocks entirely:
+
+```hcl
+resource "aws_iam_role" "github_actions_role" { ... }
+resource "aws_iam_role_policy_attachment" "administrator_access" { ... }
+resource "aws_iam_role_policy_attachment" "additional_policies" { ... }
+```
+
+The CloudWatch log group `aws_cloudwatch_log_group.github_actions_logs` MUST stay — it is still useful and not tied to the role.
+
+- [ ] **Step 2: Remove obsolete outputs**
+
+Edit `aws/github-oidc-auth/modules/outputs.tf`. Delete:
+
+```hcl
+output "github_actions_role_arn" { ... }
+output "github_actions_role_name" { ... }
+output "allowed_branches" { ... }
+```
+
+- [ ] **Step 3: Format and validate**
+
+```bash
+cd aws/github-oidc-auth
+terraform fmt -recursive .
+make validate ENV=develop
+make validate ENV=production
+```
+
+Expected: pass.
+
+- [ ] **Step 4: Plan develop**
+
+```bash
+cd aws/github-oidc-auth && make plan ENV=develop
+```
+
+Expected: ONLY destroys related to `aws_iam_role.github_actions_role` and its `aws_iam_role_policy_attachment.administrator_access` (count 1) and `aws_iam_role_policy_attachment.additional_policies` (count 0 in our case → no entry to destroy). No other diffs.
+
+If the plan touches `plan` / `apply` roles or any other resource, STOP and investigate.
+
+- [ ] **Step 5: Plan production**
+
+```bash
+cd aws/github-oidc-auth && make plan ENV=production
+```
+
+Expected: same shape.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add aws/github-oidc-auth/
+git commit -s -m "feat(aws/github-oidc-auth): remove legacy github_actions_role
+
+Superseded by plan-role and apply-role (PR #...). workflow-config.yaml
+no longer references the legacy ARN."
+```
+
+- [ ] **Step 7: Apply develop**
+
+```bash
+cd aws/github-oidc-auth && make apply ENV=develop
+```
+
+- [ ] **Step 8: Apply production**
+
+```bash
+cd aws/github-oidc-auth && make apply ENV=production
+```
+
+---
+
+## Task 9: Phase 4 — Add `permissions: actions: read` to ci-gatekeeper
+
+**Files:**
+- Modify: `.github/workflows/ci-gatekeeper.yaml`
+
+- [ ] **Step 1: Insert the `permissions:` block**
+
+Edit `.github/workflows/ci-gatekeeper.yaml`. After the `on:` block and before `jobs:`, insert:
+
+```yaml
+permissions:
+  actions: read
+```
+
+The header section should look like:
+
+```yaml
+name: 'CI Gatekeeper'
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    branches:
+      - '**'
+
+permissions:
+  actions: read
+
+jobs:
+  ci-gatekeeper:
+    name: CI Gatekeeper
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Wait for other workflows
+        uses: int128/wait-for-workflows-action@v1
+        with:
+          max-timeout-seconds: 1800 # 30 minutes
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add .github/workflows/ci-gatekeeper.yaml
+git commit -s -m "chore(workflows/ci-gatekeeper): declare permissions: actions: read
+
+Required ahead of switching the repository default workflow permissions
+to read-only; without this declaration int128/wait-for-workflows-action
+would lose access to the workflow runs API."
+```
+
+This commit can land on main on its own — it is harmless even before the default-permissions change.
+
+---
+
+## Task 10: Phase 5 — github/repository module: schema and resource
+
+**Files:**
+- Modify: `github/repository/modules/variables.tf`
+- Modify: `github/repository/modules/main.tf`
+
+- [ ] **Step 1: Extend `repositories` schema**
+
+Edit `github/repository/modules/variables.tf`. Update the `repositories` variable to add `actions_default_permissions_read`:
+
+```hcl
+variable "repositories" {
+  description = "Map of repository configurations. visibility must be one of: public, private, internal"
+  type = map(object({
+    name                             = string
+    description                      = string
+    visibility                       = string
+    allow_forking                    = optional(bool, true)
+    actions_default_permissions_read = optional(bool, false)
+    features = object({
+      issues   = bool
+      wiki     = bool
+      projects = bool
+    })
+  }))
+}
+```
+
+- [ ] **Step 2: Add `github_actions_repository_permissions` resource**
+
+Edit `github/repository/modules/main.tf`. Append:
+
+```hcl
+resource "github_actions_repository_permissions" "repository" {
+  for_each = {
+    for k, v in var.repositories :
+    k => v if v.actions_default_permissions_read
+  }
+
+  repository                   = github_repository.repository[each.key].name
+  enabled                      = true
+  default_workflow_permissions = "read"
+}
+```
+
+If Task 1 found that `default_workflow_permissions` is not supported, do NOT proceed — revisit the spec instead.
+
+- [ ] **Step 3: Format and validate**
+
+```bash
+cd github/repository
+terraform fmt -recursive .
+make validate ENV=develop
+```
+
+Expected: pass.
+
+---
+
+## Task 11: Phase 5 — opt monorepo and platform into read default
+
+**Files:**
+- Modify: `github/repository/envs/develop/monorepo.hcl`
+- Modify: `github/repository/envs/develop/platform.hcl`
+
+- [ ] **Step 1: Set the flag for monorepo**
+
+Edit `github/repository/envs/develop/monorepo.hcl`. Add `actions_default_permissions_read = true` inside the `repository` block, alongside `allow_forking`:
+
+```hcl
+locals {
+  repository = {
+    name                             = "monorepo"
+    description                      = "Monorepo for multiple services and infrastructure configurations."
+    visibility                       = "public"
+    allow_forking                    = false
+    actions_default_permissions_read = true
+    features = {
+      issues   = true
+      wiki     = false
+      projects = true
+    }
+  }
+}
+```
+
+- [ ] **Step 2: Set the flag for platform**
+
+Edit `github/repository/envs/develop/platform.hcl`. Add the same field:
+
+```hcl
+locals {
+  repository = {
+    name                             = "platform"
+    description                      = "Platform for multiple services and infrastructure configurations"
+    visibility                       = "public"
+    allow_forking                    = false
+    actions_default_permissions_read = true
+    features = {
+      issues   = true
+      wiki     = false
+      projects = true
+    }
+  }
+}
+```
+
+- [ ] **Step 3: Plan**
+
+```bash
+cd github/repository && make plan ENV=develop
+```
+
+Expected diff:
+- `module.monorepo.github_actions_repository_permissions.repository["monorepo"]` create
+- `module.platform.github_actions_repository_permissions.repository["platform"]` create
+- (No diffs for `deploy-actions`, `panicboat-actions`, `ansible`, `dotfiles`)
+
+If any other repository shows a diff, STOP and investigate.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add github/repository/
+git commit -s -m "feat(github/repository): default workflow permissions = read for monorepo and platform"
+```
+
+- [ ] **Step 5: Apply**
+
+```bash
+cd github/repository && make apply ENV=develop
+```
+
+- [ ] **Step 6: Verify in GitHub UI**
+
+For each of `monorepo` and `platform`:
+
+1. Open `https://github.com/panicboat/<repo>/settings/actions`
+2. Under "Workflow permissions", confirm "Read repository contents and packages permissions" is selected.
+
+For `deploy-actions`, `panicboat-actions`, `ansible`, `dotfiles`: confirm "Read and write permissions" is still selected (no change).
+
+- [ ] **Step 7: Verify ci-gatekeeper completes**
+
+Open a small no-op PR (e.g., touch a comment in any file). Confirm `ci-gatekeeper.yaml` runs to completion without permission errors.
+
+If `ci-gatekeeper` fails because of an additional permission, add it to its `permissions:` block via a follow-up commit on Task 9 and re-test.
+
+---
+
+## Task 12: Verify apply-role denial from PR trigger
+
+This is an out-of-band verification: temporarily install a workflow that tries to assume the apply-role from a PR and confirm it gets `AccessDenied`. Then remove the workflow.
+
+**Files:**
+- Create (temporary): `.github/workflows/_test-apply-role-deny.yaml`
+- Delete (after verification): same file
+- Branch: dedicated short-lived branch off main, e.g., `chore/apply-role-deny-test`
+
+- [ ] **Step 1: Branch off main and create the test workflow**
+
+```bash
+cd .claude/worktrees/feat-oidc-hardening
+git fetch origin
+git switch -c chore/apply-role-deny-test origin/main
+```
+
+Create `.github/workflows/_test-apply-role-deny.yaml`:
+
+```yaml
+name: 'TEST - apply-role denial'
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/_test-apply-role-deny.yaml'
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  test-deny:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Attempt to assume apply-role (expected to fail)
+        id: assume
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::559744160976:role/github-oidc-auth-develop-github-actions-apply-role
+          aws-region: us-east-1
+        continue-on-error: true
+
+      - name: Verify the assume step failed
+        run: |
+          if [[ "${{ steps.assume.outcome }}" == "success" ]]; then
+            echo "::error::apply-role was assumable from a PR — trust policy is too permissive"
+            exit 1
+          fi
+          echo "OK: apply-role assumption was denied from PR as expected"
+```
+
+- [ ] **Step 2: Commit and push**
+
+```bash
+git add .github/workflows/_test-apply-role-deny.yaml
+git commit -s -m "test(workflows): temporary apply-role denial check"
+git push -u origin HEAD
+```
+
+- [ ] **Step 3: Open PR (Draft) and observe**
+
+```bash
+gh pr create --draft --title "test: apply-role denial check (do not merge)" \
+  --body "Temporary PR to verify apply-role trust policy denies PR-triggered assumption. Will be closed without merging."
+```
+
+Watch the `TEST - apply-role denial` workflow on the PR.
+
+Expected:
+- "Attempt to assume apply-role (expected to fail)" step: outcome = `failure` (showing `AccessDenied` in logs).
+- "Verify the assume step failed" step: outcome = `success`.
+
+If the assume step succeeds (i.e., apply-role was assumed from a PR), STOP — the trust policy is not enforcing the intended denial. Investigate immediately and fix before continuing.
+
+- [ ] **Step 4: Close the PR and delete the test branch**
+
+```bash
+gh pr close --delete-branch
+```
+
+The denial test is verified by the workflow run history; nothing needs to land on `main`.
+
+- [ ] **Step 5: Switch back to the feature worktree branch**
+
+```bash
+git switch feat-oidc-hardening
+```
+
+---
+
+## Self-Review
+
+After completing all tasks, confirm against the spec:
+
+- [ ] Trust policy: `aws/github-oidc-auth/modules/main.tf` no longer constructs a condition list with `repo:.../*`; only `plan_conditions` and `apply_conditions` are used.
+- [ ] plan-role has `ReadOnlyAccess` and the DynamoDB lock policy attached. apply-role has `AdministratorAccess` and any `additional_iam_policies`.
+- [ ] `workflow-config.yaml` references plan-role for plan and apply-role for apply, in both develop and production.
+- [ ] `ci-gatekeeper.yaml` declares `permissions: actions: read`.
+- [ ] `monorepo` and `platform` show "Read repository contents and packages permissions" in GitHub UI; the other four repositories are unchanged.
+- [ ] The apply-role denial test workflow ran with the assume step failing as expected.
+- [ ] The legacy `aws_iam_role.github_actions_role` no longer exists in either env (verify via `aws iam get-role --role-name github-oidc-auth-develop-github-actions-role` returns NoSuchEntity).

--- a/docs/superpowers/specs/2026-04-30-oidc-hardening-design.md
+++ b/docs/superpowers/specs/2026-04-30-oidc-hardening-design.md
@@ -99,10 +99,12 @@ locals {
 - 削除: `github_branches`
 - それ以外は維持
 
-`envs/{develop,staging,production}/env.hcl`:
+`envs/{develop,production}/env.hcl`:
 
 - `github_branches = ["*"]` の行を削除
-- `github_environments` は環境名（`develop` / `staging` / `production`）のまま維持
+- `github_environments` は環境名（`develop` / `production`）のまま維持
+
+`envs/staging/` は env.hcl / terragrunt.hcl が無く未使用のため対象外。
 
 #### terragrunt.hcl の更新
 
@@ -160,7 +162,7 @@ permissions:
 
 破壊的変更を含むため、新 role の作成と旧 role の削除を分離した段階適用とする:
 
-1. **AWS apply (Phase 1)**: `aws/github-oidc-auth/modules/` を改修し、旧 `aws_iam_role.github_actions_role` リソースを残したまま新 plan-role / apply-role を**追加で**作成する PR をマージ。develop / staging / production の各環境で apply
+1. **AWS apply (Phase 1)**: `aws/github-oidc-auth/modules/` を改修し、旧 `aws_iam_role.github_actions_role` リソースを残したまま新 plan-role / apply-role を**追加で**作成する PR をマージ。develop / production の各環境で apply（staging は未使用のため対象外）
 2. **`workflow-config.yaml` 切替 PR**: `iam_role_plan` / `iam_role_apply` を新 role の ARN に書き換える PR をマージ。マージ後、PR で plan が plan-role で動くこと、main マージ後の apply が apply-role で動くことを確認する
 3. **AWS apply (Phase 2)**: 手順 2 の動作確認後、旧 `aws_iam_role.github_actions_role` リソース定義を削除する PR をマージし、各環境で apply。これにより不可逆な旧 role 削除を新 role の運用実績がある状態で実施する
 4. **`ci-gatekeeper.yaml` 修正 PR**: `permissions: actions: read` を追加する PR をマージ（次手順の前提）
@@ -174,7 +176,7 @@ permissions:
   - 関連ポリシーアタッチメントの差分
   - 旧 `aws_iam_role.github_actions_role` は差分に含まれない（残存）
 - 手順 3（AWS apply Phase 2）の `terragrunt plan` で旧 `aws_iam_role.github_actions_role` の削除差分のみが出る
-- staging / production でも同様（staging は workflow-config 未参照だが新構成は作成する）
+- production でも同様の差分
 - `monorepo` と `platform` の GitHub UI で `Settings → Actions → General → Workflow permissions` が "Read repository contents and packages permissions" になっていること
 - 他リポジトリ（`deploy-actions`, `panicboat-actions`, `ansible`, `dotfiles`）の Workflow permissions に変更が無いこと
 - `auto-label--deploy-trigger.yaml` の PR plan / main apply の両方が新 role で完走する

--- a/docs/superpowers/specs/2026-04-30-oidc-hardening-design.md
+++ b/docs/superpowers/specs/2026-04-30-oidc-hardening-design.md
@@ -114,10 +114,13 @@ locals {
 
 `github/repository/` 配下で `monorepo` と `platform` の default workflow permissions（GitHub Settings → Actions → General → Workflow permissions に対応）を `read` に設定する。
 
-実装方針（具体は plan 段階で確定）:
+実装は `integrations/github` provider が提供する Terraform リソースで管理することを前提とし、状態管理外の手段（`null_resource` + `local-exec` 等）でのフォールバックは取らない。失敗がサイレントになり、plan/apply の差分追跡が効かなくなるため。
 
-- `integrations/github` 6.12 系で `github_actions_repository_permissions` リソースに `default_workflow_permissions` 引数が存在すれば、そのリソースを `monorepo` / `platform` 限定で追加して使う
-- 引数が無ければ `null_resource` + `local-exec` から `gh api -X PUT /repos/{owner}/{repo}/actions/permissions/workflow -f default_workflow_permissions=read` を呼ぶ形でフォールバック
+plan 段階で provider のリソース対応状況を確認する。`integrations/github` 6.12 系で対応する場合はそのリソースを `monorepo` / `platform` 限定で追加する。対応していない場合は次のいずれかで対処する（spec を更新する）:
+
+- provider のバージョンアップ
+- 対応する別 provider の導入
+- 本要件の取り下げ（C 領域に移管、または別 spec で扱う）
 
 `variables.tf` に `actions_default_permissions_read = optional(bool, false)` を追加し、`envs/develop/{monorepo,platform}.hcl` で `true` を指定する。他のリポジトリは既定値 `false` のままで挙動変化なし。
 

--- a/docs/superpowers/specs/2026-04-30-oidc-hardening-design.md
+++ b/docs/superpowers/specs/2026-04-30-oidc-hardening-design.md
@@ -118,13 +118,12 @@ locals {
 
 実装は `integrations/github` provider が提供する Terraform リソースで管理することを前提とし、状態管理外の手段（`null_resource` + `local-exec` 等）でのフォールバックは取らない。失敗がサイレントになり、plan/apply の差分追跡が効かなくなるため。
 
-plan 段階で provider のリソース対応状況を確認する。`integrations/github` 6.12 系で対応する場合はそのリソースを `monorepo` / `platform` 限定で追加する。対応していない場合は次のいずれかで対処する（spec を更新する）:
+provider のリソース調査結果（6.12 系のスキーマで確認）:
 
-- provider のバージョンアップ
-- 対応する別 provider の導入
-- 本要件の取り下げ（C 領域に移管、または別 spec で扱う）
+- `github_actions_repository_permissions` は `enabled` / `allowed_actions` / `sha_pinning_required` を扱うリソースで、`default_workflow_permissions` は持たない
+- `github_workflow_repository_permissions` が `repository` / `default_workflow_permissions` / `can_approve_pull_request_reviews` を持つ別リソース。本 spec の目的にはこちらを使う
 
-`variables.tf` に `actions_default_permissions_read = optional(bool, false)` を追加し、`envs/develop/{monorepo,platform}.hcl` で `true` を指定する。他のリポジトリは既定値 `false` のままで挙動変化なし。
+`variables.tf` に `actions_default_permissions_read = optional(bool, false)` を追加し、`envs/develop/{monorepo,platform}.hcl` で `true` を指定する。`github_workflow_repository_permissions` を `actions_default_permissions_read = true` のリポジトリにのみ作成し、`default_workflow_permissions = "read"` と `can_approve_pull_request_reviews = false` を設定する。他のリポジトリは既定値 `false` のままで挙動変化なし。
 
 #### Workflow 側の影響
 

--- a/docs/superpowers/specs/2026-04-30-oidc-hardening-design.md
+++ b/docs/superpowers/specs/2026-04-30-oidc-hardening-design.md
@@ -140,8 +140,6 @@ permissions:
   actions: read
 ```
 
-実機検証で他に不足する権限が出たら `permissions:` に明示追加する。
-
 ### `workflow-config.yaml` の更新
 
 各環境の `iam_role_plan` / `iam_role_apply` を新 role の ARN に置換。フィールド構造（`required_attributes` 含む）は維持。
@@ -160,37 +158,37 @@ permissions:
 
 ## Apply ordering
 
-破壊的変更を含むため、ARN 切り替え・役割削除・default workflow permissions 切替を段階的に行う:
+破壊的変更を含むため、新 role の作成と旧 role の削除を分離した段階適用とする:
 
-1. `aws/github-oidc-auth/modules/` を新構成（plan-role + apply-role）に書き換える PR をマージし、各環境で apply。実装上は旧 `github_actions_role` リソース定義を main.tf から外して新 2 ロールを作成する形にし、削除と新規作成を一度の apply で行う
-2. `workflow-config.yaml` の `iam_role_plan` / `iam_role_apply` を新 ARN に書き換える PR をマージ
-3. `ci-gatekeeper.yaml` に `permissions: actions: read` を追加する PR をマージ（次手順の前提）
-4. `github/repository/envs/develop/{monorepo,platform}.hcl` で `actions_default_permissions_read = true` を有効化して apply
-5. 動作確認: PR で plan が plan-role で動く、main マージ後に apply が apply-role で動く、`auto-label--deploy-trigger.yaml` と `ci-gatekeeper.yaml` が完走する
-
-手順 1 の旧 role 削除は同時に行う前提だが、もし新 role の動作不安が大きい場合は plan 段階で「新 role 作成のみ → workflow-config 切替 → 旧 role 削除」の 3 段階に分割することも検討する。
+1. **AWS apply (Phase 1)**: `aws/github-oidc-auth/modules/` を改修し、旧 `aws_iam_role.github_actions_role` リソースを残したまま新 plan-role / apply-role を**追加で**作成する PR をマージ。develop / staging / production の各環境で apply
+2. **`workflow-config.yaml` 切替 PR**: `iam_role_plan` / `iam_role_apply` を新 role の ARN に書き換える PR をマージ。マージ後、PR で plan が plan-role で動くこと、main マージ後の apply が apply-role で動くことを確認する
+3. **AWS apply (Phase 2)**: 手順 2 の動作確認後、旧 `aws_iam_role.github_actions_role` リソース定義を削除する PR をマージし、各環境で apply。これにより不可逆な旧 role 削除を新 role の運用実績がある状態で実施する
+4. **`ci-gatekeeper.yaml` 修正 PR**: `permissions: actions: read` を追加する PR をマージ（次手順の前提）
+5. **GitHub default permissions apply**: `github/repository/envs/develop/{monorepo,platform}.hcl` で `actions_default_permissions_read = true` を有効化して apply。`ci-gatekeeper.yaml` を含む全 workflow が完走することを確認する
 
 ## Verification
 
-- `aws/github-oidc-auth/envs/develop` の `terragrunt plan` で以下の差分が出る:
-  - `aws_iam_role.github_actions_role` 削除
+- 手順 1（AWS apply Phase 1）の `terragrunt plan` で以下の差分が出る:
   - `aws_iam_role.plan` 新規作成
   - `aws_iam_role.apply` 新規作成
   - 関連ポリシーアタッチメントの差分
+  - 旧 `aws_iam_role.github_actions_role` は差分に含まれない（残存）
+- 手順 3（AWS apply Phase 2）の `terragrunt plan` で旧 `aws_iam_role.github_actions_role` の削除差分のみが出る
 - staging / production でも同様（staging は workflow-config 未参照だが新構成は作成する）
 - `monorepo` と `platform` の GitHub UI で `Settings → Actions → General → Workflow permissions` が "Read repository contents and packages permissions" になっていること
 - 他リポジトリ（`deploy-actions`, `panicboat-actions`, `ansible`, `dotfiles`）の Workflow permissions に変更が無いこと
 - `auto-label--deploy-trigger.yaml` の PR plan / main apply の両方が新 role で完走する
 - `ci-gatekeeper.yaml` が default read 環境下で完走する
-- 試行: PR ブランチで apply-role を assume する step を仕込んだ workflow を実行し、`AccessDenied` で失敗すること（任意の検証）
+- **拒否確認**: PR ブランチで apply-role の ARN を assume する step を持つテスト workflow を一時的に作成し PR を出して動作させ、`AccessDenied` で失敗することを確認する。確認後にテスト workflow は削除する
 
 ## Rollback
 
 各 step の rollback:
 
-- 手順 4（GitHub default permissions）: `actions_default_permissions_read = false` に戻して apply、または UI で "Read and write permissions" に戻す
-- 手順 3（ci-gatekeeper permissions）: 影響なし。読み取り権限の追加は default が write でも害はない
-- 手順 2（`workflow-config.yaml`）: 旧 ARN に戻す PR をマージ
-- 手順 1（IAM role 構成変更）: 該当 commit を revert して apply。旧 `github_actions_role` が再作成される
+- 手順 5（GitHub default permissions）: `actions_default_permissions_read = false` に戻して apply
+- 手順 4（ci-gatekeeper permissions）: 影響なし。読み取り権限の追加は default が write でも害はない
+- 手順 3（旧 role 削除）: 該当 commit を revert して apply。旧 `github_actions_role` が再作成される
+- 手順 2（`workflow-config.yaml`）: 旧 ARN に戻す PR をマージ。旧 role はまだ存在するため即座に旧経路に戻る
+- 手順 1（新 role 作成）: 該当 commit を revert して apply。新 role が削除される
 
-最も影響が大きいのは手順 1（旧 role の削除と新 role 作成）。apply 直後に手順 2 の ARN 切替がマージされるまでは、`auto-label--deploy-trigger.yaml` から AWS への認証が失敗する時間帯がある。手順 1 と手順 2 の間隔を最小化するため、両 PR を同時に準備し連続でマージする運用を取る。
+3 段階分離の利点として、旧 role が残った状態（手順 1〜2）であれば旧経路に即座に戻せる。手順 3 の旧 role 削除以降に問題が出た場合は手順 3 を revert する。

--- a/docs/superpowers/specs/2026-04-30-oidc-hardening-design.md
+++ b/docs/superpowers/specs/2026-04-30-oidc-hardening-design.md
@@ -1,0 +1,193 @@
+# OIDC Trust Policy Tightening and Plan/Apply Role Split
+
+## Background
+
+`monorepo` と `platform` は GitHub Actions から OIDC で AWS に認証している（`aws/github-oidc-auth/`）。現在の構成は fork PR が許可されると AdministratorAccess を持つ role を assume できる経路が開く。
+
+主な問題点:
+
+1. **Trust policy の `sub` 条件が広い**: `repo:panicboat/{repo}:*` が含まれ、PR トリガー（`:pull_request`）も match する。fork PR の OIDC token も `sub` の repo 部分は base リポジトリ名になるため、fork PR からも assume できる。
+2. **plan / apply の権限分離がない**: `iam_role_plan` と `iam_role_apply` が同一 role（`AdministratorAccess` アタッチ）。plan 経路でも全権限が付く。
+3. **`GITHUB_TOKEN` 既定権限が広い**: monorepo / platform の Actions 設定で default workflow permissions が write のままで、workflow が `permissions:` を宣言しなければ書き込み可能。
+
+`allow_forking = false`（PR #224）が一次ゲートだが、設定が逆戻りしたり内部脅威に対する防御を持たないため、AWS 認証層と GitHub Actions 設定層で多層防御を入れる。
+
+## Goals
+
+- AWS OIDC trust policy から `repo:panicboat/{repo}:*` を除去する
+- IAM role を **plan-role**（ReadOnly + state lock RW）と **apply-role**（AdministratorAccess）に分離する
+- plan-role の trust は PR と main に限定、apply-role の trust は main push と environment ゲートに限定する
+- `monorepo` と `platform` の Actions の default workflow permissions を read-only にする
+- `workflow-config.yaml` の `iam_role_plan` / `iam_role_apply` を新 ARN に切り替える
+
+## Non-Goals
+
+- monorepo / platform 以外のリポジトリの OIDC 設定変更
+- monorepo と platform で OIDC role を repo 別に分離する（共有を維持）
+- GitHub Environments + required reviewers の追加（Approach C の領域、本 spec の対象外）
+- `allowed_actions` allowlist 化（Approach C の領域）
+- `.github/CODEOWNERS` の細分化（既存の `* @panicboat` を維持）
+- Branch protection の追加変更
+- `terragrunt apply` の実機適用（plan / 実行は別途）
+
+## Design
+
+### AWS layer (`aws/github-oidc-auth/`)
+
+#### Trust policy の構成変更
+
+`modules/main.tf` の `local.all_conditions` を廃止し、role ごとに専用の条件リストを用意する。
+
+新しい条件リスト:
+
+```hcl
+locals {
+  # plan-role: PR トリガーと main 上での plan を許可
+  plan_conditions = flatten([
+    for repo in var.github_repos : [
+      "repo:${var.github_org}/${repo}:pull_request",
+      "repo:${var.github_org}/${repo}:ref:refs/heads/main",
+    ]
+  ])
+
+  # apply-role: main push と environment 経由のみ
+  apply_conditions = flatten([
+    for repo in var.github_repos : concat(
+      ["repo:${var.github_org}/${repo}:ref:refs/heads/main"],
+      [for env in var.github_environments :
+        "repo:${var.github_org}/${repo}:environment:${env}"]
+    )
+  ])
+}
+```
+
+旧 `repo_conditions`（`repo:.../{repo}:*`）と `branch_conditions`（`["*"]` の展開で実質ワイルドカードになっていた）は削除する。`var.github_branches` 変数も用途がなくなるため削除（envs 側でも参照を外す）。
+
+#### IAM role の分割
+
+旧 `aws_iam_role.github_actions_role`（単一 role に AdministratorAccess）を廃止し、以下 2 つに置き換える:
+
+1. **`aws_iam_role.plan`**
+   - 名前: `${var.project_name}-${var.environment}-github-actions-plan-role`
+   - Trust: `plan_conditions`
+   - アタッチポリシー:
+     - `arn:aws:iam::aws:policy/ReadOnlyAccess`
+     - 新規 customer-managed policy: Terragrunt state lock 用に DynamoDB lock table（`terragrunt-state-locks`）への `PutItem` / `DeleteItem` / `GetItem`
+   - 備考: state バケット（`terragrunt-state-${account_id}`）の読み取りは `ReadOnlyAccess` の `s3:Get*` / `s3:List*` でカバーされる。書き込みは付与しない。
+
+2. **`aws_iam_role.apply`**
+   - 名前: `${var.project_name}-${var.environment}-github-actions-apply-role`
+   - Trust: `apply_conditions`
+   - アタッチポリシー:
+     - `arn:aws:iam::aws:policy/AdministratorAccess`（現状維持）
+
+`var.additional_iam_policies` は apply-role にのみアタッチする。
+
+#### Outputs の更新
+
+`modules/outputs.tf`:
+
+- 削除: `github_actions_role_arn`, `github_actions_role_name`, `allowed_branches`
+- 追加: `plan_role_arn`, `plan_role_name`, `apply_role_arn`, `apply_role_name`
+
+`oidc_provider_arn`, `oidc_provider_url`, `cloudwatch_log_group_*`, `github_org`, `github_repos`, `allowed_environments` は維持。
+
+#### Variables の整理
+
+`modules/variables.tf`:
+
+- 削除: `github_branches`
+- それ以外は維持
+
+`envs/{develop,staging,production}/env.hcl`:
+
+- `github_branches = ["*"]` の行を削除
+- `github_environments` は環境名（`develop` / `staging` / `production`）のまま維持
+
+#### terragrunt.hcl の更新
+
+`envs/{env}/terragrunt.hcl` の `inputs` から `github_branches` 参照を削除。
+
+### GitHub Actions layer (`github/repository/`)
+
+#### Default workflow permissions の read 化
+
+`github/repository/` 配下で `monorepo` と `platform` の default workflow permissions（GitHub Settings → Actions → General → Workflow permissions に対応）を `read` に設定する。
+
+実装方針（具体は plan 段階で確定）:
+
+- `integrations/github` 6.12 系で `github_actions_repository_permissions` リソースに `default_workflow_permissions` 引数が存在すれば、そのリソースを `monorepo` / `platform` 限定で追加して使う
+- 引数が無ければ `null_resource` + `local-exec` から `gh api -X PUT /repos/{owner}/{repo}/actions/permissions/workflow -f default_workflow_permissions=read` を呼ぶ形でフォールバック
+
+`variables.tf` に `actions_default_permissions_read = optional(bool, false)` を追加し、`envs/develop/{monorepo,platform}.hcl` で `true` を指定する。他のリポジトリは既定値 `false` のままで挙動変化なし。
+
+#### Workflow 側の影響
+
+既存 workflow を確認した結果、書き込み権限が要る workflow は top-level `permissions:` で明示宣言済:
+
+- `auto-approve.yaml`: `pull-requests: write`
+- `auto-label--deploy-trigger.yaml`: `id-token: write`, `contents: write`, `pull-requests: write`
+- `auto-label--label-dispatcher.yaml`: `pull-requests: write`, `issues: write`
+- `reusable--*.yaml`: 各 job 内で `permissions:` 宣言
+
+`ci-gatekeeper.yaml` のみ `permissions:` 未宣言。default を `read` にすると `GITHUB_TOKEN` には `contents: read` / `packages: read` / `metadata: read` 程度しか付かず、`int128/wait-for-workflows-action` が要求する `actions: read`（workflow run の状態を REST API で取得）が無くなる。default 切替前に以下の `permissions:` を追加する必要がある:
+
+```yaml
+permissions:
+  actions: read
+```
+
+実機検証で他に不足する権限が出たら `permissions:` に明示追加する。
+
+### `workflow-config.yaml` の更新
+
+各環境の `iam_role_plan` / `iam_role_apply` を新 role の ARN に置換。フィールド構造（`required_attributes` 含む）は維持。
+
+```yaml
+- environment: develop
+  stacks:
+    terragrunt:
+      aws_region: us-east-1
+      iam_role_plan:  arn:aws:iam::559744160976:role/github-oidc-auth-develop-github-actions-plan-role
+      iam_role_apply: arn:aws:iam::559744160976:role/github-oidc-auth-develop-github-actions-apply-role
+      kubernetes: {}
+```
+
+`production` も同様。`local` は変更なし。
+
+## Apply ordering
+
+破壊的変更を含むため、ARN 切り替え・役割削除・default workflow permissions 切替を段階的に行う:
+
+1. `aws/github-oidc-auth/modules/` を新構成（plan-role + apply-role）に書き換える PR をマージし、各環境で apply。実装上は旧 `github_actions_role` リソース定義を main.tf から外して新 2 ロールを作成する形にし、削除と新規作成を一度の apply で行う
+2. `workflow-config.yaml` の `iam_role_plan` / `iam_role_apply` を新 ARN に書き換える PR をマージ
+3. `ci-gatekeeper.yaml` に `permissions: actions: read` を追加する PR をマージ（次手順の前提）
+4. `github/repository/envs/develop/{monorepo,platform}.hcl` で `actions_default_permissions_read = true` を有効化して apply
+5. 動作確認: PR で plan が plan-role で動く、main マージ後に apply が apply-role で動く、`auto-label--deploy-trigger.yaml` と `ci-gatekeeper.yaml` が完走する
+
+手順 1 の旧 role 削除は同時に行う前提だが、もし新 role の動作不安が大きい場合は plan 段階で「新 role 作成のみ → workflow-config 切替 → 旧 role 削除」の 3 段階に分割することも検討する。
+
+## Verification
+
+- `aws/github-oidc-auth/envs/develop` の `terragrunt plan` で以下の差分が出る:
+  - `aws_iam_role.github_actions_role` 削除
+  - `aws_iam_role.plan` 新規作成
+  - `aws_iam_role.apply` 新規作成
+  - 関連ポリシーアタッチメントの差分
+- staging / production でも同様（staging は workflow-config 未参照だが新構成は作成する）
+- `monorepo` と `platform` の GitHub UI で `Settings → Actions → General → Workflow permissions` が "Read repository contents and packages permissions" になっていること
+- 他リポジトリ（`deploy-actions`, `panicboat-actions`, `ansible`, `dotfiles`）の Workflow permissions に変更が無いこと
+- `auto-label--deploy-trigger.yaml` の PR plan / main apply の両方が新 role で完走する
+- `ci-gatekeeper.yaml` が default read 環境下で完走する
+- 試行: PR ブランチで apply-role を assume する step を仕込んだ workflow を実行し、`AccessDenied` で失敗すること（任意の検証）
+
+## Rollback
+
+各 step の rollback:
+
+- 手順 4（GitHub default permissions）: `actions_default_permissions_read = false` に戻して apply、または UI で "Read and write permissions" に戻す
+- 手順 3（ci-gatekeeper permissions）: 影響なし。読み取り権限の追加は default が write でも害はない
+- 手順 2（`workflow-config.yaml`）: 旧 ARN に戻す PR をマージ
+- 手順 1（IAM role 構成変更）: 該当 commit を revert して apply。旧 `github_actions_role` が再作成される
+
+最も影響が大きいのは手順 1（旧 role の削除と新 role 作成）。apply 直後に手順 2 の ARN 切替がマージされるまでは、`auto-label--deploy-trigger.yaml` から AWS への認証が失敗する時間帯がある。手順 1 と手順 2 の間隔を最小化するため、両 PR を同時に準備し連続でマージする運用を取る。

--- a/workflow-config.yaml
+++ b/workflow-config.yaml
@@ -8,16 +8,16 @@ environments:
     stacks:
       terragrunt:
         aws_region: us-east-1
-        iam_role_plan: arn:aws:iam::559744160976:role/github-oidc-auth-develop-github-actions-role
-        iam_role_apply: arn:aws:iam::559744160976:role/github-oidc-auth-develop-github-actions-role
+        iam_role_plan: arn:aws:iam::559744160976:role/github-oidc-auth-develop-github-actions-plan-role
+        iam_role_apply: arn:aws:iam::559744160976:role/github-oidc-auth-develop-github-actions-apply-role
       kubernetes: {}
 
   - environment: production
     stacks:
       terragrunt:
         aws_region: ap-northeast-1
-        iam_role_plan: arn:aws:iam::559744160976:role/github-oidc-auth-production-github-actions-role
-        iam_role_apply: arn:aws:iam::559744160976:role/github-oidc-auth-production-github-actions-role
+        iam_role_plan: arn:aws:iam::559744160976:role/github-oidc-auth-production-github-actions-plan-role
+        iam_role_apply: arn:aws:iam::559744160976:role/github-oidc-auth-production-github-actions-apply-role
       kubernetes: {}
 
 stack_conventions:


### PR DESCRIPTION
Phase 1 + Phase 2 of OIDC hardening per docs/superpowers/specs/2026-04-30-oidc-hardening-design.md.

- New plan-role / apply-role with tightened trust conditions
- workflow-config.yaml switched to new ARNs
- Legacy github_actions_role still present (removed in Phase 3)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Separated GitHub Actions execution roles into distinct plan (read-only) and apply (full access) roles for improved security separation between workflow stages.

* **Refactor**
  * Removed branch-based access control; workflows now restricted to specific Git refs and environment gates.

* **Documentation**
  * Added OIDC hardening implementation plan and design specification outlining multi-layer authentication improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->