### PR TITLE
chore(.github): enable Renovate lockFileMaintenance for terraform lock files

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -27,6 +27,11 @@
   ],
   "minimumReleaseAge": "1 day",
   "separateMinorPatch": false,
+  "lockFileMaintenance": {
+    "enabled": true,
+    "schedule": ["before 4am every weekday"],
+    "automerge": true
+  },
   "packageRules": [
     {
       "description": "Default: separate PRs per package",


### PR DESCRIPTION
## Summary

- Renovate に `lockFileMaintenance` を有効化し、`.terraform.lock.hcl` を別 PR で定期更新させる
- `rangeStrategy: bump` で constraint だけが更新され lock が取り残されると、CI の `tofu init` が `locked provider ... does not match configured version constraint` で失敗する（[PR #245](https://github.com/panicboat/platform/pull/245) で発生）
- スケジュール・automerge は既存ポリシーに合わせて weekday 4am / automerge 有効。production への automerge は既存ルールでブロック継続

## Caveats

- これは恒久対策 (将来の bump への保険)。現在 open 中の [PR #245](https://github.com/panicboat/platform/pull/245) は本変更だけでは復旧しない（手動で `tofu providers lock` を回し直す必要あり）
- Terragrunt の env 別 lock 管理 (`envs/*/.terraform.lock.hcl`) との相性は初回 maintenance PR の挙動を観察して評価する。期待通りに動かない場合は customManagers + post-update スクリプト方式へ切り替える

## Test plan

- [ ] PR の Renovate config validator が pass する
- [ ] merge 後、次回 Renovate 実行で `lockFileMaintenance` PR が生成されることを確認
- [ ] 生成された PR が `aws/*/envs/*/.terraform.lock.hcl` を更新し、CI の `tofu init` が pass することを確認