### PR TITLE
feat(kubernetes,aws/eks): install Cilium chaining mode + remove kube-proxy (Plan 1b)

### DIFF
--- a/aws/eks/README.md
+++ b/aws/eks/README.md
@@ -23,7 +23,7 @@ EKS clusters `eks-${env}` for the panicboat platform.
 | Endpoint | public + private 両方有効 |
 | Authentication | EKS Access Entries (`authentication_mode = "API"`) |
 | Compute | Managed Node Group `system` (m6g.large × 2-4, AL2023 ARM64, gp3 50 GiB) |
-| Add-ons | vpc-cni / kube-proxy / coredns / aws-ebs-csi-driver / eks-pod-identity-agent (all AWS-managed) |
+| Add-ons | vpc-cni / coredns / aws-ebs-csi-driver / eks-pod-identity-agent (all AWS-managed; kube-proxy は Cilium kubeProxyReplacement で代替) |
 | IRSA | enabled; vpc-cni と aws-ebs-csi-driver は別途 IRSA role |
 | Secrets envelope encryption | 無効 (Out of Scope, spec 参照) |
 | Control plane logs | `audit` + `authenticator` のみ、CloudWatch retention 7 日 |

--- a/aws/eks/modules/addons.tf
+++ b/aws/eks/modules/addons.tf
@@ -2,8 +2,9 @@
 #
 # IRSA roles for vpc-cni and aws-ebs-csi-driver are created via the
 # terraform-aws-modules/iam iam-role-for-service-accounts submodule and
-# wired into the addon definitions. kube-proxy / coredns / pod-identity-agent
-# do not need IRSA.
+# wired into the addon definitions. coredns / pod-identity-agent do not need IRSA. kube-proxy is intentionally
+# omitted because Cilium is configured with kubeProxyReplacement=true (see
+# kubernetes/components/cilium/production/values.yaml.gotmpl).
 #
 # Note on submodule naming: v5 of the IAM module shipped a dedicated
 # `iam-role-for-service-accounts-eks` submodule. v6.0 renamed it to
@@ -59,10 +60,6 @@ locals {
       resolve_conflicts_on_create = "OVERWRITE"
       resolve_conflicts_on_update = "OVERWRITE"
       service_account_role_arn    = module.vpc_cni_irsa.arn
-    }
-    kube-proxy = {
-      resolve_conflicts_on_create = "OVERWRITE"
-      resolve_conflicts_on_update = "OVERWRITE"
     }
     coredns = {
       most_recent                 = true

--- a/aws/eks/modules/node_groups.tf
+++ b/aws/eks/modules/node_groups.tf
@@ -1,7 +1,7 @@
 # node_groups.tf - EKS managed node group definitions.
 #
 # Single "system" group on Graviton (ARM64) sized to host the platform
-# components (Cilium / kube-proxy / CoreDNS / Prometheus-Operator / Loki /
+# components (Cilium / CoreDNS / Prometheus-Operator / Loki /
 # Tempo / OTel Collector / Beyla) plus headroom. Application workloads will
 # be hosted on Karpenter-managed nodes (separate spec).
 

--- a/docs/superpowers/plans/2026-05-03-eks-production-cilium-chaining.md
+++ b/docs/superpowers/plans/2026-05-03-eks-production-cilium-chaining.md
@@ -1,0 +1,1327 @@
+# EKS Production Cilium Chaining Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** EKS production cluster `eks-production` 上で Cilium 1.18.x を chaining mode（VPC CNI と共存）で動作させ、KPR / 独立 Envoy DaemonSet / Gateway Controller / Hubble を有効化する。spec の Open Questions 1-4 を実機検証で解消する。
+
+**Architecture:** local 環境のパターンを踏襲して `kubernetes/components/cilium/production/` を新設し、Makefile の `hydrate-index` を env-aware に変更してから `make hydrate ENV=production` で manifests を生成する。Cilium と kube-proxy 共存期間を作るため、(1) Flux suspend 中に手動 `kubectl apply -k` で Cilium を入れ、(2) 検証完了後に PR を merge して terragrunt CI が `kube-proxy` addon を削除し、(3) `flux resume` で GitOps 管理に adopt させる、という 3 段階で進める。
+
+**Tech Stack:** Cilium 1.18.x, Helmfile, Kustomize, kubectl, FluxCD 2.x, Terraform/OpenTofu, Terragrunt, AWS EKS (1.35), AL2023 ARM64, `eks-login.sh`
+
+**Spec:** `docs/superpowers/specs/2026-05-03-eks-production-cilium-chaining-design.md`
+
+---
+
+## File Structure
+
+| File | Status | Responsibility |
+|---|---|---|
+| `kubernetes/Makefile` | modify | `hydrate-index` ターゲットを env-aware に変更（env-specific path 優先 + env-non-specific fallback） |
+| `kubernetes/helmfile.yaml.gotmpl` | modify | `production` env block に `cluster.eksApiEndpoint` を追加 |
+| `kubernetes/components/cilium/production/helmfile.yaml.gotmpl` | create | production 用 helmfile（local の helmfile.yaml と同型、`k8sServiceHost` を gotmpl で差し込み） |
+| `kubernetes/components/cilium/production/values.yaml` | create | production 用 Cilium values（chaining mode + KPR + Envoy DaemonSet + Gateway Controller） |
+| `kubernetes/manifests/production/cilium/manifest.yaml` | create (hydrated) | `make hydrate ENV=production` で生成される rendered Cilium manifest |
+| `kubernetes/manifests/production/cilium/kustomization.yaml` | create (hydrated) | 同上、`resources: - manifest.yaml` |
+| `kubernetes/manifests/production/00-namespaces/namespaces.yaml` | create or empty (hydrated) | env-aware ロジックの結果。Cilium は kube-system 利用なので **空** |
+| `kubernetes/manifests/production/00-namespaces/kustomization.yaml` | create (hydrated) | 同上、`resources: - namespaces.yaml` |
+| `kubernetes/manifests/production/kustomization.yaml` | regenerate (hydrated) | `resources: [./00-namespaces, ./cilium]` |
+| `aws/eks/modules/addons.tf` | modify | `cluster_addons` map から `kube-proxy` block を削除（KPR=true で不要） |
+
+> **依存 spec / plan の前提**:
+> - ロードマップ spec: `docs/superpowers/specs/2026-05-02-eks-production-platform-roadmap-design.md`（merged）
+> - Plan 1a (Flux bootstrap): merged in PR #255 → eks-production cluster は FluxCD bootstrap 済
+> - Cilium 設計 spec: `docs/superpowers/specs/2026-05-03-eks-production-cilium-chaining-design.md`（同 PR で merge 予定）
+
+> **Out of scope（spec を継承）**:
+> - Hubble UI 公開（Phase 4 の Plan 4-x）
+> - HTTPRoute / CiliumEnvoyConfig による monorepo 認証実装（monorepo K8s 移行 spec）
+> - `endpointRoutes.enabled = false` 検証（本 plan で `true` が pass すれば未実施で打ち切り）
+> - Cluster Mesh / Egress Gateway
+
+---
+
+### Task 0: 前提条件の確認
+
+**Files:** （read only）
+
+実装前に prerequisite が揃っていることを確認する。
+
+- [ ] **Step 1: worktree とブランチを確認**
+
+```bash
+cd /Users/takanokenichi/GitHub/panicboat/platform/.claude/worktrees/feat/eks-production-cilium-chaining
+git rev-parse --abbrev-ref HEAD
+```
+
+Expected: `feat/eks-production-cilium-chaining`
+
+以後すべてのコマンドはこの worktree で実行する。
+
+- [ ] **Step 2: 必須 CLI が install 済であることを確認**
+
+```bash
+flux --version
+kubectl version --client | head -1
+helmfile --version
+helm version
+kustomize version
+cilium version --client
+```
+
+Expected: 各 CLI が version を返す。`cilium` CLI は Cilium chart のクライアント側 verification に使う（`cilium status` / `cilium connectivity test`）。未 install なら `brew install cilium-cli` または `https://github.com/cilium/cilium-cli/releases`。
+
+- [ ] **Step 3: production cluster へ kubectl 接続できることを確認**
+
+```bash
+source ~/Workspace/eks-login.sh production
+kubectl cluster-info
+```
+
+Expected: `Kubernetes control plane is running at https://<cluster-id>.gr7.ap-northeast-1.eks.amazonaws.com`
+
+- [ ] **Step 4: 現在の Cilium / kube-proxy 状態を記録**
+
+```bash
+kubectl get pods -n kube-system | grep -E "(cilium|kube-proxy)"
+```
+
+Expected:
+- `kube-proxy-*`: Running（EKS managed addon）
+- `cilium-*`: なし（未 install）
+
+すでに Cilium が動いている場合は本 plan 開始前に状況確認が必要。
+
+- [ ] **Step 5: Flux の現在の状態を記録**
+
+```bash
+flux get all -n flux-system
+flux get kustomizations -n flux-system flux-system -o json | jq '.[] | {name, ready: .ready, suspended: .suspended}'
+```
+
+Expected: `flux-system` Kustomization が `Ready: True`、`Suspended: false`。
+
+- [ ] **Step 6: production cluster の API endpoint を取得**
+
+```bash
+aws eks describe-cluster \
+  --region ap-northeast-1 \
+  --name eks-production \
+  --query 'cluster.endpoint' \
+  --output text
+```
+
+Expected: `https://<cluster-id>.gr7.ap-northeast-1.eks.amazonaws.com` のような URL。
+
+URL から `https://` を除いた hostname 部分（`<cluster-id>.gr7.ap-northeast-1.eks.amazonaws.com`）を **記録**。Task 2 で `cluster.eksApiEndpoint` の値として使う。
+
+- [ ] **Step 7: 現在の `make hydrate ENV=local` 出力の baseline を記録**
+
+```bash
+cd kubernetes
+make hydrate ENV=local 2>&1 | tail -5
+sha256sum manifests/local/00-namespaces/namespaces.yaml
+cd ..
+```
+
+Expected: hydrate が成功し、`manifests/local/00-namespaces/namespaces.yaml` の SHA256 ハッシュが取得できる。Task 1 完了後にこのハッシュと比較して **backward compat（local の namespace 出力が変わらない）**を verify する。
+
+ハッシュ値を **記録**（例: `abc123...`）。Task 1 Step 5 で再計算して比較する。
+
+---
+
+### Task 1: Makefile の `hydrate-index` を env-aware に変更
+
+**Files:**
+- Modify: `kubernetes/Makefile`
+
+現状の `hydrate-index` は `find components -maxdepth 2 -name namespace.yaml` で全 component の namespace.yaml を env 非依存に集めている。これを「**`components/<comp>/<env>/` ディレクトリが存在する component のみ**」に絞り、namespace.yaml の配置位置は env-specific を優先、なければ env-non-specific を fallback する。
+
+- [ ] **Step 1: 現状の hydrate-index ターゲットを確認**
+
+```bash
+grep -n "find components -maxdepth 2 -name namespace.yaml" kubernetes/Makefile
+```
+
+Expected: 1 行 hit（line 107 付近）。この行を含む `find ... | xargs ... > namespaces.yaml` 部分が変更対象。
+
+- [ ] **Step 2: Makefile を編集**
+
+`kubernetes/Makefile` の `hydrate-index` ターゲット内、以下の 2 行：
+
+```makefile
+	find components -maxdepth 2 -name namespace.yaml | sort | \
+		xargs -I{} sh -c 'echo "---"; cat "{}"' > "$$env_dir/00-namespaces/namespaces.yaml"; \
+```
+
+を以下に置き換える：
+
+```makefile
+	: > "$$env_dir/00-namespaces/namespaces.yaml"; \
+	for comp_dir in components/*/$(ENV)/; do \
+		[ -d "$$comp_dir" ] || continue; \
+		comp_name=$$(basename "$$(dirname "$$comp_dir")"); \
+		if [ -f "components/$$comp_name/$(ENV)/namespace.yaml" ]; then \
+			echo "---" >> "$$env_dir/00-namespaces/namespaces.yaml"; \
+			cat "components/$$comp_name/$(ENV)/namespace.yaml" >> "$$env_dir/00-namespaces/namespaces.yaml"; \
+		elif [ -f "components/$$comp_name/namespace.yaml" ]; then \
+			echo "---" >> "$$env_dir/00-namespaces/namespaces.yaml"; \
+			cat "components/$$comp_name/namespace.yaml" >> "$$env_dir/00-namespaces/namespaces.yaml"; \
+		fi; \
+	done; \
+```
+
+ロジック：
+
+1. `components/*/$(ENV)/` に matchするディレクトリ（= 当該 env で deploy される component）のみを iterate
+2. 各 component について env-specific な `<comp>/<env>/namespace.yaml` があればそれを優先、無ければ env-non-specific な `<comp>/namespace.yaml` を fallback として include
+3. どちらも無ければ skip（Cilium のように kube-system 利用で namespace.yaml 不要な component）
+
+- [ ] **Step 3: Makefile syntax を簡易チェック**
+
+```bash
+make -n -C kubernetes hydrate-index ENV=local 2>&1 | head -3
+```
+
+Expected: `set -euo pipefail; env_dir="manifests/local"; ...` のような shell command がプリント表示される（実行はされない、`-n` は dry-run）。Makefile syntax error が出ないこと。
+
+- [ ] **Step 4: ENV=local で hydrate-index を実行（backward compat 検証）**
+
+```bash
+cd kubernetes
+make hydrate-index ENV=local 2>&1 | tail -3
+sha256sum manifests/local/00-namespaces/namespaces.yaml
+cd ..
+```
+
+Expected: Task 0 Step 7 で記録したハッシュと **完全一致**。一致しない場合は Step 2 のロジックが既存の local 動作を破壊している。差分を確認：
+
+```bash
+git diff -- kubernetes/manifests/local/00-namespaces/namespaces.yaml
+```
+
+差分があれば Step 2 のロジックを見直す。env-non-specific fallback が想定通り機能しているか確認。
+
+- [ ] **Step 5: ENV=production で hydrate-index を実行（新挙動検証）**
+
+```bash
+cd kubernetes
+make hydrate-index ENV=production 2>&1 | tail -3
+wc -c manifests/production/00-namespaces/namespaces.yaml
+cat manifests/production/00-namespaces/namespaces.yaml
+cd ..
+```
+
+Expected:
+- `wc -c` の結果が **0 または小さい数値**（cilium production component がまだ無いため、production env でデプロイされる component が存在せず、namespaces.yaml は空）
+- `cat` 出力も空
+
+`components/*/production/` ディレクトリは Task 2-4 完了まで存在しないため、本 step では「production 用 component が無い → namespaces.yaml が空」という状態を確認する。
+
+- [ ] **Step 6: 既存の local hydrate を完全に再実行して全体動作を verify**
+
+```bash
+cd kubernetes
+make hydrate ENV=local
+cd ..
+git status --short kubernetes/manifests/local/
+```
+
+Expected: `git status` で kubernetes/manifests/local/ 配下に diff が **無い**（現在の commit 状態と一致）。差分が出る場合は Step 4 で見つからなかった backward compat 問題。
+
+- [ ] **Step 7: 副次的に作られた production 配下を一旦削除（次の Task でクリーンに hydrate するため）**
+
+```bash
+rm -rf kubernetes/manifests/production/00-namespaces
+ls kubernetes/manifests/production/
+```
+
+Expected: `kubernetes/manifests/production/` に `kustomization.yaml`（Plan 1a で作成した空 scaffold）のみ残る。
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add kubernetes/Makefile
+git commit -s -m "$(cat <<'EOF'
+feat(kubernetes): make hydrate-index env-aware
+
+components/*/$(ENV)/ ディレクトリが存在する component のみを namespace
+収集対象とし、env-specific namespace.yaml を優先、なければ env-non-specific
+namespace.yaml を fallback で include するロジックに変更。これにより
+production 環境で deploy しない component の namespace が production
+manifests に混入することを避ける。local 環境の出力は backward compat
+を維持。
+EOF
+)"
+```
+
+Expected: 1 file changed, commit が `feat/eks-production-cilium-chaining` ブランチに追加される。
+
+---
+
+### Task 2: 親 helmfile.yaml.gotmpl に cluster.eksApiEndpoint を追加
+
+**Files:**
+- Modify: `kubernetes/helmfile.yaml.gotmpl`
+
+production env block に `cluster.eksApiEndpoint` を追加して、cilium production helmfile から `.Values.cluster.eksApiEndpoint` で参照可能にする。
+
+- [ ] **Step 1: 現状を確認**
+
+```bash
+cat kubernetes/helmfile.yaml.gotmpl
+```
+
+Expected: Plan 1a で追加した `production` env block が以下のように existing：
+
+```yaml
+  production:
+    values:
+      - cluster:
+          name: eks-production
+          isLocal: false
+```
+
+- [ ] **Step 2: production env block に eksApiEndpoint を追加**
+
+`kubernetes/helmfile.yaml.gotmpl` の `production:` block を以下に変更：
+
+```yaml
+  production:
+    values:
+      - cluster:
+          name: eks-production
+          isLocal: false
+          # eks-production cluster の API server endpoint hostname（https:// は含まない）
+          # Task 0 Step 6 で取得した値を使用
+          eksApiEndpoint: <CLUSTER_ENDPOINT_HOSTNAME>
+```
+
+`<CLUSTER_ENDPOINT_HOSTNAME>` は Task 0 Step 6 で取得した hostname（例: `ABCDEF.gr7.ap-northeast-1.eks.amazonaws.com`）に置き換える。
+
+- [ ] **Step 3: helmfile が production env を引き続き認識することを確認**
+
+```bash
+cd kubernetes
+helmfile -e production list 2>&1 | head -5
+cd ..
+```
+
+Expected: エラーで落ちないこと。`Error: environment "production" is not defined` が出ないこと。
+
+components/*/production/ がまだ無いため `no matches for path: components/*/production/helmfile.yaml` のような output で良い。
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add kubernetes/helmfile.yaml.gotmpl
+git commit -s -m "$(cat <<'EOF'
+feat(kubernetes): add eksApiEndpoint to production helmfile values
+
+cilium production の helmfile から .Values.cluster.eksApiEndpoint で
+EKS API server endpoint hostname を参照できるように追加する。
+KPR=true で必要となる k8sServiceHost の動的差し込みに使う。
+EOF
+)"
+```
+
+---
+
+### Task 3: cilium production 用 helmfile.yaml.gotmpl を作成
+
+**Files:**
+- Create: `kubernetes/components/cilium/production/helmfile.yaml.gotmpl`
+
+local の helmfile.yaml を参考に、production 用 helmfile を作成。`k8sServiceHost` を `.Values.cluster.eksApiEndpoint` で差し込めるように gotmpl 化。
+
+- [ ] **Step 1: ディレクトリを作成**
+
+```bash
+mkdir -p kubernetes/components/cilium/production
+```
+
+- [ ] **Step 2: helmfile.yaml.gotmpl を作成**
+
+`kubernetes/components/cilium/production/helmfile.yaml.gotmpl` を以下の内容で作成：
+
+```yaml
+# =============================================================================
+# Cilium Helmfile for production
+# =============================================================================
+# Cilium 1.18.x を chaining mode (VPC CNI 共存) で deploy する。
+# KPR / Gateway Controller / 独立 Envoy DaemonSet / Hubble を有効化。
+# k8sServiceHost は .Values.cluster.eksApiEndpoint で動的に差し込む。
+# =============================================================================
+environments:
+  production:
+
+---
+repositories:
+  - name: cilium
+    url: https://helm.cilium.io/
+
+releases:
+  - name: cilium
+    namespace: kube-system
+    chart: cilium/cilium
+    version: "1.18.6"
+    values:
+      - values.yaml.gotmpl
+```
+
+`values.yaml` ではなく `values.yaml.gotmpl` を referenced しているのは、`k8sServiceHost` を `.Values.cluster.eksApiEndpoint` で差し込むため（Task 4 で `values.yaml.gotmpl` として作成）。
+
+- [ ] **Step 3: Commit（values 作成は次 Task のため、helmfile のみ先行 commit）**
+
+```bash
+git add kubernetes/components/cilium/production/helmfile.yaml.gotmpl
+git commit -s -m "$(cat <<'EOF'
+feat(kubernetes/components/cilium): add production helmfile
+
+production 環境用の helmfile を新設。version は local と同じ 1.18.6。
+values は values.yaml.gotmpl で gotmpl 経由 EKS API endpoint を差し込む形にする
+（次 commit で values.yaml.gotmpl を追加）。
+EOF
+)"
+```
+
+---
+
+### Task 4: cilium production 用 values.yaml.gotmpl を作成
+
+**Files:**
+- Create: `kubernetes/components/cilium/production/values.yaml.gotmpl`
+
+spec で確定した values を gotmpl として作成。
+
+- [ ] **Step 1: values.yaml.gotmpl を作成**
+
+`kubernetes/components/cilium/production/values.yaml.gotmpl` を以下の内容で作成：
+
+```yaml
+# Cilium CNI Configuration for production (eks-production)
+# Reference: docs/superpowers/specs/2026-05-03-eks-production-cilium-chaining-design.md
+
+# =============================================================================
+# CNI Chaining Mode（VPC CNI が IPAM/datapath、Cilium は L7/policy/observability）
+# =============================================================================
+cni:
+  chainingMode: aws-cni
+  exclusive: false
+
+# =============================================================================
+# Routing & Masquerade
+# =============================================================================
+routingMode: native
+endpointRoutes:
+  enabled: true
+enableIPv4Masquerade: false
+ipv6:
+  enabled: false
+
+# =============================================================================
+# Kube Proxy Replacement: 完全置換
+# =============================================================================
+# kube-proxy addon は spec の Migration sequence Step 5 で terragrunt 経由で削除
+kubeProxyReplacement: true
+k8sServiceHost: {{ .Values.cluster.eksApiEndpoint }}
+k8sServicePort: 443
+
+# =============================================================================
+# Operator: HA
+# =============================================================================
+operator:
+  replicas: 2
+  rollOutPods: true
+
+# =============================================================================
+# L7 Proxy: 独立 DaemonSet
+# =============================================================================
+envoy:
+  enabled: true
+
+# =============================================================================
+# Gateway API（東西用、北南は ALB Controller）
+# =============================================================================
+gatewayAPI:
+  enabled: true
+
+# =============================================================================
+# Socket-level LB（Beyla / hostNetwork Pod が ClusterIP に到達するため）
+# =============================================================================
+socketLB:
+  enabled: true
+
+# =============================================================================
+# Hubble（UI は port-forward only、Phase 4 で Ingress 公開）
+# =============================================================================
+hubble:
+  enabled: true
+  relay:
+    enabled: true
+  ui:
+    enabled: true
+  metrics:
+    enabled:
+      - dns
+      - drop
+      - tcp
+      - flow
+      - icmp
+      - http
+    serviceMonitor:
+      enabled: false                  # Phase 3 で prometheus-operator 導入後に true
+
+# =============================================================================
+# DNS Proxy（hostNetwork Pod の DNS resolution に必要）
+# =============================================================================
+dnsProxy:
+  enabled: true
+
+# =============================================================================
+# Prometheus Metrics
+# =============================================================================
+prometheus:
+  enabled: false                      # Phase 3 で prometheus-operator 導入後に true
+```
+
+- [ ] **Step 2: helmfile が values を読めることを確認**
+
+```bash
+cd kubernetes
+helmfile -e production list 2>&1
+cd ..
+```
+
+Expected: `cilium` release が一覧に表示される（chart/version が解決される）。
+
+```
+NAME    NAMESPACE    ENABLED    INSTALLED    LABELS    CHART          VERSION
+cilium  kube-system  true       false        ...       cilium/cilium  1.18.6
+```
+
+- [ ] **Step 3: helmfile template で実際の rendering を確認**
+
+```bash
+cd kubernetes
+helmfile -e production template --skip-tests 2>&1 | head -30
+cd ..
+```
+
+Expected: Cilium の Kubernetes manifest がプリント開始される（Service、Deployment、DaemonSet、ConfigMap 等）。
+
+エラーなく rendering できれば values.yaml.gotmpl の構文が valid。`{{ .Values.cluster.eksApiEndpoint }}` が **Task 2 で設定した hostname に置換**されているか、output 内 `k8sServiceHost` 周辺で確認：
+
+```bash
+cd kubernetes
+helmfile -e production template --skip-tests 2>&1 | grep -A 2 "k8s-service-host\|kube-apiserver-endpoint" | head -10
+cd ..
+```
+
+Expected: hostname が gotmpl から正しく差し込まれている。
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add kubernetes/components/cilium/production/values.yaml.gotmpl
+git commit -s -m "$(cat <<'EOF'
+feat(kubernetes/components/cilium): add production values.yaml.gotmpl
+
+spec 2026-05-03-eks-production-cilium-chaining-design.md で確定した
+chaining mode + KPR + L7 Envoy DaemonSet + Gateway Controller + Hubble の
+values 一式を追加する。k8sServiceHost は .Values.cluster.eksApiEndpoint
+で gotmpl 差し込み、prometheus / serviceMonitor は Phase 3 で有効化。
+EOF
+)"
+```
+
+---
+
+### Task 5: `make hydrate ENV=production` を実行して manifests を生成・commit
+
+**Files:**
+- Create: `kubernetes/manifests/production/cilium/manifest.yaml`（hydrated output）
+- Create: `kubernetes/manifests/production/cilium/kustomization.yaml`（hydrated output）
+- Create: `kubernetes/manifests/production/00-namespaces/namespaces.yaml`（empty for cilium）
+- Create: `kubernetes/manifests/production/00-namespaces/kustomization.yaml`（hydrated output）
+- Modify: `kubernetes/manifests/production/kustomization.yaml`（hydrated regeneration）
+
+- [ ] **Step 1: hydrate を実行**
+
+```bash
+cd kubernetes
+make hydrate ENV=production
+cd ..
+```
+
+Expected: 標準出力に `💧 Hydrating manifests for production...` → `Hydrating cilium...` → `✅ Manifests hydrated` のような flow。
+
+- [ ] **Step 2: 生成された structure を確認**
+
+```bash
+find kubernetes/manifests/production -type f
+```
+
+Expected:
+```
+kubernetes/manifests/production/kustomization.yaml
+kubernetes/manifests/production/00-namespaces/kustomization.yaml
+kubernetes/manifests/production/00-namespaces/namespaces.yaml
+kubernetes/manifests/production/cilium/kustomization.yaml
+kubernetes/manifests/production/cilium/manifest.yaml
+```
+
+- [ ] **Step 3: 00-namespaces の中身が空であることを確認（cilium が kube-system 利用のため）**
+
+```bash
+wc -c kubernetes/manifests/production/00-namespaces/namespaces.yaml
+cat kubernetes/manifests/production/00-namespaces/namespaces.yaml
+```
+
+Expected: byte 数 = 0 または非常に小さく、内容が空（または `---` のみ）。Cilium は kube-system を使うため namespace.yaml を持たない。
+
+- [ ] **Step 4: manifests/production/kustomization.yaml が cilium を参照することを確認**
+
+```bash
+cat kubernetes/manifests/production/kustomization.yaml
+```
+
+Expected:
+```yaml
+resources:
+  - ./00-namespaces
+  - ./cilium
+```
+
+Plan 1a で書いた banner 付き手書き版は hydrate-index で **完全に上書き**されているはず。banner / apiVersion / kind は消える（hydrate output style に揃う）。
+
+- [ ] **Step 5: kustomize build で valid であることを確認**
+
+```bash
+kustomize build kubernetes/manifests/production 2>&1 | head -20
+```
+
+Expected: Cilium の各種 K8s リソース（Deployment, DaemonSet, Service, ConfigMap, ServiceAccount, ClusterRole, ClusterRoleBinding 等）が出力される。エラーなし。
+
+```bash
+kustomize build kubernetes/manifests/production 2>&1 | grep -c "^kind:"
+```
+
+Expected: 数十〜100 程度（Cilium chart は多くのリソースを生成する）。
+
+- [ ] **Step 6: cilium/manifest.yaml の主要設定を sanity-check**
+
+```bash
+grep -E "(routingMode|chainingMode|kubeProxyReplacement|enable-gateway-api|envoy|endpointRoutes)" kubernetes/manifests/production/cilium/manifest.yaml | head -20
+```
+
+Expected:
+- `routing-mode: native` または `routingMode: "native"`
+- `chainingMode: "aws-cni"` または cni-chaining mode 設定
+- `kube-proxy-replacement: "true"` または同等
+- `enable-gateway-api: "true"`
+- `enable-envoy-config: "true"`
+- `endpoint-routes: "true"`
+
+検出されない設定があれば values.yaml.gotmpl の rendering を再確認。
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add kubernetes/manifests/production/
+git commit -s -m "$(cat <<'EOF'
+feat(kubernetes/manifests/production): hydrate cilium production manifests
+
+make hydrate ENV=production の output を commit する。
+- cilium/manifest.yaml: chaining mode + KPR + L7 + Gateway Controller の rendered output
+- 00-namespaces/namespaces.yaml: cilium は kube-system 利用のため空
+- kustomization.yaml: ./00-namespaces と ./cilium を resource として参照
+EOF
+)"
+```
+
+---
+
+### Task 6: aws/eks/modules/addons.tf から kube-proxy addon を削除
+
+**Files:**
+- Modify: `aws/eks/modules/addons.tf`
+
+KPR=true で kube-proxy DaemonSet が不要になるため、EKS managed addon の `kube-proxy` block を削除する。**この変更は terragrunt apply で適用されるが、apply のタイミングは spec の Migration sequence Step 5（Cilium 検証完了後）に user が手動で行う**。本 task は apply は実行せず、Terraform 設定の変更のみ。
+
+- [ ] **Step 1: 現状の addons.tf を確認**
+
+```bash
+grep -A 4 "kube-proxy = {" aws/eks/modules/addons.tf
+```
+
+Expected:
+```
+    kube-proxy = {
+      resolve_conflicts_on_create = "OVERWRITE"
+      resolve_conflicts_on_update = "OVERWRITE"
+    }
+```
+
+この block を Step 2 で削除する。
+
+- [ ] **Step 2: kube-proxy block を削除**
+
+`aws/eks/modules/addons.tf` の `cluster_addons` map 内、以下 4 行（および直後の空行）を削除：
+
+```
+    kube-proxy = {
+      resolve_conflicts_on_create = "OVERWRITE"
+      resolve_conflicts_on_update = "OVERWRITE"
+    }
+```
+
+削除後、`cluster_addons` map は `vpc-cni` / `coredns` / `aws-ebs-csi-driver` / `eks-pod-identity-agent` の 4 つのみを含む状態になる。
+
+- [ ] **Step 3: ファイル冒頭の comment を更新**
+
+`aws/eks/modules/addons.tf` の冒頭 comment 内、以下の文を：
+
+```
+# kube-proxy / coredns / pod-identity-agent
+# do not need IRSA.
+```
+
+以下に書き換え：
+
+```
+# coredns / pod-identity-agent do not need IRSA. kube-proxy is intentionally
+# omitted because Cilium is configured with kubeProxyReplacement=true (see
+# kubernetes/components/cilium/production/values.yaml.gotmpl).
+```
+
+- [ ] **Step 4: terraform validate で syntax チェック**
+
+```bash
+cd aws/eks/envs/production
+TG_TF_PATH=tofu terragrunt init --backend=false 2>&1 | tail -3
+TG_TF_PATH=tofu terragrunt validate 2>&1
+cd ../../../..
+```
+
+Expected: `Success! The configuration is valid.`
+
+`init --backend=false` は state を触らずに providers / modules を取得する safe な validate モード。
+
+- [ ] **Step 5: terraform plan を実行して変更内容を確認（apply はしない）**
+
+```bash
+cd aws/eks/envs/production
+TG_TF_PATH=tofu terragrunt plan 2>&1 | grep -E "(kube-proxy|Plan:)" | head -10
+cd ../../../..
+```
+
+Expected:
+- `module.eks.aws_eks_addon.this["kube-proxy"]` が `# will be destroyed` と表示される
+- `Plan: 0 to add, 0 to change, 1 to destroy.`
+
+差分が 1 destroy のみであれば想定通り。それ以外（add や change が出る、kube-proxy 以外が destroy される等）は Step 2 で別の block を誤って削除した可能性あり、確認。
+
+> **注意**: 本 step では apply は **実行しない**。apply は spec の Migration sequence Step 5（Cilium 検証完了後）に user が実行する。ここでは plan で変更内容を verify するのみ。
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add aws/eks/modules/addons.tf
+git commit -s -m "$(cat <<'EOF'
+feat(aws/eks): remove kube-proxy from EKS managed addons
+
+Cilium chaining mode で kubeProxyReplacement=true を有効化したため、
+kube-proxy DaemonSet が不要になる。EKS managed addon block から
+kube-proxy を削除する。本 commit の terragrunt apply は Cilium が
+production cluster で検証完了した後（spec の Migration sequence
+Step 5）に実行する。
+EOF
+)"
+```
+
+---
+
+### Task 7: ブランチを push して Draft PR を作成
+
+**Files:** （git 操作のみ）
+
+ここまでの code 変更を Draft PR として user に提示し、user が cluster operations Phase へ移る。
+
+- [ ] **Step 1: 全 commit を確認**
+
+```bash
+git log --oneline origin/main..HEAD
+```
+
+Expected: Task 1-6 の commit + spec commit (`ad0bb48`) が並んでいる。
+
+```
+<sha> feat(aws/eks): remove kube-proxy from EKS managed addons
+<sha> feat(kubernetes/manifests/production): hydrate cilium production manifests
+<sha> feat(kubernetes/components/cilium): add production values.yaml.gotmpl
+<sha> feat(kubernetes/components/cilium): add production helmfile
+<sha> feat(kubernetes): add eksApiEndpoint to production helmfile values
+<sha> feat(kubernetes): make hydrate-index env-aware
+ad0bb48 docs(eks): add Plan 1b (Cilium chaining mode) design spec
+```
+
+- [ ] **Step 2: ブランチを push**
+
+```bash
+git push -u origin feat/eks-production-cilium-chaining
+```
+
+Expected: `branch 'feat/eks-production-cilium-chaining' set up to track 'origin/feat/eks-production-cilium-chaining'`
+
+- [ ] **Step 3: Draft PR を作成**
+
+```bash
+gh pr create --draft --base main \
+  --title "feat(kubernetes,aws/eks): install Cilium chaining mode + remove kube-proxy (Plan 1b)" \
+  --body "$(cat <<'EOF'
+## Summary
+
+- Cilium 1.18.6 を chaining mode（VPC CNI 共存）で eks-production に install
+- KPR=true / endpointRoutes.enabled=true / envoy.enabled=true（独立 DaemonSet）/ Gateway Controller=true
+- kube-proxy EKS managed addon を削除（KPR で代替）
+- `kubernetes/Makefile` の `hydrate-index` を env-aware に変更（local の動作は backward compat）
+
+Plan: ``docs/superpowers/plans/2026-05-03-eks-production-cilium-chaining.md``
+Spec: ``docs/superpowers/specs/2026-05-03-eks-production-cilium-chaining-design.md``
+
+これは Phase 1 (Foundation) の **Plan 1b**。Plan 1a (Flux bootstrap, #255) の後続。次は Plan 1c で foundation addons (ALB Controller / ExternalDNS / Metrics Server / KEDA / Gateway API CRDs)。
+
+## Migration sequence (operator が手動で実施)
+
+merge 前に以下の順で実施：
+
+1. ``flux suspend kustomization flux-system -n flux-system``
+2. PR branch を checkout して ``kubectl apply -k kubernetes/manifests/production/cilium/``
+3. Verification battery (Q1-Q4 + Gateway API + Hubble + connectivity test) — 詳細は plan の Task 10
+4. Mark PR ready for review → main merge → CI が terragrunt apply (kube-proxy 削除)
+5. Post-removal verification (Q2 final: kube-proxy NotFound)
+6. ``flux resume kustomization flux-system -n flux-system`` → Cilium adoption + idempotency check
+
+## Test plan
+
+### Code-level (PR 作成時点で完了済)
+
+- [x] ``make hydrate ENV=local`` の output が backward compat（manifests/local に diff なし）
+- [x] ``make hydrate ENV=production`` で cilium と空の 00-namespaces が生成される
+- [x] ``kustomize build kubernetes/manifests/production`` が valid
+- [x] ``helmfile -e production template`` で Cilium manifest が rendering される
+- [x] ``terragrunt plan`` で kube-proxy addon の destroy 1 件が表示される（apply は merge 後）
+
+### Cluster-level (operator 実行)
+
+- [ ] ``cilium status`` で KubeProxyReplacement: True / Gateway API: enabled
+- [ ] ``cilium connectivity test`` 全 pass
+- [ ] CiliumEnvoyConfig が Reconciled: True
+- [ ] cilium-envoy DaemonSet が各 node で Running
+- [ ] Gateway リソースが Programmed: True、HTTPRoute が Accepted: True
+- [ ] hubble observe で flow が見える
+- [ ] kube-proxy 削除後も Pod 間疎通が維持される
+- [ ] Flux resume 後、cilium が drift なしで adopt される
+EOF
+)" 2>&1 | tail -3
+```
+
+Expected: PR URL が表示される（`https://github.com/panicboat/platform/pull/<num>`）。
+
+- [ ] **Step 4: PR URL を user に共有**
+
+```bash
+gh pr view --json url --jq .url
+```
+
+PR URL を controller (Claude) が user に提示。以後の Task 8-13 は user 実行。
+
+---
+
+### Task 8: (USER) production cluster の Flux を suspend
+
+**Files:** （cluster 状態変更のみ）
+
+operator が production cluster で Cilium 検証を行う前に Flux を suspend し、検証中の試行錯誤が GitOps と競合しないようにする。
+
+- [ ] **Step 1: production cluster へ kubectl 接続**
+
+```bash
+source ~/Workspace/eks-login.sh production
+kubectl config current-context
+```
+
+Expected: `arn:aws:eks:ap-northeast-1:559744160976:cluster/eks-production`
+
+- [ ] **Step 2: 現在の Flux 状態を確認**
+
+```bash
+flux get kustomizations -n flux-system flux-system
+```
+
+Expected: `READY: True`、`SUSPENDED: False`。
+
+- [ ] **Step 3: Flux を suspend**
+
+```bash
+flux suspend kustomization flux-system -n flux-system
+```
+
+Expected: `► suspending Kustomization flux-system in flux-system namespace ✔ Kustomization suspended`
+
+- [ ] **Step 4: suspend を確認**
+
+```bash
+flux get kustomizations -n flux-system flux-system
+```
+
+Expected: `SUSPENDED: True`。
+
+これ以降、main ブランチへの変更が production cluster に自動適用されることはない（再開は Task 13）。
+
+---
+
+### Task 9: (USER) PR branch から Cilium を手動 apply
+
+**Files:** （cluster 状態変更のみ）
+
+PR が draft の状態で、PR branch を local に checkout し、hydrate 済の Cilium manifests を `kubectl apply -k` で直接 apply する。kube-proxy はまだ動いているので Service routing は二重化されるが正常動作する。
+
+- [ ] **Step 1: PR branch を local に fetch**
+
+```bash
+git fetch origin feat/eks-production-cilium-chaining
+git checkout feat/eks-production-cilium-chaining
+```
+
+Expected: branch 切り替え成功。`git log --oneline -3` で Task 6 の commit が HEAD として見える。
+
+- [ ] **Step 2: kustomize build で実際に apply される manifest を最終確認**
+
+```bash
+kustomize build kubernetes/manifests/production/cilium 2>&1 | grep -c "^kind:"
+```
+
+Expected: 数十〜100 程度の kind: 行。
+
+- [ ] **Step 3: Cilium manifests を apply**
+
+```bash
+kubectl apply --server-side --force-conflicts -k kubernetes/manifests/production/cilium/
+```
+
+Expected: 多数の `applied` メッセージ（Deployment, DaemonSet, Service, ConfigMap, RBAC 等が created）。
+
+エラーが出る場合は `kubectl describe` / `kubectl get events -n kube-system --sort-by=.lastTimestamp | tail -30` で原因確認。
+
+- [ ] **Step 4: Cilium agent / operator / envoy の起動を待つ**
+
+```bash
+kubectl rollout status -n kube-system daemonset/cilium --timeout=300s
+kubectl rollout status -n kube-system deployment/cilium-operator --timeout=300s
+kubectl rollout status -n kube-system daemonset/cilium-envoy --timeout=300s
+```
+
+Expected: 3 つすべて `successfully rolled out`。
+
+タイムアウトする場合：
+- `kubectl get pods -n kube-system | grep cilium` で Pod 状態確認
+- `kubectl logs -n kube-system <pod-name>` でログ確認
+
+- [ ] **Step 5: Hubble Relay の起動を確認**
+
+```bash
+kubectl rollout status -n kube-system deployment/hubble-relay --timeout=180s
+kubectl rollout status -n kube-system deployment/hubble-ui --timeout=180s
+```
+
+Expected: 両方とも `successfully rolled out`。
+
+これで Cilium が install 完了。Task 10 で動作 verification を実施。
+
+---
+
+### Task 10: (USER) Verification battery を実行
+
+**Files:** （read only / 一時的な test resource の create + delete）
+
+spec の Open Questions 1-4 + Gateway API + Hubble + connectivity test を網羅的に確認する。すべて pass したら Task 11 に進む。
+
+- [ ] **Step 1: Q1 verification — Cilium 全体ステータス**
+
+```bash
+cilium status
+```
+
+Expected:
+- `Cilium`: `OK` (running on all nodes)
+- `Cluster Pods`: `<n>/<n> managed by Cilium`
+- `Operator`: `OK`
+- `Envoy DaemonSet`: `OK`
+- `Hubble Relay`: `OK`
+- `Hubble UI`: `OK`
+- `KubeProxyReplacement`: `True`（重要、Q2 の確定）
+- `Gateway API`: `enabled`（重要、Q1 の一部）
+
+- [ ] **Step 2: Q3 verification — endpointRoutes.enabled=true**
+
+```bash
+kubectl get cm -n kube-system cilium-config -o jsonpath='{.data.enable-endpoint-routes}'
+echo
+```
+
+Expected: `true`
+
+```bash
+cilium endpoint list 2>&1 | head -10
+```
+
+Expected: 各 endpoint が `Ready` 状態でリスト表示される。
+
+- [ ] **Step 3: Q4 verification — envoy.enabled=true（独立 DaemonSet）**
+
+```bash
+kubectl get ds -n kube-system cilium-envoy -o wide
+```
+
+Expected: `cilium-envoy` DaemonSet が存在、各 node で 1/1 Ready。
+
+```bash
+kubectl exec -n kube-system $(kubectl get pod -n kube-system -l k8s-app=cilium -o name | head -1) -- cilium-dbg envoy admin server-info 2>&1 | head -3
+```
+
+Expected: Envoy admin server からの response（version 情報等）。
+
+- [ ] **Step 4: Q1 verification — CiliumEnvoyConfig 動作確認**
+
+minimal な CEC を apply して reconcile されるか確認：
+
+```bash
+cat <<'EOF' | kubectl apply -f -
+apiVersion: cilium.io/v2
+kind: CiliumEnvoyConfig
+metadata:
+  name: smoke-test-cec
+  namespace: kube-system
+spec:
+  services:
+    - name: kubernetes
+      namespace: default
+  resources:
+    - "@type": type.googleapis.com/envoy.config.listener.v3.Listener
+      name: smoke-test-listener
+      address:
+        socket_address:
+          address: "127.0.0.1"
+          port_value: 19999
+EOF
+```
+
+Expected: `ciliumenvoyconfig.cilium.io/smoke-test-cec created`
+
+```bash
+sleep 5
+kubectl get ciliumenvoyconfig smoke-test-cec -n kube-system -o jsonpath='{.status.conditions[?(@.type=="Reconciled")].status}'
+echo
+```
+
+Expected: `True`
+
+cleanup：
+
+```bash
+kubectl delete ciliumenvoyconfig smoke-test-cec -n kube-system
+```
+
+- [ ] **Step 5: Gateway API 動作確認**
+
+```bash
+kubectl get gatewayclass cilium
+```
+
+Expected: `cilium` GatewayClass が `ACCEPTED: True` で存在。
+
+minimal な Gateway を apply：
+
+```bash
+cat <<'EOF' | kubectl apply -f -
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: smoke-test-gateway
+  namespace: default
+spec:
+  gatewayClassName: cilium
+  listeners:
+    - name: http
+      protocol: HTTP
+      port: 80
+EOF
+```
+
+Expected: `gateway.gateway.networking.k8s.io/smoke-test-gateway created`
+
+```bash
+sleep 30
+kubectl get gateway smoke-test-gateway -n default -o jsonpath='{.status.conditions[?(@.type=="Programmed")].status}'
+echo
+```
+
+Expected: `True`
+
+cleanup：
+
+```bash
+kubectl delete gateway smoke-test-gateway -n default
+```
+
+- [ ] **Step 6: Hubble 動作確認**
+
+```bash
+hubble observe --last 10 --output compact 2>&1 | head -15
+```
+
+Expected: 直近の network flow が表示される（kube-system Pod 間の通信等）。`No flows` の場合は cluster がアイドル状態の可能性、しばらく待ってから再実行。
+
+- [ ] **Step 7: Q1 final — Cilium 公式 connectivity test**
+
+> **注意**: `cilium connectivity test` は test namespace を作成して数分間 test を走らせる。chaining mode + KPR の組み合わせでは一部 test が **flaky** な場合があるため、`--test '!check-log-errors'` で除外し、check-log-errors の発生は別途記録する。
+
+```bash
+cilium connectivity test --test '!check-log-errors' 2>&1 | tail -30
+```
+
+Expected: 最終行が `[=] 0/<n> tests failed` で終わる（all pass）。失敗 test がある場合は具体的な test 名を確認し、Cilium docs / GitHub issues で既知問題か調査。
+
+> **注意**: test 完了後、`cilium-test-1` namespace が cluster に残る。clean up したい場合は：
+
+```bash
+cilium connectivity test --cleanup-only
+```
+
+- [ ] **Step 8: 全体ステータスの最終 snapshot**
+
+```bash
+kubectl get pods -n kube-system | grep cilium
+echo "---"
+kubectl get gatewayclass
+echo "---"
+flux get kustomizations -n flux-system flux-system   # まだ Suspended: True のはず
+```
+
+Expected:
+- すべての cilium-* Pod が Running
+- `cilium` GatewayClass が ACCEPTED: True
+- Flux が Suspended: True
+
+すべての検証が pass したら Task 11 に進む。pass しない項目があれば spec の Rollback strategy（Step 3 / Step 4）に従って `helm uninstall` または values 修正後 `kubectl apply --server-side --force-conflicts -k` で再 apply。
+
+---
+
+### Task 11: (USER) PR を ready にして merge、CI が kube-proxy addon を削除
+
+**Files:** （Terraform state 変更、cluster 状態変更）
+
+ここで PR を `Ready for review` に変更し、main へ merge する。merge 後 CI が terragrunt apply を実行し、`kube-proxy` EKS managed addon が削除される。
+
+- [ ] **Step 1: PR を Ready for review に変更**
+
+```bash
+gh pr ready
+```
+
+または GitHub UI で `Ready for review` ボタンを押す。
+
+- [ ] **Step 2: review approve（self-approve または別 reviewer）**
+
+```bash
+gh pr review --approve
+```
+
+または GitHub UI で approve。
+
+- [ ] **Step 3: PR を main へ merge**
+
+```bash
+gh pr merge --squash --delete-branch
+```
+
+または GitHub UI で merge。
+
+> **注意**: ここで CI が terragrunt apply を実行する。aws/eks の plan で確認した `kube-proxy addon destroy` が適用される。CI が完了するまで 3-5 分。
+
+- [ ] **Step 4: CI workflow を tail で見る**
+
+```bash
+gh run watch
+```
+
+または GitHub Actions の UI で workflow 進捗を見る。Expected: `aws/eks/envs/production` の terragrunt apply が success で完了する。
+
+CI 失敗時は `gh run view --log` で原因確認。よくある問題: AWS API rate limit、IAM 権限不足、依存リソースの destroy 順序問題。
+
+- [ ] **Step 5: kube-proxy DaemonSet が削除されたことを確認**
+
+```bash
+kubectl get ds -n kube-system kube-proxy 2>&1
+```
+
+Expected: `Error from server (NotFound): daemonsets.apps "kube-proxy" not found`
+
+```bash
+kubectl get pods -n kube-system | grep kube-proxy
+```
+
+Expected: 結果が空（kube-proxy Pod が無い）。
+
+これで Q2 の最終確認 (`kube-proxy NotFound`) が pass。
+
+---
+
+### Task 12: (USER) kube-proxy 削除後の疎通検証
+
+**Files:** （read only / 一時 test resource）
+
+kube-proxy が削除された状態で Cilium KPR が単独で Service routing を担当していることを確認する。
+
+- [ ] **Step 1: 既存 Service への ClusterIP 経由疎通**
+
+```bash
+kubectl run smoke-svc-test --rm -i --restart=Never --image=busybox -- wget -qO- --timeout=5 http://kubernetes.default.svc.cluster.local 2>&1 | head -5
+```
+
+Expected: `wget: error getting response: Connection refused` 系のメッセージ（K8s API は HTTPS 認証必須なので接続自体は確立される、このエラー文言は接続成功を示す）。タイムアウトしたり `bad address` が出ると DNS / Service routing 失敗。
+
+- [ ] **Step 2: cilium status 再確認**
+
+```bash
+cilium status
+```
+
+Expected: `KubeProxyReplacement: True`、kube-proxy が無い状態でも `OK` で動作継続。
+
+- [ ] **Step 3: hubble で flow を観測**
+
+```bash
+hubble observe --last 20 --output compact 2>&1 | head -20
+```
+
+Expected: 直近の flow が観測される（Step 1 で発生した Service 通信を含む）。
+
+- [ ] **Step 4: 全 Pod が Running を維持**
+
+```bash
+kubectl get pods -A | grep -v Running | grep -v Completed | head -10
+```
+
+Expected: 結果が空（または header のみ）。kube-proxy 削除で機能不全に陥った Pod が無いこと。
+
+すべて pass したら Task 13 に進む。
+
+---
+
+### Task 13: (USER) Flux を resume + adoption 確認 + 冪等性確認
+
+**Files:** （cluster 状態変更）
+
+Flux を再開し、main の Cilium manifests を adopt させる。drift が無いこと（Flux apply が unchanged で完了する）を verify。
+
+- [ ] **Step 1: Flux を resume**
+
+```bash
+flux resume kustomization flux-system -n flux-system
+```
+
+Expected: `► resuming Kustomization flux-system in flux-system namespace ✔ Kustomization resumed`
+
+- [ ] **Step 2: 強制 reconcile で sync 状態を確認**
+
+```bash
+flux reconcile source git flux-system -n flux-system
+flux reconcile kustomization flux-system -n flux-system
+```
+
+Expected: 両方とも `applied revision: main@sha1:<sha>` で完了する。
+
+- [ ] **Step 3: Cilium が drift なしで adopt されたことを確認**
+
+```bash
+flux get kustomizations -n flux-system flux-system
+```
+
+Expected: `READY: True`、`MESSAGE: Applied revision: main@sha1:<sha>`、`SUSPENDED: False`。
+
+```bash
+kubectl describe kustomization flux-system -n flux-system | grep -A 3 "Status:"
+```
+
+Expected: `Conditions` 内に `Type: Ready, Status: True`、`Reason: ReconciliationSucceeded` が見える。
+
+- [ ] **Step 4: Cilium Pod が drift で再起動していないことを確認**
+
+```bash
+kubectl get pods -n kube-system | grep cilium
+```
+
+Expected: 各 cilium-* Pod の `AGE` が Task 9 で起動した時間（数十分〜数時間前）と一致。Flux resume で AGE が 0 にリセットされていない（= 不要な rollout が発生していない）。
+
+もし Flux が drift を検知して全 Cilium Pod を再起動した場合、`kubectl apply --server-side --force-conflicts` のフィールド管理と Flux の field manager の不一致が原因の可能性。`kubectl get pods -o yaml | grep -A 5 managedFields` で確認。
+
+- [ ] **Step 5: 冪等性確認（再 reconcile しても unchanged）**
+
+```bash
+flux reconcile kustomization flux-system -n flux-system
+sleep 10
+kubectl get events -n flux-system --sort-by=.lastTimestamp | tail -5
+```
+
+Expected: 直近の event に `ReconciliationSucceeded` または `Normal` が出ており、Pod 再起動・apply の警告が無い。
+
+- [ ] **Step 6: Plan 1b 完了の最終 snapshot**
+
+```bash
+echo "=== Cilium status ==="
+cilium status --wait
+echo ""
+echo "=== Flux status ==="
+flux get all -n flux-system
+echo ""
+echo "=== EKS addons ==="
+aws eks list-addons --region ap-northeast-1 --cluster-name eks-production
+```
+
+Expected:
+- Cilium status all OK、KubeProxyReplacement True、Gateway API enabled
+- Flux GitRepository / Kustomization READY True、SUSPENDED False
+- EKS addons から `kube-proxy` が消えており、`vpc-cni` / `coredns` / `aws-ebs-csi-driver` / `eks-pod-identity-agent` のみ
+
+すべて pass したら **Plan 1b 完了**。次は Plan 1c（ALB Controller / ExternalDNS / Metrics Server / KEDA / Gateway API CRDs）。
+
+---
+
+## Self-review checklist
+
+このセクションは Plan 完成後に書き手（Claude）が自己 review する項目。実装者は Skip して構わない。
+
+- [x] **Spec coverage**:
+  - Spec の Components 変更マトリクス（Cilium production helmfile / values / 親 helmfile / Makefile / addons.tf / hydrated manifests）→ Task 1-6 でカバー
+  - Migration sequence Step 1（Flux suspend）→ Task 8
+  - Migration sequence Step 2（PR merge with code）→ Task 7（PR 作成）+ Task 11（merge）
+  - Migration sequence Step 3（手動 helm install）→ Task 9（kubectl apply -k で代替）
+  - Migration sequence Step 4（verification）→ Task 10
+  - Migration sequence Step 5（kube-proxy 削除）→ Task 11（CI が apply）
+  - Migration sequence Step 6（post-removal verification）→ Task 12
+  - Migration sequence Step 7（flux resume + adopt）→ Task 13
+  - Migration sequence Step 8（idempotency）→ Task 13 Step 5
+  - Verification checklist の Q1-Q4 + Gateway API + Hubble → Task 10 全 step
+  - Open Questions 1-4 確定値（KPR=true, endpointRoutes=true, envoy=true, chaining 動作） → values.yaml.gotmpl と Task 10 verification で確認
+- [x] **Placeholder scan**:
+  - `<CLUSTER_ENDPOINT_HOSTNAME>` は Task 0 Step 6 で取得した実値に置換する明示的指示あり
+  - `TBD` / `implement later` 等の禁止文言なし
+- [x] **Type / signature consistency**:
+  - File path: 全 task で同一（kubernetes/components/cilium/production/{helmfile.yaml.gotmpl, values.yaml.gotmpl}, kubernetes/manifests/production/cilium/{manifest.yaml, kustomization.yaml}）
+  - Helmfile values reference: `.Values.cluster.eksApiEndpoint` を Task 2 で定義、Task 4 で参照
+- [x] **CLAUDE.md 準拠**:
+  - 出力言語日本語、コミット `-s`、`Co-Authored-By` 不付与、PR は `--draft`、`-u origin HEAD`、Conventional Commits
+- [x] **代替パスを user 実行に明示**:
+  - kubectl apply -k で apply（spec の "helm install" の代わり）→ Migration sequence Step 3 と差異が出るが、Hydration Pattern の利点（実 manifest を Git に commit）と一致しており、Flux adoption も clean に成立

