### PR TITLE
test: apply-role denial check (do not merge)

### DIFF
--- a/.github/workflows/_test-apply-role-deny.yaml
+++ b/.github/workflows/_test-apply-role-deny.yaml
@@ -1,0 +1,30 @@
+name: 'TEST - apply-role denial'
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/_test-apply-role-deny.yaml'
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  test-deny:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Attempt to assume apply-role (expected to fail)
+        id: assume
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::559744160976:role/github-oidc-auth-develop-github-actions-apply-role
+          aws-region: us-east-1
+        continue-on-error: true
+
+      - name: Verify the assume step failed
+        run: |
+          if [[ "${{ steps.assume.outcome }}" == "success" ]]; then
+            echo "::error::apply-role was assumable from a PR — trust policy is too permissive"
+            exit 1
+          fi
+          echo "OK: apply-role assumption was denied from PR as expected"


### PR DESCRIPTION
## Purpose

One-shot verification that the apply-role denies PR-triggered \`sts:AssumeRoleWithWebIdentity\`.

The trust policy is supposed to allow only \`ref:refs/heads/main\` and \`environment:{develop,production}\` subjects. PR triggers carry the \`pull_request\` subject, so the assume step MUST fail with \`AccessDenied\`.

## Workflow run expectations

- \`Attempt to assume apply-role\` step: outcome = \`failure\` (\`AccessDenied\` in the action log)
- \`Verify the assume step failed\` step: outcome = \`success\`

If the assume step succeeds, the trust policy is wrong. Stop and investigate.

## Cleanup

After confirming the expected outcome, this PR is closed without merging — nothing here is intended to land on \`main\`.