### PR TITLE
docs: reflect Plan 1b post-execution learnings

### DIFF
--- a/docs/superpowers/plans/2026-05-03-eks-production-cilium-chaining.md
+++ b/docs/superpowers/plans/2026-05-03-eks-production-cilium-chaining.md
@@ -1325,3 +1325,43 @@ Expected:
   - 出力言語日本語、コミット `-s`、`Co-Authored-By` 不付与、PR は `--draft`、`-u origin HEAD`、Conventional Commits
 - [x] **代替パスを user 実行に明示**:
   - kubectl apply -k で apply（spec の "helm install" の代わり）→ Migration sequence Step 3 と差異が出るが、Hydration Pattern の利点（実 manifest を Git に commit）と一致しており、Flux adoption も clean に成立
+
+---
+
+## Lessons Learned (post-execution)
+
+Plan 1b 実行後に判明した知見。Plan 1c 以降の plan 設計時に反映する。
+
+### L1: `terraform-aws-modules/eks/aws v21` の `aws_eks_addon` の `preserve` 挙動
+
+EKS managed addon を terragrunt で削除しても、state に `preserve = true` が設定されている場合、AWS は addon registration を削除するだけで Kubernetes resource (DaemonSet/Deployment) は残す。
+
+**症状:** Task 6 の addons.tf 修正 → terragrunt apply success → しかし `kubectl get ds -n kube-system kube-proxy` がまだ存在。
+
+**対処:** Migration sequence Step 6 (post-removal verification) に「DaemonSet 自体が消えているか確認、残っていれば `kubectl delete daemonset` で手動削除」のチェックを追加する。または `aws/eks/modules/addons.tf` の addon block に `preserve = false` を明示する（ただし他の addon でも安全側で `preserve = true` のままにすべきものがあるなら、`kube-proxy` だけ `preserve = false` にする）。
+
+### L2: `make hydrate-component` が `helmfile template` に `-e $(ENV)` を渡していなかった
+
+local 環境では `values.yaml`（gotmpl ではない）を使っていたため発覚していなかった。production の `values.yaml.gotmpl` で `{{ .Values.cluster.* }}` を使った瞬間、helmfile が production env を選択できず `map has no entry for key "cluster"` エラー。Task 5 で `-e $(ENV)` 追加で修正済（commit `ec270da`）。
+
+**今後の plan 設計時の note:** gotmpl values を使う component を新設する場合、`make hydrate ENV=<env>` の動作確認を Task 1（Makefile 変更）の verification step に明示的に含める。
+
+### L3: helmfile v1.4 が parent → child env values を auto-inherit しない
+
+親 `kubernetes/helmfile.yaml.gotmpl` の `environments.<env>.values` は、子 helmfile（`kubernetes/components/<comp>/<env>/helmfile.yaml`）に継承されない。
+
+**対処:** 子 helmfile 側で同じ value を再定義する（重複だが確実）。または `helmfiles:` directive 内で `values: [...]` で forward する pattern を使う（複数 component で値を共有する必要が出た時に検討）。
+
+### L4: 親 helmfile の `helmfiles:` glob は `helmfile.yaml.gotmpl` にマッチしない
+
+`components/*/{{ .Environment.Name }}/helmfile.yaml` の glob は `.gotmpl` 拡張子の子 helmfile を拾わない。子 helmfile が gotmpl 処理を必要とする場合でも、ファイル名は `helmfile.yaml` のままにし、release 内の `values: [values.yaml.gotmpl]` で values 側だけ gotmpl 化する（Task 3 fix で対処済、commit `974bf98`）。
+
+### L5: Cilium connectivity test ICMP 失敗（EKS 環境）
+
+EKS Cluster SG が ICMP を許可していないため、`cilium connectivity test` の `client-to-client:ping-*` および `pod-to-host:ping-*` が断続的に失敗する。TCP/HTTP は全 pass。
+
+**対処:** production アプリ（monorepo）が gRPC/HTTP のみで ICMP に依存しないため、本 plan としては受け入れ可能。ICMP が必要になった場合は別 issue で `aws/eks/modules/` の cluster SG に ICMP 許可ルールを追加する spec を起こす。
+
+### L6: Hubble TLS auto.method の default `helm` は public Git repo に秘密鍵を出す
+
+Cilium chart の `hubble.tls.auto.method` が default の `helm` の場合、Helm が auto-generate した CA / Hubble relay/server の TLS 秘密鍵が rendered manifest に焼き込まれる。public Git repo の Hydration Pattern では production の秘密鍵が git history に残るため、`cronJob` mode に切り替え（Task 5 fix、commit `bf8ab39`）で cluster 内生成 / rotate に変更。

--- a/kubernetes/README.md
+++ b/kubernetes/README.md
@@ -296,6 +296,21 @@ flowchart LR
 
 EKS production cluster `eks-production`（`ap-northeast-1`）の運用手順。
 