--- a/docs/superpowers/plans/2026-05-03-eks-production-cilium-chaining.md
+++ b/docs/superpowers/plans/2026-05-03-eks-production-cilium-chaining.md
@@ -19,7 +19,7 @@
 | `kubernetes/Makefile` | modify | `hydrate-index` ターゲットを env-aware に変更（env-specific path 優先 + env-non-specific fallback） |
 | `kubernetes/helmfile.yaml.gotmpl` | modify | `production` env block に `cluster.eksApiEndpoint` を追加 |
 | `kubernetes/components/cilium/production/helmfile.yaml` | create | production 用 helmfile（local の helmfile.yaml と同型、`k8sServiceHost` を gotmpl で差し込み） |
-| `kubernetes/components/cilium/production/values.yaml` | create | production 用 Cilium values（chaining mode + KPR + Envoy DaemonSet + Gateway Controller） |
+| `kubernetes/components/cilium/production/values.yaml.gotmpl` | create | production 用 Cilium values（chaining mode + KPR + Envoy DaemonSet + Gateway Controller） |
 | `kubernetes/manifests/production/cilium/manifest.yaml` | create (hydrated) | `make hydrate ENV=production` で生成される rendered Cilium manifest |
 | `kubernetes/manifests/production/cilium/kustomization.yaml` | create (hydrated) | 同上、`resources: - manifest.yaml` |
 | `kubernetes/manifests/production/00-namespaces/namespaces.yaml` | create or empty (hydrated) | env-aware ロジックの結果。Cilium は kube-system 利用なので **空** |

--- a/docs/superpowers/plans/2026-05-03-eks-production-cilium-chaining.md
+++ b/docs/superpowers/plans/2026-05-03-eks-production-cilium-chaining.md
@@ -18,7 +18,7 @@
 |---|---|---|
 | `kubernetes/Makefile` | modify | `hydrate-index` ターゲットを env-aware に変更（env-specific path 優先 + env-non-specific fallback） |
 | `kubernetes/helmfile.yaml.gotmpl` | modify | `production` env block に `cluster.eksApiEndpoint` を追加 |
-| `kubernetes/components/cilium/production/helmfile.yaml.gotmpl` | create | production 用 helmfile（local の helmfile.yaml と同型、`k8sServiceHost` を gotmpl で差し込み） |
+| `kubernetes/components/cilium/production/helmfile.yaml` | create | production 用 helmfile（local の helmfile.yaml と同型、`k8sServiceHost` を gotmpl で差し込み） |
 | `kubernetes/components/cilium/production/values.yaml` | create | production 用 Cilium values（chaining mode + KPR + Envoy DaemonSet + Gateway Controller） |
 | `kubernetes/manifests/production/cilium/manifest.yaml` | create (hydrated) | `make hydrate ENV=production` で生成される rendered Cilium manifest |
 | `kubernetes/manifests/production/cilium/kustomization.yaml` | create (hydrated) | 同上、`resources: - manifest.yaml` |
@@ -326,10 +326,10 @@ EOF
 
 ---
 
-### Task 3: cilium production 用 helmfile.yaml.gotmpl を作成
+### Task 3: cilium production 用 helmfile.yaml を作成
 
 **Files:**
-- Create: `kubernetes/components/cilium/production/helmfile.yaml.gotmpl`
+- Create: `kubernetes/components/cilium/production/helmfile.yaml`
 
 local の helmfile.yaml を参考に、production 用 helmfile を作成。`k8sServiceHost` を `.Values.cluster.eksApiEndpoint` で差し込めるように gotmpl 化。
 
