### PR TITLE
feat(github/repository): disable rebase merge for all panicboat repos

### DIFF
--- a/github/repository/modules/main.tf
+++ b/github/repository/modules/main.tf
@@ -14,7 +14,7 @@ resource "github_repository" "repository" {
 
   allow_merge_commit     = false
   allow_squash_merge     = true
-  allow_rebase_merge     = true
+  allow_rebase_merge     = false
   allow_update_branch    = true
   allow_auto_merge       = true
   delete_branch_on_merge = true


### PR DESCRIPTION
## Summary
- Disable `allow_rebase_merge` for all repositories managed by `github/repository` module
- Enforces Squash-only merge strategy across all panicboat repos
- Required for upcoming `release-please` rollout in `deploy-actions` (commit history must align 1:1 with PR titles for Conventional Commits parsing)

Part of the SHA pinning rollout. See `monorepo:docs/superpowers/specs/2026-05-01-github-actions-sha-pinning-rollout-design.md`.

## Test plan
- [ ] Terragrunt plan shows `allow_rebase_merge: true → false` for all repos
- [ ] After merge, `gh repo view --json rebaseMergeAllowed` returns `false` for sample repos