+### Cluster overview (post Plan 1b)
+
+`eks-production` cluster は **Cilium 1.18.x が chaining mode (VPC CNI 共存)** で稼働し、`kubeProxyReplacement: true` で kube-proxy を eBPF で代替している。
+
+| 層 | 担当 |
+|---|---|
+| CNI / IPAM / datapath | VPC CNI（AWS managed addon）|
+| L3/L4/L7 NetworkPolicy | Cilium |
+| Service routing (kube-proxy 代替) | Cilium KPR（eBPF）|
+| L7 proxy | Cilium Envoy DaemonSet（独立、`envoy.enabled: true`）|
+| 東西の HTTPRoute / Gateway API | Cilium Gateway Controller（東西専用、北南は ALB Controller）|
+| Observability | Hubble（TLS は `cronJob` mode で cluster 内自動 rotate）|
+
+EKS managed addon としては `kube-proxy` を削除済（KPR で代替）。残存 addon: `vpc-cni` / `coredns` / `aws-ebs-csi-driver` / `eks-pod-identity-agent`。
+
 ### Initial Bootstrap (one-time)
 
 cluster を新規作成した直後に 1 回だけ実行する。すでに完了済の場合は skip。
@@ -330,6 +345,24 @@ flux reconcile kustomization flux-system -n flux-system
 flux get all -A
 ```
 
+### Cilium-specific operations
+
+```bash
+# Cilium 全体ヘルスチェック
+cilium status
+
+# 接続性テスト（test namespace を作る、数分かかる）
+cilium connectivity test --test '!check-log-errors'
+# 完了後の test namespace 手動削除
+kubectl delete namespace cilium-test-1 cilium-test-ccnp1 cilium-test-ccnp2 --ignore-not-found
+
+# Hubble flow 観測
+hubble observe --last 20
+
+# Hubble UI（Phase 4 で外部公開予定、現状は port-forward only）
+cilium hubble ui
+```
+
 ### Troubleshooting
 
 | 症状 | 原因 / 対処 |
@@ -338,6 +371,10 @@ flux get all -A
 | `Kustomization` が `BuildFailed` | `flux logs --kind=Kustomization` で kustomize build エラーを確認。`kubectl get kustomizations.kustomize.toolkit.fluxcd.io -n flux-system flux-system -o yaml` で `.status.conditions` も見る |
 | Flux が main の最新を sync しない | GitRepository の `interval: 1m` が効いているか確認。OOM / pod restart の可能性なら `kubectl get pods -n flux-system` |
 | `kubectl: error: ... credentials` | `eks-login.sh production` を再 source（session 1 時間で expire） |
+| EKS managed addon を削除したが Kubernetes DaemonSet が残る | `terraform-aws-modules/eks/aws v21` の `aws_eks_addon` が state に `preserve = true` を設定する場合がある。terragrunt apply は addon registration だけ削除し DaemonSet は残す挙動。`kubectl delete daemonset <name> -n kube-system` で手動削除 |
+| `cilium status` で `Cluster Pods: X/Y managed by Cilium` の差分（Y - X）が常に 0 にならない | hostNetwork pod（cilium-agent / cilium-envoy / cilium-operator 等）は Cilium endpoint を持たないため Cilium 管理対象外。差分が `cilium DaemonSet replicas × node + cilium-operator replicas` 程度なら steady state |
+| Cilium install 前から動いていた pod が Cilium 管理下に入らない | chaining mode では Cilium 設定が CNI conf に反映されるのは Pod 再作成時。`kubectl rollout restart -n flux-system deployment` 等で再作成すると chained になる |
+| `cilium connectivity test` で ICMP のみ失敗（TCP/HTTP は pass） | EKS Cluster SG が ICMP を明示許可していない可能性。production アプリが TCP のみなら無視で OK。ICMP が必要なら別 issue で SG ルール追加 |
 
 ### GitOps 原則
 


### PR DESCRIPTION
## Summary

- `kubernetes/README.md`: `## Production Operations` セクションに以下を追記
  - `### Cluster overview (post Plan 1b)`: chaining mode + KPR + Envoy DaemonSet + Gateway Controller + Hubble の構成表
  - `### Cilium-specific operations`: `cilium status` / connectivity test / hubble observe 等のコマンド集
  - `### Troubleshooting` テーブルに Plan 1b 学び 4 件を追加（preserve=true 挙動 / Cluster Pods 差分 / chaining mode の pod 再作成 / ICMP 失敗）
- `docs/superpowers/plans/2026-05-03-eks-production-cilium-chaining.md`: `## Lessons Learned (post-execution)` セクションを末尾に追加（L1–L6 の 6 項目）

## Test plan

- [x] `grep -c "^##" kubernetes/README.md` が 33（変更前より増加）
- [x] `grep -c "^##" docs/superpowers/plans/2026-05-03-eks-production-cilium-chaining.md` が 28（変更前より増加）
- [x] `### Cluster overview (post Plan 1b)` が `### Initial Bootstrap (one-time)` の直前に挿入
- [x] `### Cilium-specific operations` が `### Daily Operations` の直後かつ `### Troubleshooting` の直前に挿入
- [x] Troubleshooting テーブルの既存 4 行が維持され、末尾に 4 行追加
- [x] `## Lessons Learned` セクションが Self-review checklist の後に追加