@@ -339,9 +339,9 @@ local の helmfile.yaml を参考に、production 用 helmfile を作成。`k8sS
 mkdir -p kubernetes/components/cilium/production
 ```
 
-- [ ] **Step 2: helmfile.yaml.gotmpl を作成**
+- [ ] **Step 2: helmfile.yaml を作成**
 
-`kubernetes/components/cilium/production/helmfile.yaml.gotmpl` を以下の内容で作成：
+`kubernetes/components/cilium/production/helmfile.yaml` を以下の内容で作成：
 
 ```yaml
 # =============================================================================
@@ -373,7 +373,7 @@ releases:
 - [ ] **Step 3: Commit（values 作成は次 Task のため、helmfile のみ先行 commit）**
 
 ```bash
-git add kubernetes/components/cilium/production/helmfile.yaml.gotmpl
+git add kubernetes/components/cilium/production/helmfile.yaml
 git commit -s -m "$(cat <<'EOF'
 feat(kubernetes/components/cilium): add production helmfile
 
@@ -1319,7 +1319,7 @@ Expected:
   - `<CLUSTER_ENDPOINT_HOSTNAME>` は Task 0 Step 6 で取得した実値に置換する明示的指示あり
   - `TBD` / `implement later` 等の禁止文言なし
 - [x] **Type / signature consistency**:
-  - File path: 全 task で同一（kubernetes/components/cilium/production/{helmfile.yaml.gotmpl, values.yaml.gotmpl}, kubernetes/manifests/production/cilium/{manifest.yaml, kustomization.yaml}）
+  - File path: 全 task で同一（kubernetes/components/cilium/production/{helmfile.yaml, values.yaml.gotmpl}, kubernetes/manifests/production/cilium/{manifest.yaml, kustomization.yaml}）
   - Helmfile values reference: `.Values.cluster.eksApiEndpoint` を Task 2 で定義、Task 4 で参照
 - [x] **CLAUDE.md 準拠**:
   - 出力言語日本語、コミット `-s`、`Co-Authored-By` 不付与、PR は `--draft`、`-u origin HEAD`、Conventional Commits

--- a/docs/superpowers/specs/2026-05-03-eks-production-cilium-chaining-design.md
+++ b/docs/superpowers/specs/2026-05-03-eks-production-cilium-chaining-design.md
@@ -1,0 +1,309 @@
+# EKS Production Cilium Chaining Mode Design
+
+## Overview
+
+EKS production cluster `eks-production`（`ap-northeast-1`）に Cilium を chaining mode で導入し、VPC CNI と共存させた状態で Kube-Proxy Replacement (KPR) / Gateway Controller / 独立 Envoy DaemonSet / Hubble を有効化する。本 spec は **Plan 1b** として、Phase 1 Foundation の 3 plan のうち 2 つ目を扱う。
+
+ロードマップ spec（`2026-05-02-eks-production-platform-roadmap-design.md`）の Decision 2 (chaining mode) と Decision 4 (Pattern B-Full) を継承する。新規 architectural decision は本 spec では生じず、**設定実装と Open Questions の実機検証**が主スコープ。
+
+## Goals
+
+1. Cilium 1.18.x を chaining mode（VPC CNI と共存）で `eks-production` に導入する
+2. ロードマップ spec の Open Questions 1-4 を実機検証で解消する
+3. Plan 1c 以降が依存する L7 Envoy / Gateway Controller / Hubble の動作基盤を作る
+4. Cilium components を Flux GitOps の管理下に置き、以後の更新は GitOps 経由に統一する
+5. Cilium 用に `kubernetes/components/cilium/production/` を新設し、`make hydrate ENV=production` の env-aware 化も合わせて行う
+
+## Non-goals (Out of scope, with explicit follow-up tracking)
+
+以下は本 spec で扱わない。各項目は明示的に follow-up 先を記録する。
+
+- **Hubble UI の外部公開** → Phase 4 で oauth2-proxy / ALB OIDC を含めた認証ゲートと一括設計（Plan 4-x として別 spec で扱う）。本 spec 期間中は port-forward のみで運用
+- **HTTPRoute / CiliumEnvoyConfig による monorepo 認証実装** → monorepo K8s 移行 spec
+- **Cilium Cluster Mesh / Egress Gateway** → Future Specs（必要発生時に別 spec）
+- **`endpointRoutes.enabled = false` の検証** → 本 spec 期間の検証で `true` が機能すれば再評価不要、Future Specs として記録
+- **EKS CNI 戦略見直し（chaining → ENI mode 移行）** → ロードマップ spec の Future Specs を継承
+
+## Architecture decisions
+
+ロードマップ spec の決定を継承するのみ。本 spec で新規追加する決定はない。
+
+| 継承元 | 内容 |
+|---|---|
+| Roadmap Decision 2 | CNI は chaining mode（VPC CNI primary + Cilium secondary） |
+| Roadmap Decision 4 | 東西は Pattern B-Full（Cilium GW + HTTPRoute + CEC で JWT 検証） |
+
+## Open Questions resolution（spec 確定値）
+
+ロードマップ spec で未確定だった 4 項目について、本 spec で値を確定する。実機検証の手順は Verification セクションを参照。
+
+| # | Question | 確定値 | 根拠 |
+|---|---|---|---|
+| Q1 | chaining + KPR + Gateway + CEC が EKS 1.35 / AL2023 ARM64 で動作するか | **直接検証で確認**。失敗時は逐次対処、最終フォールバックはロードマップ spec の Future Specs（ENI mode 移行）に escalate | AWS 公式 blog で chaining + KPR + L7 機能の事例があるが、EKS minor version / AMI / Cilium version の固有組み合わせは検証必須 |
+| Q2 | KPR `true` (full) vs `partial` | **`true`（full）** | AWS 公式 blog の事例が full mode、Cilium 公式 chaining セットアップ手順も full mode で記述。`partial` は kube-proxy と Cilium の併存で挙動が読みづらい |
+| Q3 | `endpointRoutes.enabled` の値 | **`true`** | chaining mode で Cilium 側に endpoint route を持たせると Hubble / NetworkPolicy が確実に機能する。`false` だと Cilium が endpoint を見えなくなる場合がある |
+| Q4 | `envoy.enabled` を独立 DaemonSet vs agent 内蔵 | **`true`（独立 DaemonSet）** | Pattern B-Full で L7 proxy がクリティカルパスに入るため、agent crash / restart の影響を proxy から切り離す。Cilium 1.16+ の推奨パターン |
+
+## Cilium production values
+
+`kubernetes/components/cilium/production/values.yaml` の最終形：
+
+```yaml
+# =============================================================================
+# CNI Chaining Mode（VPC CNI が IPAM/datapath を担当、Cilium は L7/policy/observability）
+# =============================================================================
+cni:
+  chainingMode: aws-cni
+  exclusive: false
+
+# =============================================================================
+# Routing & Masquerade
+# =============================================================================
+routingMode: native
+endpointRoutes:
+  enabled: true
+enableIPv4Masquerade: false
+ipv6:
+  enabled: false
+
+# =============================================================================
+# Kube Proxy Replacement: 完全置換
+# =============================================================================
+kubeProxyReplacement: true
+k8sServiceHost: <eks-api-endpoint>     # helmfile gotmpl で .Values.cluster.eksApiEndpoint から差し込み
+k8sServicePort: 443
+
+# =============================================================================
+# Operator: HA
+# =============================================================================
+operator:
+  replicas: 2
+  rollOutPods: true
+
+# =============================================================================
+# L7 Proxy: 独立 DaemonSet
+# =============================================================================
+envoy:
+  enabled: true
+
+# =============================================================================
+# Gateway API（東西用、北南は ALB Controller）
+# =============================================================================
+gatewayAPI:
+  enabled: true
+
+# =============================================================================
+# Socket-level LB（Beyla / hostNetwork Pod が ClusterIP に到達するため）
+# =============================================================================
+socketLB:
+  enabled: true
+
+# =============================================================================
+# Hubble（UI は port-forward only、Phase 4 で Ingress 公開）
+# =============================================================================
+hubble:
+  enabled: true
+  relay:
+    enabled: true
+  ui:
+    enabled: true
+  metrics:
+    enabled:
+      - dns
+      - drop
+      - tcp
+      - flow
+      - icmp
+      - http
+    serviceMonitor:
+      enabled: false                  # Phase 3 で prometheus-operator 導入後に true へ切り替え
+
+# =============================================================================
+# DNS Proxy（hostNetwork Pod の DNS resolution に必要）
+# =============================================================================
+dnsProxy:
+  enabled: true
+
+# =============================================================================
+# Prometheus Metrics
+# =============================================================================
+prometheus:
+  enabled: false                      # Phase 3 で prometheus-operator 導入後に true へ切り替え
+```
+
+local 環境（`kubernetes/components/cilium/local/values.yaml`）からの主な差分：
+
+- `cni.chainingMode: aws-cni` + `cni.exclusive: false`（chaining 化）
+- `ipam.operator.clusterPoolIPv4PodCIDRList` を削除（VPC CNI が IPAM 担当）
+- `routingMode: native` を追加
+- `endpointRoutes.enabled: true` を追加
+- `enableIPv4Masquerade: false` に変更（local は true）
+- `k8sServiceHost / k8sServicePort` を EKS API endpoint / 443 に変更（local は k3d server / 6443）
+- `operator.replicas: 2` に変更（local は 1）
+- `envoy.enabled: true` を追加（local 未指定）
+- `hubble.metrics.serviceMonitor.enabled: false`（Phase 3 まで）
+- `prometheus.enabled: false`（Phase 3 まで）
+
+## Components 変更マトリクス
+
+| File / Resource | 種別 | 内容 |
+|---|---|---|
+| `kubernetes/components/cilium/production/helmfile.yaml.gotmpl` | create | production env 用 helmfile。`k8sServiceHost` を `.Values.cluster.eksApiEndpoint` から差し込み |
+| `kubernetes/components/cilium/production/values.yaml` | create | 上記 production values（gotmpl 置換あり） |
+| `kubernetes/helmfile.yaml.gotmpl` | modify | `production` env block に `cluster.eksApiEndpoint` を追加 |
+| `kubernetes/Makefile` | modify | `hydrate-index` を **env-aware** に変更（`find components/*/$(ENV)/namespace.yaml` で env 限定） |
+| `kubernetes/manifests/production/` | regenerate | `make hydrate ENV=production` で `cilium/` と `00-namespaces/`（cilium namespace のみ）を再生成 |
+| `aws/eks/modules/addons.tf` | modify | `kube-proxy` addon を **削除**（KPR=true で不要） |
+| `aws/eks/envs/production/.terraform.lock.hcl` | regenerate | terragrunt apply で再生成 |
+
+`kubernetes/components/cilium/production/namespace.yaml` は **作成しない**（Cilium は `kube-system` を使用、既存 namespace のため）。
+
+### Makefile env-aware 化の方針
+
+現状の `hydrate-index` は `find components -maxdepth 2 -name namespace.yaml` で全 component の namespace.yaml を env 非依存に収集している。これを「**`components/<comp>/<env>/` ディレクトリが存在する component のみ**」を対象にするロジックに変更する。
+
+要件：
+
+1. ある env 用の `make hydrate ENV=<env>` で生成される `manifests/<env>/00-namespaces/namespaces.yaml` には、その env で実際にデプロイされる component の namespace のみ含まれる
+2. namespace.yaml の配置位置は **`components/<comp>/<env>/namespace.yaml`**（env-specific）と **`components/<comp>/namespace.yaml`**（env-non-specific）の両方をサポートする。env-specific が優先、なければ env-non-specific を fallback
+3. 既存 local 環境の動作（opentelemetry / opentelemetry-collector / prometheus-operator の namespace が含まれる）を破壊しない後方互換性を維持
+
+具体的な Makefile syntax は実装 plan で提示する。本 spec では **「env-aware かつ後方互換」** という設計要件のみを定める。
+
+Phase 3 で全 component の namespace を `<comp>/<env>/namespace.yaml` 配下に移行した時点で、env-non-specific fallback path を削除する（Future Specs に記録）。
+
+## Migration sequence
+
+production cluster は現在 **kube-proxy DaemonSet（EKS managed addon）が動作中、Cilium 未 install** の状態。順序を間違えると Service routing が一時的に死ぬので、以下の順で実施する。
+
+| Step | 内容 | 実行者 | Flux 状態 |
+|---|---|---|---|
+| 1 | production cluster の Flux Kustomization を suspend する: `flux suspend kustomization flux-system -n flux-system` | user | suspended |
+| 2 | `kubernetes/components/cilium/production/` 一式 + Makefile env-aware 化 + `make hydrate ENV=production` 結果（`manifests/production/cilium/` + `manifests/production/00-namespaces/`）を 1 つの PR として main にマージ | controller (subagent) + user | suspended |
+| 3 | operator が production cluster に `helm upgrade --install cilium cilium/cilium --version <ver> -n kube-system -f /path/to/rendered/values.yaml` で **手動 install**（Flux 経由ではない） | user | suspended |
+| 4 | Verification checklist 完走（Q1-Q4 + Gateway API + connectivity test） | user | suspended |
+| 5 | EKS の `kube-proxy` addon を terragrunt で削除（`aws/eks/modules/addons.tf` 修正 → PR → review → main merge → terragrunt apply） | user | suspended |
+| 6 | kube-proxy 削除後の疎通再確認（Q2 の `kube-proxy NotFound` 含む） | user | suspended |
+| 7 | `flux resume kustomization flux-system -n flux-system` で Flux 再開。Flux が既存の Helm release を adopt し、以後 GitOps 管理 | user | active |
+| 8 | `flux reconcile kustomization flux-system -n flux-system` 後、Cilium が drift なしで sync 完了することを確認（冪等性） | user | active |
+
+> **設計意図**: Step 1 で先に Flux を suspend してから Step 2-6 を実施することで、検証中の試行錯誤（`helm uninstall` → values 修正 → `helm install` 等）が GitOps と競合しない。Step 7 で Flux に adopt させる際、すでに正常動作している release が Helm 管理外から GitOps 管理に乗り換える形になる。
+
+## Verification checklist
+
+各 Open Question について、以下のコマンドが pass すれば解消とみなす。
+
+### Q1: chaining + KPR + Gateway + CEC が EKS で動作
+
+```bash
+# Cilium 全体ステータス
+cilium status                              # → "KubeProxyReplacement: True", "Gateway API: enabled"
+
+# Cilium 公式の connectivity test（数分かかる）
+cilium connectivity test --test '!check-log-errors'   # → all tests pass
+
+# CiliumEnvoyConfig の動作確認（最小例）
+cat <<'EOF' | kubectl apply -f -
+apiVersion: cilium.io/v2
+kind: CiliumEnvoyConfig
+metadata:
+  name: smoke-test-cec
+  namespace: kube-system
+spec:
+  services:
+    - name: kubernetes
+      namespace: default
+  resources: []
+EOF
+kubectl get ciliumenvoyconfig smoke-test-cec -n kube-system -o jsonpath='{.status.conditions[?(@.type=="Reconciled")].status}'   # → "True"
+kubectl delete ciliumenvoyconfig smoke-test-cec -n kube-system
+```
+
+### Q2: KPR=true（full）
+
+```bash
+cilium status | grep KubeProxyReplacement   # → "True"
+# Step 4-5 完了後
+kubectl get ds -n kube-system kube-proxy   # → NotFound
+```
+
+### Q3: endpointRoutes.enabled=true
+
+```bash
+# 任意の node にログインして
+kubectl debug node/<node-name> -it --image=ubuntu -- ip route | grep cilium   # → cilium endpoint route が見える
+
+# Pod レベルでも
+cilium endpoint list                       # 全 endpoint が "Ready"
+```
+
+### Q4: envoy.enabled=true（独立 DaemonSet）
+
+```bash
+kubectl get ds -n kube-system cilium-envoy   # → DaemonSet 存在、各 node で Running
+kubectl exec -n kube-system <cilium-pod> -- cilium-dbg envoy status   # → reachable
+```
+
+### Gateway API 動作確認
+
+```bash
+# 内部 Gateway 1 個 + HTTPRoute 1 個で疎通
+cat <<'EOF' | kubectl apply -f -
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: smoke-test-gateway
+  namespace: default
+spec:
+  gatewayClassName: cilium
+  listeners:
+    - name: http
+      protocol: HTTP
+      port: 80
+EOF
+kubectl get gateway smoke-test-gateway -n default -o jsonpath='{.status.conditions[?(@.type=="Programmed")].status}'   # → "True"
+kubectl delete gateway smoke-test-gateway -n default
+```
+
+### Hubble 動作確認
+
+```bash
+cilium hubble enable    # 既に enabled なら no-op
+hubble observe --last 10   # 直近 10 件のフローが見える
+```
+
+すべての項目が pass したら Migration sequence Step 5（kube-proxy addon 削除）に進む。Step 6 で Q2 の `kube-proxy NotFound` を再確認する。
+
+## Rollback strategy
+
+Migration sequence の各 step に対応した戻し方：
+
+| 失敗フェーズ | 戻し方 |
+|---|---|
+| Step 3 (Cilium install 直後) | `helm uninstall cilium -n kube-system` → kube-proxy が引き続き動作、cluster は install 前の状態 |
+| Step 4 (検証中に Open Question が pass しない) | values.yaml を調整 → `helm upgrade --install cilium ...` で再 apply。それでも動かなければ Step 3 と同じく uninstall |
+| Step 5 (kube-proxy 削除後に問題発生) | terragrunt で `kube-proxy` addon を再追加 → terragrunt apply → kube-proxy 復活 |
+| Step 7 (Flux 管理移管後に drift) | `flux suspend kustomization flux-system -n flux-system` → 手で修正 → `flux resume`。values の問題なら main へ修正 PR |
+
+すべてのフェーズで **production にアプリ未投入のため業務影響なし**。失敗時は安全に戻せる。
+
+## Future Specs（明示的に記録）
+
+本 spec のスコープ外で、別 spec として追跡する：
+
+- **Plan 4-x: Hubble UI 公開 + 認証ゲート連動**: Hubble UI を Grafana と並びで公開、oauth2-proxy or ALB OIDC で認証ゲート設置
+- **monorepo K8s 移行**: HTTPRoute + CiliumEnvoyConfig + JWT filter で Pattern B-Full を本格運用
+- **Cluster Mesh / Egress Gateway**: 必要発生時
+- **EKS CNI 戦略見直し**（ロードマップ spec から継承）: chaining → ENI mode 移行検討
+- **`endpointRoutes.enabled = false` 検証**: 本 spec の検証で `true` が機能すれば不要。問題発生時に再評価
+- **`make hydrate-index` の env-non-specific path 完全廃止**: Phase 3 で全 component の namespace を env 配下に移行した時点で実施
+
+## References
+
+- ロードマップ spec: `docs/superpowers/specs/2026-05-02-eks-production-platform-roadmap-design.md`
+- Plan 1a (Flux bootstrap): `docs/superpowers/plans/2026-05-02-eks-production-flux-bootstrap.md`（merged in PR #255）
+- aws-eks-production spec: `docs/superpowers/specs/2026-04-30-aws-eks-production-design.md`
+- aws-eks-production plan: `docs/superpowers/plans/2026-05-01-aws-eks-production.md`
+- monorepo authentication design: `panicboat/monorepo` の `docs/分散システム設計/AUTHENTICATION.md`
+- AWS blog: "Getting started with Cilium service mesh on Amazon EKS" (`https://aws.amazon.com/jp/blogs/opensource/getting-started-with-cilium-service-mesh-on-amazon-eks/`)
+- Cilium blog: "Installing Cilium on EKS in Overlay(BYOCNI) and CNI Chaining Mode" (2025-07-08, `https://cilium.io/blog/2025/07/08/byonci-overlay-install/`)

--- a/kubernetes/Makefile
+++ b/kubernetes/Makefile
@@ -102,8 +102,18 @@ hydrate-index: ## Regenerate manifests/$(ENV) index and cleanup orphans (usage: 
 	@set -euo pipefail; \
 	env_dir="manifests/$(ENV)"; \
 	mkdir -p "$$env_dir/00-namespaces"; \
-	find components -maxdepth 2 -name namespace.yaml | sort | \
-		xargs -I{} sh -c 'echo "---"; cat "{}"' > "$$env_dir/00-namespaces/namespaces.yaml"; \
+	: > "$$env_dir/00-namespaces/namespaces.yaml"; \
+	for comp_dir in components/*/$(ENV)/; do \
+		[ -d "$$comp_dir" ] || continue; \
+		comp_name=$$(basename "$$(dirname "$$comp_dir")"); \
+		if [ -f "components/$$comp_name/$(ENV)/namespace.yaml" ]; then \
+			echo "---" >> "$$env_dir/00-namespaces/namespaces.yaml"; \
+			cat "components/$$comp_name/$(ENV)/namespace.yaml" >> "$$env_dir/00-namespaces/namespaces.yaml"; \
+		elif [ -f "components/$$comp_name/namespace.yaml" ]; then \
+			echo "---" >> "$$env_dir/00-namespaces/namespaces.yaml"; \
+			cat "components/$$comp_name/namespace.yaml" >> "$$env_dir/00-namespaces/namespaces.yaml"; \
+		fi; \
+	done; \
 	printf "resources:\n  - namespaces.yaml\n" > "$$env_dir/00-namespaces/kustomization.yaml"; \
 	for dir in $$(ls -d "$$env_dir"/*/ 2>/dev/null); do \
 		name=$$(basename "$$dir"); \

--- a/kubernetes/Makefile
+++ b/kubernetes/Makefile
@@ -84,7 +84,7 @@ hydrate-component: ## Hydrate single component (usage: make hydrate-component CO
 	mkdir -p "$$out_dir"; \
 	: > "$$out_dir/manifest.yaml"; \
 	if [ -f "$$component_dir/helmfile.yaml" ]; then \
-		helmfile -f "$$component_dir/helmfile.yaml" template --include-crds --skip-tests >> "$$out_dir/manifest.yaml"; \
+		helmfile -f "$$component_dir/helmfile.yaml" -e $(ENV) template --include-crds --skip-tests >> "$$out_dir/manifest.yaml"; \
 	fi; \
 	if [ -d "$$component_dir/kustomization" ]; then \
 		echo "---" >> "$$out_dir/manifest.yaml"; \

--- a/kubernetes/components/cilium/production/helmfile.yaml
+++ b/kubernetes/components/cilium/production/helmfile.yaml
@@ -7,7 +7,6 @@
 # =============================================================================
 environments:
   production:
-
 ---
 repositories:
   - name: cilium

--- a/kubernetes/components/cilium/production/helmfile.yaml
+++ b/kubernetes/components/cilium/production/helmfile.yaml
@@ -7,6 +7,9 @@
 # =============================================================================
 environments:
   production:
+    values:
+      - cluster:
+          eksApiEndpoint: BD10E7689A05E46191305DDC7BE6CA67.gr7.ap-northeast-1.eks.amazonaws.com
 ---
 repositories:
   - name: cilium

--- a/kubernetes/components/cilium/production/helmfile.yaml
+++ b/kubernetes/components/cilium/production/helmfile.yaml
@@ -7,6 +7,10 @@
 # =============================================================================
 environments:
   production:
+    # NOTE: helmfile v1.4 は親 helmfile.yaml.gotmpl の environments values を
+    # 子 helmfile に auto-inherit しないため、ここで再定義する。
+    # eksApiEndpoint の値は kubernetes/helmfile.yaml.gotmpl の production env
+    # block と同期すること（cluster recreate 等で endpoint hostname が変わる場合）。
     values:
       - cluster:
           eksApiEndpoint: BD10E7689A05E46191305DDC7BE6CA67.gr7.ap-northeast-1.eks.amazonaws.com

--- a/kubernetes/components/cilium/production/helmfile.yaml.gotmpl
+++ b/kubernetes/components/cilium/production/helmfile.yaml.gotmpl
@@ -1,0 +1,22 @@
+# =============================================================================
+# Cilium Helmfile for production
+# =============================================================================
+# Cilium 1.18.x を chaining mode (VPC CNI 共存) で deploy する。
+# KPR / Gateway Controller / 独立 Envoy DaemonSet / Hubble を有効化。
+# k8sServiceHost は .Values.cluster.eksApiEndpoint で動的に差し込む。
+# =============================================================================
+environments:
+  production:
+
+---
+repositories:
+  - name: cilium
+    url: https://helm.cilium.io/
+
+releases:
+  - name: cilium
+    namespace: kube-system
+    chart: cilium/cilium
+    version: "1.18.6"
+    values:
+      - values.yaml.gotmpl

--- a/kubernetes/components/cilium/production/values.yaml.gotmpl
+++ b/kubernetes/components/cilium/production/values.yaml.gotmpl
@@ -56,6 +56,11 @@ socketLB:
 # =============================================================================
 hubble:
   enabled: true
+  # TLS certs を Helm 自動生成（chart values に焼き込み）ではなく cluster 内
+  # CronJob で生成・rotate する。public Git repo に Hubble の秘密鍵を出さない。
+  tls:
+    auto:
+      method: cronJob
   relay:
     enabled: true
   ui:

--- a/kubernetes/components/cilium/production/values.yaml.gotmpl
+++ b/kubernetes/components/cilium/production/values.yaml.gotmpl
@@ -1,0 +1,84 @@
+# Cilium CNI Configuration for production (eks-production)
+# Reference: docs/superpowers/specs/2026-05-03-eks-production-cilium-chaining-design.md
+
+# =============================================================================
+# CNI Chaining Mode（VPC CNI が IPAM/datapath、Cilium は L7/policy/observability）
+# =============================================================================
+cni:
+  chainingMode: aws-cni
+  exclusive: false
+
+# =============================================================================
+# Routing & Masquerade
+# =============================================================================
+routingMode: native
+endpointRoutes:
+  enabled: true
+enableIPv4Masquerade: false
+ipv6:
+  enabled: false
+
+# =============================================================================
+# Kube Proxy Replacement: 完全置換
+# =============================================================================
+# kube-proxy addon は spec の Migration sequence Step 5 で terragrunt 経由で削除
+kubeProxyReplacement: true
+k8sServiceHost: {{ .Values.cluster.eksApiEndpoint }}
+k8sServicePort: 443
+
+# =============================================================================
+# Operator: HA
+# =============================================================================
+operator:
+  replicas: 2
+  rollOutPods: true
+
+# =============================================================================
+# L7 Proxy: 独立 DaemonSet
+# =============================================================================
+envoy:
+  enabled: true
+
+# =============================================================================
+# Gateway API（東西用、北南は ALB Controller）
+# =============================================================================
+gatewayAPI:
+  enabled: true
+
+# =============================================================================
+# Socket-level LB（Beyla / hostNetwork Pod が ClusterIP に到達するため）
+# =============================================================================
+socketLB:
+  enabled: true
+
+# =============================================================================
+# Hubble（UI は port-forward only、Phase 4 で Ingress 公開）
+# =============================================================================
+hubble:
+  enabled: true
+  relay:
+    enabled: true
+  ui:
+    enabled: true
+  metrics:
+    enabled:
+      - dns
+      - drop
+      - tcp
+      - flow
+      - icmp
+      - http
+    serviceMonitor:
+      enabled: false                  # Phase 3 で prometheus-operator 導入後に true
+
+# =============================================================================
+# DNS Proxy（hostNetwork Pod の DNS resolution に必要）
+# =============================================================================
+dnsProxy:
+  enabled: true
+
+# =============================================================================
+# Prometheus Metrics
+# =============================================================================
+prometheus:
+  enabled: false                      # Phase 3 で prometheus-operator 導入後に true

--- a/kubernetes/helmfile.yaml.gotmpl
+++ b/kubernetes/helmfile.yaml.gotmpl
@@ -23,6 +23,8 @@ environments:
       - cluster:
           name: eks-production
           isLocal: false
+          # eks-production cluster の API server endpoint hostname（https:// は含まない）
+          eksApiEndpoint: BD10E7689A05E46191305DDC7BE6CA67.gr7.ap-northeast-1.eks.amazonaws.com
   # TODO: (staging) Uncomment and configure when staging cluster is provisioned
   # staging:
   #   values:

--- a/kubernetes/manifests/production/00-namespaces/kustomization.yaml
+++ b/kubernetes/manifests/production/00-namespaces/kustomization.yaml
@@ -1,0 +1,2 @@
+resources:
+  - namespaces.yaml

--- a/kubernetes/manifests/production/cilium/kustomization.yaml
+++ b/kubernetes/manifests/production/cilium/kustomization.yaml
@@ -1,0 +1,2 @@
+resources:
+  - manifest.yaml

