### PR TITLE
feat(github/branch): require Validate PR title and SHA pin checks on main

### DIFF
--- a/github/branch/envs/develop/deploy-actions.hcl
+++ b/github/branch/envs/develop/deploy-actions.hcl
@@ -6,7 +6,12 @@ locals {
     branch_protection = {
       main = merge(
         local.defaults.locals.branch_protection.main,
-        {}
+        {
+          required_status_checks = [
+            "Validate PR title",
+            "Ensure actions are pinned to SHAs",
+          ]
+        }
       )
     }
   }

--- a/github/branch/envs/develop/monorepo.hcl
+++ b/github/branch/envs/develop/monorepo.hcl
@@ -8,6 +8,7 @@ locals {
         local.defaults.locals.branch_protection.main,
         {
           required_status_checks = [
+            "CI Gatekeeper",
             "Validate PR title",
             "Ensure actions are pinned to SHAs",
           ]

--- a/github/branch/envs/develop/monorepo.hcl
+++ b/github/branch/envs/develop/monorepo.hcl
@@ -7,7 +7,10 @@ locals {
       main = merge(
         local.defaults.locals.branch_protection.main,
         {
-          required_status_checks = ["CI Gatekeeper"]
+          required_status_checks = [
+            "Validate PR title",
+            "Ensure actions are pinned to SHAs",
+          ]
         }
       )
     }

--- a/github/branch/envs/develop/panicboat-actions.hcl
+++ b/github/branch/envs/develop/panicboat-actions.hcl
@@ -6,7 +6,12 @@ locals {
     branch_protection = {
       main = merge(
         local.defaults.locals.branch_protection.main,
-        {}
+        {
+          required_status_checks = [
+            "Validate PR title",
+            "Ensure actions are pinned to SHAs",
+          ]
+        }
       )
     }
   }

--- a/github/branch/envs/develop/platform.hcl
+++ b/github/branch/envs/develop/platform.hcl
@@ -8,6 +8,7 @@ locals {
         local.defaults.locals.branch_protection.main,
         {
           required_status_checks = [
+            "CI Gatekeeper",
             "Validate PR title",
             "Ensure actions are pinned to SHAs",
           ]

--- a/github/branch/envs/develop/platform.hcl
+++ b/github/branch/envs/develop/platform.hcl
@@ -7,7 +7,10 @@ locals {
       main = merge(
         local.defaults.locals.branch_protection.main,
         {
-          required_status_checks = ["CI Gatekeeper"]
+          required_status_checks = [
+            "Validate PR title",
+            "Ensure actions are pinned to SHAs",
+          ]
         }
       )
     }


### PR DESCRIPTION
## Summary
- Add `required_status_checks` to branch protection ruleset for `deploy-actions`, `panicboat-actions`, `monorepo`, `platform`
- Required checks: `Validate PR title`, `Ensure actions are pinned to SHAs`
- Final phase of the SHA pinning rollout. Both check workflows have been deployed and verified across all four repos in earlier phases.

Part of the SHA pinning rollout. See `monorepo:docs/superpowers/specs/2026-05-01-github-actions-sha-pinning-rollout-design.md`.

## Test plan
- [ ] Terragrunt plan shows ruleset updates with new `required_check` entries for the 4 repos
- [ ] After apply, `gh api repos/<owner>/<repo>/branches/main/protection/required_status_checks` returns the 2 contexts for each repo

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced branch protection requirements for main branches with additional status checks, including PR title validation and GitHub Actions pinning verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->