### PR TITLE
feat(oidc): remove legacy github_actions_role

### DIFF
--- a/aws/github-oidc-auth/modules/main.tf
+++ b/aws/github-oidc-auth/modules/main.tf
@@ -50,21 +50,6 @@ locals {
       "repo:${var.github_org}/${repo}:environment:${env}"]
     )
   ])
-
-  # Legacy trust conditions — preserved verbatim until aws_iam_role.github_actions_role
-  # is removed in Phase 3. Reproduces the previous concat(repo_wildcard, branch_wildcard,
-  # environment) construction exactly so that the in-flight trust policy is not changed
-  # by this plan. The branch wildcard is hard-coded because var.github_branches was ["*"]
-  # in both envs at the time it was removed; this entire local goes away with the legacy
-  # role, so the hard-code does not need to become a variable.
-  legacy_conditions = flatten([
-    for repo in var.github_repos : concat(
-      ["repo:${var.github_org}/${repo}:*"],
-      ["repo:${var.github_org}/${repo}:ref:refs/heads/*"],
-      [for env in var.github_environments :
-      "repo:${var.github_org}/${repo}:environment:${env}"]
-    )
-  ])
 }
 
 # Plan role: read-only AWS access + Terragrunt state lock RW
@@ -178,51 +163,6 @@ resource "aws_iam_role_policy_attachment" "apply_administrator_access" {
 resource "aws_iam_role_policy_attachment" "apply_additional_policies" {
   count      = length(var.additional_iam_policies)
   role       = aws_iam_role.apply.name
-  policy_arn = var.additional_iam_policies[count.index]
-}
-
-# IAM Role for GitHub Actions OIDC
-resource "aws_iam_role" "github_actions_role" {
-  name                 = "${var.project_name}-${var.environment}-github-actions-role"
-  max_session_duration = var.max_session_duration
-
-  assume_role_policy = jsonencode({
-    Version = "2012-10-17"
-    Statement = [
-      {
-        Effect = "Allow"
-        Principal = {
-          Federated = local.oidc_provider_arn
-        }
-        Action = "sts:AssumeRoleWithWebIdentity"
-        Condition = {
-          StringEquals = {
-            "token.actions.githubusercontent.com:aud" = "sts.amazonaws.com"
-          }
-          StringLike = {
-            "token.actions.githubusercontent.com:sub" = local.legacy_conditions
-          }
-        }
-      }
-    ]
-  })
-
-  tags = merge(var.common_tags, {
-    Name    = "${var.project_name}-${var.environment}-github-actions-role"
-    Purpose = "github-actions-oidc"
-  })
-}
-
-# Attach AdministratorAccess for full AWS access
-resource "aws_iam_role_policy_attachment" "administrator_access" {
-  role       = aws_iam_role.github_actions_role.name
-  policy_arn = "arn:aws:iam::aws:policy/AdministratorAccess"
-}
-
-# Attach any additional policies specified
-resource "aws_iam_role_policy_attachment" "additional_policies" {
-  count      = length(var.additional_iam_policies)
-  role       = aws_iam_role.github_actions_role.name
   policy_arn = var.additional_iam_policies[count.index]
 }
 

--- a/aws/github-oidc-auth/modules/outputs.tf
+++ b/aws/github-oidc-auth/modules/outputs.tf
@@ -1,15 +1,5 @@
 # outputs.tf - Output values for GitHub OIDC Auth module
 
-output "github_actions_role_arn" {
-  description = "ARN of the GitHub Actions IAM role"
-  value       = aws_iam_role.github_actions_role.arn
-}
-
-output "github_actions_role_name" {
-  description = "Name of the GitHub Actions IAM role"
-  value       = aws_iam_role.github_actions_role.name
-}
-
 output "oidc_provider_arn" {
   description = "ARN of the GitHub OIDC provider"
   value       = local.oidc_provider_arn


### PR DESCRIPTION
## Summary

Phase 3 of OIDC hardening per `docs/superpowers/specs/2026-04-30-oidc-hardening-design.md`.

- Removes `aws_iam_role.github_actions_role` and its `AdministratorAccess` policy attachment
- Removes the now-unused `local.legacy_conditions` trust-condition helper
- Removes the legacy outputs `github_actions_role_arn` / `github_actions_role_name`

The legacy role was kept temporarily so PR #230 could land Phase 1 (new plan-role / apply-role) + Phase 2 (workflow-config ARN switch) without disturbing in-flight workflow runs. CI verified plan and apply against the new ARNs on both `develop` and `production` after #230 merged, so the legacy role is now safe to delete.

## Plan output

Both environments: `Plan: 0 to add, 0 to change, 2 to destroy.`

Destroyed (per env):
- `aws_iam_role.github_actions_role`
- `aws_iam_role_policy_attachment.administrator_access`

(`aws_iam_role_policy_attachment.additional_policies` has `count = 0` since `var.additional_iam_policies = []` in both envs.)

## Test plan

- [ ] PR plan job for develop reports `2 to destroy` and runs against the new plan-role ARN (`...-plan-role`)
- [ ] PR plan job for production reports `2 to destroy` and runs against the new plan-role ARN
- [ ] After merge, apply job for develop deletes the legacy role using the new apply-role ARN (`...-apply-role`)
- [ ] After merge, apply job for production deletes the legacy role using the new apply-role ARN
- [ ] `aws iam get-role --role-name github-oidc-auth-develop-github-actions-role` returns `NoSuchEntity` post-apply
- [ ] Same for production