--- a/kubernetes/manifests/production/cilium/manifest.yaml
+++ b/kubernetes/manifests/production/cilium/manifest.yaml
@@ -1,0 +1,2248 @@
+---
+# Source: cilium/templates/cilium-secrets-namespace.yaml
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: "cilium-secrets"
+  labels:
+    app.kubernetes.io/part-of: cilium
+  annotations:
+---
+# Source: cilium/templates/cilium-agent/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: "cilium"
+  namespace: kube-system
+---
+# Source: cilium/templates/cilium-envoy/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: "cilium-envoy"
+  namespace: kube-system
+---
+# Source: cilium/templates/cilium-operator/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: "cilium-operator"
+  namespace: kube-system
+---
+# Source: cilium/templates/hubble-relay/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: "hubble-relay"
+  namespace: kube-system
+automountServiceAccountToken: false
+---
+# Source: cilium/templates/hubble-ui/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: "hubble-ui"
+  namespace: kube-system
+---
+# Source: cilium/templates/cilium-ca-secret.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: cilium-ca
+  namespace: kube-system
+data:
+  ca.crt: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURFekNDQWZ1Z0F3SUJBZ0lRVGdhbThMbTFZMzZrZGRWbTcrci9HREFOQmdrcWhraUc5dzBCQVFzRkFEQVUKTVJJd0VBWURWUVFERXdsRGFXeHBkVzBnUTBFd0hoY05Nall3TlRBeU1UYzBOREUzV2hjTk1qa3dOVEF4TVRjMApOREUzV2pBVU1SSXdFQVlEVlFRREV3bERhV3hwZFcwZ1EwRXdnZ0VpTUEwR0NTcUdTSWIzRFFFQkFRVUFBNElCCkR3QXdnZ0VLQW9JQkFRQy8yaHlqRDBxZkVhNzg5K0hsa3V4ckgzYTljYzd3L01ma0phQUFVcFBWQWIveU9GM2YKaUNIRUVIYzFVRkl3eDM3L2RjWEtJbEF6UkhyT29Hd1dOU3lTNUVBNDc5cTJ4a2UzTDkzSU1EUlhtSThZM3Y3awpwblJkK1hnS2VlR3ZJTG5QSXpXMjF3NW5uTklJSEs3S2EwVmhBOVFBWk1ScEtMRThOdjAxVHdDS3psMGFQcXJHCm5rY0ZQeDBMV0l0MGgvNzZYdnpvWjUxVWpiNGdLdUxtWGs1UVNBT0VNWWxQcDFtNVdUUHFmTEQzUXZCMXA0UmwKZVZybjNPbm44WlYrNnVaOHpQNGQ4OEFCWmFUVnJKTWI1UDN1cXRQS2w2RTNSb2ZGV2kzNko2VUE4QXN6MmRCSwpFdVlsb2ZjdWlEZFdnaU50djVMbUF1NTY4ZmpDVm8xSVp0dHRBZ01CQUFHallUQmZNQTRHQTFVZER3RUIvd1FFCkF3SUNwREFkQmdOVkhTVUVGakFVQmdnckJnRUZCUWNEQVFZSUt3WUJCUVVIQXdJd0R3WURWUjBUQVFIL0JBVXcKQXdFQi96QWRCZ05WSFE0RUZnUVVLTXdtOWhEQjJONjVFS3R2THNuaUxQOWE4Yzh3RFFZSktvWklodmNOQVFFTApCUUFEZ2dFQkFFR0ZVSmlEM1V6cmR5VFFiWXVVOUlRUGpuWWliUVNVUW9VUVFWRWg3TXpaSWVPOUdxbFFDOStaCmVQOVBYV2VHQy9NOHlBMDd0N3JlWk9LWm1yODVFcU1qOEw2dFM2N1lBTzhVRkxmaHR6ZEEwY1BGMCtuZXBxWU0KdTZpbTF3V2dlY2U2QTRSeTBWbFNXbnpkcldoc0dZTGNKZ1lGOG12VVZ1NVRqZWlGQkJxZHZ5MnIvYm9yZkR0VQpaRFB6ZWg5RkFFS1lobVZkWFY1cG9kVVhkNEgzbTRCTkk4aGREZitDN1NTNHBYazB5QTBuSTgvTTBxY01qcUJVCkRKK0xiczNROWJlaThrZTV2VzhUNDhwN0svendHL2RoUE43bUFSaWlnM1dqSms0WnQvZkdjNnphVEZVMXN2L2IKdzRpamF6OGRQdmxIQ3pXR0t0bTB6Q1BseVMxeTlQQT0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=
+  ca.key: LS0tLS1CRUdJTiBSU0EgUFJJVkFURSBLRVktLS0tLQpNSUlFb3dJQkFBS0NBUUVBdjlvY293OUtueEd1L1BmaDVaTHNheDkydlhITzhQekg1Q1dnQUZLVDFRRy84amhkCjM0Z2h4QkIzTlZCU01NZCsvM1hGeWlKUU0wUjZ6cUJzRmpVc2t1UkFPTy9hdHNaSHR5L2R5REEwVjVpUEdONysKNUtaMFhmbDRDbm5ocnlDNXp5TTF0dGNPWjV6U0NCeXV5bXRGWVFQVUFHVEVhU2l4UERiOU5VOEFpczVkR2o2cQp4cDVIQlQ4ZEMxaUxkSWYrK2w3ODZHZWRWSTIrSUNyaTVsNU9VRWdEaERHSlQ2ZFp1Vmt6Nm55dzkwTHdkYWVFClpYbGE1OXpwNS9HVmZ1cm1mTXorSGZQQUFXV2sxYXlURytUOTdxclR5cGVoTjBhSHhWb3QraWVsQVBBTE05blEKU2hMbUphSDNMb2czVm9JamJiK1M1Z0x1ZXZINHdsYU5TR2JiYlFJREFRQUJBb0lCQUE4aFUrM1dLR1BvSUoxSgpyVktPSmtBQ2dMcExEZTk2ZUFjNW9tYzBHLzJLQUVuSmdUbStRaTkwdnZvQTVpSjdzVHZUWFhCbUNWNHBzZWUyCnhoOXdQUjR1aXhRU2NuVEVxV1k4aTZpY2lKdzU1MXNtUndMZ1Q4QVRpeENFY1RSL0I3aGF4Z012N2E1bE16azUKamQxZjNWNWJ6MjNpaEl6b2pTVzdEbmdVVFc0azJqbkxHTDNOS1BkeFo0ZXVMQnd4RjBiZ1BNZVhSclNLUEhoRApGTTVZOVkrbWFPOHp4czBVa3JKek5sWTNyUm5JMDl6Nm9HT0Q2MFRKRHZSeDZOcDcvNHNXNFVJcVJ4V2NIZXhzCnlYTWpzMzB0OExRd1N1eW1ud0ZCNmJXV1FZelBjcVFFY3BRN1RaVTFlcTNxY3RpSlA4eTdtRHRQa2JDdXhjMDYKL0VYVlU0OENnWUVBNlJWOTZDYlhzbElCSE41TlgwamRFZ3pmV2grZFFqMUIzblNPNCt2Zm5YbzRxRVgxZ1VqSApLY3RqaStKUEtYaUxPUk4wSlFacXUvb1pzTEhnUWFCUEhEcW9WRDVrMDFvazZiVm9reGJVWk9nWElTN0dUU3ozCitYVEd5K3QzcjZKUmMxRDdZS0d6SWxzNTZpQVpvaHRjRkhRbEZ2cmJNYkw0S3JiQndxWndUWThDZ1lFQTByYloKakhlY2NRN0J1cTRXRGhBRS83T1lxbjZ3aVIwK00rWEg0SDd0V04weG9LZXMxbTNJUUFhaFkrZmlFLzIzMjR6NApsZ1dEMGtnMjVBcjFORC9ZU21QbSt3Q2tvWjZtTjhzRFBxZTNiNWxkY1VWcFR0ZWlkQkhHVTc0emxHODh1UXgrCnd6dHBnYjJmMmwzbDF4VkF2U3ovTk91OEZRaFh5bFNNOXl0N0FVTUNnWUJqOERjZ0J5ZU02ZVJZUUdqa1poV0QKMjhrWWwxMlNQVG0wN0Qwb05NYVlld000QTJjVW0rUHBZNiszRnIzaWhqRUxzKytrd0crYlVjMGFHZXFSdU82eQpwK1BzMnlQWUMxcXdhbndBTlZXMFBsOU1kd1hIcVhSWm5WeHZxdktTZUFKOGMwaVZVai9BaDJUNW9mSGJzK2R6ClRhbHBoUDNlL1dHeXp0R2RhRWZXdVFLQmdRQ24rWU9yYXA2WHNmL1Y1WGxIZEpYSGtWQWVlaWdZNWVyMFREVHUKVGNDL21uVTVjUEZqYnRpMzBaRk9wMGVlVUNBRk1YZnBnRFA1cWYrNEF0UTk5cmRoZGdwb0JiYzM3OVRwblRqVQo5YlpSakp6azgwUmp5WnFEbExmWmdrSjBEY2tHYTJPU0Z3YWdtcDJYNGtxYkR5SXdySEkxcWNhaHJhanVia0NCCnVYT3hLUUtCZ0JxelA4MVRYWlNURHozODNONjRjMGNxQlhHbHJONHRKTmxCWVNjZ1VwRzltR3djZG9paG9OaXUKYmxEWDh2UXBMbG8xZFhWWjJ5R3hGRHF2UzBmWStuQTJ2UFBXWkFtUnhhOGIzR0phaVRTZGk2RzFJOWVOT1RzNgpDZGVxTG5ld2oxRzQ4ck8zR0dSZG9Xb0tjRWtwazMyZFRtVTZOU0ZRR00wRkpDbzlVMWNyCi0tLS0tRU5EIFJTQSBQUklWQVRFIEtFWS0tLS0tCg==
+---
+# Source: cilium/templates/hubble/tls-helm/relay-client-secret.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: hubble-relay-client-certs
+  namespace: kube-system
+type: kubernetes.io/tls
+data:
+  ca.crt:  LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURFekNDQWZ1Z0F3SUJBZ0lRVGdhbThMbTFZMzZrZGRWbTcrci9HREFOQmdrcWhraUc5dzBCQVFzRkFEQVUKTVJJd0VBWURWUVFERXdsRGFXeHBkVzBnUTBFd0hoY05Nall3TlRBeU1UYzBOREUzV2hjTk1qa3dOVEF4TVRjMApOREUzV2pBVU1SSXdFQVlEVlFRREV3bERhV3hwZFcwZ1EwRXdnZ0VpTUEwR0NTcUdTSWIzRFFFQkFRVUFBNElCCkR3QXdnZ0VLQW9JQkFRQy8yaHlqRDBxZkVhNzg5K0hsa3V4ckgzYTljYzd3L01ma0phQUFVcFBWQWIveU9GM2YKaUNIRUVIYzFVRkl3eDM3L2RjWEtJbEF6UkhyT29Hd1dOU3lTNUVBNDc5cTJ4a2UzTDkzSU1EUlhtSThZM3Y3awpwblJkK1hnS2VlR3ZJTG5QSXpXMjF3NW5uTklJSEs3S2EwVmhBOVFBWk1ScEtMRThOdjAxVHdDS3psMGFQcXJHCm5rY0ZQeDBMV0l0MGgvNzZYdnpvWjUxVWpiNGdLdUxtWGs1UVNBT0VNWWxQcDFtNVdUUHFmTEQzUXZCMXA0UmwKZVZybjNPbm44WlYrNnVaOHpQNGQ4OEFCWmFUVnJKTWI1UDN1cXRQS2w2RTNSb2ZGV2kzNko2VUE4QXN6MmRCSwpFdVlsb2ZjdWlEZFdnaU50djVMbUF1NTY4ZmpDVm8xSVp0dHRBZ01CQUFHallUQmZNQTRHQTFVZER3RUIvd1FFCkF3SUNwREFkQmdOVkhTVUVGakFVQmdnckJnRUZCUWNEQVFZSUt3WUJCUVVIQXdJd0R3WURWUjBUQVFIL0JBVXcKQXdFQi96QWRCZ05WSFE0RUZnUVVLTXdtOWhEQjJONjVFS3R2THNuaUxQOWE4Yzh3RFFZSktvWklodmNOQVFFTApCUUFEZ2dFQkFFR0ZVSmlEM1V6cmR5VFFiWXVVOUlRUGpuWWliUVNVUW9VUVFWRWg3TXpaSWVPOUdxbFFDOStaCmVQOVBYV2VHQy9NOHlBMDd0N3JlWk9LWm1yODVFcU1qOEw2dFM2N1lBTzhVRkxmaHR6ZEEwY1BGMCtuZXBxWU0KdTZpbTF3V2dlY2U2QTRSeTBWbFNXbnpkcldoc0dZTGNKZ1lGOG12VVZ1NVRqZWlGQkJxZHZ5MnIvYm9yZkR0VQpaRFB6ZWg5RkFFS1lobVZkWFY1cG9kVVhkNEgzbTRCTkk4aGREZitDN1NTNHBYazB5QTBuSTgvTTBxY01qcUJVCkRKK0xiczNROWJlaThrZTV2VzhUNDhwN0svendHL2RoUE43bUFSaWlnM1dqSms0WnQvZkdjNnphVEZVMXN2L2IKdzRpamF6OGRQdmxIQ3pXR0t0bTB6Q1BseVMxeTlQQT0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=
+  tls.crt: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURTRENDQWpDZ0F3SUJBZ0lRSjd5YnIwalVhS0RnQUtyMVVhSVI3VEFOQmdrcWhraUc5dzBCQVFzRkFEQVUKTVJJd0VBWURWUVFERXdsRGFXeHBkVzBnUTBFd0hoY05Nall3TlRBeU1UYzBOREUzV2hjTk1qY3dOVEF5TVRjMApOREUzV2pBak1TRXdId1lEVlFRRERCZ3FMbWgxWW1Kc1pTMXlaV3hoZVM1amFXeHBkVzB1YVc4d2dnRWlNQTBHCkNTcUdTSWIzRFFFQkFRVUFBNElCRHdBd2dnRUtBb0lCQVFETm9xRmtZS3huRkhBTGNGYlNQWldvMjlhTFZQc0IKTVdTekUxa0g0aStTOGxQMytFMDJoRmNYUFQvMDN2VGJPbG1ocXk1dldUQURBUlA2TTlzNlAyYWViZlNLVXZuagpDeXRDYTVjcStsRTRRUUNHNGwwTkR5SVVoQURGNHU1YVc3c2dJbE9KcGZsbGpPTnBQYUt3ZkZKcU4rUHlXUWxxClUyMG1uS2V4MkNtMGV6di9CcHdaSnRhd3Y0elhHck1JaU1JcGhJdXczQUw4L3B0UzJtOWFlRUdyNEdjYVp3eUMKWEJKMzk1bTNacmgzRlBWU0QvbXAzYWpHM2tYYkJzZ3JmQjVtRnVnYWc3TU0rYjRYbkRrTEFDMkZ0L211TUtkRApZZ3hoR2RLMU1BL3Z4SExQU05EWVZvK0ZBdWN6eTE1Z0xWSHZhbXVwMWpBWW9nTWNvQVpKL0piQkFnTUJBQUdqCmdZWXdnWU13RGdZRFZSMFBBUUgvQkFRREFnV2dNQjBHQTFVZEpRUVdNQlFHQ0NzR0FRVUZCd01CQmdnckJnRUYKQlFjREFqQU1CZ05WSFJNQkFmOEVBakFBTUI4R0ExVWRJd1FZTUJhQUZDak1KdllRd2RqZXVSQ3JieTdKNGl6LwpXdkhQTUNNR0ExVWRFUVFjTUJxQ0dDb3VhSFZpWW14bExYSmxiR0Y1TG1OcGJHbDFiUzVwYnpBTkJna3Foa2lHCjl3MEJBUXNGQUFPQ0FRRUFxaVFmMVp4U0ozOVJrL2oxcktvZ0gycVBLeFVjUlRIK0p5QWMyV2Naam9lOE9MM0UKRzcvVUFza253TnBJWTRzNkNXVXZYaHpBd01QQmVvMjc4Zzlhc1dIb1MyRXlKb2toczgxZ0tna0tZMHlEci9iaAowUThvdjZSNUhwWHBZOUIwS3VzaGZPek9SNFpGbE1nUDZ6ZHE3UWJvQURqMEpJNWxvNVZNLzZ6cHhOWHdIS3JjCmo1QXN4djZPTGtWWVpGSUgzRmNiS0JuaXZiNFJ5RkVGTUk3eDFtVWNwVnoxY0xWOFo5M2RGcGh6WGtrbkx4ZkkKaDYvYVJVNzUvRDlzeVVzYVljTlhiSWxqOUFXci9ZZEllZzZxcjNiTFdhV2ZicTlSOWJqaTRCL0QyT3BJN0RvSwpZUXdOajROWDhJdXpEVDAvVzlucE83Z29BcGI4bVpBWmZyR2wzQT09Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K
+  tls.key: LS0tLS1CRUdJTiBSU0EgUFJJVkFURSBLRVktLS0tLQpNSUlFcEFJQkFBS0NBUUVBemFLaFpHQ3NaeFJ3QzNCVzBqMlZxTnZXaTFUN0FURmtzeE5aQitJdmt2SlQ5L2hOCk5vUlhGejAvOU43MDJ6cFpvYXN1YjFrd0F3RVQralBiT2o5bW5tMzBpbEw1NHdzclFtdVhLdnBST0VFQWh1SmQKRFE4aUZJUUF4ZUx1V2x1N0lDSlRpYVg1Wll6amFUMmlzSHhTYWpmajhsa0phbE50SnB5bnNkZ3B0SHM3L3dhYwpHU2JXc0wrTTF4cXpDSWpDS1lTTHNOd0MvUDZiVXRwdlduaEJxK0JuR21jTWdsd1NkL2VadDJhNGR4VDFVZy81CnFkMm94dDVGMndiSUszd2VaaGJvR29PekRQbStGNXc1Q3dBdGhiZjVyakNuUTJJTVlSblN0VEFQNzhSeXowalEKMkZhUGhRTG5NOHRlWUMxUjcycHJxZFl3R0tJREhLQUdTZnlXd1FJREFRQUJBb0lCQUFDTnhoSi9vaWM2Nmx4VgpocDVWVlNCWnl6ZWYySGMxMjFnU0hzVERLcTZpSVhEREJlNDJLQWZqZmRjYWZKMVVpR1pEa0VIemd3b1hDQ2M5CjJZTE1KZW9hVUxUSXFXeWZuSk8ydDNjQnFwTlV0WHduZ3Vta2wwcG4ycHF0MUVlQkJMMSs2aXV1TzBBM1EydUcKbzNnSE5hK2NpK3djcWtaVGlERTQ3Y2l3Vk5oc0ZVemxWR2V4MUhoMVk3UHdPUUJTV28rSDZFdWRFWngvVWlvNAowMjFmOEdQOWtlK1FRSFQ0Tmk4enQwbXhOY2Y5YjZFM3FzVVRtNUhBeVd0OHV3OHNidEdoZVdjbmJWRXR5Wkk4Cml1d3k2MW1FUmpncDlUSVN2OFY1Wm5VdHMyYzIwMkZHYlNuQ09SZ2hzSlIweXlpdktaalFycXhUOHIvV1J5djEKNkZpalFZTUNnWUVBMEJnNGhBSkc4S2RzVDBiSlFNMTViY2ZSN3J6dTZybTdZcjJLNDFLcFhnNFU1VVFhdk8zRAp0WTRhYWdrQ2ZJZXpmOWE1cEs5cVpaOWgrYjlSUk5mVlhZenZZaWtyaTR0TjVBVUZ0VXBXRlk4dXYySExYVXFaCmhnVXFncEc0ckNFcGgrZFlNenpmWldSeHduNUE4VjRDZmUwSXJrSGpjSmhHZFIySUlTdlMzUDhDZ1lFQS9QbDQKenM2ODJVb1NkbUZKam5NY2pkYzZldFpqdEJabHk3MDE4cmc2ajVnTTRoaSszV2FwaTNQTWhXT3ltSGpiSHZWMwp0YzJxS3JMdld2Q3ovc0J4MHVMaDJwdEthc3czZElJYS8ybmVQUXFwaFJXL2EwbGNzWXhHYis4RmFidHE2c0tDCmVSUUVFYTVMOFFIZkc5RWNwQzE5VUp2OHlmZEF0WWwrYmg0RHpEOENnWUFzSXJiNTZMRzdJUWRyMlF1ZVh2WSsKUG45Y0wxNU5FbytYNWJPcmUwREkzaHU0ZExWbkZOYkpqeFl6SHk0VDA0UlN2T3dxN2JtWFRES3ZrZEJlMVpnLwplMERhaFBqalkreGxURnRsbEJxbC8vUmVTeE9pK2N1T0RWSnkxdzFnRkxpR1JwOENYd3JTcW5jbVZUalkrS04yCnFldUphaGdmTFd6a01odEpUYzR2YVFLQmdRQ1ltRE5UTEVtbUdKUkNiRFRlaEhrNDVoY1VlYlh5cjRBQUFjWkUKL3ZQMEloZkRXb0huTTBJYUtHTzZJb1ZjaTZwQlpuZ3Jaais3T2V3L3d1b1FSUzFqdEEvZ3VjT040Rm1qSWNmLwpRWEVaQ1JGd2djblJnWk0wVmhVMjk4c2dHRGxLR3NKeEhxM0ZySW1LZTBLRm1RSFoxc2E4bFJ0TENLWXoyeGcwCmZFNTJLUUtCZ1FDaWZiSTA4MVZMKzcxRStpakFGWkhKdW1kSitQMGhYQlRBSFg4dFpINEl6eW56Q1B5bUhDbmgKRS8vc0ozUXc0TzFtdEtZcVZIVVczUk9DTHNBRmpraEE2aTlZVUlmSStBZitsb1NpWEl0SFhmRFRwU2dSRjhQNwpydUFVTHY1SlQ4L3ZIcmZwK2p1UHM3blMxSmY4dzlhejVjdVB4QmQvR3ZsdktSaXVnQklpUXc9PQotLS0tLUVORCBSU0EgUFJJVkFURSBLRVktLS0tLQo=
+---
+# Source: cilium/templates/hubble/tls-helm/server-secret.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: hubble-server-certs
+  namespace: kube-system
+type: kubernetes.io/tls
+data:
+  ca.crt:  LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURFekNDQWZ1Z0F3SUJBZ0lRVGdhbThMbTFZMzZrZGRWbTcrci9HREFOQmdrcWhraUc5dzBCQVFzRkFEQVUKTVJJd0VBWURWUVFERXdsRGFXeHBkVzBnUTBFd0hoY05Nall3TlRBeU1UYzBOREUzV2hjTk1qa3dOVEF4TVRjMApOREUzV2pBVU1SSXdFQVlEVlFRREV3bERhV3hwZFcwZ1EwRXdnZ0VpTUEwR0NTcUdTSWIzRFFFQkFRVUFBNElCCkR3QXdnZ0VLQW9JQkFRQy8yaHlqRDBxZkVhNzg5K0hsa3V4ckgzYTljYzd3L01ma0phQUFVcFBWQWIveU9GM2YKaUNIRUVIYzFVRkl3eDM3L2RjWEtJbEF6UkhyT29Hd1dOU3lTNUVBNDc5cTJ4a2UzTDkzSU1EUlhtSThZM3Y3awpwblJkK1hnS2VlR3ZJTG5QSXpXMjF3NW5uTklJSEs3S2EwVmhBOVFBWk1ScEtMRThOdjAxVHdDS3psMGFQcXJHCm5rY0ZQeDBMV0l0MGgvNzZYdnpvWjUxVWpiNGdLdUxtWGs1UVNBT0VNWWxQcDFtNVdUUHFmTEQzUXZCMXA0UmwKZVZybjNPbm44WlYrNnVaOHpQNGQ4OEFCWmFUVnJKTWI1UDN1cXRQS2w2RTNSb2ZGV2kzNko2VUE4QXN6MmRCSwpFdVlsb2ZjdWlEZFdnaU50djVMbUF1NTY4ZmpDVm8xSVp0dHRBZ01CQUFHallUQmZNQTRHQTFVZER3RUIvd1FFCkF3SUNwREFkQmdOVkhTVUVGakFVQmdnckJnRUZCUWNEQVFZSUt3WUJCUVVIQXdJd0R3WURWUjBUQVFIL0JBVXcKQXdFQi96QWRCZ05WSFE0RUZnUVVLTXdtOWhEQjJONjVFS3R2THNuaUxQOWE4Yzh3RFFZSktvWklodmNOQVFFTApCUUFEZ2dFQkFFR0ZVSmlEM1V6cmR5VFFiWXVVOUlRUGpuWWliUVNVUW9VUVFWRWg3TXpaSWVPOUdxbFFDOStaCmVQOVBYV2VHQy9NOHlBMDd0N3JlWk9LWm1yODVFcU1qOEw2dFM2N1lBTzhVRkxmaHR6ZEEwY1BGMCtuZXBxWU0KdTZpbTF3V2dlY2U2QTRSeTBWbFNXbnpkcldoc0dZTGNKZ1lGOG12VVZ1NVRqZWlGQkJxZHZ5MnIvYm9yZkR0VQpaRFB6ZWg5RkFFS1lobVZkWFY1cG9kVVhkNEgzbTRCTkk4aGREZitDN1NTNHBYazB5QTBuSTgvTTBxY01qcUJVCkRKK0xiczNROWJlaThrZTV2VzhUNDhwN0svendHL2RoUE43bUFSaWlnM1dqSms0WnQvZkdjNnphVEZVMXN2L2IKdzRpamF6OGRQdmxIQ3pXR0t0bTB6Q1BseVMxeTlQQT0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=
+  tls.crt: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURWakNDQWo2Z0F3SUJBZ0lRVGNnSFBJN0dJcDBNTGVQRzZYbXNpREFOQmdrcWhraUc5dzBCQVFzRkFEQVUKTVJJd0VBWURWUVFERXdsRGFXeHBkVzBnUTBFd0hoY05Nall3TlRBeU1UYzBOREUzV2hjTk1qY3dOVEF5TVRjMApOREUzV2pBcU1TZ3dKZ1lEVlFRRERCOHFMbVJsWm1GMWJIUXVhSFZpWW14bExXZHljR011WTJsc2FYVnRMbWx2Ck1JSUJJakFOQmdrcWhraUc5dzBCQVFFRkFBT0NBUThBTUlJQkNnS0NBUUVBenZqVnlxdlBUNVhzOVhGVDZ0aUYKQ0QyTkk4L1FEVGxBUlpMNzFMbStlOUNYVlVFUEhDNHdoSUZxMzlQRFFaV0MyL3I1dHA3V0o0MjduQlIrc3AvZwpBeXd5SW5RRUJXM3pKejRENkU3cEhrNFExUWQ0Ri9GK2RQeFArYm4vZExoMjhZcFppcEFBYTZUVTI3ekNIK0FTCmJKTllHSUg4czZMaEFmUlRiMUNOTlVONlVxUzkrQnhoVlJGZktLMngyRGZMOGM4L2NPaG55Ym1mYU9XZHNoTHAKeW5ueDJsWHE5a0JsWElyenVHZkZPZGx2NjdCUnc0YUpoUU1DUVpMZ1NKT0VGaVVobmloOE5HY21RWWlJRHJPTQpCZ3FSSnEyd0dMTjFEZnRKY1VhTW9pZFBMZXVVZFpmekVIUEFQZi9OOVVSYThtRDZDQm5wSHd4ZVBhclp3cENFCi93SURBUUFCbzRHTk1JR0tNQTRHQTFVZER3RUIvd1FFQXdJRm9EQWRCZ05WSFNVRUZqQVVCZ2dyQmdFRkJRY0QKQVFZSUt3WUJCUVVIQXdJd0RBWURWUjBUQVFIL0JBSXdBREFmQmdOVkhTTUVHREFXZ0JRb3pDYjJFTUhZM3JrUQpxMjh1eWVJcy8xcnh6ekFxQmdOVkhSRUVJekFoZ2g4cUxtUmxabUYxYkhRdWFIVmlZbXhsTFdkeWNHTXVZMmxzCmFYVnRMbWx2TUEwR0NTcUdTSWIzRFFFQkN3VUFBNElCQVFBeU5ReVZld1VCbWtSV1NINHZYaTRNR0F6dWNHMTIKQUlpSUhUK0ROcWRYS3Bpd2YyQWZuSXA1QmpoVzlLS3VCY29MSzRSTkdOb3lQZk03K3U1YTVOY0l2SktycW85Wgo1Tmc3Z09kbExNeU5tclhaWXh1Vng2Vnl1dVZLVUpCMnFZZUNLM0xubHZUT1FXQjhva0ZZZ1dzTk9tMjU1STY3CkVva1hMMERYTm4rNGMrRUFHQk5iWUgzUEliNURMc0Y4SW1ZTVNBN040c3pOMmsrVzFoRkZyb0tCRW4xdWZHMk0KekQvS3o0YjdsckJQNjV2eVJHQ3ZCZjVaU0RSRW5QTnFMRGV6dVEyRnk3UVlZSUJJN01HNUFyS09id3JibzRvNQpwSlo4MFgzSGwvcmJxVld2cEpjc256KzNJaDVudjNJUG82L1VqU21icjRJODllZTJHck5YZWFLNAotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==
+  tls.key: LS0tLS1CRUdJTiBSU0EgUFJJVkFURSBLRVktLS0tLQpNSUlFb3dJQkFBS0NBUUVBenZqVnlxdlBUNVhzOVhGVDZ0aUZDRDJOSTgvUURUbEFSWkw3MUxtK2U5Q1hWVUVQCkhDNHdoSUZxMzlQRFFaV0MyL3I1dHA3V0o0MjduQlIrc3AvZ0F5d3lJblFFQlczekp6NEQ2RTdwSGs0UTFRZDQKRi9GK2RQeFArYm4vZExoMjhZcFppcEFBYTZUVTI3ekNIK0FTYkpOWUdJSDhzNkxoQWZSVGIxQ05OVU42VXFTOQorQnhoVlJGZktLMngyRGZMOGM4L2NPaG55Ym1mYU9XZHNoTHB5bm54MmxYcTlrQmxYSXJ6dUdmRk9kbHY2N0JSCnc0YUpoUU1DUVpMZ1NKT0VGaVVobmloOE5HY21RWWlJRHJPTUJncVJKcTJ3R0xOMURmdEpjVWFNb2lkUExldVUKZFpmekVIUEFQZi9OOVVSYThtRDZDQm5wSHd4ZVBhclp3cENFL3dJREFRQUJBb0lCQUFLdW5FZU91aTc2dVIrUgo1RVppbjYzSUtKRGYrQWoyNlNmaWs1eWhtS1RUUXFySDBGRzhnNlkxeDBmalZWdE9MVmh4Ymg1eDZMZ25wdXdvCmhUZWo1b0g3WnVldnhzNVZOTVJuL29Ua1JPUVhZQXJaY1RMRlQwS05YNDk3QXlMenU1M3ZKUkxua0I5ZTA5L0kKVTNRaXJRV0Z0alZ0UDZWc3dFUHUzMEwvRHZZQ055Q2N1QmNQMUg5bVBFdERmUDJiaE5NYmhMZTNkUytYT1VWcQpBR1BHNXJINlp2K2ZPSkFya2FXdnJwSlh4S1dvdjBUSFkrSUNzOFNxcjZyUG1mdWM1RFNZTzdWT3NYVm5UK2h5CnJBdFBDWGwxNC93bWxlL0NKZ1ZZV0ZTN1hKbC9KSzVocWlYUzFXV1NJQ2ZnakNKTlVZcjg2UlpycmltYnVqcmQKK0JibzZnMENnWUVBK3VuQTRoNW9mTWVWZnYzSmhGRDRFWGVETE1RUWlmWTdLWlNsS2tScE1BVFpsQWhLMmc1QQpPVFN6bEN6QnlzbitTOUxGaTY5L0FMRDJ1dGx3ZDNVbWhsVW8rQWYyd3I0dlkvWW95dUwzaUdGcmVKS3JpekgwCldLOHIvekR6OUdmNWZJdmNlOG9MdFhEd29PUnpIdS9IMlErRHRXcEhuMkJKSDlTRExka0N1TTBDZ1lFQTB5c0cKcnVYdlZyMDh6a1JrdTZsQUZjbEdNNGZGa1BmNHhOSlpiN29wdzFhZlVZa1Rka2VIRE9jL0YvdGErRjg2VCtQeApybU16UUZsdmRIWHVXTEZESlgxVXlUVXlTeVJYd1ovdjlJQnN5bGtNVmlQRm1VMXczTEF1QnVGaHczckdleW14CmljVWVGS3NUY1J1TEZKVEFqUkFYL1kxQkpScHhvRzRVaXlDS3BQc0NnWUEzVTZIZmVsc0o0S3g3UXhUVFkxTS8KN3IxeStveTNEeDkrakxOYXZaa0FLS0dkZmJLYm9IYlM1bWNPcmt2UkhuYy9XdXVLWUprOW1zZmM3YU5hQS9BSgp3TzkydWJMVXdFRU01ck9hQVRBWjEzbHVMZEU3c1RreThQVmZvUGk2Rk04emdsZU15RUdLc2F1dG5wSXY2U21GCkdHR3ZlQTd3K3JkRkdJUVFjUUNqcFFLQmdRQ3ZERkM2OVVLay9iUUZMTzd3SFlwUlJRc2J0bVlSR1c0d0Frcy8KY2V3aTBKQzdMMDFoMUVOZ2IrVitoTS9SYW1kVlNKalV2Y2tEZzkvL2c2OHorS1czMHlCUXR2ZGRFT0JxVXFIQQpaaUZJeis2SkRaaEV6OHhLTlFYQ2tGelJoZG80eU1ReWQ2UEs4RkhxaGpHUnV3bXZKZk10TFVZZWNzQlVoRXdsClZMRjV0d0tCZ0FuM3IrdW13SitkdDhQcEV4cUxpbFpZMG9xRzhkUjhJYk5TQ2Q3NHFUU0VsWnBMejRsUU9yKzUKMTRHdXI0SGlIdnI0WkliYzlJSndOV3ZyYjFieDYzMjBldkhKTG11eFBqVzhOOU16am1tbnJXYUdsVHJ6RDBpRQpWUm9lams0WG0yZk0wSGdmaVp4M20rNm96Q0ZGMFBsSEFNSmVtRlVoSG9oQUVSV293cjdtCi0tLS0tRU5EIFJTQSBQUklWQVRFIEtFWS0tLS0tCg==
+---
+# Source: cilium/templates/cilium-configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cilium-config
+  namespace: kube-system
+data:
+
+  # Identity allocation mode selects how identities are shared between cilium
+  # nodes by setting how they are stored. The options are "crd", "kvstore" or
+  # "doublewrite-readkvstore" / "doublewrite-readcrd".
+  # - "crd" stores identities in kubernetes as CRDs (custom resource definition).
+  #   These can be queried with:
+  #     kubectl get ciliumid
+  # - "kvstore" stores identities in an etcd kvstore, that is
+  #   configured below. Cilium versions before 1.6 supported only the kvstore
+  #   backend. Upgrades from these older cilium versions should continue using
+  #   the kvstore by commenting out the identity-allocation-mode below, or
+  #   setting it to "kvstore".
+  # - "doublewrite" modes store identities in both the kvstore and CRDs. This is useful
+  #   for seamless migrations from the kvstore mode to the crd mode. Consult the
+  #   documentation for more information on how to perform the migration.
+  identity-allocation-mode: crd
+
+  identity-heartbeat-timeout: "30m0s"
+  identity-gc-interval: "15m0s"
+  cilium-endpoint-gc-interval: "5m0s"
+  nodes-gc-interval: "5m0s"
+
+  # If you want to run cilium in debug mode change this value to true
+  debug: "false"
+  debug-verbose: ""
+  metrics-sampling-interval: "5m"
+  # The agent can be put into the following three policy enforcement modes
+  # default, always and never.
+  # https://docs.cilium.io/en/latest/security/policy/intro/#policy-enforcement-modes
+  enable-policy: "default"
+  policy-cidr-match-mode: ""
+  # If you want metrics enabled in cilium-operator, set the port for
+  # which the Cilium Operator will have their metrics exposed.
+  # NOTE that this will open the port on the nodes where Cilium operator pod
+  # is scheduled.
+  operator-prometheus-serve-addr: ":9963"
+  enable-metrics: "true"
+  enable-envoy-config: "true"
+  envoy-config-retry-interval: "15s"
+  enable-gateway-api: "true"
+  enable-gateway-api-secrets-sync: "true"
+  enable-gateway-api-proxy-protocol: "false"
+  enable-gateway-api-app-protocol: "false"
+  enable-gateway-api-alpn: "false"
+  gateway-api-xff-num-trusted-hops: "0"
+  gateway-api-service-externaltrafficpolicy: "Cluster"
+  gateway-api-secrets-namespace: "cilium-secrets"
+  gateway-api-hostnetwork-enabled: "false"
+  gateway-api-hostnetwork-nodelabelselector: ""
+  enable-policy-secrets-sync: "true"
+  policy-secrets-only-from-secrets-namespace: "true"
+  policy-secrets-namespace: "cilium-secrets"
+
+  # Enable IPv4 addressing. If enabled, all endpoints are allocated an IPv4
+  # address.
+  enable-ipv4: "true"
+
+  # Enable IPv6 addressing. If enabled, all endpoints are allocated an IPv6
+  # address.
+  enable-ipv6: "false"
+  # Users who wish to specify their own custom CNI configuration file must set
+  # custom-cni-conf to "true", otherwise Cilium may overwrite the configuration.
+  custom-cni-conf: "false"
+  enable-bpf-clock-probe: "false"
+  # If you want cilium monitor to aggregate tracing for packets, set this level
+  # to "low", "medium", or "maximum". The higher the level, the less packets
+  # that will be seen in monitor output.
+  monitor-aggregation: medium
+
+  # The monitor aggregation interval governs the typical time between monitor
+  # notification events for each allowed connection.
+  #
+  # Only effective when monitor aggregation is set to "medium" or higher.
+  monitor-aggregation-interval: "5s"
+
+  # The monitor aggregation flags determine which TCP flags which, upon the
+  # first observation, cause monitor notifications to be generated.
+  #
+  # Only effective when monitor aggregation is set to "medium" or higher.
+  monitor-aggregation-flags: all
+  # Specifies the ratio (0.0-1.0] of total system memory to use for dynamic
+  # sizing of the TCP CT, non-TCP CT, NAT and policy BPF maps.
+  bpf-map-dynamic-size-ratio: "0.0025"
+  # In cni chaining mode, the other chained plugin is responsible for underlying connectivity,
+  # so cilium eBPF host routing shoud not work, and let it fall back to the legacy routing mode
+  enable-host-legacy-routing: "true"
+  # bpf-policy-map-max specifies the maximum number of entries in endpoint
+  # policy map (per endpoint)
+  bpf-policy-map-max: "16384"
+  # bpf-policy-stats-map-max specifies the maximum number of entries in global
+  # policy stats map
+  bpf-policy-stats-map-max: "65536"
+  # bpf-lb-map-max specifies the maximum number of entries in bpf lb service,
+  # backend and affinity maps.
+  bpf-lb-map-max: "65536"
+  bpf-lb-external-clusterip: "false"
+  bpf-lb-source-range-all-types: "false"
+  bpf-lb-algorithm-annotation: "false"
+  bpf-lb-mode-annotation: "false"
+
+  bpf-distributed-lru: "false"
+  bpf-events-drop-enabled: "true"
+  bpf-events-policy-verdict-enabled: "true"
+  bpf-events-trace-enabled: "true"
+
+  # Pre-allocation of map entries allows per-packet latency to be reduced, at
+  # the expense of up-front memory allocation for the entries in the maps. The
+  # default value below will minimize memory usage in the default installation;
+  # users who are sensitive to latency may consider setting this to "true".
+  #
+  # This option was introduced in Cilium 1.4. Cilium 1.3 and earlier ignore
+  # this option and behave as though it is set to "true".
+  #
+  # If this value is modified, then during the next Cilium startup the restore
+  # of existing endpoints and tracking of ongoing connections may be disrupted.
+  # As a result, reply packets may be dropped and the load-balancing decisions
+  # for established connections may change.
+  #
+  # If this option is set to "false" during an upgrade from 1.3 or earlier to
+  # 1.4 or later, then it may cause one-time disruptions during the upgrade.
+  preallocate-bpf-maps: "false"
+
+  # Name of the cluster. Only relevant when building a mesh of clusters.
+  cluster-name: "default"
+  # Unique ID of the cluster. Must be unique across all conneted clusters and
+  # in the range of 1 and 255. Only relevant when building a mesh of clusters.
+  cluster-id: "0"
+
+  # Encapsulation mode for communication between nodes
+  # Possible values:
+  #   - disabled
+  #   - vxlan (default)
+  #   - geneve
+
+  routing-mode: "native"
+  tunnel-protocol: "vxlan"
+  tunnel-source-port-range: "0-0"
+  service-no-backend-response: "reject"
+
+
+  # Enables L7 proxy for L7 policy enforcement and visibility
+  enable-l7-proxy: "true"
+  # Enable chaining with another CNI plugin
+  #
+  # Supported modes:
+  #  - none
+  #  - aws-cni
+  #  - flannel
+  #  - generic-veth
+  #  - portmap (Enables HostPort support for Cilium)
+  cni-chaining-mode: aws-cni
+  # Disable the PodCIDR route to the cilium_host interface as it is not
+  # required. While chaining, it is the responsibility of the underlying plugin
+  # to enable routing.
+  enable-local-node-route: "false"
+  enable-ipv4-masquerade: "false"
+  enable-ipv4-big-tcp: "false"
+  enable-ipv6-big-tcp: "false"
+  enable-ipv6-masquerade: "true"
+  enable-tcx: "true"
+  datapath-mode: "veth"
+  enable-masquerade-to-route-source: "false"
+
+  enable-xt-socket-fallback: "true"
+  install-no-conntrack-iptables-rules: "false"
+  iptables-random-fully: "false"
+
+  auto-direct-node-routes: "false"
+  direct-routing-skip-unreachable: "false"
+
+
+
+  kube-proxy-replacement: "true"
+  kube-proxy-replacement-healthz-bind-address: ""
+  bpf-lb-sock: "true"
+  nodeport-addresses: ""
+  enable-health-check-nodeport: "true"
+  enable-health-check-loadbalancer-ip: "false"
+  node-port-bind-protection: "true"
+  enable-auto-protect-node-port-range: "true"
+  bpf-lb-acceleration: "disabled"
+  enable-svc-source-range-check: "true"
+  enable-l2-neigh-discovery: "false"
+  k8s-require-ipv4-pod-cidr: "false"
+  k8s-require-ipv6-pod-cidr: "false"
+  enable-endpoint-routes: "true"
+  enable-k8s-networkpolicy: "true"
+  enable-endpoint-lockdown-on-policy-overflow: "false"
+  # Tell the agent to generate and write a CNI configuration file
+  write-cni-conf-when-ready: /host/etc/cni/net.d/05-cilium.conflist
+  cni-exclusive: "false"
+  cni-log-file: "/var/run/cilium/cilium-cni.log"
+  # Disable health checking, when chaining mode is not set to portmap or none
+  enable-endpoint-health-checking: "false"
+  enable-health-checking: "true"
+  health-check-icmp-failure-threshold: "3"
+  enable-well-known-identities: "false"
+  enable-node-selector-labels: "false"
+  synchronize-k8s-nodes: "true"
+  operator-api-serve-addr: "127.0.0.1:9234"
+
+  enable-hubble: "true"
+  # UNIX domain socket for Hubble server to listen to.
+  hubble-socket-path: "/var/run/cilium/hubble.sock"
+  # Address to expose Hubble metrics (e.g. ":7070"). Metrics server will be disabled if this
+  # field is not set.
+  hubble-metrics-server: ":9965"
+  hubble-metrics-server-enable-tls: "false"
+  enable-hubble-open-metrics: "false"
+  # A space separated list of metrics to enable. See [0] for available metrics.
+  #
+  # https://github.com/cilium/hubble/blob/master/Documentation/metrics.md
+  hubble-metrics:
+    dns
+    drop
+    tcp
+    flow
+    icmp
+    http
+  hubble-network-policy-correlation-enabled: "true"
+  # An additional address for Hubble server to listen to (e.g. ":4244").
+  hubble-listen-address: ":4244"
+  hubble-disable-tls: "false"
+  hubble-tls-cert-file: /var/lib/cilium/tls/hubble/server.crt
+  hubble-tls-key-file: /var/lib/cilium/tls/hubble/server.key
+  hubble-tls-client-ca-files: /var/lib/cilium/tls/hubble/client-ca.crt
+  ipam: "cluster-pool"
+  ipam-cilium-node-update-rate: "15s"
+  cluster-pool-ipv4-cidr: "10.0.0.0/8"
+  cluster-pool-ipv4-mask-size: "24"
+
+  default-lb-service-ipam: "lbipam"
+  egress-gateway-reconciliation-trigger-interval: "1s"
+  enable-vtep: "false"
+  vtep-endpoint: ""
+  vtep-cidr: ""
+  vtep-mask: ""
+  vtep-mac: ""
+  procfs: "/host/proc"
+  bpf-root: "/sys/fs/bpf"
+  cgroup-root: "/run/cilium/cgroupv2"
+
+  identity-management-mode: "agent"
+  enable-sctp: "false"
+  remove-cilium-node-taints: "true"
+  set-cilium-node-taints: "true"
+  set-cilium-is-up-condition: "true"
+  unmanaged-pod-watcher-interval: "15"
+  dnsproxy-socket-linger-timeout: "10"
+  tofqdns-dns-reject-response-code: "refused"
+  tofqdns-enable-dns-compression: "true"
+  tofqdns-endpoint-max-ip-per-hostname: "1000"
+  tofqdns-idle-connection-grace-period: "0s"
+  tofqdns-max-deferred-connection-deletes: "10000"
+  tofqdns-proxy-response-max-delay: "100ms"
+  tofqdns-preallocate-identities:  "true"
+  agent-not-ready-taint-key: "node.cilium.io/agent-not-ready"
+
+  mesh-auth-enabled: "true"
+  mesh-auth-queue-size: "1024"
+  mesh-auth-rotated-identities-queue-size: "1024"
+  mesh-auth-gc-interval: "5m0s"
+
+  proxy-xff-num-trusted-hops-ingress: "0"
+  proxy-xff-num-trusted-hops-egress: "0"
+  proxy-connect-timeout: "2"
+  proxy-initial-fetch-timeout: "30"
+  proxy-max-requests-per-connection: "0"
+  proxy-max-connection-duration-seconds: "0"
+  proxy-idle-timeout-seconds: "60"
+  proxy-max-concurrent-retries: "128"
+  http-retry-count: "3"
+  http-stream-idle-timeout: "300"
+
+  external-envoy-proxy: "true"
+  envoy-base-id: "0"
+  envoy-access-log-buffer-size: "4096"
+  envoy-keep-cap-netbindservice: "false"
+  max-connected-clusters: "255"
+  clustermesh-enable-endpoint-sync: "false"
+  clustermesh-enable-mcs-api: "false"
+  policy-default-local-cluster: "false"
+
+  nat-map-stats-entries: "32"
+  nat-map-stats-interval: "30s"
+  enable-internal-traffic-policy: "true"
+  enable-lb-ipam: "true"
+  enable-non-default-deny-policies: "true"
+  enable-source-ip-verification: "true"
+
+# Extra config allows adding arbitrary properties to the cilium config.
+# By putting it at the end of the ConfigMap, it's also possible to override existing properties.
+---
+# Source: cilium/templates/cilium-envoy/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cilium-envoy-config
+  namespace: kube-system
+data:
+  # Keep the key name as bootstrap-config.json to avoid breaking changes
+  bootstrap-config.json: |
+    {"admin":{"address":{"pipe":{"path":"/var/run/cilium/envoy/sockets/admin.sock"}}},"applicationLogConfig":{"logFormat":{"textFormat":"[%Y-%m-%d %T.%e][%t][%l][%n] [%g:%#] %v"}},"bootstrapExtensions":[{"name":"envoy.bootstrap.internal_listener","typedConfig":{"@type":"type.googleapis.com/envoy.extensions.bootstrap.internal_listener.v3.InternalListener"}}],"dynamicResources":{"cdsConfig":{"apiConfigSource":{"apiType":"GRPC","grpcServices":[{"envoyGrpc":{"clusterName":"xds-grpc-cilium"}}],"setNodeOnFirstMessageOnly":true,"transportApiVersion":"V3"},"initialFetchTimeout":"30s","resourceApiVersion":"V3"},"ldsConfig":{"apiConfigSource":{"apiType":"GRPC","grpcServices":[{"envoyGrpc":{"clusterName":"xds-grpc-cilium"}}],"setNodeOnFirstMessageOnly":true,"transportApiVersion":"V3"},"initialFetchTimeout":"30s","resourceApiVersion":"V3"}},"node":{"cluster":"ingress-cluster","id":"host~127.0.0.1~no-id~localdomain"},"overloadManager":{"resourceMonitors":[{"name":"envoy.resource_monitors.global_downstream_max_connections","typedConfig":{"@type":"type.googleapis.com/envoy.extensions.resource_monitors.downstream_connections.v3.DownstreamConnectionsConfig","max_active_downstream_connections":"50000"}}]},"staticResources":{"clusters":[{"circuitBreakers":{"thresholds":[{"maxRetries":128}]},"cleanupInterval":"2.500s","connectTimeout":"2s","lbPolicy":"CLUSTER_PROVIDED","name":"ingress-cluster","type":"ORIGINAL_DST","typedExtensionProtocolOptions":{"envoy.extensions.upstreams.http.v3.HttpProtocolOptions":{"@type":"type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions","commonHttpProtocolOptions":{"idleTimeout":"60s","maxConnectionDuration":"0s","maxRequestsPerConnection":0},"useDownstreamProtocolConfig":{}}}},{"circuitBreakers":{"thresholds":[{"maxRetries":128}]},"cleanupInterval":"2.500s","connectTimeout":"2s","lbPolicy":"CLUSTER_PROVIDED","name":"egress-cluster-tls","transportSocket":{"name":"cilium.tls_wrapper","typedConfig":{"@type":"type.googleapis.com/cilium.UpstreamTlsWrapperContext"}},"type":"ORIGINAL_DST","typedExtensionProtocolOptions":{"envoy.extensions.upstreams.http.v3.HttpProtocolOptions":{"@type":"type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions","commonHttpProtocolOptions":{"idleTimeout":"60s","maxConnectionDuration":"0s","maxRequestsPerConnection":0},"upstreamHttpProtocolOptions":{},"useDownstreamProtocolConfig":{}}}},{"circuitBreakers":{"thresholds":[{"maxRetries":128}]},"cleanupInterval":"2.500s","connectTimeout":"2s","lbPolicy":"CLUSTER_PROVIDED","name":"egress-cluster","type":"ORIGINAL_DST","typedExtensionProtocolOptions":{"envoy.extensions.upstreams.http.v3.HttpProtocolOptions":{"@type":"type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions","commonHttpProtocolOptions":{"idleTimeout":"60s","maxConnectionDuration":"0s","maxRequestsPerConnection":0},"useDownstreamProtocolConfig":{}}}},{"circuitBreakers":{"thresholds":[{"maxRetries":128}]},"cleanupInterval":"2.500s","connectTimeout":"2s","lbPolicy":"CLUSTER_PROVIDED","name":"ingress-cluster-tls","transportSocket":{"name":"cilium.tls_wrapper","typedConfig":{"@type":"type.googleapis.com/cilium.UpstreamTlsWrapperContext"}},"type":"ORIGINAL_DST","typedExtensionProtocolOptions":{"envoy.extensions.upstreams.http.v3.HttpProtocolOptions":{"@type":"type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions","commonHttpProtocolOptions":{"idleTimeout":"60s","maxConnectionDuration":"0s","maxRequestsPerConnection":0},"upstreamHttpProtocolOptions":{},"useDownstreamProtocolConfig":{}}}},{"connectTimeout":"2s","loadAssignment":{"clusterName":"xds-grpc-cilium","endpoints":[{"lbEndpoints":[{"endpoint":{"address":{"pipe":{"path":"/var/run/cilium/envoy/sockets/xds.sock"}}}}]}]},"name":"xds-grpc-cilium","type":"STATIC","typedExtensionProtocolOptions":{"envoy.extensions.upstreams.http.v3.HttpProtocolOptions":{"@type":"type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions","explicitHttpConfig":{"http2ProtocolOptions":{}}}}},{"connectTimeout":"2s","loadAssignment":{"clusterName":"/envoy-admin","endpoints":[{"lbEndpoints":[{"endpoint":{"address":{"pipe":{"path":"/var/run/cilium/envoy/sockets/admin.sock"}}}}]}]},"name":"/envoy-admin","type":"STATIC"}],"listeners":[{"address":{"socketAddress":{"address":"0.0.0.0","portValue":9964}},"filterChains":[{"filters":[{"name":"envoy.filters.network.http_connection_manager","typedConfig":{"@type":"type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager","httpFilters":[{"name":"envoy.filters.http.router","typedConfig":{"@type":"type.googleapis.com/envoy.extensions.filters.http.router.v3.Router"}}],"internalAddressConfig":{"cidrRanges":[{"addressPrefix":"10.0.0.0","prefixLen":8},{"addressPrefix":"172.16.0.0","prefixLen":12},{"addressPrefix":"192.168.0.0","prefixLen":16},{"addressPrefix":"127.0.0.1","prefixLen":32}]},"routeConfig":{"virtualHosts":[{"domains":["*"],"name":"prometheus_metrics_route","routes":[{"match":{"prefix":"/metrics"},"name":"prometheus_metrics_route","route":{"cluster":"/envoy-admin","prefixRewrite":"/stats/prometheus"}}]}]},"statPrefix":"envoy-prometheus-metrics-listener","streamIdleTimeout":"300s"}}]}],"name":"envoy-prometheus-metrics-listener"},{"address":{"socketAddress":{"address":"127.0.0.1","portValue":9878}},"filterChains":[{"filters":[{"name":"envoy.filters.network.http_connection_manager","typedConfig":{"@type":"type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager","httpFilters":[{"name":"envoy.filters.http.router","typedConfig":{"@type":"type.googleapis.com/envoy.extensions.filters.http.router.v3.Router"}}],"internalAddressConfig":{"cidrRanges":[{"addressPrefix":"10.0.0.0","prefixLen":8},{"addressPrefix":"172.16.0.0","prefixLen":12},{"addressPrefix":"192.168.0.0","prefixLen":16},{"addressPrefix":"127.0.0.1","prefixLen":32}]},"routeConfig":{"virtual_hosts":[{"domains":["*"],"name":"health","routes":[{"match":{"prefix":"/healthz"},"name":"health","route":{"cluster":"/envoy-admin","prefixRewrite":"/ready"}}]}]},"statPrefix":"envoy-health-listener","streamIdleTimeout":"300s"}}]}],"name":"envoy-health-listener"}]}}
+---
+# Source: cilium/templates/hubble-relay/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: hubble-relay-config
+  namespace: kube-system
+data:
+  config.yaml: |
+    cluster-name: default
+    peer-service: "hubble-peer.kube-system.svc.cluster.local.:443"
+    listen-address: :4245
+    gops: true
+    gops-port: "9893"
+    retry-timeout: 
+    sort-buffer-len-max: 
+    sort-buffer-drain-timeout: 
+    tls-hubble-client-cert-file: /var/lib/hubble-relay/tls/client.crt
+    tls-hubble-client-key-file: /var/lib/hubble-relay/tls/client.key
+    tls-hubble-server-ca-files: /var/lib/hubble-relay/tls/hubble-server-ca.crt
+    
+    disable-server-tls: true
+---
+# Source: cilium/templates/hubble-ui/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: hubble-ui-nginx
+  namespace: kube-system
+data:
+  nginx.conf: "server {\n    listen       8081;\n    listen       [::]:8081;\n    server_name  localhost;\n    root /app;\n    index index.html;\n    client_max_body_size 1G;\n\n    location / {\n        proxy_set_header Host $host;\n        proxy_set_header X-Real-IP $remote_addr;\n\n        location /api {\n            proxy_http_version 1.1;\n            proxy_pass_request_headers on;\n            proxy_pass http://127.0.0.1:8090;\n        }\n        location / {\n            if ($http_user_agent ~* \"kube-probe\") { access_log off; }\n            # double `/index.html` is required here\n            try_files $uri $uri/ /index.html /index.html;\n        }\n\n        # Liveness probe\n        location /healthz {\n            access_log off;\n            add_header Content-Type text/plain;\n            return 200 'ok';\n        }\n    }\n}"
+---
+# Source: cilium/templates/cilium-agent/clusterrole.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: cilium
+  labels:
+    app.kubernetes.io/part-of: cilium
+rules:
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - networkpolicies
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - discovery.k8s.io
+  resources:
+  - endpointslices
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  - services
+  - pods
+  - endpoints
+  - nodes
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - list
+  - watch
+  # This is used when validating policies in preflight. This will need to stay
+  # until we figure out how to avoid "get" inside the preflight, and then
+  # should be removed ideally.
+  - get
+- apiGroups:
+  - cilium.io
+  resources:
+  - ciliumloadbalancerippools
+  - ciliumbgppeeringpolicies
+  - ciliumbgpnodeconfigs
+  - ciliumbgpadvertisements
+  - ciliumbgppeerconfigs
+  - ciliumclusterwideenvoyconfigs
+  - ciliumclusterwidenetworkpolicies
+  - ciliumegressgatewaypolicies
+  - ciliumendpoints
+  - ciliumendpointslices
+  - ciliumenvoyconfigs
+  - ciliumidentities
+  - ciliumlocalredirectpolicies
+  - ciliumnetworkpolicies
+  - ciliumnodes
+  - ciliumnodeconfigs
+  - ciliumcidrgroups
+  - ciliuml2announcementpolicies
+  - ciliumpodippools
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - cilium.io
+  resources:
+  - ciliumidentities
+  - ciliumendpoints
+  - ciliumnodes
+  verbs:
+  - create
+- apiGroups:
+  - cilium.io
+  # To synchronize garbage collection of such resources
+  resources:
+  - ciliumidentities
+  verbs:
+  - update
+- apiGroups:
+  - cilium.io
+  resources:
+  - ciliumendpoints
+  verbs:
+  - delete
+  - get
+- apiGroups:
+  - cilium.io
+  resources:
+  - ciliumnodes
+  - ciliumnodes/status
+  verbs:
+  - get
+  - update
+- apiGroups:
+  - cilium.io
+  resources:
+  - ciliumendpoints/status
+  - ciliumendpoints
+  - ciliuml2announcementpolicies/status
+  - ciliumbgpnodeconfigs/status
+  verbs:
+  - patch
+---
+# Source: cilium/templates/cilium-operator/clusterrole.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: cilium-operator
+  labels:
+    app.kubernetes.io/part-of: cilium
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+  # to automatically delete [core|kube]dns pods so that are starting to being
+  # managed by Cilium
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  resourceNames:
+  - cilium-config
+  verbs:
+   # allow patching of the configmap to set annotations
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  # To remove node taints
+  - nodes
+  # To set NetworkUnavailable false on startup
+  - nodes/status
+  verbs:
+  - patch
+- apiGroups:
+  - discovery.k8s.io
+  resources:
+  - endpointslices
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  # to perform LB IP allocation for BGP
+  - services/status
+  verbs:
+  - update
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  # to check apiserver connectivity
+  - namespaces
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  # to perform the translation of a CNP that contains `ToGroup` to its endpoints
+  - services
+  - endpoints
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - delete
+  - patch
+- apiGroups:
+  - cilium.io
+  resources:
+  - ciliumnetworkpolicies
+  - ciliumclusterwidenetworkpolicies
+  verbs:
+  # Create auto-generated CNPs and CCNPs from Policies that have 'toGroups'
+  - create
+  - update
+  - deletecollection
+  # To update the status of the CNPs and CCNPs
+  - patch
+  - get
+  - list
+  - watch
+- apiGroups:
+  - cilium.io
+  resources:
+  - ciliumnetworkpolicies/status
+  - ciliumclusterwidenetworkpolicies/status
+  verbs:
+  # Update the auto-generated CNPs and CCNPs status.
+  - patch
+  - update
+- apiGroups:
+  - cilium.io
+  resources:
+  - ciliumendpoints
+  - ciliumidentities
+  verbs:
+  # To perform garbage collection of such resources
+  - delete
+  - list
+  - watch
+- apiGroups:
+  - cilium.io
+  resources:
+  - ciliumidentities
+  verbs:
+  # To synchronize garbage collection of such resources
+  - update
+- apiGroups:
+  - cilium.io
+  resources:
+  - ciliumnodes
+  verbs:
+  - create
+  - update
+  - get
+  - list
+  - watch
+    # To perform CiliumNode garbage collector
+  - delete
+- apiGroups:
+  - cilium.io
+  resources:
+  - ciliumnodes/status
+  verbs:
+  - update
+- apiGroups:
+  - cilium.io
+  resources:
+  - ciliumendpointslices
+  - ciliumenvoyconfigs
+  - ciliumbgppeerconfigs
+  - ciliumbgpadvertisements
+  - ciliumbgpnodeconfigs
+  verbs:
+  - create
+  - update
+  - get
+  - list
+  - watch
+  - delete
+  - patch
+- apiGroups:
+  - cilium.io
+  resources:
+  - ciliumbgpclusterconfigs/status
+  - ciliumbgppeerconfigs/status
+  verbs:
+  - update
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - update
+  resourceNames:
+  - ciliumloadbalancerippools.cilium.io
+  - ciliumbgppeeringpolicies.cilium.io
+  - ciliumbgpclusterconfigs.cilium.io
+  - ciliumbgppeerconfigs.cilium.io
+  - ciliumbgpadvertisements.cilium.io
+  - ciliumbgpnodeconfigs.cilium.io
+  - ciliumbgpnodeconfigoverrides.cilium.io
+  - ciliumclusterwideenvoyconfigs.cilium.io
+  - ciliumclusterwidenetworkpolicies.cilium.io
+  - ciliumegressgatewaypolicies.cilium.io
+  - ciliumendpoints.cilium.io
+  - ciliumendpointslices.cilium.io
+  - ciliumenvoyconfigs.cilium.io
+  - ciliumidentities.cilium.io
+  - ciliumlocalredirectpolicies.cilium.io
+  - ciliumnetworkpolicies.cilium.io
+  - ciliumnodes.cilium.io
+  - ciliumnodeconfigs.cilium.io
+  - ciliumcidrgroups.cilium.io
+  - ciliuml2announcementpolicies.cilium.io
+  - ciliumpodippools.cilium.io
+  - ciliumgatewayclassconfigs.cilium.io
+- apiGroups:
+  - cilium.io
+  resources:
+  - ciliumloadbalancerippools
+  - ciliumpodippools
+  - ciliumbgppeeringpolicies
+  - ciliumbgpclusterconfigs
+  - ciliumbgpnodeconfigoverrides
+  - ciliumbgppeerconfigs
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+    - cilium.io
+  resources:
+    - ciliumpodippools
+  verbs:
+    - create
+- apiGroups:
+  - cilium.io
+  resources:
+  - ciliumloadbalancerippools/status
+  verbs:
+  - patch
+# For cilium-operator running in HA mode.
+#
+# Cilium operator running in HA mode requires the use of ResourceLock for Leader Election
+# between multiple running instances.
+# The preferred way of doing this is to use LeasesResourceLock as edits to Leases are less
+# common and fewer objects in the cluster watch "all Leases".
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - create
+  - get
+  - update
+- apiGroups:
+  - gateway.networking.k8s.io
+  resources:
+  - gatewayclasses
+  - gateways
+  - tlsroutes
+  - httproutes
+  - grpcroutes
+  - referencegrants
+  - referencepolicies
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - gateway.networking.k8s.io
+  resources:
+  - gatewayclasses
+  verbs:
+  - patch
+- apiGroups:
+  - gateway.networking.k8s.io
+  resources:
+  - gatewayclasses/status
+  - gateways/status
+  - httproutes/status
+  - grpcroutes/status
+  - tlsroutes/status
+  verbs:
+  - update
+  - patch
+- apiGroups:
+  - cilium.io
+  resources:
+  - ciliumgatewayclassconfigs
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - cilium.io
+  resources:
+  - ciliumgatewayclassconfigs/status
+  verbs:
+  - update
+  - patch
+- apiGroups:
+  - multicluster.x-k8s.io
+  resources:
+  - serviceimports
+  verbs:
+  - get
+  - list
+  - watch
+---
+# Source: cilium/templates/hubble-ui/clusterrole.yaml
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: hubble-ui
+  labels:
+    app.kubernetes.io/part-of: cilium
+
+rules:
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - networkpolicies
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - componentstatuses
+  - endpoints
+  - namespaces
+  - nodes
+  - pods
+  - services
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - cilium.io
+  resources:
+  - "*"
+  verbs:
+  - get
+  - list
+  - watch
+---
+# Source: cilium/templates/cilium-agent/clusterrolebinding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: cilium
+  labels:
+    app.kubernetes.io/part-of: cilium
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cilium
+subjects:
+- kind: ServiceAccount
+  name: "cilium"
+  namespace: kube-system
+---
+# Source: cilium/templates/cilium-operator/clusterrolebinding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: cilium-operator
+  labels:
+    app.kubernetes.io/part-of: cilium
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cilium-operator
+subjects:
+- kind: ServiceAccount
+  name: "cilium-operator"
+  namespace: kube-system
+---
+# Source: cilium/templates/hubble-ui/clusterrolebinding.yaml
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: hubble-ui
+  labels:
+    app.kubernetes.io/part-of: cilium
+
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: hubble-ui
+subjects:
+- kind: ServiceAccount
+  name: "hubble-ui"
+  namespace: kube-system
+---
+# Source: cilium/templates/cilium-agent/role.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: cilium-config-agent
+  namespace: kube-system
+  labels:
+    app.kubernetes.io/part-of: cilium
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+---
+# Source: cilium/templates/cilium-agent/role.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: cilium-gateway-secrets
+  namespace: "cilium-secrets"
+  labels:
+    app.kubernetes.io/part-of: cilium
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+---
+# Source: cilium/templates/cilium-agent/role.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: cilium-tlsinterception-secrets
+  namespace: "cilium-secrets"
+  labels:
+    app.kubernetes.io/part-of: cilium
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+---
+# Source: cilium/templates/cilium-operator/role.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: cilium-operator-gateway-secrets
+  namespace: "cilium-secrets"
+  labels:
+    app.kubernetes.io/part-of: cilium
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - create
+  - delete
+  - update
+  - patch
+---
+# Source: cilium/templates/cilium-operator/role.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: cilium-operator-tlsinterception-secrets
+  namespace: "cilium-secrets"
+  labels:
+    app.kubernetes.io/part-of: cilium
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - create
+  - delete
+  - update
+  - patch
+---
+# Source: cilium/templates/cilium-agent/rolebinding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: cilium-config-agent
+  namespace: kube-system
+  labels:
+    app.kubernetes.io/part-of: cilium
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: cilium-config-agent
+subjects:
+  - kind: ServiceAccount
+    name: "cilium"
+    namespace: kube-system
+---
+# Source: cilium/templates/cilium-agent/rolebinding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: cilium-gateway-secrets
+  namespace: "cilium-secrets"
+  labels:
+    app.kubernetes.io/part-of: cilium
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: cilium-gateway-secrets
+subjects:
+- kind: ServiceAccount
+  name: "cilium"
+  namespace: kube-system
+---
+# Source: cilium/templates/cilium-agent/rolebinding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: cilium-tlsinterception-secrets
+  namespace: "cilium-secrets"
+  labels:
+    app.kubernetes.io/part-of: cilium
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: cilium-tlsinterception-secrets
+subjects:
+- kind: ServiceAccount
+  name: "cilium"
+  namespace: kube-system
+---
+# Source: cilium/templates/cilium-operator/rolebinding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: cilium-operator-gateway-secrets
+  namespace: "cilium-secrets"
+  labels:
+    app.kubernetes.io/part-of: cilium
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: cilium-operator-gateway-secrets
+subjects:
+- kind: ServiceAccount
+  name: "cilium-operator"
+  namespace: kube-system
+---
+# Source: cilium/templates/cilium-operator/rolebinding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: cilium-operator-tlsinterception-secrets
+  namespace: "cilium-secrets"
+  labels:
+    app.kubernetes.io/part-of: cilium
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: cilium-operator-tlsinterception-secrets
+subjects:
+- kind: ServiceAccount
+  name: "cilium-operator"
+  namespace: kube-system
+---
+# Source: cilium/templates/cilium-envoy/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: cilium-envoy
+  namespace: kube-system
+  annotations:
+    prometheus.io/scrape: "true"
+    prometheus.io/port: "9964"
+  labels:
+    k8s-app: cilium-envoy
+    app.kubernetes.io/name: cilium-envoy
+    app.kubernetes.io/part-of: cilium
+    io.cilium/app: proxy
+spec:
+  clusterIP: None
+  type: ClusterIP
+  selector:
+    k8s-app: cilium-envoy
+  ports:
+  - name: envoy-metrics
+    port: 9964
+    protocol: TCP
+    targetPort: envoy-metrics
+---
+# Source: cilium/templates/hubble-relay/service.yaml
+kind: Service
+apiVersion: v1
+metadata:
+  name: hubble-relay
+  namespace: kube-system
+  annotations:
+  labels:
+    k8s-app: hubble-relay
+    app.kubernetes.io/name: hubble-relay
+    app.kubernetes.io/part-of: cilium
+
+spec:
+  type: "ClusterIP"
+  selector:
+    k8s-app: hubble-relay
+  ports:
+  - protocol: TCP
+    port: 80
+    targetPort: grpc
+---
+# Source: cilium/templates/hubble-ui/service.yaml
+kind: Service
+apiVersion: v1
+metadata:
+  name: hubble-ui
+  namespace: kube-system
+  labels:
+    k8s-app: hubble-ui
+    app.kubernetes.io/name: hubble-ui
+    app.kubernetes.io/part-of: cilium
+
+spec:
+  type: "ClusterIP"
+  selector:
+    k8s-app: hubble-ui
+  ports:
+    - name: http
+      port: 80
+      targetPort: 8081
+---
+# Source: cilium/templates/hubble/metrics-service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: hubble-metrics
+  namespace: kube-system
+  labels:
+    k8s-app: hubble
+    app.kubernetes.io/name: hubble
+    app.kubernetes.io/part-of: cilium
+
+  annotations:
+    prometheus.io/scrape: "true"
+    prometheus.io/port: "9965"
+spec:
+  clusterIP: None
+  type: ClusterIP
+  ports:
+  - name: hubble-metrics
+    port: 9965
+    protocol: TCP
+    targetPort: hubble-metrics
+  selector:
+    k8s-app: cilium
+---
+# Source: cilium/templates/hubble/peer-service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: hubble-peer
+  namespace: kube-system
+  labels:
+    k8s-app: cilium
+    app.kubernetes.io/part-of: cilium
+    app.kubernetes.io/name: hubble-peer
+
+spec:
+  selector:
+    k8s-app: cilium
+  ports:
+  - name: peer-service
+    port: 443
+    protocol: TCP
+    targetPort: 4244
+  internalTrafficPolicy: Local
+---
+# Source: cilium/templates/cilium-agent/daemonset.yaml
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: cilium
+  namespace: kube-system
+  labels:
+    k8s-app: cilium
+    app.kubernetes.io/part-of: cilium
+    app.kubernetes.io/name: cilium-agent
+spec:
+  selector:
+    matchLabels:
+      k8s-app: cilium
+  updateStrategy:
+    rollingUpdate:
+      maxUnavailable: 2
+    type: RollingUpdate
+  template:
+    metadata:
+      annotations:
+        kubectl.kubernetes.io/default-container: cilium-agent
+      labels:
+        k8s-app: cilium
+        app.kubernetes.io/name: cilium-agent
+        app.kubernetes.io/part-of: cilium
+    spec:
+      securityContext:
+        appArmorProfile:
+          type: Unconfined
+        seccompProfile:
+          type: Unconfined
+      containers:
+      - name: cilium-agent
+        image: "quay.io/cilium/cilium:v1.18.6@sha256:42ec562a5ff6c8a860c0639f5a7611685e253fd9eb2d2fcdade693724c9166a4"
+        imagePullPolicy: IfNotPresent
+        command:
+        - cilium-agent
+        args:
+        - --config-dir=/tmp/cilium/config-map
+        startupProbe:
+          httpGet:
+            host: "127.0.0.1"
+            path: /healthz
+            port: 9879
+            scheme: HTTP
+            httpHeaders:
+            - name: "brief"
+              value: "true"
+          failureThreshold: 300
+          periodSeconds: 2
+          successThreshold: 1
+          initialDelaySeconds: 5
+        livenessProbe:
+          httpGet:
+            host: "127.0.0.1"
+            path: /healthz
+            port: 9879
+            scheme: HTTP
+            httpHeaders:
+            - name: "brief"
+              value: "true"
+            - name: "require-k8s-connectivity"
+              value: "false"
+          periodSeconds: 30
+          successThreshold: 1
+          failureThreshold: 10
+          timeoutSeconds: 5
+        readinessProbe:
+          httpGet:
+            host: "127.0.0.1"
+            path: /healthz
+            port: 9879
+            scheme: HTTP
+            httpHeaders:
+            - name: "brief"
+              value: "true"
+          periodSeconds: 30
+          successThreshold: 1
+          failureThreshold: 3
+          timeoutSeconds: 5
+        env:
+        - name: K8S_NODE_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: spec.nodeName
+        - name: CILIUM_K8S_NAMESPACE
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.namespace
+        - name: CILIUM_CLUSTERMESH_CONFIG
+          value: /var/lib/cilium/clustermesh/
+        - name: GOMEMLIMIT
+          valueFrom:
+            resourceFieldRef:
+              resource: limits.memory
+              divisor: '1'
+        - name: KUBERNETES_SERVICE_HOST
+          value: "BD10E7689A05E46191305DDC7BE6CA67.gr7.ap-northeast-1.eks.amazonaws.com"
+        - name: KUBERNETES_SERVICE_PORT
+          value: "443"
+        - name: KUBE_CLIENT_BACKOFF_BASE
+          value: "1"
+        - name: KUBE_CLIENT_BACKOFF_DURATION
+          value: "120"
+        lifecycle:
+          preStop:
+            exec:
+              command:
+              - /cni-uninstall.sh
+        ports:
+        - name: peer-service
+          containerPort: 4244
+          hostPort: 4244
+          protocol: TCP
+        - name: hubble-metrics
+          containerPort: 9965
+          hostPort: 9965
+          protocol: TCP
+        securityContext:
+          seLinuxOptions:
+            level: s0
+            type: spc_t
+          capabilities:
+            add:
+              - CHOWN
+              - KILL
+              - NET_ADMIN
+              - NET_RAW
+              - IPC_LOCK
+              - SYS_MODULE
+              - SYS_ADMIN
+              - SYS_RESOURCE
+              - DAC_OVERRIDE
+              - FOWNER
+              - SETGID
+              - SETUID
+            drop:
+              - ALL
+        terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - name: envoy-sockets
+          mountPath: /var/run/cilium/envoy/sockets
+          readOnly: false
+        # Unprivileged containers need to mount /proc/sys/net from the host
+        # to have write access
+        - mountPath: /host/proc/sys/net
+          name: host-proc-sys-net
+        # Unprivileged containers need to mount /proc/sys/kernel from the host
+        # to have write access
+        - mountPath: /host/proc/sys/kernel
+          name: host-proc-sys-kernel
+        - name: bpf-maps
+          mountPath: /sys/fs/bpf
+          # Unprivileged containers can't set mount propagation to bidirectional
+          # in this case we will mount the bpf fs from an init container that
+          # is privileged and set the mount propagation from host to container
+          # in Cilium.
+          mountPropagation: HostToContainer
+        - name: cilium-run
+          mountPath: /var/run/cilium
+        - name: cilium-netns
+          mountPath: /var/run/cilium/netns
+          mountPropagation: HostToContainer
+        - name: etc-cni-netd
+          mountPath: /host/etc/cni/net.d
+        - name: clustermesh-secrets
+          mountPath: /var/lib/cilium/clustermesh
+          readOnly: true
+          # Needed to be able to load kernel modules
+        - name: lib-modules
+          mountPath: /lib/modules
+          readOnly: true
+        - name: xtables-lock
+          mountPath: /run/xtables.lock
+        - name: hubble-tls
+          mountPath: /var/lib/cilium/tls/hubble
+          readOnly: true
+        - name: tmp
+          mountPath: /tmp
+        
+      initContainers:
+      - name: config
+        image: "quay.io/cilium/cilium:v1.18.6@sha256:42ec562a5ff6c8a860c0639f5a7611685e253fd9eb2d2fcdade693724c9166a4"
+        imagePullPolicy: IfNotPresent
+        command:
+        - cilium-dbg
+        - build-config
+        env:
+        - name: K8S_NODE_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: spec.nodeName
+        - name: CILIUM_K8S_NAMESPACE
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.namespace
+        - name: KUBERNETES_SERVICE_HOST
+          value: "BD10E7689A05E46191305DDC7BE6CA67.gr7.ap-northeast-1.eks.amazonaws.com"
+        - name: KUBERNETES_SERVICE_PORT
+          value: "443"
+        volumeMounts:
+        - name: tmp
+          mountPath: /tmp
+        terminationMessagePolicy: FallbackToLogsOnError
+      # Required to mount cgroup2 filesystem on the underlying Kubernetes node.
+      # We use nsenter command with host's cgroup and mount namespaces enabled.
+      - name: mount-cgroup
+        image: "quay.io/cilium/cilium:v1.18.6@sha256:42ec562a5ff6c8a860c0639f5a7611685e253fd9eb2d2fcdade693724c9166a4"
+        imagePullPolicy: IfNotPresent
+        env:
+        - name: CGROUP_ROOT
+          value: /run/cilium/cgroupv2
+        - name: BIN_PATH
+          value: /opt/cni/bin
+        command:
+        - sh
+        - -ec
+        # The statically linked Go program binary is invoked to avoid any
+        # dependency on utilities like sh and mount that can be missing on certain
+        # distros installed on the underlying host. Copy the binary to the
+        # same directory where we install cilium cni plugin so that exec permissions
+        # are available.
+        - |
+          cp /usr/bin/cilium-mount /hostbin/cilium-mount;
+          nsenter --cgroup=/hostproc/1/ns/cgroup --mount=/hostproc/1/ns/mnt "${BIN_PATH}/cilium-mount" $CGROUP_ROOT;
+          rm /hostbin/cilium-mount
+        volumeMounts:
+        - name: hostproc
+          mountPath: /hostproc
+        - name: cni-path
+          mountPath: /hostbin
+        terminationMessagePolicy: FallbackToLogsOnError
+        securityContext:
+          seLinuxOptions:
+            level: s0
+            type: spc_t
+          capabilities:
+            add:
+              - SYS_ADMIN
+              - SYS_CHROOT
+              - SYS_PTRACE
+            drop:
+              - ALL
+      - name: apply-sysctl-overwrites
+        image: "quay.io/cilium/cilium:v1.18.6@sha256:42ec562a5ff6c8a860c0639f5a7611685e253fd9eb2d2fcdade693724c9166a4"
+        imagePullPolicy: IfNotPresent
+        env:
+        - name: BIN_PATH
+          value: /opt/cni/bin
+        command:
+        - sh
+        - -ec
+        # The statically linked Go program binary is invoked to avoid any
+        # dependency on utilities like sh that can be missing on certain
+        # distros installed on the underlying host. Copy the binary to the
+        # same directory where we install cilium cni plugin so that exec permissions
+        # are available.
+        - |
+          cp /usr/bin/cilium-sysctlfix /hostbin/cilium-sysctlfix;
+          nsenter --mount=/hostproc/1/ns/mnt "${BIN_PATH}/cilium-sysctlfix";
+          rm /hostbin/cilium-sysctlfix
+        volumeMounts:
+        - name: hostproc
+          mountPath: /hostproc
+        - name: cni-path
+          mountPath: /hostbin
+        terminationMessagePolicy: FallbackToLogsOnError
+        securityContext:
+          seLinuxOptions:
+            level: s0
+            type: spc_t
+          capabilities:
+            add:
+              - SYS_ADMIN
+              - SYS_CHROOT
+              - SYS_PTRACE
+            drop:
+              - ALL
+      # Mount the bpf fs if it is not mounted. We will perform this task
+      # from a privileged container because the mount propagation bidirectional
+      # only works from privileged containers.
+      - name: mount-bpf-fs
+        image: "quay.io/cilium/cilium:v1.18.6@sha256:42ec562a5ff6c8a860c0639f5a7611685e253fd9eb2d2fcdade693724c9166a4"
+        imagePullPolicy: IfNotPresent
+        args:
+        - 'mount | grep "/sys/fs/bpf type bpf" || mount -t bpf bpf /sys/fs/bpf'
+        command:
+        - /bin/bash
+        - -c
+        - --
+        terminationMessagePolicy: FallbackToLogsOnError
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - name: bpf-maps
+          mountPath: /sys/fs/bpf
+          mountPropagation: Bidirectional
+      - name: clean-cilium-state
+        image: "quay.io/cilium/cilium:v1.18.6@sha256:42ec562a5ff6c8a860c0639f5a7611685e253fd9eb2d2fcdade693724c9166a4"
+        imagePullPolicy: IfNotPresent
+        command:
+        - /init-container.sh
+        env:
+        - name: CILIUM_ALL_STATE
+          valueFrom:
+            configMapKeyRef:
+              name: cilium-config
+              key: clean-cilium-state
+              optional: true
+        - name: CILIUM_BPF_STATE
+          valueFrom:
+            configMapKeyRef:
+              name: cilium-config
+              key: clean-cilium-bpf-state
+              optional: true
+        - name: WRITE_CNI_CONF_WHEN_READY
+          valueFrom:
+            configMapKeyRef:
+              name: cilium-config
+              key: write-cni-conf-when-ready
+              optional: true
+        - name: KUBERNETES_SERVICE_HOST
+          value: "BD10E7689A05E46191305DDC7BE6CA67.gr7.ap-northeast-1.eks.amazonaws.com"
+        - name: KUBERNETES_SERVICE_PORT
+          value: "443"
+        terminationMessagePolicy: FallbackToLogsOnError
+        securityContext:
+          seLinuxOptions:
+            level: s0
+            type: spc_t
+          capabilities:
+            add:
+              - NET_ADMIN
+              - SYS_MODULE
+              - SYS_ADMIN
+              - SYS_RESOURCE
+            drop:
+              - ALL
+        volumeMounts:
+        - name: bpf-maps
+          mountPath: /sys/fs/bpf
+          # Required to mount cgroup filesystem from the host to cilium agent pod
+        - name: cilium-cgroup
+          mountPath: /run/cilium/cgroupv2
+          mountPropagation: HostToContainer
+        - name: cilium-run
+          mountPath: /var/run/cilium # wait-for-kube-proxy
+      # Install the CNI binaries in an InitContainer so we don't have a writable host mount in the agent
+      - name: install-cni-binaries
+        image: "quay.io/cilium/cilium:v1.18.6@sha256:42ec562a5ff6c8a860c0639f5a7611685e253fd9eb2d2fcdade693724c9166a4"
+        imagePullPolicy: IfNotPresent
+        command:
+          - "/install-plugin.sh"
+        resources:
+          requests:
+            cpu: 100m
+            memory: 10Mi
+        securityContext:
+          seLinuxOptions:
+            level: s0
+            type: spc_t
+          capabilities:
+            drop:
+              - ALL
+        terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+          - name: cni-path
+            mountPath: /host/opt/cni/bin # .Values.cni.install
+      restartPolicy: Always
+      priorityClassName: system-node-critical
+      serviceAccountName: "cilium"
+      automountServiceAccountToken: true
+      terminationGracePeriodSeconds: 1
+      hostNetwork: true
+      
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchLabels:
+                k8s-app: cilium
+            topologyKey: kubernetes.io/hostname
+      nodeSelector:
+        kubernetes.io/os: linux
+      tolerations:
+        - operator: Exists
+      volumes:
+        # For sharing configuration between the "config" initContainer and the agent
+      - name: tmp
+        emptyDir: {}
+        # To keep state between restarts / upgrades
+      - name: cilium-run
+        hostPath:
+          path: /var/run/cilium
+          type: DirectoryOrCreate
+        # To exec into pod network namespaces
+      - name: cilium-netns
+        hostPath:
+          path: /var/run/netns
+          type: DirectoryOrCreate
+        # To keep state between restarts / upgrades for bpf maps
+      - name: bpf-maps
+        hostPath:
+          path: /sys/fs/bpf
+          type: DirectoryOrCreate
+      # To mount cgroup2 filesystem on the host or apply sysctlfix
+      - name: hostproc
+        hostPath:
+          path: /proc
+          type: Directory
+      # To keep state between restarts / upgrades for cgroup2 filesystem
+      - name: cilium-cgroup
+        hostPath:
+          path: /run/cilium/cgroupv2
+          type: DirectoryOrCreate
+      # To install cilium cni plugin in the host
+      - name: cni-path
+        hostPath:
+          path:  /opt/cni/bin
+          type: DirectoryOrCreate
+        # To install cilium cni configuration in the host
+      - name: etc-cni-netd
+        hostPath:
+          path: /etc/cni/net.d
+          type: DirectoryOrCreate
+        # To be able to load kernel modules
+      - name: lib-modules
+        hostPath:
+          path: /lib/modules
+        # To access iptables concurrently with other processes (e.g. kube-proxy)
+      - name: xtables-lock
+        hostPath:
+          path: /run/xtables.lock
+          type: FileOrCreate
+      # Sharing socket with Cilium Envoy on the same node by using a host path
+      - name: envoy-sockets
+        hostPath:
+          path: "/var/run/cilium/envoy/sockets"
+          type: DirectoryOrCreate
+        # To read the clustermesh configuration
+      - name: clustermesh-secrets
+        projected:
+          # note: the leading zero means this number is in octal representation: do not remove it
+          defaultMode: 0400
+          sources:
+          - secret:
+              name: cilium-clustermesh
+              optional: true
+              # note: items are not explicitly listed here, since the entries of this secret
+              # depend on the peers configured, and that would cause a restart of all agents
+              # at every addition/removal. Leaving the field empty makes each secret entry
+              # to be automatically projected into the volume as a file whose name is the key.
+          - secret:
+              name: clustermesh-apiserver-remote-cert
+              optional: true
+              items:
+              - key: tls.key
+                path: common-etcd-client.key
+              - key: tls.crt
+                path: common-etcd-client.crt
+              - key: ca.crt
+                path: common-etcd-client-ca.crt
+          # note: we configure the volume for the kvstoremesh-specific certificate
+          # regardless of whether KVStoreMesh is enabled or not, so that it can be
+          # automatically mounted in case KVStoreMesh gets subsequently enabled,
+          # without requiring an agent restart.
+          - secret:
+              name: clustermesh-apiserver-local-cert
+              optional: true
+              items:
+              - key: tls.key
+                path: local-etcd-client.key
+              - key: tls.crt
+                path: local-etcd-client.crt
+              - key: ca.crt
+                path: local-etcd-client-ca.crt
+      - name: host-proc-sys-net
+        hostPath:
+          path: /proc/sys/net
+          type: Directory
+      - name: host-proc-sys-kernel
+        hostPath:
+          path: /proc/sys/kernel
+          type: Directory
+      - name: hubble-tls
+        projected:
+          # note: the leading zero means this number is in octal representation: do not remove it
+          defaultMode: 0400
+          sources:
+          - secret:
+              name: hubble-server-certs
+              optional: true
+              items:
+              - key: tls.crt
+                path: server.crt
+              - key: tls.key
+                path: server.key
+              - key: ca.crt
+                path: client-ca.crt
+---
+# Source: cilium/templates/cilium-envoy/daemonset.yaml
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: cilium-envoy
+  namespace: kube-system
+  labels:
+    k8s-app: cilium-envoy
+    app.kubernetes.io/part-of: cilium
+    app.kubernetes.io/name: cilium-envoy
+    name: cilium-envoy
+spec:
+  selector:
+    matchLabels:
+      k8s-app: cilium-envoy
+  updateStrategy:
+    rollingUpdate:
+      maxUnavailable: 2
+    type: RollingUpdate
+  template:
+    metadata:
+      annotations:
+      labels:
+        k8s-app: cilium-envoy
+        name: cilium-envoy
+        app.kubernetes.io/name: cilium-envoy
+        app.kubernetes.io/part-of: cilium
+    spec:
+      securityContext:
+        appArmorProfile:
+          type: Unconfined
+      containers:
+      - name: cilium-envoy
+        image: "quay.io/cilium/cilium-envoy:v1.35.9-1767794330-db497dd19e346b39d81d7b5c0dedf6c812bcc5c9@sha256:81398e449f2d3d0a6a70527e4f641aaa685d3156bea0bb30712fae3fd8822b86"
+        imagePullPolicy: IfNotPresent
+        command:
+        - /usr/bin/cilium-envoy-starter
+        args:
+        - '--'
+        - '-c /var/run/cilium/envoy/bootstrap-config.json'
+        - '--base-id 0'
+        - '--log-level info'
+        startupProbe:
+          httpGet:
+            host: "127.0.0.1"
+            path: /healthz
+            port: 9878
+            scheme: HTTP
+          failureThreshold: 105
+          periodSeconds: 2
+          successThreshold: 1
+          initialDelaySeconds: 5
+        livenessProbe:
+          httpGet:
+            host: "127.0.0.1"
+            path: /healthz
+            port: 9878
+            scheme: HTTP
+          periodSeconds: 30
+          successThreshold: 1
+          failureThreshold: 10
+          timeoutSeconds: 5
+        readinessProbe:
+          httpGet:
+            host: "127.0.0.1"
+            path: /healthz
+            port: 9878
+            scheme: HTTP
+          periodSeconds: 30
+          successThreshold: 1
+          failureThreshold: 3
+          timeoutSeconds: 5
+        env:
+        - name: K8S_NODE_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: spec.nodeName
+        - name: CILIUM_K8S_NAMESPACE
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.namespace
+        - name: KUBERNETES_SERVICE_HOST
+          value: "BD10E7689A05E46191305DDC7BE6CA67.gr7.ap-northeast-1.eks.amazonaws.com"
+        - name: KUBERNETES_SERVICE_PORT
+          value: "443"
+        ports:
+        - name: envoy-metrics
+          containerPort: 9964
+          hostPort: 9964
+          protocol: TCP
+        securityContext:
+          seLinuxOptions:
+            level: s0
+            type: spc_t
+          capabilities:
+            add:
+              - NET_ADMIN
+              - SYS_ADMIN
+            drop:
+              - ALL
+        terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - name: envoy-sockets
+          mountPath: /var/run/cilium/envoy/sockets
+          readOnly: false
+        - name: envoy-artifacts
+          mountPath: /var/run/cilium/envoy/artifacts
+          readOnly: true
+        - name: envoy-config
+          mountPath: /var/run/cilium/envoy/
+          readOnly: true
+        - name: bpf-maps
+          mountPath: /sys/fs/bpf
+          mountPropagation: HostToContainer
+      restartPolicy: Always
+      priorityClassName: system-node-critical
+      serviceAccountName: "cilium-envoy"
+      automountServiceAccountToken: true
+      terminationGracePeriodSeconds: 1
+      hostNetwork: true
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: cilium.io/no-schedule
+                operator: NotIn
+                values:
+                - "true"
+        podAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchLabels:
+                k8s-app: cilium
+            topologyKey: kubernetes.io/hostname
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchLabels:
+                k8s-app: cilium-envoy
+            topologyKey: kubernetes.io/hostname
+      nodeSelector:
+        kubernetes.io/os: linux
+      tolerations:
+        - operator: Exists
+      volumes:
+      - name: envoy-sockets
+        hostPath:
+          path: "/var/run/cilium/envoy/sockets"
+          type: DirectoryOrCreate
+      - name: envoy-artifacts
+        hostPath:
+          path: "/var/run/cilium/envoy/artifacts"
+          type: DirectoryOrCreate
+      - name: envoy-config
+        configMap:
+          name: "cilium-envoy-config"
+          # note: the leading zero means this number is in octal representation: do not remove it
+          defaultMode: 0400
+          items:
+            - key: bootstrap-config.json
+              path: bootstrap-config.json
+        # To keep state between restarts / upgrades
+        # To keep state between restarts / upgrades for bpf maps
+      - name: bpf-maps
+        hostPath:
+          path: /sys/fs/bpf
+          type: DirectoryOrCreate
+---
+# Source: cilium/templates/cilium-operator/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: cilium-operator
+  namespace: kube-system
+  labels:
+    io.cilium/app: operator
+    name: cilium-operator
+    app.kubernetes.io/part-of: cilium
+    app.kubernetes.io/name: cilium-operator
+spec:
+  # See docs on ServerCapabilities.LeasesResourceLock in file pkg/k8s/version/version.go
+  # for more details.
+  replicas: 2
+  selector:
+    matchLabels:
+      io.cilium/app: operator
+      name: cilium-operator
+  # ensure operator update on single node k8s clusters, by using rolling update with maxUnavailable=100% in case
+  # of one replica and no user configured Recreate strategy.
+  # otherwise an update might get stuck due to the default maxUnavailable=50% in combination with the
+  # podAntiAffinity which prevents deployments of multiple operator replicas on the same node.
+  strategy:
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 50%
+    type: RollingUpdate
+  template:
+    metadata:
+      annotations:
+        # ensure pods roll when configmap updates
+        cilium.io/cilium-configmap-checksum: "43bb7aeb8cab5fdda1e963f0bfa53a8e3e854ce2563e62b50e1af915939177be"
+        prometheus.io/port: "9963"
+        prometheus.io/scrape: "true"
+      labels:
+        io.cilium/app: operator
+        name: cilium-operator
+        app.kubernetes.io/part-of: cilium
+        app.kubernetes.io/name: cilium-operator
+    spec:
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+      - name: cilium-operator
+        image: "quay.io/cilium/operator-generic:v1.18.6@sha256:34a827ce9ed021c8adf8f0feca131f53b3c54a3ef529053d871d0347ec4d69af"
+        imagePullPolicy: IfNotPresent
+        command:
+        - cilium-operator-generic
+        args:
+        - --config-dir=/tmp/cilium/config-map
+        - --debug=$(CILIUM_DEBUG)
+        env:
+        - name: K8S_NODE_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: spec.nodeName
+        - name: CILIUM_K8S_NAMESPACE
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.namespace
+        - name: CILIUM_DEBUG
+          valueFrom:
+            configMapKeyRef:
+              key: debug
+              name: cilium-config
+              optional: true
+        - name: KUBERNETES_SERVICE_HOST
+          value: "BD10E7689A05E46191305DDC7BE6CA67.gr7.ap-northeast-1.eks.amazonaws.com"
+        - name: KUBERNETES_SERVICE_PORT
+          value: "443"
+        ports:
+        - name: prometheus
+          containerPort: 9963
+          hostPort: 9963
+          protocol: TCP
+        livenessProbe:
+          httpGet:
+            host: "127.0.0.1"
+            path: /healthz
+            port: 9234
+            scheme: HTTP
+          initialDelaySeconds: 60
+          periodSeconds: 10
+          timeoutSeconds: 3
+        readinessProbe:
+          httpGet:
+            host: "127.0.0.1"
+            path: /healthz
+            port: 9234
+            scheme: HTTP
+          initialDelaySeconds: 0
+          periodSeconds: 5
+          timeoutSeconds: 3
+          failureThreshold: 5
+        volumeMounts:
+        - name: cilium-config-path
+          mountPath: /tmp/cilium/config-map
+          readOnly: true
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+        terminationMessagePolicy: FallbackToLogsOnError
+      hostNetwork: true
+      restartPolicy: Always
+      priorityClassName: system-cluster-critical
+      serviceAccountName: "cilium-operator"
+      automountServiceAccountToken: true
+      # In HA mode, cilium-operator pods must not be scheduled on the same
+      # node as they will clash with each other.
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchLabels:
+                io.cilium/app: operator
+            topologyKey: kubernetes.io/hostname
+      nodeSelector:
+        kubernetes.io/os: linux
+      tolerations:
+        - key: node-role.kubernetes.io/control-plane
+          operator: Exists
+        - key: node-role.kubernetes.io/master
+          operator: Exists
+        - key: node.kubernetes.io/not-ready
+          operator: Exists
+        - key: node.cloudprovider.kubernetes.io/uninitialized
+          operator: Exists
+        - key: node.cilium.io/agent-not-ready
+          operator: Exists
+      
+      volumes:
+        # To read the configuration from the config map
+      - name: cilium-config-path
+        configMap:
+          name: cilium-config
+---
+# Source: cilium/templates/hubble-relay/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: hubble-relay
+  namespace: kube-system
+  labels:
+    k8s-app: hubble-relay
+    app.kubernetes.io/name: hubble-relay
+    app.kubernetes.io/part-of: cilium
+
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      k8s-app: hubble-relay
+  strategy:
+    rollingUpdate:
+      maxUnavailable: 1
+    type: RollingUpdate
+  template:
+    metadata:
+      annotations:
+      labels:
+        k8s-app: hubble-relay
+        app.kubernetes.io/name: hubble-relay
+        app.kubernetes.io/part-of: cilium
+    spec:
+      securityContext:
+        fsGroup: 65532
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: hubble-relay
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            runAsGroup: 65532
+            runAsNonRoot: true
+            runAsUser: 65532
+            seccompProfile:
+              type: RuntimeDefault
+          image: "quay.io/cilium/hubble-relay:v1.18.6@sha256:fb6135e34c31e5f175cb5e75f86cea52ef2ff12b49bcefb7088ed93f5009eb8e"
+          imagePullPolicy: IfNotPresent
+          command:
+            - hubble-relay
+          args:
+            - serve
+          ports:
+            - name: grpc
+              containerPort: 4245
+          readinessProbe:
+            grpc:
+              port: 4222
+            timeoutSeconds: 3
+          # livenessProbe will kill the pod, we should be very conservative
+          # here on failures since killing the pod should be a last resort, and
+          # we should provide enough time for relay to retry before killing it.
+          livenessProbe:
+            grpc:
+              port: 4222
+            timeoutSeconds: 10
+            # Give relay time to establish connections and make a few retries
+            # before starting livenessProbes.
+            initialDelaySeconds: 10
+            # 10 second * 12 failures = 2 minutes of failure.
+            # If relay cannot become healthy after 2 minutes, then killing it
+            # might resolve whatever issue is occurring.
+            #
+            # 10 seconds is a reasonable retry period so we can see if it's
+            # failing regularly or only sporadically.
+            periodSeconds: 10
+            failureThreshold: 12
+          startupProbe:
+            grpc:
+              port: 4222
+            # Give relay time to get it's certs and establish connections and
+            # make a few retries before starting startupProbes.
+            initialDelaySeconds: 10
+            # 20 * 3 seconds = 1 minute of failure before we consider startup as failed.
+            failureThreshold: 20
+            # Retry more frequently at startup so that it can be considered started more quickly.
+            periodSeconds: 3
+          volumeMounts:
+          - name: config
+            mountPath: /etc/hubble-relay
+            readOnly: true
+          - name: tls
+            mountPath: /var/lib/hubble-relay/tls
+            readOnly: true
+          terminationMessagePolicy: FallbackToLogsOnError
+        
+      restartPolicy: Always
+      priorityClassName: 
+      serviceAccountName: "hubble-relay"
+      automountServiceAccountToken: false
+      terminationGracePeriodSeconds: 1
+      affinity:
+        podAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchLabels:
+                k8s-app: cilium
+            topologyKey: kubernetes.io/hostname
+      nodeSelector:
+        kubernetes.io/os: linux
+      volumes:
+      - name: config
+        configMap:
+          name: hubble-relay-config
+          items:
+          - key: config.yaml
+            path: config.yaml
+      - name: tls
+        projected:
+          # note: the leading zero means this number is in octal representation: do not remove it
+          defaultMode: 0400
+          sources:
+          - secret:
+              name: hubble-relay-client-certs
+              items:
+                - key: tls.crt
+                  path: client.crt
+                - key: tls.key
+                  path: client.key
+                - key: ca.crt
+                  path: hubble-server-ca.crt
+---
+# Source: cilium/templates/hubble-ui/deployment.yaml
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: hubble-ui
+  namespace: kube-system
+  labels:
+    k8s-app: hubble-ui
+    app.kubernetes.io/name: hubble-ui
+    app.kubernetes.io/part-of: cilium
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      k8s-app: hubble-ui
+  strategy:
+    rollingUpdate:
+      maxUnavailable: 1
+    type: RollingUpdate
+  template:
+    metadata:
+      annotations:
+      labels:
+        k8s-app: hubble-ui
+        app.kubernetes.io/name: hubble-ui
+        app.kubernetes.io/part-of: cilium
+    spec:
+      securityContext:
+        fsGroup: 1001
+        runAsGroup: 1001
+        runAsUser: 1001
+      priorityClassName: 
+      serviceAccountName: "hubble-ui"
+      automountServiceAccountToken: true
+      containers:
+      - name: frontend
+        image: "quay.io/cilium/hubble-ui:v0.13.3@sha256:661d5de7050182d495c6497ff0b007a7a1e379648e60830dd68c4d78ae21761d"
+        imagePullPolicy: IfNotPresent
+        ports:
+        - name: http
+          containerPort: 8081
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8081
+        readinessProbe:
+          httpGet:
+            path: /
+            port: 8081
+        volumeMounts:
+        - name: hubble-ui-nginx-conf
+          mountPath: /etc/nginx/conf.d/default.conf
+          subPath: nginx.conf
+        - name: tmp-dir
+          mountPath: /tmp
+        terminationMessagePolicy: FallbackToLogsOnError
+        securityContext:
+          allowPrivilegeEscalation: false
+      - name: backend
+        image: "quay.io/cilium/hubble-ui-backend:v0.13.3@sha256:db1454e45dc39ca41fbf7cad31eec95d99e5b9949c39daaad0fa81ef29d56953"
+        imagePullPolicy: IfNotPresent
+        env:
+        - name: EVENTS_SERVER_PORT
+          value: "8090"
+        - name: FLOWS_API_ADDR
+          value: "hubble-relay:80"
+        ports:
+        - name: grpc
+          containerPort: 8090
+        volumeMounts:
+        terminationMessagePolicy: FallbackToLogsOnError
+        securityContext:
+          allowPrivilegeEscalation: false
+      nodeSelector:
+        kubernetes.io/os: linux
+      volumes:
+      - configMap:
+          defaultMode: 420
+          name: hubble-ui-nginx
+        name: hubble-ui-nginx-conf
+      - emptyDir: {}
+        name: tmp-dir
+

