### PR TITLE
fix(aws/eks): correct apply errors (access policy ARN, CNI bootstrap, version 1.35)

### DIFF
--- a/aws/eks/envs/production/env.hcl
+++ b/aws/eks/envs/production/env.hcl
@@ -9,7 +9,7 @@ locals {
 
   # EKS Kubernetes version
   # renovate: datasource=endoflife-date depName=amazon-eks versioning=loose
-  cluster_version = "1.33"
+  cluster_version = "1.35"
 
   # Environment-specific tags
   environment_tags = {

--- a/aws/eks/modules/access_entries.tf
+++ b/aws/eks/modules/access_entries.tf
@@ -4,6 +4,11 @@
 # The CI apply role (github-oidc-auth-production-github-actions-role)
 # operates on AWS APIs only and never touches Kubernetes API; under the
 # GitOps model, all Kubernetes-side changes flow through Flux CD.
+#
+# Note on policy_arn format: EKS Access Policies use a dedicated ARN
+# scheme `arn:aws:eks::aws:cluster-access-policy/<NAME>`, NOT the IAM
+# managed policy form `arn:aws:iam::aws:policy/<NAME>`. Passing the IAM
+# form to AssociateAccessPolicy yields InvalidParameterException (400).
 
 locals {
   access_entries = {
@@ -12,7 +17,7 @@ locals {
 
       policy_associations = {
         cluster_admin = {
-          policy_arn = "arn:aws:iam::aws:policy/AmazonEKSClusterAdminPolicy"
+          policy_arn = "arn:aws:eks::aws:cluster-access-policy/AmazonEKSClusterAdminPolicy"
           access_scope = {
             type = "cluster"
           }

--- a/aws/eks/modules/addons.tf
+++ b/aws/eks/modules/addons.tf
@@ -48,6 +48,13 @@ module "ebs_csi_irsa" {
 locals {
   cluster_addons = {
     vpc-cni = {
+      # Apply vpc-cni BEFORE the node group is created so the aws-node
+      # DaemonSet has its IRSA role available the moment nodes try to
+      # join. Without this, nodes start without a working CNI and the
+      # node group fails with NodeCreationFailure (Unhealthy nodes),
+      # because the node IAM role intentionally does NOT carry
+      # AmazonEKS_CNI_Policy (see node_groups.tf comment).
+      before_compute              = true
       most_recent                 = true
       resolve_conflicts_on_create = "OVERWRITE"
       resolve_conflicts_on_update = "OVERWRITE"

--- a/docs/superpowers/plans/2026-05-01-aws-eks-production.md
+++ b/docs/superpowers/plans/2026-05-01-aws-eks-production.md
@@ -1580,3 +1580,33 @@ gh pr view --comments | head -40
 Expected: terragrunt plan の出力（追加リソース一覧）が PR comment として現れる。
 
 > ここで CI plan が手元の Task 10 の plan と一致していれば実装完了。あとはレビュー → ready for review → merge の通常フロー。`apply` は merge 後の `auto-label--deploy-trigger` が main push をトリガに `reusable--terragrunt-executor` で `terragrunt apply` を実行する設計だが、本 spec は GitOps 原則のため **production への apply は手動（Task 11 で実施済）** を推奨する。`workflow-config.yaml` で auto-apply を有効にしている場合は事前にレビュー時間を確保する。
+
+---
+
+## Errata（PR #234 マージ後の apply 失敗を踏まえた訂正）
+
+PR #234（本 plan の初回適用）を merge 後の CI apply で 2 件の誤りが顕在化した。後続 PR で修正している。本セクションは plan の歴史的訂正記録として残す。詳細は spec の Errata セクション (`docs/superpowers/specs/2026-04-30-aws-eks-production-design.md` 末尾) を参照。
+
+### E-1: Task 5 の `policy_arn` フォーマット誤り
+
+`access_entries.tf` の `policy_arn` を IAM Managed Policy ARN フォーマット (`arn:aws:iam::aws:policy/AmazonEKSClusterAdminPolicy`) で記述していたが、`aws_eks_access_policy_association` には EKS 専用の Access Policy ARN フォーマット (`arn:aws:eks::aws:cluster-access-policy/AmazonEKSClusterAdminPolicy`) を渡す必要がある。
+
+apply 時に `InvalidParameterException: The policyArn parameter format is not valid` で失敗。後続 PR で修正済。
+
+### E-2: Task 7 の vpc-cni addon に `before_compute = true` 不足
+
+`addons.tf` の `vpc-cni` addon に `before_compute = true` を指定しなかったため、addon が node group 作成「後」に apply された。Task 6 で `iam_role_attach_cni_policy = false` を指定し IRSA 経由で CNI 権限を付与する設計を採ったが、IRSA バウンドの aws-node DaemonSet が node 起動時には未稼働であり、ノードが Ready にならず `NodeCreationFailure` で node group が CREATE_FAILED になった。
+
+後続 PR で `before_compute = true` を追加して node group 作成「前」に addon を apply するように修正。`aws_eks_addon.before_compute["vpc-cni"]` という別リソースキーで作成される（`aws_eks_addon.this["vpc-cni"]` ではない）。
+
+### E-3: cluster_version の最新化（1.33 → 1.35）
+
+本 plan は `cluster_version = "1.33"` で書かれていたが、後続 PR 作成時点で EKS の最新標準サポートバージョンは `1.35` に更新済。新規 cluster で何も乗せていない状態のため、`terragrunt destroy` で一旦破棄し `1.35` で新規作成する方針を採った（EKS の minor skip upgrade 制約のため、in-place で 1.33 → 1.35 はできない）。
+
+### 後続 PR で実施した手順
+
+1. 新ブランチ `fix-aws-eks-production-apply` を `origin/main` から作成
+2. impl 修正（`access_entries.tf`, `addons.tf`, `env.hcl`）
+3. 手元で `terragrunt destroy` を実行して PR #234 の partial state を破棄
+4. Draft PR 作成 → CI plan が「全リソース新規作成（~50 add）」で成功することを確認
+5. ユーザーが ready for review → merge → CI apply で `1.35` cluster が新規作成される

--- a/docs/superpowers/specs/2026-04-30-aws-eks-production-design.md
+++ b/docs/superpowers/specs/2026-04-30-aws-eks-production-design.md
@@ -840,3 +840,51 @@ npx --yes renovate-config-validator .github/renovate.json
 - `eks-admin-production` の MFA 必須化、source IP 制限：運用が安定した段階で trust policy に Condition 追加。
 - ALB Ingress Controller / external-dns / cert-manager：Ingress 公開 workload を載せる段階で。
 - `develop` / `staging` 環境の追加：必要時に `envs/production/` を複製。renovate fileMatch は対応済み。
+
+## Errata（PR #234 マージ後の apply で判明した誤りと訂正）
+
+PR #234（本 spec の初回実装）を apply した際に 2 件の誤り、および 1 件の version 古化が判明し、後続 PR で修正している。本セクションは設計判断の記録として残す（実装は後続 PR 反映済み）。
+
+### E-1: Access Policy の `policy_arn` フォーマット誤り
+
+**当初の指定**:
+
+```hcl
+policy_arn = "arn:aws:iam::aws:policy/AmazonEKSClusterAdminPolicy"
+```
+
+**誤り**: これは IAM Managed Policy の ARN フォーマット。`aws_eks_access_policy_association` には EKS 専用の Access Policy ARN フォーマット (`arn:aws:eks::aws:cluster-access-policy/<NAME>`) を渡す必要がある。
+
+**訂正**:
+
+```hcl
+policy_arn = "arn:aws:eks::aws:cluster-access-policy/AmazonEKSClusterAdminPolicy"
+```
+
+apply 時に `InvalidParameterException: The policyArn parameter format is not valid` で失敗した。
+
+### E-2: vpc-cni addon の bootstrap 順序
+
+**当初の構成**: `aws/eks/modules/node_groups.tf` で `iam_role_attach_cni_policy = false` を指定し、CNI 権限を IRSA 経由で aws-node ServiceAccount に付与する設計を採用したが、`aws/eks/modules/addons.tf` の `vpc-cni` には `before_compute` を指定しなかった。
+
+**誤り**: `before_compute` を指定しない場合、addon は node group 作成「後」に apply される。node 起動時には IRSA を使う aws-node DaemonSet がまだ動かず、CNI が機能しないため、ノードは Ready にならず `NodeCreationFailure: Unhealthy nodes in the kubernetes cluster` で node group が CREATE_FAILED になる。
+
+**訂正**: `vpc-cni` に `before_compute = true` を追加。これで addon が node group 作成「前」に apply され、ノード起動時点で IRSA バウンドの aws-node が利用可能になる。
+
+```hcl
+vpc-cni = {
+  before_compute              = true
+  most_recent                 = true
+  resolve_conflicts_on_create = "OVERWRITE"
+  resolve_conflicts_on_update = "OVERWRITE"
+  service_account_role_arn    = module.vpc_cni_irsa.arn
+}
+```
+
+### E-3: cluster_version の更新（1.33 → 1.35）
+
+PR #234 では `cluster_version = "1.33"` で設計したが、後続 PR の作成時点で AWS EKS の最新標準サポートバージョンは `1.35` に更新済（1.33 / 1.34 / 1.35 が標準サポート）。新規 cluster 作成のため、最新 GA バージョンに揃える。
+
+**注**: EKS の Kubernetes version は **1 minor ずつしか upgrade できない**（1.33 → 1.35 のような skip 不可）。PR #234 で作成された cluster は apply 失敗 + node group 未稼働により実質的に空状態だったため、`terragrunt destroy` で一旦破棄し、`1.35` で新規作成する方針を採った。
+
+将来の minor up は Renovate（`endoflife-date/amazon-eks` datasource）が起票する PR を 1 minor ずつ手動 merge する運用とする。


### PR DESCRIPTION
## Summary

PR #234 (initial production EKS deploy) の apply で 2 件の誤りが顕在化したため修正し、合わせて `cluster_version` を最新の `1.35` に更新する。

1. **Access Policy ARN format**: `arn:aws:iam::aws:policy/AmazonEKSClusterAdminPolicy` → `arn:aws:eks::aws:cluster-access-policy/AmazonEKSClusterAdminPolicy` (EKS 専用 ARN form を使用)
2. **vpc-cni bootstrap order**: `before_compute = true` を addon に追加 (IRSA 経由で CNI 権限を渡す設計のため、addon が node group より前に apply される必要がある)
3. **cluster_version bump**: `1.33` → `1.35` (EKS の最新標準サポート)

## Apply 手順

EKS は minor skip upgrade 不可 (`1.33 → 1.35` は段階的にしかできない) ため、PR #234 で作成された (apply 失敗済の) cluster は本 PR の merge 前に **`terragrunt destroy` で破棄が必要**。controller が手元 destroy を既に実行中。

destroy 完了後 → 本 PR の CI plan が「全リソース新規作成 (~50 add)」になることを確認 → ユーザー merge → CI apply で `1.35` cluster が新規作成される。

## Spec / Plan

- Spec: \`docs/superpowers/specs/2026-04-30-aws-eks-production-design.md\` (Errata セクション追記)
- Plan: \`docs/superpowers/plans/2026-05-01-aws-eks-production.md\` (Errata セクション追記)

## Test plan

- [ ] CI で \`aws/eks/envs/production\` の \`terragrunt plan\` が「全リソース新規作成」で成功し PR コメントに掲載される
- [ ] merge 後の CI apply で cluster + node group + addon (5) + Access Policy Association すべて成功
- [ ] \`kubectl get nodes -o wide\` で m6g.large × 2 ノードが Ready
- [ ] \`kubectl get pods -n kube-system\` で aws-node / kube-proxy / coredns / ebs-csi / pod-identity-agent が Running
- [ ] \`kubectl get sa -n kube-system aws-node\` の IRSA アノテーション確認
- [ ] \`aws sts assume-role\` で \`eks-admin-production\` を assume → \`kubectl version\` が Server バージョン \`v1.35.x-eks-...\` を返す

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed EKS access entry policy configuration format for proper cluster access management
  * Corrected VPC-CNI addon deployment order to prevent node group creation failures

* **Chores**
  * Updated production Kubernetes version from 1.33 to 1.35

* **Documentation**
  * Added errata sections documenting infrastructure configuration corrections and remediation steps

<!-- end of auto-generated comment: release notes by coderabbit.ai -->