### PR TITLE
feat(github): default GITHUB_TOKEN to read on monorepo/platform + ci-gatekeeper permissions

### DIFF
--- a/.github/workflows/ci-gatekeeper.yaml
+++ b/.github/workflows/ci-gatekeeper.yaml
@@ -6,6 +6,9 @@ on:
     branches:
       - '**'
 
+permissions:
+  actions: read
+
 jobs:
   ci-gatekeeper:
     name: CI Gatekeeper

--- a/github/repository/envs/develop/monorepo.hcl
+++ b/github/repository/envs/develop/monorepo.hcl
@@ -3,7 +3,8 @@ locals {
     name          = "monorepo"
     description   = "Monorepo for multiple services and infrastructure configurations."
     visibility    = "public"
-    allow_forking = false
+    allow_forking                    = false
+    actions_default_permissions_read = true
     features = {
       issues   = true
       wiki     = false

--- a/github/repository/envs/develop/platform.hcl
+++ b/github/repository/envs/develop/platform.hcl
@@ -3,7 +3,8 @@ locals {
     name          = "platform"
     description   = "Platform for multiple services and infrastructure configurations"
     visibility    = "public"
-    allow_forking = false
+    allow_forking                    = false
+    actions_default_permissions_read = true
     features = {
       issues   = true
       wiki     = false

--- a/github/repository/modules/main.tf
+++ b/github/repository/modules/main.tf
@@ -25,6 +25,17 @@ resource "github_repository" "repository" {
   archived = false
 }
 
+resource "github_workflow_repository_permissions" "repository" {
+  for_each = {
+    for k, v in var.repositories :
+    k => v if v.actions_default_permissions_read
+  }
+
+  repository                       = github_repository.repository[each.key].name
+  default_workflow_permissions     = "read"
+  can_approve_pull_request_reviews = false
+}
+
 resource "aws_cloudwatch_log_group" "github_repository_logs" {
   for_each = var.repositories
 

--- a/github/repository/modules/variables.tf
+++ b/github/repository/modules/variables.tf
@@ -34,10 +34,11 @@ variable "github_token" {
 variable "repositories" {
   description = "Map of repository configurations. visibility must be one of: public, private, internal"
   type = map(object({
-    name          = string
-    description   = string
-    visibility    = string
-    allow_forking = optional(bool, true)
+    name                             = string
+    description                      = string
+    visibility                       = string
+    allow_forking                    = optional(bool, true)
+    actions_default_permissions_read = optional(bool, false)
     features = object({
       issues   = bool
       wiki     = bool


### PR DESCRIPTION
## Summary

Phase 4 + Phase 5 of OIDC hardening per `docs/superpowers/specs/2026-04-30-oidc-hardening-design.md`.

- **`.github/workflows/ci-gatekeeper.yaml`**: declare `permissions: actions: read` so the `int128/wait-for-workflows-action` step keeps API access once `GITHUB_TOKEN` defaults flip to read-only.
- **`github/repository/`**: introduce `github_workflow_repository_permissions` resource gated by a new `actions_default_permissions_read` flag in the repository schema. Set the flag to `true` for `monorepo` and `platform` only, which sets `default_workflow_permissions = "read"` and `can_approve_pull_request_reviews = false` on those two repos. Other repositories (`deploy-actions`, `panicboat-actions`, `ansible`, `dotfiles`) keep current behaviour.

## Plan output

`Plan: 2 to add, 2 to change, 0 to destroy.` for `github/repository` develop.

- `+ github_workflow_repository_permissions.repository["monorepo"]`
- `+ github_workflow_repository_permissions.repository["platform"]`
- `~ github_repository.repository["monorepo"]`: `allow_forking: true -> false`
- `~ github_repository.repository["platform"]`: `allow_forking: true -> false`

The `allow_forking` change is residual drift from #224 — the disable-forking commit landed on main but was never applied. This PR's apply will land both changes together (intentional bundling).

## Why bundle Phase 4 and Phase 5

Group E (workflow `permissions:` block) is a no-op until the default flips to read; Group F is the flip. Landing them in one apply removes the temporary state where `actions: read` is redundant.

## Test plan

- [ ] PR plan job for `github/repository` (develop) reports `2 to add, 2 to change, 0 to destroy` and runs against the new plan-role ARN
- [ ] After merge, apply job for `github/repository` (develop) succeeds with the new apply-role ARN
- [ ] GitHub UI: `Settings → Actions → General → Workflow permissions` for `monorepo` and `platform` shows "Read repository contents and packages permissions"
- [ ] GitHub UI: `deploy-actions`, `panicboat-actions`, `ansible`, `dotfiles` still show "Read and write permissions" (unchanged)
- [ ] GitHub UI: `monorepo` and `platform` "Allow forking" is now off (consequence of bundled drift apply)
- [ ] `ci-gatekeeper.yaml` continues to pass on this PR's own runs