--- a/kubernetes/manifests/production/cilium/manifest.yaml
+++ b/kubernetes/manifests/production/cilium/manifest.yaml
@@ -44,39 +44,12 @@ metadata:
   name: "hubble-ui"
   namespace: kube-system
 ---
-# Source: cilium/templates/cilium-ca-secret.yaml
+# Source: cilium/templates/hubble/tls-cronjob/serviceaccount.yaml
 apiVersion: v1
-kind: Secret
+kind: ServiceAccount
 metadata:
-  name: cilium-ca
+  name: "hubble-generate-certs"
   namespace: kube-system
-data:
-  ca.crt: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURFekNDQWZ1Z0F3SUJBZ0lRVGdhbThMbTFZMzZrZGRWbTcrci9HREFOQmdrcWhraUc5dzBCQVFzRkFEQVUKTVJJd0VBWURWUVFERXdsRGFXeHBkVzBnUTBFd0hoY05Nall3TlRBeU1UYzBOREUzV2hjTk1qa3dOVEF4TVRjMApOREUzV2pBVU1SSXdFQVlEVlFRREV3bERhV3hwZFcwZ1EwRXdnZ0VpTUEwR0NTcUdTSWIzRFFFQkFRVUFBNElCCkR3QXdnZ0VLQW9JQkFRQy8yaHlqRDBxZkVhNzg5K0hsa3V4ckgzYTljYzd3L01ma0phQUFVcFBWQWIveU9GM2YKaUNIRUVIYzFVRkl3eDM3L2RjWEtJbEF6UkhyT29Hd1dOU3lTNUVBNDc5cTJ4a2UzTDkzSU1EUlhtSThZM3Y3awpwblJkK1hnS2VlR3ZJTG5QSXpXMjF3NW5uTklJSEs3S2EwVmhBOVFBWk1ScEtMRThOdjAxVHdDS3psMGFQcXJHCm5rY0ZQeDBMV0l0MGgvNzZYdnpvWjUxVWpiNGdLdUxtWGs1UVNBT0VNWWxQcDFtNVdUUHFmTEQzUXZCMXA0UmwKZVZybjNPbm44WlYrNnVaOHpQNGQ4OEFCWmFUVnJKTWI1UDN1cXRQS2w2RTNSb2ZGV2kzNko2VUE4QXN6MmRCSwpFdVlsb2ZjdWlEZFdnaU50djVMbUF1NTY4ZmpDVm8xSVp0dHRBZ01CQUFHallUQmZNQTRHQTFVZER3RUIvd1FFCkF3SUNwREFkQmdOVkhTVUVGakFVQmdnckJnRUZCUWNEQVFZSUt3WUJCUVVIQXdJd0R3WURWUjBUQVFIL0JBVXcKQXdFQi96QWRCZ05WSFE0RUZnUVVLTXdtOWhEQjJONjVFS3R2THNuaUxQOWE4Yzh3RFFZSktvWklodmNOQVFFTApCUUFEZ2dFQkFFR0ZVSmlEM1V6cmR5VFFiWXVVOUlRUGpuWWliUVNVUW9VUVFWRWg3TXpaSWVPOUdxbFFDOStaCmVQOVBYV2VHQy9NOHlBMDd0N3JlWk9LWm1yODVFcU1qOEw2dFM2N1lBTzhVRkxmaHR6ZEEwY1BGMCtuZXBxWU0KdTZpbTF3V2dlY2U2QTRSeTBWbFNXbnpkcldoc0dZTGNKZ1lGOG12VVZ1NVRqZWlGQkJxZHZ5MnIvYm9yZkR0VQpaRFB6ZWg5RkFFS1lobVZkWFY1cG9kVVhkNEgzbTRCTkk4aGREZitDN1NTNHBYazB5QTBuSTgvTTBxY01qcUJVCkRKK0xiczNROWJlaThrZTV2VzhUNDhwN0svendHL2RoUE43bUFSaWlnM1dqSms0WnQvZkdjNnphVEZVMXN2L2IKdzRpamF6OGRQdmxIQ3pXR0t0bTB6Q1BseVMxeTlQQT0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=
-  ca.key: LS0tLS1CRUdJTiBSU0EgUFJJVkFURSBLRVktLS0tLQpNSUlFb3dJQkFBS0NBUUVBdjlvY293OUtueEd1L1BmaDVaTHNheDkydlhITzhQekg1Q1dnQUZLVDFRRy84amhkCjM0Z2h4QkIzTlZCU01NZCsvM1hGeWlKUU0wUjZ6cUJzRmpVc2t1UkFPTy9hdHNaSHR5L2R5REEwVjVpUEdONysKNUtaMFhmbDRDbm5ocnlDNXp5TTF0dGNPWjV6U0NCeXV5bXRGWVFQVUFHVEVhU2l4UERiOU5VOEFpczVkR2o2cQp4cDVIQlQ4ZEMxaUxkSWYrK2w3ODZHZWRWSTIrSUNyaTVsNU9VRWdEaERHSlQ2ZFp1Vmt6Nm55dzkwTHdkYWVFClpYbGE1OXpwNS9HVmZ1cm1mTXorSGZQQUFXV2sxYXlURytUOTdxclR5cGVoTjBhSHhWb3QraWVsQVBBTE05blEKU2hMbUphSDNMb2czVm9JamJiK1M1Z0x1ZXZINHdsYU5TR2JiYlFJREFRQUJBb0lCQUE4aFUrM1dLR1BvSUoxSgpyVktPSmtBQ2dMcExEZTk2ZUFjNW9tYzBHLzJLQUVuSmdUbStRaTkwdnZvQTVpSjdzVHZUWFhCbUNWNHBzZWUyCnhoOXdQUjR1aXhRU2NuVEVxV1k4aTZpY2lKdzU1MXNtUndMZ1Q4QVRpeENFY1RSL0I3aGF4Z012N2E1bE16azUKamQxZjNWNWJ6MjNpaEl6b2pTVzdEbmdVVFc0azJqbkxHTDNOS1BkeFo0ZXVMQnd4RjBiZ1BNZVhSclNLUEhoRApGTTVZOVkrbWFPOHp4czBVa3JKek5sWTNyUm5JMDl6Nm9HT0Q2MFRKRHZSeDZOcDcvNHNXNFVJcVJ4V2NIZXhzCnlYTWpzMzB0OExRd1N1eW1ud0ZCNmJXV1FZelBjcVFFY3BRN1RaVTFlcTNxY3RpSlA4eTdtRHRQa2JDdXhjMDYKL0VYVlU0OENnWUVBNlJWOTZDYlhzbElCSE41TlgwamRFZ3pmV2grZFFqMUIzblNPNCt2Zm5YbzRxRVgxZ1VqSApLY3RqaStKUEtYaUxPUk4wSlFacXUvb1pzTEhnUWFCUEhEcW9WRDVrMDFvazZiVm9reGJVWk9nWElTN0dUU3ozCitYVEd5K3QzcjZKUmMxRDdZS0d6SWxzNTZpQVpvaHRjRkhRbEZ2cmJNYkw0S3JiQndxWndUWThDZ1lFQTByYloKakhlY2NRN0J1cTRXRGhBRS83T1lxbjZ3aVIwK00rWEg0SDd0V04weG9LZXMxbTNJUUFhaFkrZmlFLzIzMjR6NApsZ1dEMGtnMjVBcjFORC9ZU21QbSt3Q2tvWjZtTjhzRFBxZTNiNWxkY1VWcFR0ZWlkQkhHVTc0emxHODh1UXgrCnd6dHBnYjJmMmwzbDF4VkF2U3ovTk91OEZRaFh5bFNNOXl0N0FVTUNnWUJqOERjZ0J5ZU02ZVJZUUdqa1poV0QKMjhrWWwxMlNQVG0wN0Qwb05NYVlld000QTJjVW0rUHBZNiszRnIzaWhqRUxzKytrd0crYlVjMGFHZXFSdU82eQpwK1BzMnlQWUMxcXdhbndBTlZXMFBsOU1kd1hIcVhSWm5WeHZxdktTZUFKOGMwaVZVai9BaDJUNW9mSGJzK2R6ClRhbHBoUDNlL1dHeXp0R2RhRWZXdVFLQmdRQ24rWU9yYXA2WHNmL1Y1WGxIZEpYSGtWQWVlaWdZNWVyMFREVHUKVGNDL21uVTVjUEZqYnRpMzBaRk9wMGVlVUNBRk1YZnBnRFA1cWYrNEF0UTk5cmRoZGdwb0JiYzM3OVRwblRqVQo5YlpSakp6azgwUmp5WnFEbExmWmdrSjBEY2tHYTJPU0Z3YWdtcDJYNGtxYkR5SXdySEkxcWNhaHJhanVia0NCCnVYT3hLUUtCZ0JxelA4MVRYWlNURHozODNONjRjMGNxQlhHbHJONHRKTmxCWVNjZ1VwRzltR3djZG9paG9OaXUKYmxEWDh2UXBMbG8xZFhWWjJ5R3hGRHF2UzBmWStuQTJ2UFBXWkFtUnhhOGIzR0phaVRTZGk2RzFJOWVOT1RzNgpDZGVxTG5ld2oxRzQ4ck8zR0dSZG9Xb0tjRWtwazMyZFRtVTZOU0ZRR00wRkpDbzlVMWNyCi0tLS0tRU5EIFJTQSBQUklWQVRFIEtFWS0tLS0tCg==
----
-# Source: cilium/templates/hubble/tls-helm/relay-client-secret.yaml
-apiVersion: v1
-kind: Secret
-metadata:
-  name: hubble-relay-client-certs
-  namespace: kube-system
-type: kubernetes.io/tls
-data:
-  ca.crt:  LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURFekNDQWZ1Z0F3SUJBZ0lRVGdhbThMbTFZMzZrZGRWbTcrci9HREFOQmdrcWhraUc5dzBCQVFzRkFEQVUKTVJJd0VBWURWUVFERXdsRGFXeHBkVzBnUTBFd0hoY05Nall3TlRBeU1UYzBOREUzV2hjTk1qa3dOVEF4TVRjMApOREUzV2pBVU1SSXdFQVlEVlFRREV3bERhV3hwZFcwZ1EwRXdnZ0VpTUEwR0NTcUdTSWIzRFFFQkFRVUFBNElCCkR3QXdnZ0VLQW9JQkFRQy8yaHlqRDBxZkVhNzg5K0hsa3V4ckgzYTljYzd3L01ma0phQUFVcFBWQWIveU9GM2YKaUNIRUVIYzFVRkl3eDM3L2RjWEtJbEF6UkhyT29Hd1dOU3lTNUVBNDc5cTJ4a2UzTDkzSU1EUlhtSThZM3Y3awpwblJkK1hnS2VlR3ZJTG5QSXpXMjF3NW5uTklJSEs3S2EwVmhBOVFBWk1ScEtMRThOdjAxVHdDS3psMGFQcXJHCm5rY0ZQeDBMV0l0MGgvNzZYdnpvWjUxVWpiNGdLdUxtWGs1UVNBT0VNWWxQcDFtNVdUUHFmTEQzUXZCMXA0UmwKZVZybjNPbm44WlYrNnVaOHpQNGQ4OEFCWmFUVnJKTWI1UDN1cXRQS2w2RTNSb2ZGV2kzNko2VUE4QXN6MmRCSwpFdVlsb2ZjdWlEZFdnaU50djVMbUF1NTY4ZmpDVm8xSVp0dHRBZ01CQUFHallUQmZNQTRHQTFVZER3RUIvd1FFCkF3SUNwREFkQmdOVkhTVUVGakFVQmdnckJnRUZCUWNEQVFZSUt3WUJCUVVIQXdJd0R3WURWUjBUQVFIL0JBVXcKQXdFQi96QWRCZ05WSFE0RUZnUVVLTXdtOWhEQjJONjVFS3R2THNuaUxQOWE4Yzh3RFFZSktvWklodmNOQVFFTApCUUFEZ2dFQkFFR0ZVSmlEM1V6cmR5VFFiWXVVOUlRUGpuWWliUVNVUW9VUVFWRWg3TXpaSWVPOUdxbFFDOStaCmVQOVBYV2VHQy9NOHlBMDd0N3JlWk9LWm1yODVFcU1qOEw2dFM2N1lBTzhVRkxmaHR6ZEEwY1BGMCtuZXBxWU0KdTZpbTF3V2dlY2U2QTRSeTBWbFNXbnpkcldoc0dZTGNKZ1lGOG12VVZ1NVRqZWlGQkJxZHZ5MnIvYm9yZkR0VQpaRFB6ZWg5RkFFS1lobVZkWFY1cG9kVVhkNEgzbTRCTkk4aGREZitDN1NTNHBYazB5QTBuSTgvTTBxY01qcUJVCkRKK0xiczNROWJlaThrZTV2VzhUNDhwN0svendHL2RoUE43bUFSaWlnM1dqSms0WnQvZkdjNnphVEZVMXN2L2IKdzRpamF6OGRQdmxIQ3pXR0t0bTB6Q1BseVMxeTlQQT0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=
-  tls.crt: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURTRENDQWpDZ0F3SUJBZ0lRSjd5YnIwalVhS0RnQUtyMVVhSVI3VEFOQmdrcWhraUc5dzBCQVFzRkFEQVUKTVJJd0VBWURWUVFERXdsRGFXeHBkVzBnUTBFd0hoY05Nall3TlRBeU1UYzBOREUzV2hjTk1qY3dOVEF5TVRjMApOREUzV2pBak1TRXdId1lEVlFRRERCZ3FMbWgxWW1Kc1pTMXlaV3hoZVM1amFXeHBkVzB1YVc4d2dnRWlNQTBHCkNTcUdTSWIzRFFFQkFRVUFBNElCRHdBd2dnRUtBb0lCQVFETm9xRmtZS3huRkhBTGNGYlNQWldvMjlhTFZQc0IKTVdTekUxa0g0aStTOGxQMytFMDJoRmNYUFQvMDN2VGJPbG1ocXk1dldUQURBUlA2TTlzNlAyYWViZlNLVXZuagpDeXRDYTVjcStsRTRRUUNHNGwwTkR5SVVoQURGNHU1YVc3c2dJbE9KcGZsbGpPTnBQYUt3ZkZKcU4rUHlXUWxxClUyMG1uS2V4MkNtMGV6di9CcHdaSnRhd3Y0elhHck1JaU1JcGhJdXczQUw4L3B0UzJtOWFlRUdyNEdjYVp3eUMKWEJKMzk1bTNacmgzRlBWU0QvbXAzYWpHM2tYYkJzZ3JmQjVtRnVnYWc3TU0rYjRYbkRrTEFDMkZ0L211TUtkRApZZ3hoR2RLMU1BL3Z4SExQU05EWVZvK0ZBdWN6eTE1Z0xWSHZhbXVwMWpBWW9nTWNvQVpKL0piQkFnTUJBQUdqCmdZWXdnWU13RGdZRFZSMFBBUUgvQkFRREFnV2dNQjBHQTFVZEpRUVdNQlFHQ0NzR0FRVUZCd01CQmdnckJnRUYKQlFjREFqQU1CZ05WSFJNQkFmOEVBakFBTUI4R0ExVWRJd1FZTUJhQUZDak1KdllRd2RqZXVSQ3JieTdKNGl6LwpXdkhQTUNNR0ExVWRFUVFjTUJxQ0dDb3VhSFZpWW14bExYSmxiR0Y1TG1OcGJHbDFiUzVwYnpBTkJna3Foa2lHCjl3MEJBUXNGQUFPQ0FRRUFxaVFmMVp4U0ozOVJrL2oxcktvZ0gycVBLeFVjUlRIK0p5QWMyV2Naam9lOE9MM0UKRzcvVUFza253TnBJWTRzNkNXVXZYaHpBd01QQmVvMjc4Zzlhc1dIb1MyRXlKb2toczgxZ0tna0tZMHlEci9iaAowUThvdjZSNUhwWHBZOUIwS3VzaGZPek9SNFpGbE1nUDZ6ZHE3UWJvQURqMEpJNWxvNVZNLzZ6cHhOWHdIS3JjCmo1QXN4djZPTGtWWVpGSUgzRmNiS0JuaXZiNFJ5RkVGTUk3eDFtVWNwVnoxY0xWOFo5M2RGcGh6WGtrbkx4ZkkKaDYvYVJVNzUvRDlzeVVzYVljTlhiSWxqOUFXci9ZZEllZzZxcjNiTFdhV2ZicTlSOWJqaTRCL0QyT3BJN0RvSwpZUXdOajROWDhJdXpEVDAvVzlucE83Z29BcGI4bVpBWmZyR2wzQT09Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K
-  tls.key: LS0tLS1CRUdJTiBSU0EgUFJJVkFURSBLRVktLS0tLQpNSUlFcEFJQkFBS0NBUUVBemFLaFpHQ3NaeFJ3QzNCVzBqMlZxTnZXaTFUN0FURmtzeE5aQitJdmt2SlQ5L2hOCk5vUlhGejAvOU43MDJ6cFpvYXN1YjFrd0F3RVQralBiT2o5bW5tMzBpbEw1NHdzclFtdVhLdnBST0VFQWh1SmQKRFE4aUZJUUF4ZUx1V2x1N0lDSlRpYVg1Wll6amFUMmlzSHhTYWpmajhsa0phbE50SnB5bnNkZ3B0SHM3L3dhYwpHU2JXc0wrTTF4cXpDSWpDS1lTTHNOd0MvUDZiVXRwdlduaEJxK0JuR21jTWdsd1NkL2VadDJhNGR4VDFVZy81CnFkMm94dDVGMndiSUszd2VaaGJvR29PekRQbStGNXc1Q3dBdGhiZjVyakNuUTJJTVlSblN0VEFQNzhSeXowalEKMkZhUGhRTG5NOHRlWUMxUjcycHJxZFl3R0tJREhLQUdTZnlXd1FJREFRQUJBb0lCQUFDTnhoSi9vaWM2Nmx4VgpocDVWVlNCWnl6ZWYySGMxMjFnU0hzVERLcTZpSVhEREJlNDJLQWZqZmRjYWZKMVVpR1pEa0VIemd3b1hDQ2M5CjJZTE1KZW9hVUxUSXFXeWZuSk8ydDNjQnFwTlV0WHduZ3Vta2wwcG4ycHF0MUVlQkJMMSs2aXV1TzBBM1EydUcKbzNnSE5hK2NpK3djcWtaVGlERTQ3Y2l3Vk5oc0ZVemxWR2V4MUhoMVk3UHdPUUJTV28rSDZFdWRFWngvVWlvNAowMjFmOEdQOWtlK1FRSFQ0Tmk4enQwbXhOY2Y5YjZFM3FzVVRtNUhBeVd0OHV3OHNidEdoZVdjbmJWRXR5Wkk4Cml1d3k2MW1FUmpncDlUSVN2OFY1Wm5VdHMyYzIwMkZHYlNuQ09SZ2hzSlIweXlpdktaalFycXhUOHIvV1J5djEKNkZpalFZTUNnWUVBMEJnNGhBSkc4S2RzVDBiSlFNMTViY2ZSN3J6dTZybTdZcjJLNDFLcFhnNFU1VVFhdk8zRAp0WTRhYWdrQ2ZJZXpmOWE1cEs5cVpaOWgrYjlSUk5mVlhZenZZaWtyaTR0TjVBVUZ0VXBXRlk4dXYySExYVXFaCmhnVXFncEc0ckNFcGgrZFlNenpmWldSeHduNUE4VjRDZmUwSXJrSGpjSmhHZFIySUlTdlMzUDhDZ1lFQS9QbDQKenM2ODJVb1NkbUZKam5NY2pkYzZldFpqdEJabHk3MDE4cmc2ajVnTTRoaSszV2FwaTNQTWhXT3ltSGpiSHZWMwp0YzJxS3JMdld2Q3ovc0J4MHVMaDJwdEthc3czZElJYS8ybmVQUXFwaFJXL2EwbGNzWXhHYis4RmFidHE2c0tDCmVSUUVFYTVMOFFIZkc5RWNwQzE5VUp2OHlmZEF0WWwrYmg0RHpEOENnWUFzSXJiNTZMRzdJUWRyMlF1ZVh2WSsKUG45Y0wxNU5FbytYNWJPcmUwREkzaHU0ZExWbkZOYkpqeFl6SHk0VDA0UlN2T3dxN2JtWFRES3ZrZEJlMVpnLwplMERhaFBqalkreGxURnRsbEJxbC8vUmVTeE9pK2N1T0RWSnkxdzFnRkxpR1JwOENYd3JTcW5jbVZUalkrS04yCnFldUphaGdmTFd6a01odEpUYzR2YVFLQmdRQ1ltRE5UTEVtbUdKUkNiRFRlaEhrNDVoY1VlYlh5cjRBQUFjWkUKL3ZQMEloZkRXb0huTTBJYUtHTzZJb1ZjaTZwQlpuZ3Jaais3T2V3L3d1b1FSUzFqdEEvZ3VjT040Rm1qSWNmLwpRWEVaQ1JGd2djblJnWk0wVmhVMjk4c2dHRGxLR3NKeEhxM0ZySW1LZTBLRm1RSFoxc2E4bFJ0TENLWXoyeGcwCmZFNTJLUUtCZ1FDaWZiSTA4MVZMKzcxRStpakFGWkhKdW1kSitQMGhYQlRBSFg4dFpINEl6eW56Q1B5bUhDbmgKRS8vc0ozUXc0TzFtdEtZcVZIVVczUk9DTHNBRmpraEE2aTlZVUlmSStBZitsb1NpWEl0SFhmRFRwU2dSRjhQNwpydUFVTHY1SlQ4L3ZIcmZwK2p1UHM3blMxSmY4dzlhejVjdVB4QmQvR3ZsdktSaXVnQklpUXc9PQotLS0tLUVORCBSU0EgUFJJVkFURSBLRVktLS0tLQo=
----
-# Source: cilium/templates/hubble/tls-helm/server-secret.yaml
-apiVersion: v1
-kind: Secret
-metadata:
-  name: hubble-server-certs
-  namespace: kube-system
-type: kubernetes.io/tls
-data:
-  ca.crt:  LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURFekNDQWZ1Z0F3SUJBZ0lRVGdhbThMbTFZMzZrZGRWbTcrci9HREFOQmdrcWhraUc5dzBCQVFzRkFEQVUKTVJJd0VBWURWUVFERXdsRGFXeHBkVzBnUTBFd0hoY05Nall3TlRBeU1UYzBOREUzV2hjTk1qa3dOVEF4TVRjMApOREUzV2pBVU1SSXdFQVlEVlFRREV3bERhV3hwZFcwZ1EwRXdnZ0VpTUEwR0NTcUdTSWIzRFFFQkFRVUFBNElCCkR3QXdnZ0VLQW9JQkFRQy8yaHlqRDBxZkVhNzg5K0hsa3V4ckgzYTljYzd3L01ma0phQUFVcFBWQWIveU9GM2YKaUNIRUVIYzFVRkl3eDM3L2RjWEtJbEF6UkhyT29Hd1dOU3lTNUVBNDc5cTJ4a2UzTDkzSU1EUlhtSThZM3Y3awpwblJkK1hnS2VlR3ZJTG5QSXpXMjF3NW5uTklJSEs3S2EwVmhBOVFBWk1ScEtMRThOdjAxVHdDS3psMGFQcXJHCm5rY0ZQeDBMV0l0MGgvNzZYdnpvWjUxVWpiNGdLdUxtWGs1UVNBT0VNWWxQcDFtNVdUUHFmTEQzUXZCMXA0UmwKZVZybjNPbm44WlYrNnVaOHpQNGQ4OEFCWmFUVnJKTWI1UDN1cXRQS2w2RTNSb2ZGV2kzNko2VUE4QXN6MmRCSwpFdVlsb2ZjdWlEZFdnaU50djVMbUF1NTY4ZmpDVm8xSVp0dHRBZ01CQUFHallUQmZNQTRHQTFVZER3RUIvd1FFCkF3SUNwREFkQmdOVkhTVUVGakFVQmdnckJnRUZCUWNEQVFZSUt3WUJCUVVIQXdJd0R3WURWUjBUQVFIL0JBVXcKQXdFQi96QWRCZ05WSFE0RUZnUVVLTXdtOWhEQjJONjVFS3R2THNuaUxQOWE4Yzh3RFFZSktvWklodmNOQVFFTApCUUFEZ2dFQkFFR0ZVSmlEM1V6cmR5VFFiWXVVOUlRUGpuWWliUVNVUW9VUVFWRWg3TXpaSWVPOUdxbFFDOStaCmVQOVBYV2VHQy9NOHlBMDd0N3JlWk9LWm1yODVFcU1qOEw2dFM2N1lBTzhVRkxmaHR6ZEEwY1BGMCtuZXBxWU0KdTZpbTF3V2dlY2U2QTRSeTBWbFNXbnpkcldoc0dZTGNKZ1lGOG12VVZ1NVRqZWlGQkJxZHZ5MnIvYm9yZkR0VQpaRFB6ZWg5RkFFS1lobVZkWFY1cG9kVVhkNEgzbTRCTkk4aGREZitDN1NTNHBYazB5QTBuSTgvTTBxY01qcUJVCkRKK0xiczNROWJlaThrZTV2VzhUNDhwN0svendHL2RoUE43bUFSaWlnM1dqSms0WnQvZkdjNnphVEZVMXN2L2IKdzRpamF6OGRQdmxIQ3pXR0t0bTB6Q1BseVMxeTlQQT0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=
-  tls.crt: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURWakNDQWo2Z0F3SUJBZ0lRVGNnSFBJN0dJcDBNTGVQRzZYbXNpREFOQmdrcWhraUc5dzBCQVFzRkFEQVUKTVJJd0VBWURWUVFERXdsRGFXeHBkVzBnUTBFd0hoY05Nall3TlRBeU1UYzBOREUzV2hjTk1qY3dOVEF5TVRjMApOREUzV2pBcU1TZ3dKZ1lEVlFRRERCOHFMbVJsWm1GMWJIUXVhSFZpWW14bExXZHljR011WTJsc2FYVnRMbWx2Ck1JSUJJakFOQmdrcWhraUc5dzBCQVFFRkFBT0NBUThBTUlJQkNnS0NBUUVBenZqVnlxdlBUNVhzOVhGVDZ0aUYKQ0QyTkk4L1FEVGxBUlpMNzFMbStlOUNYVlVFUEhDNHdoSUZxMzlQRFFaV0MyL3I1dHA3V0o0MjduQlIrc3AvZwpBeXd5SW5RRUJXM3pKejRENkU3cEhrNFExUWQ0Ri9GK2RQeFArYm4vZExoMjhZcFppcEFBYTZUVTI3ekNIK0FTCmJKTllHSUg4czZMaEFmUlRiMUNOTlVONlVxUzkrQnhoVlJGZktLMngyRGZMOGM4L2NPaG55Ym1mYU9XZHNoTHAKeW5ueDJsWHE5a0JsWElyenVHZkZPZGx2NjdCUnc0YUpoUU1DUVpMZ1NKT0VGaVVobmloOE5HY21RWWlJRHJPTQpCZ3FSSnEyd0dMTjFEZnRKY1VhTW9pZFBMZXVVZFpmekVIUEFQZi9OOVVSYThtRDZDQm5wSHd4ZVBhclp3cENFCi93SURBUUFCbzRHTk1JR0tNQTRHQTFVZER3RUIvd1FFQXdJRm9EQWRCZ05WSFNVRUZqQVVCZ2dyQmdFRkJRY0QKQVFZSUt3WUJCUVVIQXdJd0RBWURWUjBUQVFIL0JBSXdBREFmQmdOVkhTTUVHREFXZ0JRb3pDYjJFTUhZM3JrUQpxMjh1eWVJcy8xcnh6ekFxQmdOVkhSRUVJekFoZ2g4cUxtUmxabUYxYkhRdWFIVmlZbXhsTFdkeWNHTXVZMmxzCmFYVnRMbWx2TUEwR0NTcUdTSWIzRFFFQkN3VUFBNElCQVFBeU5ReVZld1VCbWtSV1NINHZYaTRNR0F6dWNHMTIKQUlpSUhUK0ROcWRYS3Bpd2YyQWZuSXA1QmpoVzlLS3VCY29MSzRSTkdOb3lQZk03K3U1YTVOY0l2SktycW85Wgo1Tmc3Z09kbExNeU5tclhaWXh1Vng2Vnl1dVZLVUpCMnFZZUNLM0xubHZUT1FXQjhva0ZZZ1dzTk9tMjU1STY3CkVva1hMMERYTm4rNGMrRUFHQk5iWUgzUEliNURMc0Y4SW1ZTVNBN040c3pOMmsrVzFoRkZyb0tCRW4xdWZHMk0KekQvS3o0YjdsckJQNjV2eVJHQ3ZCZjVaU0RSRW5QTnFMRGV6dVEyRnk3UVlZSUJJN01HNUFyS09id3JibzRvNQpwSlo4MFgzSGwvcmJxVld2cEpjc256KzNJaDVudjNJUG82L1VqU21icjRJODllZTJHck5YZWFLNAotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==
-  tls.key: LS0tLS1CRUdJTiBSU0EgUFJJVkFURSBLRVktLS0tLQpNSUlFb3dJQkFBS0NBUUVBenZqVnlxdlBUNVhzOVhGVDZ0aUZDRDJOSTgvUURUbEFSWkw3MUxtK2U5Q1hWVUVQCkhDNHdoSUZxMzlQRFFaV0MyL3I1dHA3V0o0MjduQlIrc3AvZ0F5d3lJblFFQlczekp6NEQ2RTdwSGs0UTFRZDQKRi9GK2RQeFArYm4vZExoMjhZcFppcEFBYTZUVTI3ekNIK0FTYkpOWUdJSDhzNkxoQWZSVGIxQ05OVU42VXFTOQorQnhoVlJGZktLMngyRGZMOGM4L2NPaG55Ym1mYU9XZHNoTHB5bm54MmxYcTlrQmxYSXJ6dUdmRk9kbHY2N0JSCnc0YUpoUU1DUVpMZ1NKT0VGaVVobmloOE5HY21RWWlJRHJPTUJncVJKcTJ3R0xOMURmdEpjVWFNb2lkUExldVUKZFpmekVIUEFQZi9OOVVSYThtRDZDQm5wSHd4ZVBhclp3cENFL3dJREFRQUJBb0lCQUFLdW5FZU91aTc2dVIrUgo1RVppbjYzSUtKRGYrQWoyNlNmaWs1eWhtS1RUUXFySDBGRzhnNlkxeDBmalZWdE9MVmh4Ymg1eDZMZ25wdXdvCmhUZWo1b0g3WnVldnhzNVZOTVJuL29Ua1JPUVhZQXJaY1RMRlQwS05YNDk3QXlMenU1M3ZKUkxua0I5ZTA5L0kKVTNRaXJRV0Z0alZ0UDZWc3dFUHUzMEwvRHZZQ055Q2N1QmNQMUg5bVBFdERmUDJiaE5NYmhMZTNkUytYT1VWcQpBR1BHNXJINlp2K2ZPSkFya2FXdnJwSlh4S1dvdjBUSFkrSUNzOFNxcjZyUG1mdWM1RFNZTzdWT3NYVm5UK2h5CnJBdFBDWGwxNC93bWxlL0NKZ1ZZV0ZTN1hKbC9KSzVocWlYUzFXV1NJQ2ZnakNKTlVZcjg2UlpycmltYnVqcmQKK0JibzZnMENnWUVBK3VuQTRoNW9mTWVWZnYzSmhGRDRFWGVETE1RUWlmWTdLWlNsS2tScE1BVFpsQWhLMmc1QQpPVFN6bEN6QnlzbitTOUxGaTY5L0FMRDJ1dGx3ZDNVbWhsVW8rQWYyd3I0dlkvWW95dUwzaUdGcmVKS3JpekgwCldLOHIvekR6OUdmNWZJdmNlOG9MdFhEd29PUnpIdS9IMlErRHRXcEhuMkJKSDlTRExka0N1TTBDZ1lFQTB5c0cKcnVYdlZyMDh6a1JrdTZsQUZjbEdNNGZGa1BmNHhOSlpiN29wdzFhZlVZa1Rka2VIRE9jL0YvdGErRjg2VCtQeApybU16UUZsdmRIWHVXTEZESlgxVXlUVXlTeVJYd1ovdjlJQnN5bGtNVmlQRm1VMXczTEF1QnVGaHczckdleW14CmljVWVGS3NUY1J1TEZKVEFqUkFYL1kxQkpScHhvRzRVaXlDS3BQc0NnWUEzVTZIZmVsc0o0S3g3UXhUVFkxTS8KN3IxeStveTNEeDkrakxOYXZaa0FLS0dkZmJLYm9IYlM1bWNPcmt2UkhuYy9XdXVLWUprOW1zZmM3YU5hQS9BSgp3TzkydWJMVXdFRU01ck9hQVRBWjEzbHVMZEU3c1RreThQVmZvUGk2Rk04emdsZU15RUdLc2F1dG5wSXY2U21GCkdHR3ZlQTd3K3JkRkdJUVFjUUNqcFFLQmdRQ3ZERkM2OVVLay9iUUZMTzd3SFlwUlJRc2J0bVlSR1c0d0Frcy8KY2V3aTBKQzdMMDFoMUVOZ2IrVitoTS9SYW1kVlNKalV2Y2tEZzkvL2c2OHorS1czMHlCUXR2ZGRFT0JxVXFIQQpaaUZJeis2SkRaaEV6OHhLTlFYQ2tGelJoZG80eU1ReWQ2UEs4RkhxaGpHUnV3bXZKZk10TFVZZWNzQlVoRXdsClZMRjV0d0tCZ0FuM3IrdW13SitkdDhQcEV4cUxpbFpZMG9xRzhkUjhJYk5TQ2Q3NHFUU0VsWnBMejRsUU9yKzUKMTRHdXI0SGlIdnI0WkliYzlJSndOV3ZyYjFieDYzMjBldkhKTG11eFBqVzhOOU16am1tbnJXYUdsVHJ6RDBpRQpWUm9lams0WG0yZk0wSGdmaVp4M20rNm96Q0ZGMFBsSEFNSmVtRlVoSG9oQUVSV293cjdtCi0tLS0tRU5EIFJTQSBQUklWQVRFIEtFWS0tLS0tCg==
 ---
 # Source: cilium/templates/cilium-configmap.yaml
 apiVersion: v1
@@ -1018,6 +991,44 @@ rules:
   - update
   - patch
 ---
+# Source: cilium/templates/hubble/tls-cronjob/role.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: hubble-generate-certs
+  namespace: kube-system
+  labels:
+    app.kubernetes.io/part-of: cilium
+
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - create
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    resourceNames:
+      - hubble-server-certs
+      - hubble-relay-client-certs
+      - hubble-relay-server-certs
+      - hubble-metrics-server-certs
+      - hubble-ui-client-certs
+    verbs:
+      - update
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    resourceNames:
+      - cilium-ca
+    verbs:
+      - get
+      - update
+---
 # Source: cilium/templates/cilium-agent/rolebinding.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -1101,6 +1112,24 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: "cilium-operator"
+  namespace: kube-system
+---
+# Source: cilium/templates/hubble/tls-cronjob/rolebinding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: hubble-generate-certs
+  namespace: kube-system
+  labels:
+    app.kubernetes.io/part-of: cilium
+
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: hubble-generate-certs
+subjects:
+- kind: ServiceAccount
+  name: "hubble-generate-certs"
   namespace: kube-system
 ---
 # Source: cilium/templates/cilium-envoy/service.yaml
@@ -2245,4 +2274,156 @@ spec:
         name: hubble-ui-nginx-conf
       - emptyDir: {}
         name: tmp-dir
+---
+# Source: cilium/templates/hubble/tls-cronjob/cronjob.yaml
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: hubble-generate-certs
+  namespace: kube-system
+  labels:
+    k8s-app: hubble-generate-certs
+    app.kubernetes.io/name: hubble-generate-certs
+    app.kubernetes.io/part-of: cilium
+spec:
+  schedule: "0 0 1 */4 *"
+  concurrencyPolicy: Forbid
+  jobTemplate:
+    spec:
+      template:
+        metadata:
+          labels:
+            k8s-app: hubble-generate-certs
+        spec:
+          securityContext:
+            seccompProfile:
+              type: RuntimeDefault
+          containers:
+            - name: certgen
+              image: "quay.io/cilium/certgen:v0.3.1@sha256:2825dbfa6f89cbed882fd1d81e46a56c087e35885825139923aa29eb8aec47a9"
+              imagePullPolicy: IfNotPresent
+              securityContext:
+                capabilities:
+                  drop:
+                  - ALL
+                allowPrivilegeEscalation: false
+              command:
+                - "/usr/bin/cilium-certgen"
+              # Because this is executed as a job, we pass the values as command
+              # line args instead of via config map. This allows users to inspect
+              # the values used in past runs by inspecting the completed pod.
+              args:
+                - "--ca-generate=true"
+                - "--ca-reuse-secret"
+                - "--ca-secret-namespace=kube-system"
+                - "--ca-secret-name=cilium-ca"
+                - "--ca-common-name=Cilium CA"
+              env:
+                - name: CILIUM_CERTGEN_CONFIG
+                  value: |
+                    certs:
+                    - name: hubble-server-certs
+                      namespace: kube-system
+                      commonName: "*.default.hubble-grpc.cilium.io"
+                      hosts:
+                      - "*.default.hubble-grpc.cilium.io"
+                      usage:
+                      - signing
+                      - key encipherment
+                      - server auth
+                      - client auth
+                      validity: 8760h
+                    - name: hubble-relay-client-certs
+                      namespace: kube-system
+                      commonName: "*.hubble-relay.cilium.io"
+                      hosts:
+                      - "*.hubble-relay.cilium.io"
+                      usage:
+                      - signing
+                      - key encipherment
+                      - client auth
+                      validity: 8760h
+                
+          hostNetwork: false
+          serviceAccount: "hubble-generate-certs"
+          serviceAccountName: "hubble-generate-certs"
+          automountServiceAccountToken: true
+          restartPolicy: OnFailure
+          affinity:
+      ttlSecondsAfterFinished: 1800
+---
+# Source: cilium/templates/hubble/tls-cronjob/job.yaml
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: hubble-generate-certs
+  namespace: kube-system
+  labels:
+    k8s-app: hubble-generate-certs
+    app.kubernetes.io/name: hubble-generate-certs
+    app.kubernetes.io/part-of: cilium
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+spec:
+  template:
+    metadata:
+      labels:
+        k8s-app: hubble-generate-certs
+    spec:
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: certgen
+          image: "quay.io/cilium/certgen:v0.3.1@sha256:2825dbfa6f89cbed882fd1d81e46a56c087e35885825139923aa29eb8aec47a9"
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            capabilities:
+              drop:
+              - ALL
+            allowPrivilegeEscalation: false
+          command:
+            - "/usr/bin/cilium-certgen"
+          # Because this is executed as a job, we pass the values as command
+          # line args instead of via config map. This allows users to inspect
+          # the values used in past runs by inspecting the completed pod.
+          args:
+            - "--ca-generate=true"
+            - "--ca-reuse-secret"
+            - "--ca-secret-namespace=kube-system"
+            - "--ca-secret-name=cilium-ca"
+            - "--ca-common-name=Cilium CA"
+          env:
+            - name: CILIUM_CERTGEN_CONFIG
+              value: |
+                certs:
+                - name: hubble-server-certs
+                  namespace: kube-system
+                  commonName: "*.default.hubble-grpc.cilium.io"
+                  hosts:
+                  - "*.default.hubble-grpc.cilium.io"
+                  usage:
+                  - signing
+                  - key encipherment
+                  - server auth
+                  - client auth
+                  validity: 8760h
+                - name: hubble-relay-client-certs
+                  namespace: kube-system
+                  commonName: "*.hubble-relay.cilium.io"
+                  hosts:
+                  - "*.hubble-relay.cilium.io"
+                  usage:
+                  - signing
+                  - key encipherment
+                  - client auth
+                  validity: 8760h
+            
+      hostNetwork: false
+      serviceAccount: "hubble-generate-certs"
+      serviceAccountName: "hubble-generate-certs"
+      automountServiceAccountToken: true
+      restartPolicy: OnFailure
+      affinity:
+  ttlSecondsAfterFinished: 1800
 

--- a/kubernetes/manifests/production/kustomization.yaml
+++ b/kubernetes/manifests/production/kustomization.yaml
@@ -1,11 +1,3 @@
-# =============================================================================
-# Production manifests entry point
-# =============================================================================
-# 本ファイルは Plan 1a 時点では空。後続 plan で components を追加した際に
-# `make hydrate ENV=production` が再生成する。
-# 手動で resources を編集するのは避ける（hydrate で上書きされる）。
-# =============================================================================
-apiVersion: kustomize.config.k8s.io/v1beta1
-kind: Kustomization
-
-resources: []
+resources:
+  - ./00-namespaces
+  - ./cilium


### PR DESCRIPTION
## Summary

Plan 1b: production EKS cluster `eks-production` に Cilium 1.18.6 を **chaining mode (VPC CNI 共存)** で導入し、KPR / 独立 Envoy DaemonSet / Gateway Controller / Hubble を有効化する。kube-proxy EKS managed addon は KPR で代替するため削除。

### Code 変更（本 PR）

- `kubernetes/Makefile`: `hydrate-index` を env-aware に変更（local backward compat 維持）+ `hydrate-component` の helmfile に `-e $(ENV)` 追加
- `kubernetes/helmfile.yaml.gotmpl`: production env block に `cluster.eksApiEndpoint` 追加
- `kubernetes/components/cilium/production/`: helmfile.yaml + values.yaml.gotmpl を新設（chaining + KPR=true + Envoy DaemonSet + Gateway API + Hubble、Hubble TLS は cronJob mode で秘密鍵を git 外に）
- `kubernetes/manifests/production/`: hydrate output（cilium/manifest.yaml + 00-namespaces 空 + kustomization 再生成）
- `aws/eks/modules/addons.tf`: `kube-proxy` block を削除 + 理由コメント
- `aws/eks/README.md` / `aws/eks/modules/node_groups.tf`: kube-proxy 記載を post-merge 状態に更新

### Documents

- Plan: `docs/superpowers/plans/2026-05-03-eks-production-cilium-chaining.md`
- Spec: `docs/superpowers/specs/2026-05-03-eks-production-cilium-chaining-design.md`

これは Phase 1 (Foundation) の **Plan 1b**。Plan 1a (Flux bootstrap, #255) の後続。次は Plan 1c で foundation addons (ALB Controller / ExternalDNS / Metrics Server / KEDA / Gateway API CRDs)。

## Migration sequence (operator が手動で実施、merge 前)

1. ``flux suspend kustomization flux-system -n flux-system``
2. PR branch を checkout して ``kubectl apply --server-side --force-conflicts -k kubernetes/manifests/production/cilium/``
3. Verification battery (Q1-Q4 + Gateway API + Hubble + cilium connectivity test) — 詳細は plan の Task 10
4. Mark PR ready for review → main merge → CI が terragrunt apply で kube-proxy 削除
5. Post-removal verification (Q2 final: kube-proxy NotFound)
6. ``flux resume kustomization flux-system -n flux-system`` → Cilium adoption + idempotency check

## Test plan

### Code-level (PR 作成時点で完了済)

- [x] ``make hydrate ENV=local`` の output が backward compat（manifests/local の SHA256 一致）
- [x] ``make hydrate ENV=production`` で cilium と空の 00-namespaces が生成される
- [x] ``kustomize build kubernetes/manifests/production`` が valid（41 resources）
- [x] ``helmfile -e production template`` で Cilium manifest が rendering、`KUBERNETES_SERVICE_HOST` が実 hostname に展開される
- [x] Hubble TLS 秘密鍵が manifest に含まれない（cronJob mode）
- [x] ``terragrunt validate`` 成功
- [x] ``terragrunt plan`` で kube-proxy addon の destroy 1 件のみ（Plan: 0 to add, 0 to change, 1 to destroy）

### Cluster-level (operator 実行)

- [ ] ``cilium status`` で KubeProxyReplacement: True / Gateway API: enabled
- [ ] ``cilium connectivity test`` 全 pass
- [ ] CiliumEnvoyConfig が Reconciled: True
- [ ] cilium-envoy DaemonSet が各 node で Running
- [ ] Gateway リソースが Programmed: True、HTTPRoute が Accepted: True
- [ ] hubble observe で flow が見える
- [ ] kube-proxy 削除後も Pod 間疎通が維持される
- [ ] Flux resume 後、cilium が drift なしで adopt される

## Out of scope (spec を継承)

- Hubble UI 公開（Phase 4 の Plan 4-x）
- HTTPRoute / CiliumEnvoyConfig による monorepo 認証実装（monorepo K8s 移行 spec）
- Cluster Mesh / Egress Gateway（Future Specs）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Deployed Cilium 1.18.x to EKS production cluster with chaining mode integration alongside VPC CNI
  * Enabled Cilium's kube-proxy replacement functionality for native Kubernetes networking
  * Added L7 proxy capabilities, Gateway API support, and Hubble observability platform

* **Documentation**
  * Added implementation plan and design specification for Cilium production deployment workflow

* **Chores**
  * Removed kube-proxy from EKS managed add-ons; migrated to Cilium-native proxy replacement
  * Enhanced build process for environment-specific manifest generation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->