### PR TITLE
feat(kubernetes): install gateway-api CRDs + metrics-server + KEDA (Plan 1c-α)

### DIFF
--- a/docs/superpowers/plans/2026-05-03-eks-production-foundation-addons-alpha.md
+++ b/docs/superpowers/plans/2026-05-03-eks-production-foundation-addons-alpha.md
@@ -1,0 +1,1051 @@
+# EKS Production Foundation Addons (alpha) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** EKS production cluster `eks-production` に **Gateway API CRDs (v1.2.1 Standard channel)** + **Metrics Server (chart 3.13.0)** + **KEDA (chart 2.19.0)** を Flux GitOps 経由で導入する。Plan 1c-α として Phase 1 Foundation の AWS 非依存 3 コンポーネントを完了させる。
+
+**Architecture:** `kubernetes/components/{gateway-api,metrics-server,keda}/production/` を新設し、`make hydrate ENV=production` で `manifests/production/` を再生成、1 PR にまとめて main へ merge する。Plan 1b と異なり Flux suspend は不要（既存 service routing への破壊的変更なし）、merge 後 Flux が自動で reconcile する。`kubernetes/README.md` の Production Operations セクションも更新して新コンポーネントの運用手順を反映する。
+
+**Tech Stack:** Kubernetes 1.35, Cilium 1.18.6, Gateway API v1.2.1 (Standard channel), Metrics Server Helm chart 3.13.0, KEDA Helm chart 2.19.0, Helmfile, Kustomize, FluxCD 2.x, kubectl, AWS EKS, AL2023 ARM64
+
+**Spec:** `docs/superpowers/specs/2026-05-03-eks-production-foundation-addons-alpha-design.md`
+
+---
+
+## File Structure
+
+| File | Status | Responsibility |
+|---|---|---|
+| `kubernetes/components/gateway-api/production/kustomization/kustomization.yaml` | create | Gateway API v1.2.1 Standard channel CRDs（upstream URL） |
+| `kubernetes/components/metrics-server/production/helmfile.yaml` | create | Metrics Server Helm release（chart 3.13.0、namespace: kube-system） |
+| `kubernetes/components/metrics-server/production/values.yaml` | create | `--kubelet-preferred-address-types=InternalIP` + resource requests |
+| `kubernetes/components/keda/production/helmfile.yaml` | create | KEDA Helm release（chart 2.19.0、namespace: keda） |
+| `kubernetes/components/keda/production/values.yaml` | create | KEDA values（chart デフォルト中心） |
+| `kubernetes/components/keda/production/namespace.yaml` | create | `keda` namespace 定義（env-aware hydrate-index で拾う） |
+| `kubernetes/manifests/production/gateway-api/manifest.yaml` | create (hydrated) | `make hydrate ENV=production` 出力 |
+| `kubernetes/manifests/production/gateway-api/kustomization.yaml` | create (hydrated) | 同上、`resources: - manifest.yaml` |
+| `kubernetes/manifests/production/metrics-server/manifest.yaml` | create (hydrated) | 同上 |
+| `kubernetes/manifests/production/metrics-server/kustomization.yaml` | create (hydrated) | 同上 |
+| `kubernetes/manifests/production/keda/manifest.yaml` | create (hydrated) | 同上 |
+| `kubernetes/manifests/production/keda/kustomization.yaml` | create (hydrated) | 同上 |
+| `kubernetes/manifests/production/00-namespaces/namespaces.yaml` | regenerated | env-aware hydrate-index で keda namespace が追加 |
+| `kubernetes/manifests/production/kustomization.yaml` | regenerated | `[./00-namespaces, ./cilium, ./gateway-api, ./keda, ./metrics-server]` |
+| `kubernetes/README.md` | modify | Production Operations セクションに新コンポーネントの運用手順を追加 |
+
+> **依存 spec / plan の前提**:
+> - ロードマップ spec: `docs/superpowers/specs/2026-05-02-eks-production-platform-roadmap-design.md`（merged）
+> - Plan 1a (Flux bootstrap): merged in PR #255
+> - Plan 1b (Cilium chaining): merged in PR #257
+> - Plan 1b 学び反映: merged in PR #259
+> - Plan 1c-α 設計 spec: `docs/superpowers/specs/2026-05-03-eks-production-foundation-addons-alpha-design.md`（同 PR で merge 予定）
+
+> **Out of scope（spec を継承）**:
+> - AWS Load Balancer Controller / ExternalDNS / IRSA / ACM 証明書（Plan 1c-β）
+> - Gateway API Experimental channel
+> - KEDA AWS scaler（SQS / EventBridge 等）の IRSA 設定
+> - Hubble UI / Grafana の Gateway 経由公開（Phase 4）
+
+---
+
+### Task 0: 前提条件の確認
+
+**Files:** （read only）
+
+実装前に prerequisite が揃っていることを確認する。
+
+- [ ] **Step 1: worktree とブランチを確認**
+
+```bash
+cd /Users/takanokenichi/GitHub/panicboat/platform/.claude/worktrees/feat/eks-production-foundation-addons-alpha
+git rev-parse --abbrev-ref HEAD
+```
+
+Expected: `feat/eks-production-foundation-addons-alpha`
+
+以後すべてのコマンドはこの worktree で実行する。
+
+- [ ] **Step 2: 必須 CLI が install 済であることを確認**
+
+```bash
+flux --version
+kubectl version --client | head -1
+helmfile --version
+helm version --short
+kustomize version
+```
+
+Expected: 各 CLI が version を返す。
+
+- [ ] **Step 3: 親 helmfile で production env が認識されることを確認**
+
+```bash
+cd kubernetes
+helmfile -e production list 2>&1 | head -5
+cd ..
+```
+
+Expected: `cilium` release が一覧に出る（Plan 1b で追加した production cilium component が見える）。Error なし。
+
+- [ ] **Step 4: Helm chart リポジトリの reachability を確認**
+
+```bash
+helm repo add metrics-server https://kubernetes-sigs.github.io/metrics-server 2>&1 || true
+helm repo add kedacore https://kedacore.github.io/charts 2>&1 || true
+helm repo update >/dev/null 2>&1
+helm search repo metrics-server/metrics-server --version=3.13.0 --output=json | head -3
+helm search repo kedacore/keda --version=2.19.0 --output=json | head -3
+```
+
+Expected: 各 chart の version 3.13.0 / 2.19.0 が見つかる（リポジトリ到達可能 + version 確定）。
+
+- [ ] **Step 5: Plan 1b で hydrate された production manifests が存在することを確認**
+
+```bash
+ls kubernetes/manifests/production/
+```
+
+Expected:
+```
+00-namespaces/
+cilium/
+kustomization.yaml
+```
+
+これに新たに `gateway-api/`、`metrics-server/`、`keda/` が追加される。
+
+---
+
+### Task 1: gateway-api production component を作成
+
+**Files:**
+- Create: `kubernetes/components/gateway-api/production/kustomization/kustomization.yaml`
+
+local の `kubernetes/components/gateway-api/local/kustomization/kustomization.yaml` と同型で、Gateway API v1.2.1 Standard channel の upstream install YAML を kustomize `resources` で参照する。
+
+- [ ] **Step 1: ディレクトリを作成**
+
+```bash
+mkdir -p kubernetes/components/gateway-api/production/kustomization
+```
+
+- [ ] **Step 2: kustomization.yaml を作成**
+
+`kubernetes/components/gateway-api/production/kustomization/kustomization.yaml` を以下の内容で作成：
+
+```yaml
+# =============================================================================
+# Gateway API CRDs Kustomization for production
+# =============================================================================
+# Installs the standard Gateway API CRDs from the upstream project.
+# These CRDs are required by the Cilium Gateway Controller (gatewayAPI.enabled
+# is true in kubernetes/components/cilium/production/values.yaml.gotmpl).
+#
+# Gateway API Version: v1.2.1
+# https://gateway-api.sigs.k8s.io/
+#
+# Standard channel covers GatewayClass / Gateway / HTTPRoute / GRPCRoute /
+# ReferenceGrant. Experimental channel (TCPRoute / TLSRoute / etc.) は
+# 必要が出たタイミングで別 spec で評価する（Future Specs）。
+# =============================================================================
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.2.1/standard-install.yaml
+```
+
+local 版との差分は banner コメントの「local」→「production」と production 固有の説明文（Cilium Gateway Controller の前提である旨）のみ。version pin は同じ v1.2.1。
+
+- [ ] **Step 3: kustomize build でリソースが取得できることを確認**
+
+```bash
+kustomize build kubernetes/components/gateway-api/production/kustomization 2>&1 | head -30
+```
+
+Expected: GatewayClass / Gateway / HTTPRoute / GRPCRoute / ReferenceGrant の CRDs が rendering される（5 個程度）。
+
+```bash
+kustomize build kubernetes/components/gateway-api/production/kustomization 2>&1 | grep -c "^kind: CustomResourceDefinition"
+```
+
+Expected: `5` 程度（Standard channel が含む CRDs の数）。
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add kubernetes/components/gateway-api/production/
+git commit -s -m "$(cat <<'EOF'
+feat(kubernetes/components/gateway-api): add production kustomization
+
+Cilium Gateway Controller (gatewayAPI.enabled: true) の前提となる
+Gateway API v1.2.1 Standard channel CRDs を upstream URL から
+kustomize で取得する production 用 kustomization を追加する。
+Version pin は local と同じ v1.2.1。
+EOF
+)"
+```
+
+Expected: 1 file changed, commit が `feat/eks-production-foundation-addons-alpha` ブランチに追加される。
+
+---
+
+### Task 2: metrics-server production component を作成
+
+**Files:**
+- Create: `kubernetes/components/metrics-server/production/helmfile.yaml`
+- Create: `kubernetes/components/metrics-server/production/values.yaml`
+
+EKS 用に `--kubelet-preferred-address-types=InternalIP` を arg として追加し、resource requests / limits を控えめに設定。
+
+- [ ] **Step 1: ディレクトリを作成**
+
+```bash
+mkdir -p kubernetes/components/metrics-server/production
+```
+
+- [ ] **Step 2: helmfile.yaml を作成**
+
+`kubernetes/components/metrics-server/production/helmfile.yaml`:
+
+```yaml
+# =============================================================================
+# Metrics Server Helmfile for production
+# =============================================================================
+# Provides resource metrics (CPU / memory) for HPA and `kubectl top`.
+# Required by KEDA-generated HPAs as well.
+# =============================================================================
+environments:
+  production:
+---
+repositories:
+  - name: metrics-server
+    url: https://kubernetes-sigs.github.io/metrics-server
+
+releases:
+  - name: metrics-server
+    namespace: kube-system
+    chart: metrics-server/metrics-server
+    version: "3.13.0"
+    values:
+      - values.yaml
+```
+
+- [ ] **Step 3: values.yaml を作成**
+
+`kubernetes/components/metrics-server/production/values.yaml`:
+
+```yaml
+# Metrics Server values for production
+# Reference: docs/superpowers/specs/2026-05-03-eks-production-foundation-addons-alpha-design.md
+
+# =============================================================================
+# Args
+# =============================================================================
+# EKS の kubelet は InternalIP で待ち受けるため、優先 address type に InternalIP
+# を指定する。default の "InternalIP,ExternalIP,Hostname" でも動くが、
+# InternalIP-only にすることで kubelet 接続が安定する。
+args:
+  - --kubelet-preferred-address-types=InternalIP
+
+# =============================================================================
+# Resources
+# =============================================================================
+resources:
+  requests:
+    cpu: 100m
+    memory: 200Mi
+  limits:
+    cpu: 1000m
+    memory: 1Gi
+
+# =============================================================================
+# Replicas
+# =============================================================================
+# Phase 1 では single replica。HA 化は monorepo 投入時に再評価。
+replicas: 1
+```
+
+- [ ] **Step 4: helmfile が release を認識することを確認**
+
+```bash
+cd kubernetes
+helmfile -e production list 2>&1 | grep -E "(NAME|metrics-server|cilium)" | head -5
+cd ..
+```
+
+Expected: `cilium` と `metrics-server` の 2 release が一覧に表示される。
+
+```
+NAME            NAMESPACE     ENABLED  INSTALLED  ...  CHART                              VERSION
+cilium          kube-system   true     true       ...  cilium/cilium                      1.18.6
+metrics-server  kube-system   true     true       ...  metrics-server/metrics-server      3.13.0
+```
+
+- [ ] **Step 5: helmfile template でレンダリングを確認**
+
+```bash
+cd kubernetes
+helmfile -e production --selector name=metrics-server template --skip-tests 2>&1 | head -20
+helmfile -e production --selector name=metrics-server template --skip-tests 2>&1 | grep -c "^kind:"
+cd ..
+```
+
+Expected: 1 つ目で Deployment / Service / SA / RBAC 等の YAML が出力。2 つ目で 10 程度の `kind:` カウント（Metrics Server の chart は 10 リソース前後）。
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add kubernetes/components/metrics-server/production/
+git commit -s -m "$(cat <<'EOF'
+feat(kubernetes/components/metrics-server): add production helmfile + values
+
+HPA の前提となる Metrics Server を chart version 3.13.0 で固定して
+production 用 helmfile / values を追加する。EKS 用に
+--kubelet-preferred-address-types=InternalIP を arg に指定し、
+resource requests / limits は production 想定の控えめ値で設定。
+EOF
+)"
+```
+
+---
+
+### Task 3: keda production component を作成
+
+**Files:**
+- Create: `kubernetes/components/keda/production/helmfile.yaml`
+- Create: `kubernetes/components/keda/production/values.yaml`
+- Create: `kubernetes/components/keda/production/namespace.yaml`
+
+KEDA は新規 namespace `keda` を使うため、`namespace.yaml` を env-aware hydrate-index で拾わせる。
+
+- [ ] **Step 1: ディレクトリを作成**
+
+```bash
+mkdir -p kubernetes/components/keda/production
+```
+
+- [ ] **Step 2: namespace.yaml を作成**
+
+`kubernetes/components/keda/production/namespace.yaml`:
+
+```yaml
+# =============================================================================
+# KEDA Namespace
+# =============================================================================
+# This namespace contains:
+#   - keda-operator (controller for ScaledObject / ScaledJob / TriggerAuthentication)
+#   - keda-operator-metrics-apiserver (external metrics API server)
+# =============================================================================
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: keda
+  labels:
+    app.kubernetes.io/name: keda
+```
+
+- [ ] **Step 3: helmfile.yaml を作成**
+
+`kubernetes/components/keda/production/helmfile.yaml`:
+
+```yaml
+# =============================================================================
+# KEDA Helmfile for production
+# =============================================================================
+# KEDA (Kubernetes Event-driven Autoscaling) installs ScaledObject / ScaledJob
+# CRDs and provides external triggers (Prometheus / Cron / SQS / etc.) on top
+# of native HPA. The chart includes the operator and metrics-apiserver.
+# =============================================================================
+environments:
+  production:
+---
+repositories:
+  - name: kedacore
+    url: https://kedacore.github.io/charts
+
+releases:
+  - name: keda
+    namespace: keda
+    chart: kedacore/keda
+    version: "2.19.0"
+    values:
+      - values.yaml
+```
+
+- [ ] **Step 4: values.yaml を作成**
+
+`kubernetes/components/keda/production/values.yaml`:
+
+```yaml
+# KEDA values for production
+# Reference: docs/superpowers/specs/2026-05-03-eks-production-foundation-addons-alpha-design.md
+
+# =============================================================================
+# Resources / Replicas
+# =============================================================================
+# Phase 1 では chart デフォルトを採用。HA 化や resource tuning は
+# monorepo の async worker 投入時に再評価する。
+# AWS scaler (SQS / EventBridge / DynamoDB Streams) の IRSA 設定も
+# 利用が顕在化したタイミングで別 spec で扱う。
+```
+
+- [ ] **Step 5: helmfile が release を認識することを確認**
+
+```bash
+cd kubernetes
+helmfile -e production list 2>&1 | grep -E "(NAME|cilium|metrics-server|keda)" | head -5
+cd ..
+```
+
+Expected: `cilium` / `metrics-server` / `keda` の 3 release が一覧に表示される。
+
+- [ ] **Step 6: helmfile template でレンダリングを確認**
+
+```bash
+cd kubernetes
+helmfile -e production --selector name=keda template --skip-tests 2>&1 | grep -c "^kind:"
+cd ..
+```
+
+Expected: 30 〜 50 程度の `kind:` カウント（KEDA chart は controller / metrics-apiserver / RBAC / CRDs 含めてリソース数が多い）。
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add kubernetes/components/keda/production/
+git commit -s -m "$(cat <<'EOF'
+feat(kubernetes/components/keda): add production helmfile + values + namespace
+
+Pod autoscaling foundation の event-driven trigger layer として KEDA を
+chart version 2.19.0 で固定して production 用 component を追加する。
+namespace は keda（chart デフォルト）で env-aware hydrate-index に
+namespace.yaml を拾わせる。values は chart default 中心、HA tuning や
+AWS scaler IRSA は monorepo 投入時に再評価。
+EOF
+)"
+```
+
+---
+
+### Task 4: `make hydrate ENV=production` を実行して manifests を生成・commit
+
+**Files (auto-generated by hydrate):**
+- Create: `kubernetes/manifests/production/gateway-api/manifest.yaml`
+- Create: `kubernetes/manifests/production/gateway-api/kustomization.yaml`
+- Create: `kubernetes/manifests/production/metrics-server/manifest.yaml`
+- Create: `kubernetes/manifests/production/metrics-server/kustomization.yaml`
+- Create: `kubernetes/manifests/production/keda/manifest.yaml`
+- Create: `kubernetes/manifests/production/keda/kustomization.yaml`
+- Modify: `kubernetes/manifests/production/00-namespaces/namespaces.yaml`（keda namespace 追加）
+- Modify: `kubernetes/manifests/production/kustomization.yaml`（4 component 参照に拡張）
+
+- [ ] **Step 1: hydrate を実行**
+
+```bash
+cd kubernetes
+make hydrate ENV=production
+cd ..
+```
+
+Expected: `💧 Hydrating manifests for production...` → `Hydrating cilium...` `Hydrating gateway-api...` `Hydrating keda...` `Hydrating metrics-server...` → `✅ Manifests hydrated`
+
+- [ ] **Step 2: 生成された structure を確認**
+
+```bash
+find kubernetes/manifests/production -maxdepth 2 -type d | sort
+```
+
+Expected:
+```
+kubernetes/manifests/production
+kubernetes/manifests/production/00-namespaces
+kubernetes/manifests/production/cilium
+kubernetes/manifests/production/gateway-api
+kubernetes/manifests/production/keda
+kubernetes/manifests/production/metrics-server
+```
+
+- [ ] **Step 3: 00-namespaces に keda namespace が追加されたことを確認**
+
+```bash
+cat kubernetes/manifests/production/00-namespaces/namespaces.yaml
+```
+
+Expected: `keda` namespace の YAML が含まれる（cilium は kube-system 利用なので namespace.yaml なし、keda のみ）。具体的には：
+
+```yaml
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: keda
+  labels:
+    app.kubernetes.io/name: keda
+```
+
+- [ ] **Step 4: top-level kustomization.yaml が 4 component を参照することを確認**
+
+```bash
+cat kubernetes/manifests/production/kustomization.yaml
+```
+
+Expected:
+```yaml
+resources:
+  - ./00-namespaces
+  - ./cilium
+  - ./gateway-api
+  - ./keda
+  - ./metrics-server
+```
+
+- [ ] **Step 5: kustomize build で全体が valid であることを確認**
+
+```bash
+kustomize build kubernetes/manifests/production 2>&1 | grep -c "^kind:"
+```
+
+Expected: 80 〜 130 程度（Cilium 41 + Gateway API CRDs 5 + Metrics Server ~10 + KEDA 30〜50 + Namespace 1）。エラーなし。
+
+- [ ] **Step 6: 各 manifest の主要設定を sanity-check**
+
+```bash
+echo "=== Gateway API CRDs ==="
+grep -E "kind: CustomResourceDefinition" kubernetes/manifests/production/gateway-api/manifest.yaml | head -10
+echo ""
+echo "=== Metrics Server args ==="
+grep -A 3 "args:" kubernetes/manifests/production/metrics-server/manifest.yaml | head -10
+echo ""
+echo "=== KEDA operator deployment ==="
+grep -E "(kind: Deployment|name: keda-operator)" kubernetes/manifests/production/keda/manifest.yaml | head -5
+```
+
+Expected:
+- Gateway API: GatewayClass / Gateway / HTTPRoute / GRPCRoute / ReferenceGrant の CRDs
+- Metrics Server: `--kubelet-preferred-address-types=InternalIP` が args 内に存在
+- KEDA: `keda-operator` Deployment が存在
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add kubernetes/manifests/production/
+git commit -s -m "$(cat <<'EOF'
+feat(kubernetes/manifests/production): hydrate gateway-api + metrics-server + keda
+
+make hydrate ENV=production の output を commit する。
+- gateway-api/manifest.yaml: Gateway API v1.2.1 Standard channel CRDs
+- metrics-server/manifest.yaml: chart 3.13.0 の rendered output
+- keda/manifest.yaml: chart 2.19.0 の rendered output
+- 00-namespaces/namespaces.yaml: keda namespace 追加
+- kustomization.yaml: cilium / gateway-api / keda / metrics-server を resources として参照
+EOF
+)"
+```
+
+---
+
+### Task 5: kubernetes/README.md の Production Operations セクションを更新
+
+**Files:**
+- Modify: `kubernetes/README.md`
+
+Plan 1c-α の 3 コンポーネントを Production Operations セクションに反映する。
+
+- [ ] **Step 1: 現状の README 構成を確認**
+
+```bash
+grep -n "^### " kubernetes/README.md | head -20
+```
+
+Expected: `## Production Operations` 以下の subsections（Cluster overview / Initial Bootstrap / Daily Operations / Cilium-specific operations / Troubleshooting / GitOps 原則）が見える。
+
+- [ ] **Step 2: Cluster overview セクションを更新**
+
+`kubernetes/README.md` の `### Cluster overview (post Plan 1b)` セクションを以下に書き換える（行を追加する形）：
+
+`### Cluster overview (post Plan 1b)` のセクションタイトルを `### Cluster overview (post Plan 1c-α)` に変更し、既存のテーブルの下に以下の追加表を append：
+
+````markdown
+加えて Plan 1c-α で以下の foundation addons を導入：
+
+| Addon | Namespace | 役割 |
+|---|---|---|
+| Gateway API CRDs | (cluster-scoped) | Cilium Gateway Controller の前提（Standard channel v1.2.1） |
+| Metrics Server | `kube-system` | Pod の resource metrics を公開、HPA / KEDA-generated HPA の前提 |
+| KEDA | `keda` | Event-driven autoscaling layer（HPA を内部生成） |
+````
+
+- [ ] **Step 3: Cilium-specific operations の直後に Foundation addon operations セクションを追加**
+
+`### Cilium-specific operations` セクションの直後（次の `### Troubleshooting` の前）に、以下の新セクションを追加：
+
+````markdown
+### Foundation addon operations
+
+```bash
+# Gateway API（Cilium Gateway Controller）
+kubectl get gatewayclass cilium                          # Programmed: True
+kubectl get gateway -A                                   # cluster 内の Gateway 一覧
+kubectl get httproute -A                                 # HTTPRoute 一覧
+
+# Metrics Server
+kubectl top nodes                                        # node の CPU/Memory
+kubectl top pods -A | head                               # pod の CPU/Memory
+kubectl logs -n kube-system deploy/metrics-server --tail=20
+
+# KEDA
+kubectl get scaledobject -A                              # ScaledObject 一覧
+kubectl get hpa -A | grep keda-hpa                       # KEDA-generated HPA
+kubectl logs -n keda deploy/keda-operator --tail=20
+```
+````
+
+- [ ] **Step 4: Troubleshooting テーブルに行を追加**
+
+`### Troubleshooting` テーブルの末尾（既存の Plan 1b 学び 4 行の後）に以下の行を追加：
+
+````markdown
+| `kubectl top` が `Metrics API not available` を返す | metrics-server が未 Ready or kubelet certs / preferred address types の不一致。`kubectl logs -n kube-system deploy/metrics-server` で確認 |
+| `GatewayClass cilium` が `Programmed: False` | Cilium operator が CRDs を picking up していない。`kubectl logs -n kube-system deploy/cilium-operator` で確認、Cilium pod の rolling restart が必要なケースあり |
+| KEDA `ScaledObject` が `Ready: False` | trigger 設定誤り or RBAC error。`kubectl describe scaledobject <name> -n <ns>` で詳細を確認 |
+````
+
+- [ ] **Step 5: README の整合性確認**
+
+```bash
+grep -c "^##" kubernetes/README.md
+```
+
+Expected: section count が 9 個以上を維持（Plan 1a の 9 + 新規ゼロ、見出し追加なし、subsection 追加のみのため）。
+
+```bash
+grep -c "^### " kubernetes/README.md
+```
+
+Expected: subsection count が増えている（既存 + Foundation addon operations の 1 増分）。
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add kubernetes/README.md
+git commit -s -m "$(cat <<'EOF'
+docs(kubernetes): reflect Plan 1c-α addons in README
+
+Production Operations セクションに Plan 1c-α で導入する Foundation
+addons (Gateway API CRDs / Metrics Server / KEDA) を反映する。
+- Cluster overview に foundation addon の追加テーブル
+- Foundation addon operations セクション新設（運用コマンド集）
+- Troubleshooting に metrics-server / GatewayClass / KEDA ScaledObject
+  の対処エントリ 3 件追加
+EOF
+)"
+```
+
+---
+
+### Task 6: ブランチを push して Draft PR を作成
+
+**Files:** （git 操作のみ）
+
+ここまでの code 変更を Draft PR として user に提示する。
+
+- [ ] **Step 1: 全 commit を確認**
+
+```bash
+git log --oneline origin/main..HEAD
+```
+
+Expected:
+```
+<sha> docs(kubernetes): reflect Plan 1c-α addons in README
+<sha> feat(kubernetes/manifests/production): hydrate gateway-api + metrics-server + keda
+<sha> feat(kubernetes/components/keda): add production helmfile + values + namespace
+<sha> feat(kubernetes/components/metrics-server): add production helmfile + values
+<sha> feat(kubernetes/components/gateway-api): add production kustomization
+<sha> docs(eks): add Plan 1c-α (foundation addons alpha) design spec
+```
+
+合計 6 commits（spec 1 + components 3 + hydrate 1 + README 1）。
+
+- [ ] **Step 2: ブランチを push**
+
+```bash
+git push -u origin feat/eks-production-foundation-addons-alpha
+```
+
+Expected: `branch 'feat/eks-production-foundation-addons-alpha' set up to track 'origin/feat/eks-production-foundation-addons-alpha'`
+
+- [ ] **Step 3: Draft PR を作成**
+
+```bash
+gh pr create --draft --base main \
+  --title "feat(kubernetes): install gateway-api CRDs + metrics-server + KEDA (Plan 1c-α)" \
+  --body "$(cat <<'EOF'
+## Summary
+
+Plan 1c-α: production EKS cluster `eks-production` に AWS 非依存の Foundation addons 3 件を Flux GitOps 経由で導入する。
+
+### Code 変更（本 PR）
+
+- `kubernetes/components/gateway-api/production/`: Gateway API v1.2.1 Standard channel CRDs を upstream URL から kustomize で取得
+- `kubernetes/components/metrics-server/production/`: Helm chart 3.13.0、`--kubelet-preferred-address-types=InternalIP` 追加
+- `kubernetes/components/keda/production/`: Helm chart 2.19.0、namespace `keda` 新設
+- `kubernetes/manifests/production/`: hydrate output（4 component + 00-namespaces）
+- `kubernetes/README.md`: Production Operations セクション更新（Cluster overview / Foundation addon operations / Troubleshooting）
+
+### Documents
+
+- Plan: ``docs/superpowers/plans/2026-05-03-eks-production-foundation-addons-alpha.md``
+- Spec: ``docs/superpowers/specs/2026-05-03-eks-production-foundation-addons-alpha-design.md``
+
+これは Phase 1 (Foundation) の **Plan 1c-α**。次は Plan 1c-β で AWS 連携の foundation (ALB Controller / ExternalDNS / IRSA / ACM)。
+
+## Migration sequence
+
+Plan 1b と異なり既存 service routing への破壊的変更がないため、Flux suspend は不要。merge 後 Flux が自動で reconcile する。
+
+1. Code 変更を 1 PR で main へ merge
+2. CI: Hydrate Kubernetes (production) workflow が auto-run（既存）
+3. Flux が main を pull → 差分（CRDs install + Helm release × 2 + namespace 追加）を apply
+4. Verification battery を operator が手動実行
+
+## Test plan
+
+### Code-level (PR 作成時点で完了済)
+
+- [x] ``helmfile -e production list`` で cilium / metrics-server / keda の 3 release が表示される
+- [x] ``helmfile -e production --selector name=metrics-server template`` が valid
+- [x] ``helmfile -e production --selector name=keda template`` が valid
+- [x] ``kustomize build kubernetes/components/gateway-api/production/kustomization`` で CRDs 5 個 rendering
+- [x] ``kustomize build kubernetes/manifests/production`` が valid（80-130 resources）
+- [x] ``kubernetes/manifests/production/00-namespaces/namespaces.yaml`` に keda namespace 追加
+- [x] ``kubernetes/manifests/production/kustomization.yaml`` が `[./00-namespaces, ./cilium, ./gateway-api, ./keda, ./metrics-server]` を参照
+
+### Cluster-level (operator 実行、merge 後)
+
+- [ ] ``flux get kustomizations -n flux-system flux-system`` で `Applied revision: main@<sha>` が新 commit を反映
+- [ ] ``kubectl get crd | grep gateway.networking.k8s.io`` で 5 個程度の CRDs
+- [ ] ``kubectl get gatewayclass cilium`` で `Programmed: True`（Cilium operator が CRDs を picking up）
+- [ ] ``kubectl top nodes`` および ``kubectl top pods -A`` が値を返す（Metrics Server 動作）
+- [ ] ``kubectl get deployment -n keda`` で ``keda-operator`` / ``keda-operator-metrics-apiserver`` が Ready
+- [ ] minimal Gateway を apply → Programmed: True
+- [ ] minimal ScaledObject を apply → KEDA-managed HPA が auto-create される
+
+## Out of scope (spec を継承)
+
+- AWS Load Balancer Controller / ExternalDNS / IRSA / ACM（Plan 1c-β）
+- Gateway API Experimental channel
+- KEDA AWS scaler の IRSA 設定（monorepo の async worker 投入時）
+- Hubble UI / Grafana の Gateway 経由公開（Phase 4）
+EOF
+)" 2>&1 | tail -3
+```
+
+Expected: PR URL が表示される（`https://github.com/panicboat/platform/pull/<num>`）。
+
+- [ ] **Step 4: PR URL を user に共有**
+
+```bash
+gh pr view --json url --jq .url
+```
+
+PR URL を controller (Claude) が user に提示。以後の Task 7-8 は user 実行。
+
+---
+
+### Task 7: (USER) PR を ready にして merge、Flux 自動 reconcile を待つ
+
+**Files:** （cluster 状態変更）
+
+Plan 1b と異なり Flux suspend は不要。PR を ready / merge し、Flux が自動で apply するのを待つ。
+
+- [ ] **Step 1: PR を Ready for review に変更**
+
+```bash
+gh pr ready
+```
+
+または GitHub UI で `Ready for review` ボタンを押す。
+
+- [ ] **Step 2: review approve（self-approve または別 reviewer）**
+
+```bash
+gh pr review --approve
+```
+
+- [ ] **Step 3: PR を main へ merge**
+
+```bash
+gh pr merge --squash --delete-branch
+```
+
+merge 後、Hydrate Kubernetes (production) workflow が CI で auto-run する。
+
+- [ ] **Step 4: CI workflow が完了することを確認**
+
+```bash
+gh run watch
+```
+
+または GitHub Actions UI で workflow 進捗を確認。Expected: 全 step success。
+
+- [ ] **Step 5: production cluster 接続して Flux reconcile を確認**
+
+```bash
+source ~/.zshrc
+eks-login production
+flux reconcile source git flux-system -n flux-system
+flux reconcile kustomization flux-system -n flux-system
+flux get kustomizations -n flux-system flux-system
+```
+
+Expected: 最後の `flux get` で `READY: True`、`MESSAGE: Applied revision: main@<merged sha>`。
+
+- [ ] **Step 6: 新リソースが apply されたことを確認**
+
+```bash
+kubectl get crd | grep gateway.networking.k8s.io
+kubectl get deployment -n kube-system metrics-server
+kubectl get deployment -n keda
+```
+
+Expected:
+- Gateway API CRDs が 5 個程度 install 済
+- metrics-server deployment が Ready 1/1
+- keda deployment が `keda-operator` / `keda-operator-metrics-apiserver` の 2 個 Ready
+
+reconcile に時間がかかる場合は `flux get all -A` で進捗確認。
+
+---
+
+### Task 8: (USER) Verification battery を実行
+
+**Files:** （read only / 一時 test resource の create + delete）
+
+各 component が期待通り動作することを確認する。
+
+- [ ] **Step 1: Gateway API verification**
+
+```bash
+# CRDs install 確認
+kubectl get crd 2>&1 | grep "gateway.networking.k8s.io" | wc -l
+```
+
+Expected: `5` 程度（GatewayClass / Gateway / HTTPRoute / GRPCRoute / ReferenceGrant）。
+
+```bash
+# Cilium が GatewayClass を register したことを確認
+kubectl get gatewayclass cilium
+kubectl get gatewayclass cilium -o jsonpath='{.status.conditions[?(@.type=="Accepted")].status}{"\n"}'
+```
+
+Expected: `gatewayclass.gateway.networking.k8s.io/cilium` が `ACCEPTED: True` で表示される。jsonpath 出力が `True`。
+
+最初は Cilium operator が CRDs を picking up するのに 30 〜 60 秒かかる場合がある。`Not Found` の場合：
+
+```bash
+kubectl rollout restart -n kube-system deploy/cilium-operator
+sleep 60
+kubectl get gatewayclass cilium
+```
+
+```bash
+# minimal Gateway を apply して動作確認
+cat <<'EOF' | kubectl apply -f -
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: smoke-test-gateway
+  namespace: default
+spec:
+  gatewayClassName: cilium
+  listeners:
+    - name: http
+      protocol: HTTP
+      port: 80
+EOF
+sleep 30
+kubectl get gateway smoke-test-gateway -n default -o jsonpath='{.status.conditions[?(@.type=="Programmed")].status}{"\n"}'
+```
+
+Expected: `True`。
+
+cleanup:
+
+```bash
+kubectl delete gateway smoke-test-gateway -n default
+```
+
+- [ ] **Step 2: Metrics Server verification**
+
+```bash
+kubectl get deployment -n kube-system metrics-server
+```
+
+Expected: `READY 1/1`。
+
+```bash
+kubectl top nodes
+```
+
+Expected: 各 node の CPU / Memory 値が表示される。最初の collection に 30 秒程度かかる場合あり。
+
+```bash
+kubectl top pods -A | head -10
+```
+
+Expected: 各 pod の CPU / Memory 値が表示される。
+
+エラーが出る場合（例 `Metrics API not available`）：
+
+```bash
+kubectl logs -n kube-system deploy/metrics-server --tail=30
+```
+
+`x509: cannot validate certificate` 系のエラーが出る場合は `--kubelet-insecure-tls` の追加を要検討（spec の Future Specs ではないが、EKS の AMI / kubelet cert の挙動次第。本 plan の範囲では values.yaml 修正なしで動く想定）。
+
+- [ ] **Step 3: KEDA verification**
+
+```bash
+kubectl get deployment -n keda
+```
+
+Expected:
+```
+NAME                              READY   UP-TO-DATE   AVAILABLE   AGE
+keda-operator                     1/1     1            1           ...
+keda-operator-metrics-apiserver   1/1     1            1           ...
+```
+
+`keda-admission-webhooks` が含まれる場合もある（chart version による）。すべて 1/1 で Ready。
+
+```bash
+kubectl get crd 2>&1 | grep "keda.sh"
+```
+
+Expected:
+```
+clustertriggerauthentications.keda.sh
+scaledjobs.keda.sh
+scaledobjects.keda.sh
+triggerauthentications.keda.sh
+```
+
+```bash
+# Smoke test: minimal ScaledObject (CPU baseline)
+cat <<'EOF' | kubectl apply -f -
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: keda-smoke-test
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: smoke-target
+  namespace: keda-smoke-test
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: smoke-target
+  template:
+    metadata:
+      labels:
+        app: smoke-target
+    spec:
+      containers:
+        - name: pause
+          image: registry.k8s.io/pause:3.10
+          resources:
+            requests:
+              cpu: 50m
+            limits:
+              cpu: 100m
+---
+apiVersion: keda.sh/v1alpha1
+kind: ScaledObject
+metadata:
+  name: smoke-test-so
+  namespace: keda-smoke-test
+spec:
+  scaleTargetRef:
+    name: smoke-target
+  minReplicaCount: 1
+  maxReplicaCount: 3
+  triggers:
+    - type: cpu
+      metadata:
+        type: Utilization
+        value: "50"
+EOF
+sleep 30
+kubectl get hpa -n keda-smoke-test
+```
+
+Expected: KEDA が auto-create した HPA が 1 件表示される（name は `keda-hpa-smoke-test-so`）。
+
+```bash
+kubectl get scaledobject -n keda-smoke-test smoke-test-so -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}{"\n"}'
+```
+
+Expected: `True`。
+
+cleanup:
+
+```bash
+kubectl delete namespace keda-smoke-test
+```
+
+- [ ] **Step 4: 全体 Flux 状態の最終確認**
+
+```bash
+flux get all -n flux-system | head -10
+flux get kustomizations -A
+```
+
+Expected: GitRepository / Kustomization 全部 Ready: True、Suspended: False。
+
+- [ ] **Step 5: 冪等性確認**
+
+```bash
+flux reconcile kustomization flux-system -n flux-system
+sleep 10
+kubectl get events -n flux-system --sort-by=.lastTimestamp | tail -5
+```
+
+Expected: 直近の event に `ReconciliationSucceeded` または `Normal` のみ。Pod 再起動 / apply 警告なし。
+
+- [ ] **Step 6: 全 Pod が Running を維持していることを最終確認**
+
+```bash
+kubectl get pods -A | grep -v Running | grep -v Completed
+```
+
+Expected: 結果が空（または header のみ）。Plan 1c-α 投入で stuck した pod が無いこと。
+
+すべて pass したら **Plan 1c-α 完了**。次は Plan 1c-β（ALB Controller / ExternalDNS / IRSA / ACM）の brainstorming に進む。
+
+---
+
+## Self-review checklist
+
+このセクションは Plan 完成後に書き手（Claude）が自己 review する項目。実装者は Skip して構わない。
+
+- [x] **Spec coverage**:
+  - Spec の Goals 1-5 → Task 1-5（component 作成）+ Task 7-8（cluster-level verification）でカバー
+  - Spec の Components 変更マトリクス → File Structure と Task 1-5 で 1 対 1 対応
+  - Spec の Migration sequence → Task 6（PR）+ Task 7（user merge → Flux auto reconcile）
+  - Spec の Verification checklist → Task 8 で全項目を網羅
+  - Spec の Architecture decisions（継承） → Task 内で参照
+  - Spec の Future Specs → Plan の Out of scope 注記で参照
+- [x] **Placeholder scan**:
+  - すべての Step に exact 値 / exact command 記載
+  - `<sha>` のみ commit hash placeholder（実装時に確定）
+  - `TBD` / `implement later` 等の禁止文言なし
+- [x] **Type / signature consistency**:
+  - File path: 全 task で同一
+  - Helm chart version: Task 2 で 3.13.0 固定 / Task 3 で 2.19.0 固定 / Task 1 で v1.2.1 固定、Task 4 hydrate / Task 8 verification で同じ値を確認
+- [x] **CLAUDE.md 準拠**:
+  - 出力言語日本語、コミット `-s`、`Co-Authored-By` 不付与、PR は `--draft`、`-u origin HEAD`、Conventional Commits
+- [x] **README 更新が含まれている**: Task 5 で kubernetes/README.md を Production Operations セクション 3 箇所修正

--- a/docs/superpowers/plans/2026-05-03-eks-production-foundation-addons-alpha.md
+++ b/docs/superpowers/plans/2026-05-03-eks-production-foundation-addons-alpha.md
@@ -239,13 +239,18 @@ releases:
 # Reference: docs/superpowers/specs/2026-05-03-eks-production-foundation-addons-alpha-design.md
 
 # =============================================================================
-# Args
+# defaultArgs override
 # =============================================================================
-# EKS の kubelet は InternalIP で待ち受けるため、優先 address type に InternalIP
-# を指定する。default の "InternalIP,ExternalIP,Hostname" でも動くが、
-# InternalIP-only にすることで kubelet 接続が安定する。
-args:
+# chart の defaultArgs を上書きして --kubelet-preferred-address-types を
+# InternalIP のみに narrow する。EKS の kubelet は InternalIP で待ち受けるため
+# preference list を 1 つに絞ることで明示的な制約を表す。
+# defaultArgs を上書きすることで chart の args ロジック（defaultArgs に args を
+# append する仕様）による flag 重複を避ける。
+defaultArgs:
+  - --cert-dir=/tmp
   - --kubelet-preferred-address-types=InternalIP
+  - --kubelet-use-node-status-port
+  - --metric-resolution=15s
 
 # =============================================================================
 # Resources
@@ -261,7 +266,8 @@ resources:
 # =============================================================================
 # Replicas
 # =============================================================================
-# Phase 1 では single replica。HA 化は monorepo 投入時に再評価。
+# single replica。Metrics Server は state を持たないので軽微な再起動 gap を許容する。
+# HA 化は trade-off を再評価した上で Future Specs。
 replicas: 1
 ```
 

--- a/docs/superpowers/specs/2026-05-03-eks-production-foundation-addons-alpha-design.md
+++ b/docs/superpowers/specs/2026-05-03-eks-production-foundation-addons-alpha-design.md
@@ -1,0 +1,258 @@
+# EKS Production Foundation Addons (alpha) Design
+
+## Overview
+
+Phase 1 Foundation の残り（Plan 1a / 1b に続く）のうち、**AWS 非依存の 3 コンポーネント** を production EKS cluster `eks-production` に導入する。Plan 1c-α として位置づけ、Plan 1c-β では AWS 連携のある残り 2 コンポーネント（AWS Load Balancer Controller、ExternalDNS）と IRSA / ACM 等を扱う。
+
+本 spec のスコープ：
+
+- **Gateway API CRDs**: 現状 Cilium が `gatewayAPI.enabled: true` で稼働しているが CRDs が未 install のため Gateway Controller が機能しない状態を解消
+- **Metrics Server**: HPA の resource metrics provider
+- **KEDA**: event-driven autoscaling foundation（Phase 5 で nginx の `ScaledObject` demo に使用）
+
+ロードマップ spec（`2026-05-02-eks-production-platform-roadmap-design.md`）の **Decision 6**（Pod autoscaling foundation = Metrics Server + KEDA）と Phase 1 完了条件のうち、3 項目を本 spec で消化する。
+
+## Goals
+
+1. Gateway API v1.2.1 Standard channel の CRDs を production cluster に install する
+2. Cilium Gateway Controller が GatewayClass `cilium` を register する状態を作る
+3. Metrics Server を install し `kubectl top` が動作する状態を作る
+4. KEDA controller / metrics-apiserver を install し `ScaledObject` リソースが reconcile される状態を作る
+5. 上記 3 コンポーネントを Flux GitOps の管理下に置く
+
+## Non-goals (Out of scope, with follow-up tracking)
+
+- **AWS Load Balancer Controller** → Plan 1c-β
+- **ExternalDNS** → Plan 1c-β
+- **IRSA / ACM 証明書 / Route53 hosted zone 連携** → Plan 1c-β
+- **実ワークロードでの HPA / ScaledObject 利用** → monorepo 移行 / Phase 5
+- **Gateway API Experimental channel**（TCPRoute / TLSRoute / GRPCRoute experimental 機能） → Future Specs
+- **KEDA AWS scaler の IRSA 設定**（SQS / EventBridge / DynamoDB Streams 等） → monorepo の async worker 投入時に別 spec
+- **Hubble UI / Grafana の Gateway 経由公開** → Phase 4 spec
+
+## Architecture decisions
+
+ロードマップ spec の Decision を継承するのみ、本 spec で新規 architectural decision は発生しない。
+
+| 継承元 | 内容 |
+|---|---|
+| Roadmap Decision 6 | Pod autoscaling foundation = Metrics Server + KEDA。KEDA は HPA を置き換えず HPA を内部生成する layer であり、Metrics Server は KEDA が作る HPA でも resource metrics 用に必要 |
+| Roadmap Phase 1 完了条件 | "`kubectl top pods` が値を返す" "KEDA controller が起動し、`ScaledObject` リソースが作成可能" "Cilium Gateway Controller が `Gateway` リソースから cluster 内部 LB を立ち上げる（東西用、北南未使用）" |
+
+## Component decisions
+
+各コンポーネントの実装上の値を確定する。
+
+### Gateway API CRDs
+
+- **Channel**: **Standard**
+  - Decision rationale: Pattern B-Full（HTTPRoute + CiliumEnvoyConfig による JWT 検証）は HTTPRoute のみで成立し、Standard channel に含まれる。Experimental の TCPRoute / TLSRoute / GRPCRoute / BackendTLSPolicy 等は本 spec の範囲では不要
+  - Future Specs: 必要が出たら別 spec で Experimental に切り替え（Cilium Gateway Controller は Experimental も sustaining sup）
+- **Version**: **v1.2.1**（local の `kubernetes/components/gateway-api/local/kustomization/` と同じ pin）
+  - Renovate で local / production を同時 bump させる（環境差を作らない）
+- **Install method**: upstream release URL を kustomize で参照（local と同型）
+  - URL: `https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.2.1/standard-install.yaml`
+
+### Metrics Server
+
+- **Helm chart**: `metrics-server/metrics-server`（Helm repo: `https://kubernetes-sigs.github.io/metrics-server`）
+- **Version**: 最新 stable（v3.12.x 系を実装時点で固定、Renovate で追従）
+- **Namespace**: `kube-system`
+- **Args**: `--kubelet-preferred-address-types=InternalIP`（EKS の慣習。kubelet が node の InternalIP で待ち受けするため）
+- **Replicas**: 1（軽量 component、HA は将来必要なら検討）
+- **Resource requests**: 控えめに `cpu: 100m / memory: 200Mi`
+
+### KEDA
+
+- **Helm chart**: `kedacore/keda`（Helm repo: `https://kedacore.github.io/charts`）
+- **Version**: 最新 stable（v2.16.x or v2.17.x 系を実装時点で固定、Renovate で追従）
+- **Namespace**: `keda`（chart デフォルト）
+  - 新規 namespace のため `kubernetes/components/keda/production/namespace.yaml` を別途用意し、env-aware hydrate-index に拾わせる
+- **Components**: chart デフォルトで `keda-operator` + `keda-operator-metrics-apiserver` + 関連 RBAC / CRDs（ScaledObject / ScaledJob / TriggerAuthentication 等）
+- **Resource requests**: chart デフォルト
+
+## Components 変更マトリクス
+
+| File / Resource | 種別 | 内容 |
+|---|---|---|
+| `kubernetes/components/gateway-api/production/kustomization/kustomization.yaml` | create | upstream Gateway API CRDs v1.2.1 standard-install.yaml を kustomize `resources` で参照（local と同型） |
+| `kubernetes/components/metrics-server/production/helmfile.yaml` | create | Helm chart 参照、release in `kube-system` |
+| `kubernetes/components/metrics-server/production/values.yaml` | create | `args` に `--kubelet-preferred-address-types=InternalIP` を追加、resource requests 設定 |
+| `kubernetes/components/keda/production/helmfile.yaml` | create | Helm chart 参照、release in `keda` namespace |
+| `kubernetes/components/keda/production/values.yaml` | create | デフォルト値中心 |
+| `kubernetes/components/keda/production/namespace.yaml` | create | `keda` namespace 定義（env-aware hydrate-index で拾わせる） |
+| `kubernetes/manifests/production/gateway-api/` | hydrated | `make hydrate ENV=production` 出力 |
+| `kubernetes/manifests/production/metrics-server/` | hydrated | 同上 |
+| `kubernetes/manifests/production/keda/` | hydrated | 同上 |
+| `kubernetes/manifests/production/00-namespaces/namespaces.yaml` | regenerated | env-aware logic で keda の namespace.yaml が追加される |
+| `kubernetes/manifests/production/kustomization.yaml` | regenerated | `[./00-namespaces, ./cilium, ./gateway-api, ./keda, ./metrics-server]` |
+
+## Migration sequence
+
+Plan 1b（Cilium 移行）と異なり、本 spec のコンポーネントは **既存 service routing に影響しない純粋な追加** のみ。Flux suspend は不要、PR merge → Flux 自動 reconcile で完結する。
+
+| Step | 内容 | 実行者 | Flux 状態 |
+|---|---|---|---|
+| 1 | `kubernetes/components/{gateway-api,metrics-server,keda}/production/` 一式 + `make hydrate ENV=production` 結果（`manifests/production/{gateway-api,metrics-server,keda}/` + 更新された `00-namespaces` + 更新された `kustomization.yaml`）を 1 PR としてまとめて main へ merge | controller (subagent) + user | active |
+| 2 | merge 後 Flux が main を取得 → 差分（CRD install + Helm release × 2 + namespace 追加）を apply | Flux 自動 | active |
+| 3 | Verification checklist 完走（後述） | user | active |
+
+> 設計意図：Plan 1b の kube-proxy 削除のような「既存 routing への破壊的変更」がないため、Flux 経由の通常 reconcile で安全に展開できる。manual apply / Flux suspend は不要。
+
+## Verification checklist
+
+各 Goal について、以下のコマンドが pass すれば達成とみなす。
+
+### Gateway API CRDs
+
+```bash
+# CRDs install 確認
+kubectl get crd 2>&1 | grep -E "gateway.networking.k8s.io" | wc -l
+# 期待: 5 個程度（GatewayClass / Gateway / HTTPRoute / GRPCRoute / ReferenceGrant）
+
+# Cilium Gateway Controller が register する GatewayClass 確認
+kubectl get gatewayclass cilium
+# 期待: ACCEPTED: True（Cilium operator が CRDs を picking up して register、30 秒程度かかる）
+
+# 動作確認（minimal Gateway 1 個 apply）
+cat <<'EOF' | kubectl apply -f -
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: smoke-test-gateway
+  namespace: default
+spec:
+  gatewayClassName: cilium
+  listeners:
+    - name: http
+      protocol: HTTP
+      port: 80
+EOF
+sleep 30
+kubectl get gateway smoke-test-gateway -n default -o jsonpath='{.status.conditions[?(@.type=="Programmed")].status}'
+# 期待: True
+kubectl delete gateway smoke-test-gateway -n default
+```
+
+### Metrics Server
+
+```bash
+kubectl get deployment -n kube-system metrics-server
+# 期待: READY 1/1
+
+# resource metrics の取得確認
+kubectl top nodes
+# 期待: 各 node の CPU / Memory 値が表示される
+kubectl top pods -A | head -10
+# 期待: 各 pod の CPU / Memory 値が表示される
+```
+
+### KEDA
+
+```bash
+kubectl get deployment -n keda
+# 期待: keda-operator 1/1, keda-operator-metrics-apiserver 1/1
+
+kubectl get crd 2>&1 | grep keda.sh
+# 期待: ScaledObject / ScaledJob / TriggerAuthentication / ClusterTriggerAuthentication 等
+
+# Smoke test: minimal ScaledObject（CPU baseline）
+cat <<'EOF' | kubectl apply -f -
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: keda-smoke-test
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: smoke-target
+  namespace: keda-smoke-test
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: smoke-target
+  template:
+    metadata:
+      labels:
+        app: smoke-target
+    spec:
+      containers:
+        - name: pause
+          image: registry.k8s.io/pause:3.10
+          resources:
+            requests:
+              cpu: 50m
+            limits:
+              cpu: 100m
+---
+apiVersion: keda.sh/v1alpha1
+kind: ScaledObject
+metadata:
+  name: smoke-test-so
+  namespace: keda-smoke-test
+spec:
+  scaleTargetRef:
+    name: smoke-target
+  minReplicaCount: 1
+  maxReplicaCount: 3
+  triggers:
+    - type: cpu
+      metadata:
+        type: Utilization
+        value: "50"
+EOF
+sleep 30
+# KEDA が HPA を生成することを確認
+kubectl get hpa -n keda-smoke-test
+# 期待: keda-hpa-smoke-test-so（KEDA が auto-create）
+
+kubectl get scaledobject -n keda-smoke-test smoke-test-so -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}'
+# 期待: True
+kubectl delete namespace keda-smoke-test
+```
+
+### Flux
+
+```bash
+flux get kustomizations -n flux-system flux-system
+# 期待: READY: True, MESSAGE: Applied revision: main@<sha>
+
+flux get all -A | head -20
+# 期待: 全 resource Ready
+```
+
+## Rollback strategy
+
+PR merge 後に問題が発覚した場合：
+
+| 失敗フェーズ | 戻し方 |
+|---|---|
+| Gateway API CRDs install で問題発生 | 通常は無害（純粋な API 拡張）。問題があれば revert PR + `kubectl delete -k <upstream-url>` で CRDs を削除（既存 Gateway/HTTPRoute がない前提） |
+| Metrics Server で `kubectl top` が動かない | revert PR + `helm uninstall metrics-server -n kube-system`、values 修正後 re-apply。HPA を未利用なので業務影響なし |
+| KEDA controller が起動しない | revert PR + `helm uninstall keda -n keda` + `kubectl delete namespace keda`、ScaledObject を未利用なので業務影響なし |
+| Flux reconciliation が失敗 | `flux logs --kind=Kustomization` で原因確認、values / hydrated manifest を修正して main へ追加 commit |
+
+すべてのフェーズで **production にアプリ未投入のため業務影響なし**。
+
+## Future Specs（明示的に記録）
+
+本 spec のスコープ外で、別 spec として追跡する：
+
+- **Plan 1c-β**: AWS Load Balancer Controller + ExternalDNS + IRSA + ACM 証明書 + Route53 連携
+- **Gateway API Experimental channel への切り替え**: TCPRoute / TLSRoute / GRPCRoute / BackendTLSPolicy 等が必要になったタイミング
+- **KEDA AWS scaler の IRSA 設定**: monorepo の async worker（SQS / EventBridge consumer 等）投入時
+- **Metrics Server HA 化**: production 規模が大きくなり single replica が SPOF になった時
+
+## References
+
+- ロードマップ spec: `docs/superpowers/specs/2026-05-02-eks-production-platform-roadmap-design.md`
+- Plan 1a (Flux bootstrap): merged in PR #255
+- Plan 1b spec (Cilium chaining): `docs/superpowers/specs/2026-05-03-eks-production-cilium-chaining-design.md`、merged in PR #257
+- Plan 1b learnings: merged in PR #259
+- Local Gateway API CRDs reference: `kubernetes/components/gateway-api/local/kustomization/kustomization.yaml`
+- Cilium Gateway API documentation (1.18): `https://docs.cilium.io/en/v1.18/network/servicemesh/gateway-api/gateway-api/`
+- Gateway API release v1.2.1: `https://github.com/kubernetes-sigs/gateway-api/releases/tag/v1.2.1`
+- Metrics Server Helm chart: `https://github.com/kubernetes-sigs/metrics-server/tree/master/charts/metrics-server`
+- KEDA Helm chart: `https://github.com/kedacore/charts`

--- a/kubernetes/README.md
+++ b/kubernetes/README.md
@@ -296,7 +296,7 @@ flowchart LR
 
 EKS production cluster `eks-production`（`ap-northeast-1`）の運用手順。
 
-### Cluster overview (post Plan 1b)
+### Cluster overview (post Plan 1c-α)
 
 `eks-production` cluster は **Cilium 1.18.x が chaining mode (VPC CNI 共存)** で稼働し、`kubeProxyReplacement: true` で kube-proxy を eBPF で代替している。
 
@@ -310,6 +310,14 @@ EKS production cluster `eks-production`（`ap-northeast-1`）の運用手順。
 | Observability | Hubble（TLS は `cronJob` mode で cluster 内自動 rotate）|
 
 EKS managed addon としては `kube-proxy` を削除済（KPR で代替）。残存 addon: `vpc-cni` / `coredns` / `aws-ebs-csi-driver` / `eks-pod-identity-agent`。
+
+加えて Plan 1c-α で以下の foundation addons を導入：
+
+| Addon | Namespace | 役割 |
+|---|---|---|
+| Gateway API CRDs | (cluster-scoped) | Cilium Gateway Controller の前提（Standard channel v1.2.1） |
+| Metrics Server | `kube-system` | Pod の resource metrics を公開、HPA / KEDA-generated HPA の前提 |
+| KEDA | `keda` | Event-driven autoscaling layer（HPA を内部生成） |
 
 ### Initial Bootstrap (one-time)
 
@@ -363,6 +371,25 @@ hubble observe --last 20
 cilium hubble ui
 ```
 
+### Foundation addon operations
+
+```bash
+# Gateway API（Cilium Gateway Controller）
+kubectl get gatewayclass cilium                          # Programmed: True
+kubectl get gateway -A                                   # cluster 内の Gateway 一覧
+kubectl get httproute -A                                 # HTTPRoute 一覧
+
+# Metrics Server
+kubectl top nodes                                        # node の CPU/Memory
+kubectl top pods -A | head                               # pod の CPU/Memory
+kubectl logs -n kube-system deploy/metrics-server --tail=20
+
+# KEDA
+kubectl get scaledobject -A                              # ScaledObject 一覧
+kubectl get hpa -A | grep keda-hpa                       # KEDA-generated HPA
+kubectl logs -n keda deploy/keda-operator --tail=20
+```
+
 ### Troubleshooting
 
 | 症状 | 原因 / 対処 |
@@ -375,6 +402,9 @@ cilium hubble ui
 | `cilium status` で `Cluster Pods: X/Y managed by Cilium` の差分（Y - X）が常に 0 にならない | hostNetwork pod（cilium-agent / cilium-envoy / cilium-operator 等）は Cilium endpoint を持たないため Cilium 管理対象外。差分が `cilium DaemonSet replicas × node + cilium-operator replicas` 程度なら steady state |
 | Cilium install 前から動いていた pod が Cilium 管理下に入らない | chaining mode では Cilium 設定が CNI conf に反映されるのは Pod 再作成時。`kubectl rollout restart -n flux-system deployment` 等で再作成すると chained になる |
 | `cilium connectivity test` で ICMP のみ失敗（TCP/HTTP は pass） | EKS Cluster SG が ICMP を明示許可していない可能性。production アプリが TCP のみなら無視で OK。ICMP が必要なら別 issue で SG ルール追加 |
+| `kubectl top` が `Metrics API not available` を返す | metrics-server が未 Ready or kubelet certs / preferred address types の不一致。`kubectl logs -n kube-system deploy/metrics-server` で確認 |
+| `GatewayClass cilium` が `Programmed: False` | Cilium operator が CRDs を picking up していない。`kubectl logs -n kube-system deploy/cilium-operator` で確認、Cilium pod の rolling restart が必要なケースあり |
+| KEDA `ScaledObject` が `Ready: False` | trigger 設定誤り or RBAC error。`kubectl describe scaledobject <name> -n <ns>` で詳細を確認 |
 
 ### GitOps 原則
 

--- a/kubernetes/components/gateway-api/production/kustomization/kustomization.yaml
+++ b/kubernetes/components/gateway-api/production/kustomization/kustomization.yaml
@@ -1,0 +1,19 @@
+# =============================================================================
+# Gateway API CRDs Kustomization for production
+# =============================================================================
+# Installs the standard Gateway API CRDs from the upstream project.
+# These CRDs are required by the Cilium Gateway Controller (gatewayAPI.enabled
+# is true in kubernetes/components/cilium/production/values.yaml.gotmpl).
+#
+# Gateway API Version: v1.2.1
+# https://gateway-api.sigs.k8s.io/
+#
+# Standard channel covers GatewayClass / Gateway / HTTPRoute / GRPCRoute /
+# ReferenceGrant. Experimental channel (TCPRoute / TLSRoute / etc.) は
+# 必要が出たタイミングで別 spec で評価する（Future Specs）。
+# =============================================================================
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.2.1/standard-install.yaml

--- a/kubernetes/components/keda/production/helmfile.yaml
+++ b/kubernetes/components/keda/production/helmfile.yaml
@@ -1,0 +1,21 @@
+# =============================================================================
+# KEDA Helmfile for production
+# =============================================================================
+# KEDA (Kubernetes Event-driven Autoscaling) installs ScaledObject / ScaledJob
+# CRDs and provides external triggers (Prometheus / Cron / SQS / etc.) on top
+# of native HPA. The chart includes the operator and metrics-apiserver.
+# =============================================================================
+environments:
+  production:
+---
+repositories:
+  - name: kedacore
+    url: https://kedacore.github.io/charts
+
+releases:
+  - name: keda
+    namespace: keda
+    chart: kedacore/keda
+    version: "2.19.0"
+    values:
+      - values.yaml

--- a/kubernetes/components/keda/production/namespace.yaml
+++ b/kubernetes/components/keda/production/namespace.yaml
@@ -1,0 +1,13 @@
+# =============================================================================
+# KEDA Namespace
+# =============================================================================
+# This namespace contains:
+#   - keda-operator (controller for ScaledObject / ScaledJob / TriggerAuthentication)
+#   - keda-operator-metrics-apiserver (external metrics API server)
+# =============================================================================
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: keda
+  labels:
+    app.kubernetes.io/name: keda

--- a/kubernetes/components/keda/production/values.yaml
+++ b/kubernetes/components/keda/production/values.yaml
@@ -1,0 +1,10 @@
+# KEDA values for production
+# Reference: docs/superpowers/specs/2026-05-03-eks-production-foundation-addons-alpha-design.md
+
+# =============================================================================
+# Resources / Replicas
+# =============================================================================
+# Phase 1 では chart デフォルトを採用。HA 化や resource tuning は
+# monorepo の async worker 投入時に再評価する。
+# AWS scaler (SQS / EventBridge / DynamoDB Streams) の IRSA 設定も
+# 利用が顕在化したタイミングで別 spec で扱う。

--- a/kubernetes/components/metrics-server/production/helmfile.yaml
+++ b/kubernetes/components/metrics-server/production/helmfile.yaml
@@ -1,0 +1,20 @@
+# =============================================================================
+# Metrics Server Helmfile for production
+# =============================================================================
+# Provides resource metrics (CPU / memory) for HPA and `kubectl top`.
+# Required by KEDA-generated HPAs as well.
+# =============================================================================
+environments:
+  production:
+---
+repositories:
+  - name: metrics-server
+    url: https://kubernetes-sigs.github.io/metrics-server
+
+releases:
+  - name: metrics-server
+    namespace: kube-system
+    chart: metrics-server/metrics-server
+    version: "3.13.0"
+    values:
+      - values.yaml

--- a/kubernetes/components/metrics-server/production/values.yaml
+++ b/kubernetes/components/metrics-server/production/values.yaml
@@ -2,13 +2,18 @@
 # Reference: docs/superpowers/specs/2026-05-03-eks-production-foundation-addons-alpha-design.md
 
 # =============================================================================
-# Args
+# defaultArgs override
 # =============================================================================
-# EKS の kubelet は InternalIP で待ち受けるため、優先 address type に InternalIP
-# を指定する。default の "InternalIP,ExternalIP,Hostname" でも動くが、
-# InternalIP-only にすることで kubelet 接続が安定する。
-args:
+# chart の defaultArgs を上書きして --kubelet-preferred-address-types を
+# InternalIP のみに narrow する。EKS の kubelet は InternalIP で待ち受けるため
+# preference list を 1 つに絞ることで明示的な制約を表す。
+# defaultArgs を上書きすることで chart の args ロジック（defaultArgs に args を
+# append する仕様）による flag 重複を避ける。
+defaultArgs:
+  - --cert-dir=/tmp
   - --kubelet-preferred-address-types=InternalIP
+  - --kubelet-use-node-status-port
+  - --metric-resolution=15s
 
 # =============================================================================
 # Resources
@@ -24,5 +29,6 @@ resources:
 # =============================================================================
 # Replicas
 # =============================================================================
-# Phase 1 では single replica。HA 化は monorepo 投入時に再評価。
+# single replica。Metrics Server は state を持たないので軽微な再起動 gap を許容する。
+# HA 化は trade-off を再評価した上で Future Specs。
 replicas: 1

--- a/kubernetes/components/metrics-server/production/values.yaml
+++ b/kubernetes/components/metrics-server/production/values.yaml
@@ -1,0 +1,28 @@
+# Metrics Server values for production
+# Reference: docs/superpowers/specs/2026-05-03-eks-production-foundation-addons-alpha-design.md
+
+# =============================================================================
+# Args
+# =============================================================================
+# EKS の kubelet は InternalIP で待ち受けるため、優先 address type に InternalIP
+# を指定する。default の "InternalIP,ExternalIP,Hostname" でも動くが、
+# InternalIP-only にすることで kubelet 接続が安定する。
+args:
+  - --kubelet-preferred-address-types=InternalIP
+
+# =============================================================================
+# Resources
+# =============================================================================
+resources:
+  requests:
+    cpu: 100m
+    memory: 200Mi
+  limits:
+    cpu: 1000m
+    memory: 1Gi
+
+# =============================================================================
+# Replicas
+# =============================================================================
+# Phase 1 では single replica。HA 化は monorepo 投入時に再評価。
+replicas: 1

--- a/kubernetes/manifests/production/00-namespaces/namespaces.yaml
+++ b/kubernetes/manifests/production/00-namespaces/namespaces.yaml
@@ -1,0 +1,14 @@
+---
+# =============================================================================
+# KEDA Namespace
+# =============================================================================
+# This namespace contains:
+#   - keda-operator (controller for ScaledObject / ScaledJob / TriggerAuthentication)
+#   - keda-operator-metrics-apiserver (external metrics API server)
+# =============================================================================
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: keda
+  labels:
+    app.kubernetes.io/name: keda

--- a/kubernetes/manifests/production/gateway-api/kustomization.yaml
+++ b/kubernetes/manifests/production/gateway-api/kustomization.yaml
@@ -1,0 +1,2 @@
+resources:
+  - manifest.yaml

--- a/kubernetes/manifests/production/gateway-api/manifest.yaml
+++ b/kubernetes/manifests/production/gateway-api/manifest.yaml
@@ -1,0 +1,10313 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/3328
+    gateway.networking.k8s.io/bundle-version: v1.2.1
+    gateway.networking.k8s.io/channel: standard
+  creationTimestamp: null
+  name: gatewayclasses.gateway.networking.k8s.io
+spec:
+  group: gateway.networking.k8s.io
+  names:
+    categories:
+    - gateway-api
+    kind: GatewayClass
+    listKind: GatewayClassList
+    plural: gatewayclasses
+    shortNames:
+    - gc
+    singular: gatewayclass
+  scope: Cluster
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.controllerName
+      name: Controller
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Accepted")].status
+      name: Accepted
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - jsonPath: .spec.description
+      name: Description
+      priority: 1
+      type: string
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: |-
+          GatewayClass describes a class of Gateways available to the user for creating
+          Gateway resources.
+
+          It is recommended that this resource be used as a template for Gateways. This
+          means that a Gateway is based on the state of the GatewayClass at the time it
+          was created and changes to the GatewayClass or associated parameters are not
+          propagated down to existing Gateways. This recommendation is intended to
+          limit the blast radius of changes to GatewayClass or associated parameters.
+          If implementations choose to propagate GatewayClass changes to existing
+          Gateways, that MUST be clearly documented by the implementation.
+
+          Whenever one or more Gateways are using a GatewayClass, implementations SHOULD
+          add the `gateway-exists-finalizer.gateway.networking.k8s.io` finalizer on the
+          associated GatewayClass. This ensures that a GatewayClass associated with a
+          Gateway is not deleted while in use.
+
+          GatewayClass is a Cluster level resource.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec defines the desired state of GatewayClass.
+            properties:
+              controllerName:
+                description: |-
+                  ControllerName is the name of the controller that is managing Gateways of
+                  this class. The value of this field MUST be a domain prefixed path.
+
+                  Example: "example.net/gateway-controller".
+
+                  This field is not mutable and cannot be empty.
+
+                  Support: Core
+                maxLength: 253
+                minLength: 1
+                pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\/[A-Za-z0-9\/\-._~%!$&'()*+,;=:]+$
+                type: string
+                x-kubernetes-validations:
+                - message: Value is immutable
+                  rule: self == oldSelf
+              description:
+                description: Description helps describe a GatewayClass with more details.
+                maxLength: 64
+                type: string
+              parametersRef:
+                description: |-
+                  ParametersRef is a reference to a resource that contains the configuration
+                  parameters corresponding to the GatewayClass. This is optional if the
+                  controller does not require any additional configuration.
+
+                  ParametersRef can reference a standard Kubernetes resource, i.e. ConfigMap,
+                  or an implementation-specific custom resource. The resource can be
+                  cluster-scoped or namespace-scoped.
+
+                  If the referent cannot be found, refers to an unsupported kind, or when
+                  the data within that resource is malformed, the GatewayClass SHOULD be
+                  rejected with the "Accepted" status condition set to "False" and an
+                  "InvalidParameters" reason.
+
+                  A Gateway for this GatewayClass may provide its own `parametersRef`. When both are specified,
+                  the merging behavior is implementation specific.
+                  It is generally recommended that GatewayClass provides defaults that can be overridden by a Gateway.
+
+                  Support: Implementation-specific
+                properties:
+                  group:
+                    description: Group is the group of the referent.
+                    maxLength: 253
+                    pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                    type: string
+                  kind:
+                    description: Kind is kind of the referent.
+                    maxLength: 63
+                    minLength: 1
+                    pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                    type: string
+                  name:
+                    description: Name is the name of the referent.
+                    maxLength: 253
+                    minLength: 1
+                    type: string
+                  namespace:
+                    description: |-
+                      Namespace is the namespace of the referent.
+                      This field is required when referring to a Namespace-scoped resource and
+                      MUST be unset when referring to a Cluster-scoped resource.
+                    maxLength: 63
+                    minLength: 1
+                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                    type: string
+                required:
+                - group
+                - kind
+                - name
+                type: object
+            required:
+            - controllerName
+            type: object
+          status:
+            default:
+              conditions:
+              - lastTransitionTime: "1970-01-01T00:00:00Z"
+                message: Waiting for controller
+                reason: Pending
+                status: Unknown
+                type: Accepted
+            description: |-
+              Status defines the current state of GatewayClass.
+
+              Implementations MUST populate status on all GatewayClass resources which
+              specify their controller name.
+            properties:
+              conditions:
+                default:
+                - lastTransitionTime: "1970-01-01T00:00:00Z"
+                  message: Waiting for controller
+                  reason: Pending
+                  status: Unknown
+                  type: Accepted
+                description: |-
+                  Conditions is the current status from the controller for
+                  this GatewayClass.
+
+                  Controllers should prefer to publish conditions using values
+                  of GatewayClassConditionType for the type of each Condition.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                maxItems: 8
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - jsonPath: .spec.controllerName
+      name: Controller
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Accepted")].status
+      name: Accepted
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - jsonPath: .spec.description
+      name: Description
+      priority: 1
+      type: string
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: |-
+          GatewayClass describes a class of Gateways available to the user for creating
+          Gateway resources.
+
+          It is recommended that this resource be used as a template for Gateways. This
+          means that a Gateway is based on the state of the GatewayClass at the time it
+          was created and changes to the GatewayClass or associated parameters are not
+          propagated down to existing Gateways. This recommendation is intended to
+          limit the blast radius of changes to GatewayClass or associated parameters.
+          If implementations choose to propagate GatewayClass changes to existing
+          Gateways, that MUST be clearly documented by the implementation.
+
+          Whenever one or more Gateways are using a GatewayClass, implementations SHOULD
+          add the `gateway-exists-finalizer.gateway.networking.k8s.io` finalizer on the
+          associated GatewayClass. This ensures that a GatewayClass associated with a
+          Gateway is not deleted while in use.
+
+          GatewayClass is a Cluster level resource.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec defines the desired state of GatewayClass.
+            properties:
+              controllerName:
+                description: |-
+                  ControllerName is the name of the controller that is managing Gateways of
+                  this class. The value of this field MUST be a domain prefixed path.
+
+                  Example: "example.net/gateway-controller".
+
+                  This field is not mutable and cannot be empty.
+
+                  Support: Core
+                maxLength: 253
+                minLength: 1
+                pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\/[A-Za-z0-9\/\-._~%!$&'()*+,;=:]+$
+                type: string
+                x-kubernetes-validations:
+                - message: Value is immutable
+                  rule: self == oldSelf
+              description:
+                description: Description helps describe a GatewayClass with more details.
+                maxLength: 64
+                type: string
+              parametersRef:
+                description: |-
+                  ParametersRef is a reference to a resource that contains the configuration
+                  parameters corresponding to the GatewayClass. This is optional if the
+                  controller does not require any additional configuration.
+
+                  ParametersRef can reference a standard Kubernetes resource, i.e. ConfigMap,
+                  or an implementation-specific custom resource. The resource can be
+                  cluster-scoped or namespace-scoped.
+
+                  If the referent cannot be found, refers to an unsupported kind, or when
+                  the data within that resource is malformed, the GatewayClass SHOULD be
+                  rejected with the "Accepted" status condition set to "False" and an
+                  "InvalidParameters" reason.
+
+                  A Gateway for this GatewayClass may provide its own `parametersRef`. When both are specified,
+                  the merging behavior is implementation specific.
+                  It is generally recommended that GatewayClass provides defaults that can be overridden by a Gateway.
+
+                  Support: Implementation-specific
+                properties:
+                  group:
+                    description: Group is the group of the referent.
+                    maxLength: 253
+                    pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                    type: string
+                  kind:
+                    description: Kind is kind of the referent.
+                    maxLength: 63
+                    minLength: 1
+                    pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                    type: string
+                  name:
+                    description: Name is the name of the referent.
+                    maxLength: 253
+                    minLength: 1
+                    type: string
+                  namespace:
+                    description: |-
+                      Namespace is the namespace of the referent.
+                      This field is required when referring to a Namespace-scoped resource and
+                      MUST be unset when referring to a Cluster-scoped resource.
+                    maxLength: 63
+                    minLength: 1
+                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                    type: string
+                required:
+                - group
+                - kind
+                - name
+                type: object
+            required:
+            - controllerName
+            type: object
+          status:
+            default:
+              conditions:
+              - lastTransitionTime: "1970-01-01T00:00:00Z"
+                message: Waiting for controller
+                reason: Pending
+                status: Unknown
+                type: Accepted
+            description: |-
+              Status defines the current state of GatewayClass.
+
+              Implementations MUST populate status on all GatewayClass resources which
+              specify their controller name.
+            properties:
+              conditions:
+                default:
+                - lastTransitionTime: "1970-01-01T00:00:00Z"
+                  message: Waiting for controller
+                  reason: Pending
+                  status: Unknown
+                  type: Accepted
+                description: |-
+                  Conditions is the current status from the controller for
+                  this GatewayClass.
+
+                  Controllers should prefer to publish conditions using values
+                  of GatewayClassConditionType for the type of each Condition.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                maxItems: 8
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/3328
+    gateway.networking.k8s.io/bundle-version: v1.2.1
+    gateway.networking.k8s.io/channel: standard
+  creationTimestamp: null
+  name: gateways.gateway.networking.k8s.io
+spec:
+  group: gateway.networking.k8s.io
+  names:
+    categories:
+    - gateway-api
+    kind: Gateway
+    listKind: GatewayList
+    plural: gateways
+    shortNames:
+    - gtw
+    singular: gateway
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.gatewayClassName
+      name: Class
+      type: string
+    - jsonPath: .status.addresses[*].value
+      name: Address
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Programmed")].status
+      name: Programmed
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: |-
+          Gateway represents an instance of a service-traffic handling infrastructure
+          by binding Listeners to a set of IP addresses.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec defines the desired state of Gateway.
+            properties:
+              addresses:
+                description: |+
+                  Addresses requested for this Gateway. This is optional and behavior can
+                  depend on the implementation. If a value is set in the spec and the
+                  requested address is invalid or unavailable, the implementation MUST
+                  indicate this in the associated entry in GatewayStatus.Addresses.
+
+                  The Addresses field represents a request for the address(es) on the
+                  "outside of the Gateway", that traffic bound for this Gateway will use.
+                  This could be the IP address or hostname of an external load balancer or
+                  other networking infrastructure, or some other address that traffic will
+                  be sent to.
+
+                  If no Addresses are specified, the implementation MAY schedule the
+                  Gateway in an implementation-specific manner, assigning an appropriate
+                  set of Addresses.
+
+                  The implementation MUST bind all Listeners to every GatewayAddress that
+                  it assigns to the Gateway and add a corresponding entry in
+                  GatewayStatus.Addresses.
+
+                  Support: Extended
+
+                items:
+                  description: GatewayAddress describes an address that can be bound
+                    to a Gateway.
+                  oneOf:
+                  - properties:
+                      type:
+                        enum:
+                        - IPAddress
+                      value:
+                        anyOf:
+                        - format: ipv4
+                        - format: ipv6
+                  - properties:
+                      type:
+                        not:
+                          enum:
+                          - IPAddress
+                  properties:
+                    type:
+                      default: IPAddress
+                      description: Type of the address.
+                      maxLength: 253
+                      minLength: 1
+                      pattern: ^Hostname|IPAddress|NamedAddress|[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\/[A-Za-z0-9\/\-._~%!$&'()*+,;=:]+$
+                      type: string
+                    value:
+                      description: |-
+                        Value of the address. The validity of the values will depend
+                        on the type and support by the controller.
+
+                        Examples: `1.2.3.4`, `128::1`, `my-ip-address`.
+                      maxLength: 253
+                      minLength: 1
+                      type: string
+                  required:
+                  - value
+                  type: object
+                  x-kubernetes-validations:
+                  - message: Hostname value must only contain valid characters (matching
+                      ^(\*\.)?[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$)
+                    rule: 'self.type == ''Hostname'' ? self.value.matches(r"""^(\*\.)?[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$"""):
+                      true'
+                maxItems: 16
+                type: array
+                x-kubernetes-validations:
+                - message: IPAddress values must be unique
+                  rule: 'self.all(a1, a1.type == ''IPAddress'' ? self.exists_one(a2,
+                    a2.type == a1.type && a2.value == a1.value) : true )'
+                - message: Hostname values must be unique
+                  rule: 'self.all(a1, a1.type == ''Hostname'' ? self.exists_one(a2,
+                    a2.type == a1.type && a2.value == a1.value) : true )'
+              gatewayClassName:
+                description: |-
+                  GatewayClassName used for this Gateway. This is the name of a
+                  GatewayClass resource.
+                maxLength: 253
+                minLength: 1
+                type: string
+              infrastructure:
+                description: |-
+                  Infrastructure defines infrastructure level attributes about this Gateway instance.
+
+                  Support: Extended
+                properties:
+                  annotations:
+                    additionalProperties:
+                      description: |-
+                        AnnotationValue is the value of an annotation in Gateway API. This is used
+                        for validation of maps such as TLS options. This roughly matches Kubernetes
+                        annotation validation, although the length validation in that case is based
+                        on the entire size of the annotations struct.
+                      maxLength: 4096
+                      minLength: 0
+                      type: string
+                    description: |-
+                      Annotations that SHOULD be applied to any resources created in response to this Gateway.
+
+                      For implementations creating other Kubernetes objects, this should be the `metadata.annotations` field on resources.
+                      For other implementations, this refers to any relevant (implementation specific) "annotations" concepts.
+
+                      An implementation may chose to add additional implementation-specific annotations as they see fit.
+
+                      Support: Extended
+                    maxProperties: 8
+                    type: object
+                    x-kubernetes-validations:
+                    - message: Annotation keys must be in the form of an optional
+                        DNS subdomain prefix followed by a required name segment of
+                        up to 63 characters.
+                      rule: self.all(key, key.matches(r"""^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?([A-Za-z0-9][-A-Za-z0-9_.]{0,61})?[A-Za-z0-9]$"""))
+                    - message: If specified, the annotation key's prefix must be a
+                        DNS subdomain not longer than 253 characters in total.
+                      rule: self.all(key, key.split("/")[0].size() < 253)
+                  labels:
+                    additionalProperties:
+                      description: |-
+                        LabelValue is the value of a label in the Gateway API. This is used for validation
+                        of maps such as Gateway infrastructure labels. This matches the Kubernetes
+                        label validation rules:
+                        * must be 63 characters or less (can be empty),
+                        * unless empty, must begin and end with an alphanumeric character ([a-z0-9A-Z]),
+                        * could contain dashes (-), underscores (_), dots (.), and alphanumerics between.
+
+                        Valid values include:
+
+                        * MyValue
+                        * my.name
+                        * 123-my-value
+                      maxLength: 63
+                      minLength: 0
+                      pattern: ^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$
+                      type: string
+                    description: |-
+                      Labels that SHOULD be applied to any resources created in response to this Gateway.
+
+                      For implementations creating other Kubernetes objects, this should be the `metadata.labels` field on resources.
+                      For other implementations, this refers to any relevant (implementation specific) "labels" concepts.
+
+                      An implementation may chose to add additional implementation-specific labels as they see fit.
+
+                      If an implementation maps these labels to Pods, or any other resource that would need to be recreated when labels
+                      change, it SHOULD clearly warn about this behavior in documentation.
+
+                      Support: Extended
+                    maxProperties: 8
+                    type: object
+                    x-kubernetes-validations:
+                    - message: Label keys must be in the form of an optional DNS subdomain
+                        prefix followed by a required name segment of up to 63 characters.
+                      rule: self.all(key, key.matches(r"""^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?([A-Za-z0-9][-A-Za-z0-9_.]{0,61})?[A-Za-z0-9]$"""))
+                    - message: If specified, the label key's prefix must be a DNS
+                        subdomain not longer than 253 characters in total.
+                      rule: self.all(key, key.split("/")[0].size() < 253)
+                  parametersRef:
+                    description: |-
+                      ParametersRef is a reference to a resource that contains the configuration
+                      parameters corresponding to the Gateway. This is optional if the
+                      controller does not require any additional configuration.
+
+                      This follows the same semantics as GatewayClass's `parametersRef`, but on a per-Gateway basis
+
+                      The Gateway's GatewayClass may provide its own `parametersRef`. When both are specified,
+                      the merging behavior is implementation specific.
+                      It is generally recommended that GatewayClass provides defaults that can be overridden by a Gateway.
+
+                      Support: Implementation-specific
+                    properties:
+                      group:
+                        description: Group is the group of the referent.
+                        maxLength: 253
+                        pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                        type: string
+                      kind:
+                        description: Kind is kind of the referent.
+                        maxLength: 63
+                        minLength: 1
+                        pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                        type: string
+                      name:
+                        description: Name is the name of the referent.
+                        maxLength: 253
+                        minLength: 1
+                        type: string
+                    required:
+                    - group
+                    - kind
+                    - name
+                    type: object
+                type: object
+              listeners:
+                description: |-
+                  Listeners associated with this Gateway. Listeners define
+                  logical endpoints that are bound on this Gateway's addresses.
+                  At least one Listener MUST be specified.
+
+                  Each Listener in a set of Listeners (for example, in a single Gateway)
+                  MUST be _distinct_, in that a traffic flow MUST be able to be assigned to
+                  exactly one listener. (This section uses "set of Listeners" rather than
+                  "Listeners in a single Gateway" because implementations MAY merge configuration
+                  from multiple Gateways onto a single data plane, and these rules _also_
+                  apply in that case).
+
+                  Practically, this means that each listener in a set MUST have a unique
+                  combination of Port, Protocol, and, if supported by the protocol, Hostname.
+
+                  Some combinations of port, protocol, and TLS settings are considered
+                  Core support and MUST be supported by implementations based on their
+                  targeted conformance profile:
+
+                  HTTP Profile
+
+                  1. HTTPRoute, Port: 80, Protocol: HTTP
+                  2. HTTPRoute, Port: 443, Protocol: HTTPS, TLS Mode: Terminate, TLS keypair provided
+
+                  TLS Profile
+
+                  1. TLSRoute, Port: 443, Protocol: TLS, TLS Mode: Passthrough
+
+                  "Distinct" Listeners have the following property:
+
+                  The implementation can match inbound requests to a single distinct
+                  Listener. When multiple Listeners share values for fields (for
+                  example, two Listeners with the same Port value), the implementation
+                  can match requests to only one of the Listeners using other
+                  Listener fields.
+
+                  For example, the following Listener scenarios are distinct:
+
+                  1. Multiple Listeners with the same Port that all use the "HTTP"
+                     Protocol that all have unique Hostname values.
+                  2. Multiple Listeners with the same Port that use either the "HTTPS" or
+                     "TLS" Protocol that all have unique Hostname values.
+                  3. A mixture of "TCP" and "UDP" Protocol Listeners, where no Listener
+                     with the same Protocol has the same Port value.
+
+                  Some fields in the Listener struct have possible values that affect
+                  whether the Listener is distinct. Hostname is particularly relevant
+                  for HTTP or HTTPS protocols.
+
+                  When using the Hostname value to select between same-Port, same-Protocol
+                  Listeners, the Hostname value must be different on each Listener for the
+                  Listener to be distinct.
+
+                  When the Listeners are distinct based on Hostname, inbound request
+                  hostnames MUST match from the most specific to least specific Hostname
+                  values to choose the correct Listener and its associated set of Routes.
+
+                  Exact matches must be processed before wildcard matches, and wildcard
+                  matches must be processed before fallback (empty Hostname value)
+                  matches. For example, `"foo.example.com"` takes precedence over
+                  `"*.example.com"`, and `"*.example.com"` takes precedence over `""`.
+
+                  Additionally, if there are multiple wildcard entries, more specific
+                  wildcard entries must be processed before less specific wildcard entries.
+                  For example, `"*.foo.example.com"` takes precedence over `"*.example.com"`.
+                  The precise definition here is that the higher the number of dots in the
+                  hostname to the right of the wildcard character, the higher the precedence.
+
+                  The wildcard character will match any number of characters _and dots_ to
+                  the left, however, so `"*.example.com"` will match both
+                  `"foo.bar.example.com"` _and_ `"bar.example.com"`.
+
+                  If a set of Listeners contains Listeners that are not distinct, then those
+                  Listeners are Conflicted, and the implementation MUST set the "Conflicted"
+                  condition in the Listener Status to "True".
+
+                  Implementations MAY choose to accept a Gateway with some Conflicted
+                  Listeners only if they only accept the partial Listener set that contains
+                  no Conflicted Listeners. To put this another way, implementations may
+                  accept a partial Listener set only if they throw out *all* the conflicting
+                  Listeners. No picking one of the conflicting listeners as the winner.
+                  This also means that the Gateway must have at least one non-conflicting
+                  Listener in this case, otherwise it violates the requirement that at
+                  least one Listener must be present.
+
+                  The implementation MUST set a "ListenersNotValid" condition on the
+                  Gateway Status when the Gateway contains Conflicted Listeners whether or
+                  not they accept the Gateway. That Condition SHOULD clearly
+                  indicate in the Message which Listeners are conflicted, and which are
+                  Accepted. Additionally, the Listener status for those listeners SHOULD
+                  indicate which Listeners are conflicted and not Accepted.
+
+                  A Gateway's Listeners are considered "compatible" if:
+
+                  1. They are distinct.
+                  2. The implementation can serve them in compliance with the Addresses
+                     requirement that all Listeners are available on all assigned
+                     addresses.
+
+                  Compatible combinations in Extended support are expected to vary across
+                  implementations. A combination that is compatible for one implementation
+                  may not be compatible for another.
+
+                  For example, an implementation that cannot serve both TCP and UDP listeners
+                  on the same address, or cannot mix HTTPS and generic TLS listens on the same port
+                  would not consider those cases compatible, even though they are distinct.
+
+                  Note that requests SHOULD match at most one Listener. For example, if
+                  Listeners are defined for "foo.example.com" and "*.example.com", a
+                  request to "foo.example.com" SHOULD only be routed using routes attached
+                  to the "foo.example.com" Listener (and not the "*.example.com" Listener).
+                  This concept is known as "Listener Isolation". Implementations that do
+                  not support Listener Isolation MUST clearly document this.
+
+                  Implementations MAY merge separate Gateways onto a single set of
+                  Addresses if all Listeners across all Gateways are compatible.
+
+                  Support: Core
+                items:
+                  description: |-
+                    Listener embodies the concept of a logical endpoint where a Gateway accepts
+                    network connections.
+                  properties:
+                    allowedRoutes:
+                      default:
+                        namespaces:
+                          from: Same
+                      description: |-
+                        AllowedRoutes defines the types of routes that MAY be attached to a
+                        Listener and the trusted namespaces where those Route resources MAY be
+                        present.
+
+                        Although a client request may match multiple route rules, only one rule
+                        may ultimately receive the request. Matching precedence MUST be
+                        determined in order of the following criteria:
+
+                        * The most specific match as defined by the Route type.
+                        * The oldest Route based on creation timestamp. For example, a Route with
+                          a creation timestamp of "2020-09-08 01:02:03" is given precedence over
+                          a Route with a creation timestamp of "2020-09-08 01:02:04".
+                        * If everything else is equivalent, the Route appearing first in
+                          alphabetical order (namespace/name) should be given precedence. For
+                          example, foo/bar is given precedence over foo/baz.
+
+                        All valid rules within a Route attached to this Listener should be
+                        implemented. Invalid Route rules can be ignored (sometimes that will mean
+                        the full Route). If a Route rule transitions from valid to invalid,
+                        support for that Route rule should be dropped to ensure consistency. For
+                        example, even if a filter specified by a Route rule is invalid, the rest
+                        of the rules within that Route should still be supported.
+
+                        Support: Core
+                      properties:
+                        kinds:
+                          description: |-
+                            Kinds specifies the groups and kinds of Routes that are allowed to bind
+                            to this Gateway Listener. When unspecified or empty, the kinds of Routes
+                            selected are determined using the Listener protocol.
+
+                            A RouteGroupKind MUST correspond to kinds of Routes that are compatible
+                            with the application protocol specified in the Listener's Protocol field.
+                            If an implementation does not support or recognize this resource type, it
+                            MUST set the "ResolvedRefs" condition to False for this Listener with the
+                            "InvalidRouteKinds" reason.
+
+                            Support: Core
+                          items:
+                            description: RouteGroupKind indicates the group and kind
+                              of a Route resource.
+                            properties:
+                              group:
+                                default: gateway.networking.k8s.io
+                                description: Group is the group of the Route.
+                                maxLength: 253
+                                pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                type: string
+                              kind:
+                                description: Kind is the kind of the Route.
+                                maxLength: 63
+                                minLength: 1
+                                pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                                type: string
+                            required:
+                            - kind
+                            type: object
+                          maxItems: 8
+                          type: array
+                        namespaces:
+                          default:
+                            from: Same
+                          description: |-
+                            Namespaces indicates namespaces from which Routes may be attached to this
+                            Listener. This is restricted to the namespace of this Gateway by default.
+
+                            Support: Core
+                          properties:
+                            from:
+                              default: Same
+                              description: |-
+                                From indicates where Routes will be selected for this Gateway. Possible
+                                values are:
+
+                                * All: Routes in all namespaces may be used by this Gateway.
+                                * Selector: Routes in namespaces selected by the selector may be used by
+                                  this Gateway.
+                                * Same: Only Routes in the same namespace may be used by this Gateway.
+
+                                Support: Core
+                              enum:
+                              - All
+                              - Selector
+                              - Same
+                              type: string
+                            selector:
+                              description: |-
+                                Selector must be specified when From is set to "Selector". In that case,
+                                only Routes in Namespaces matching this Selector will be selected by this
+                                Gateway. This field is ignored for other values of "From".
+
+                                Support: Core
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
+                                  items:
+                                    description: |-
+                                      A label selector requirement is a selector that contains values, a key, and an operator that
+                                      relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the
+                                          selector applies to.
+                                        type: string
+                                      operator:
+                                        description: |-
+                                          operator represents a key's relationship to a set of values.
+                                          Valid operators are In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: |-
+                                          values is an array of string values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                          the values array must be empty. This array is replaced during a strategic
+                                          merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: |-
+                                    matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                    operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                  type: object
+                              type: object
+                              x-kubernetes-map-type: atomic
+                          type: object
+                      type: object
+                    hostname:
+                      description: |-
+                        Hostname specifies the virtual hostname to match for protocol types that
+                        define this concept. When unspecified, all hostnames are matched. This
+                        field is ignored for protocols that don't require hostname based
+                        matching.
+
+                        Implementations MUST apply Hostname matching appropriately for each of
+                        the following protocols:
+
+                        * TLS: The Listener Hostname MUST match the SNI.
+                        * HTTP: The Listener Hostname MUST match the Host header of the request.
+                        * HTTPS: The Listener Hostname SHOULD match at both the TLS and HTTP
+                          protocol layers as described above. If an implementation does not
+                          ensure that both the SNI and Host header match the Listener hostname,
+                          it MUST clearly document that.
+
+                        For HTTPRoute and TLSRoute resources, there is an interaction with the
+                        `spec.hostnames` array. When both listener and route specify hostnames,
+                        there MUST be an intersection between the values for a Route to be
+                        accepted. For more information, refer to the Route specific Hostnames
+                        documentation.
+
+                        Hostnames that are prefixed with a wildcard label (`*.`) are interpreted
+                        as a suffix match. That means that a match for `*.example.com` would match
+                        both `test.example.com`, and `foo.test.example.com`, but not `example.com`.
+
+                        Support: Core
+                      maxLength: 253
+                      minLength: 1
+                      pattern: ^(\*\.)?[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                      type: string
+                    name:
+                      description: |-
+                        Name is the name of the Listener. This name MUST be unique within a
+                        Gateway.
+
+                        Support: Core
+                      maxLength: 253
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                      type: string
+                    port:
+                      description: |-
+                        Port is the network port. Multiple listeners may use the
+                        same port, subject to the Listener compatibility rules.
+
+                        Support: Core
+                      format: int32
+                      maximum: 65535
+                      minimum: 1
+                      type: integer
+                    protocol:
+                      description: |-
+                        Protocol specifies the network protocol this listener expects to receive.
+
+                        Support: Core
+                      maxLength: 255
+                      minLength: 1
+                      pattern: ^[a-zA-Z0-9]([-a-zA-Z0-9]*[a-zA-Z0-9])?$|[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\/[A-Za-z0-9]+$
+                      type: string
+                    tls:
+                      description: |-
+                        TLS is the TLS configuration for the Listener. This field is required if
+                        the Protocol field is "HTTPS" or "TLS". It is invalid to set this field
+                        if the Protocol field is "HTTP", "TCP", or "UDP".
+
+                        The association of SNIs to Certificate defined in GatewayTLSConfig is
+                        defined based on the Hostname field for this listener.
+
+                        The GatewayClass MUST use the longest matching SNI out of all
+                        available certificates for any TLS handshake.
+
+                        Support: Core
+                      properties:
+                        certificateRefs:
+                          description: |-
+                            CertificateRefs contains a series of references to Kubernetes objects that
+                            contains TLS certificates and private keys. These certificates are used to
+                            establish a TLS handshake for requests that match the hostname of the
+                            associated listener.
+
+                            A single CertificateRef to a Kubernetes Secret has "Core" support.
+                            Implementations MAY choose to support attaching multiple certificates to
+                            a Listener, but this behavior is implementation-specific.
+
+                            References to a resource in different namespace are invalid UNLESS there
+                            is a ReferenceGrant in the target namespace that allows the certificate
+                            to be attached. If a ReferenceGrant does not allow this reference, the
+                            "ResolvedRefs" condition MUST be set to False for this listener with the
+                            "RefNotPermitted" reason.
+
+                            This field is required to have at least one element when the mode is set
+                            to "Terminate" (default) and is optional otherwise.
+
+                            CertificateRefs can reference to standard Kubernetes resources, i.e.
+                            Secret, or implementation-specific custom resources.
+
+                            Support: Core - A single reference to a Kubernetes Secret of type kubernetes.io/tls
+
+                            Support: Implementation-specific (More than one reference or other resource types)
+                          items:
+                            description: |-
+                              SecretObjectReference identifies an API object including its namespace,
+                              defaulting to Secret.
+
+                              The API object must be valid in the cluster; the Group and Kind must
+                              be registered in the cluster for this reference to be valid.
+
+                              References to objects with invalid Group and Kind are not valid, and must
+                              be rejected by the implementation, with appropriate Conditions set
+                              on the containing object.
+                            properties:
+                              group:
+                                default: ""
+                                description: |-
+                                  Group is the group of the referent. For example, "gateway.networking.k8s.io".
+                                  When unspecified or empty string, core API group is inferred.
+                                maxLength: 253
+                                pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                type: string
+                              kind:
+                                default: Secret
+                                description: Kind is kind of the referent. For example
+                                  "Secret".
+                                maxLength: 63
+                                minLength: 1
+                                pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                                type: string
+                              name:
+                                description: Name is the name of the referent.
+                                maxLength: 253
+                                minLength: 1
+                                type: string
+                              namespace:
+                                description: |-
+                                  Namespace is the namespace of the referenced object. When unspecified, the local
+                                  namespace is inferred.
+
+                                  Note that when a namespace different than the local namespace is specified,
+                                  a ReferenceGrant object is required in the referent namespace to allow that
+                                  namespace's owner to accept the reference. See the ReferenceGrant
+                                  documentation for details.
+
+                                  Support: Core
+                                maxLength: 63
+                                minLength: 1
+                                pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                type: string
+                            required:
+                            - name
+                            type: object
+                          maxItems: 64
+                          type: array
+                        mode:
+                          default: Terminate
+                          description: |-
+                            Mode defines the TLS behavior for the TLS session initiated by the client.
+                            There are two possible modes:
+
+                            - Terminate: The TLS session between the downstream client and the
+                              Gateway is terminated at the Gateway. This mode requires certificates
+                              to be specified in some way, such as populating the certificateRefs
+                              field.
+                            - Passthrough: The TLS session is NOT terminated by the Gateway. This
+                              implies that the Gateway can't decipher the TLS stream except for
+                              the ClientHello message of the TLS protocol. The certificateRefs field
+                              is ignored in this mode.
+
+                            Support: Core
+                          enum:
+                          - Terminate
+                          - Passthrough
+                          type: string
+                        options:
+                          additionalProperties:
+                            description: |-
+                              AnnotationValue is the value of an annotation in Gateway API. This is used
+                              for validation of maps such as TLS options. This roughly matches Kubernetes
+                              annotation validation, although the length validation in that case is based
+                              on the entire size of the annotations struct.
+                            maxLength: 4096
+                            minLength: 0
+                            type: string
+                          description: |-
+                            Options are a list of key/value pairs to enable extended TLS
+                            configuration for each implementation. For example, configuring the
+                            minimum TLS version or supported cipher suites.
+
+                            A set of common keys MAY be defined by the API in the future. To avoid
+                            any ambiguity, implementation-specific definitions MUST use
+                            domain-prefixed names, such as `example.com/my-custom-option`.
+                            Un-prefixed names are reserved for key names defined by Gateway API.
+
+                            Support: Implementation-specific
+                          maxProperties: 16
+                          type: object
+                      type: object
+                      x-kubernetes-validations:
+                      - message: certificateRefs or options must be specified when
+                          mode is Terminate
+                        rule: 'self.mode == ''Terminate'' ? size(self.certificateRefs)
+                          > 0 || size(self.options) > 0 : true'
+                  required:
+                  - name
+                  - port
+                  - protocol
+                  type: object
+                maxItems: 64
+                minItems: 1
+                type: array
+                x-kubernetes-list-map-keys:
+                - name
+                x-kubernetes-list-type: map
+                x-kubernetes-validations:
+                - message: tls must not be specified for protocols ['HTTP', 'TCP',
+                    'UDP']
+                  rule: 'self.all(l, l.protocol in [''HTTP'', ''TCP'', ''UDP''] ?
+                    !has(l.tls) : true)'
+                - message: tls mode must be Terminate for protocol HTTPS
+                  rule: 'self.all(l, (l.protocol == ''HTTPS'' && has(l.tls)) ? (l.tls.mode
+                    == '''' || l.tls.mode == ''Terminate'') : true)'
+                - message: hostname must not be specified for protocols ['TCP', 'UDP']
+                  rule: 'self.all(l, l.protocol in [''TCP'', ''UDP'']  ? (!has(l.hostname)
+                    || l.hostname == '''') : true)'
+                - message: Listener name must be unique within the Gateway
+                  rule: self.all(l1, self.exists_one(l2, l1.name == l2.name))
+                - message: Combination of port, protocol and hostname must be unique
+                    for each listener
+                  rule: 'self.all(l1, self.exists_one(l2, l1.port == l2.port && l1.protocol
+                    == l2.protocol && (has(l1.hostname) && has(l2.hostname) ? l1.hostname
+                    == l2.hostname : !has(l1.hostname) && !has(l2.hostname))))'
+            required:
+            - gatewayClassName
+            - listeners
+            type: object
+          status:
+            default:
+              conditions:
+              - lastTransitionTime: "1970-01-01T00:00:00Z"
+                message: Waiting for controller
+                reason: Pending
+                status: Unknown
+                type: Accepted
+              - lastTransitionTime: "1970-01-01T00:00:00Z"
+                message: Waiting for controller
+                reason: Pending
+                status: Unknown
+                type: Programmed
+            description: Status defines the current state of Gateway.
+            properties:
+              addresses:
+                description: |+
+                  Addresses lists the network addresses that have been bound to the
+                  Gateway.
+
+                  This list may differ from the addresses provided in the spec under some
+                  conditions:
+
+                    * no addresses are specified, all addresses are dynamically assigned
+                    * a combination of specified and dynamic addresses are assigned
+                    * a specified address was unusable (e.g. already in use)
+
+                items:
+                  description: GatewayStatusAddress describes a network address that
+                    is bound to a Gateway.
+                  oneOf:
+                  - properties:
+                      type:
+                        enum:
+                        - IPAddress
+                      value:
+                        anyOf:
+                        - format: ipv4
+                        - format: ipv6
+                  - properties:
+                      type:
+                        not:
+                          enum:
+                          - IPAddress
+                  properties:
+                    type:
+                      default: IPAddress
+                      description: Type of the address.
+                      maxLength: 253
+                      minLength: 1
+                      pattern: ^Hostname|IPAddress|NamedAddress|[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\/[A-Za-z0-9\/\-._~%!$&'()*+,;=:]+$
+                      type: string
+                    value:
+                      description: |-
+                        Value of the address. The validity of the values will depend
+                        on the type and support by the controller.
+
+                        Examples: `1.2.3.4`, `128::1`, `my-ip-address`.
+                      maxLength: 253
+                      minLength: 1
+                      type: string
+                  required:
+                  - value
+                  type: object
+                  x-kubernetes-validations:
+                  - message: Hostname value must only contain valid characters (matching
+                      ^(\*\.)?[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$)
+                    rule: 'self.type == ''Hostname'' ? self.value.matches(r"""^(\*\.)?[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$"""):
+                      true'
+                maxItems: 16
+                type: array
+              conditions:
+                default:
+                - lastTransitionTime: "1970-01-01T00:00:00Z"
+                  message: Waiting for controller
+                  reason: Pending
+                  status: Unknown
+                  type: Accepted
+                - lastTransitionTime: "1970-01-01T00:00:00Z"
+                  message: Waiting for controller
+                  reason: Pending
+                  status: Unknown
+                  type: Programmed
+                description: |-
+                  Conditions describe the current conditions of the Gateway.
+
+                  Implementations should prefer to express Gateway conditions
+                  using the `GatewayConditionType` and `GatewayConditionReason`
+                  constants so that operators and tools can converge on a common
+                  vocabulary to describe Gateway state.
+
+                  Known condition types are:
+
+                  * "Accepted"
+                  * "Programmed"
+                  * "Ready"
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                maxItems: 8
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              listeners:
+                description: Listeners provide status for each unique listener port
+                  defined in the Spec.
+                items:
+                  description: ListenerStatus is the status associated with a Listener.
+                  properties:
+                    attachedRoutes:
+                      description: |-
+                        AttachedRoutes represents the total number of Routes that have been
+                        successfully attached to this Listener.
+
+                        Successful attachment of a Route to a Listener is based solely on the
+                        combination of the AllowedRoutes field on the corresponding Listener
+                        and the Route's ParentRefs field. A Route is successfully attached to
+                        a Listener when it is selected by the Listener's AllowedRoutes field
+                        AND the Route has a valid ParentRef selecting the whole Gateway
+                        resource or a specific Listener as a parent resource (more detail on
+                        attachment semantics can be found in the documentation on the various
+                        Route kinds ParentRefs fields). Listener or Route status does not impact
+                        successful attachment, i.e. the AttachedRoutes field count MUST be set
+                        for Listeners with condition Accepted: false and MUST count successfully
+                        attached Routes that may themselves have Accepted: false conditions.
+
+                        Uses for this field include troubleshooting Route attachment and
+                        measuring blast radius/impact of changes to a Listener.
+                      format: int32
+                      type: integer
+                    conditions:
+                      description: Conditions describe the current condition of this
+                        listener.
+                      items:
+                        description: Condition contains details for one aspect of
+                          the current state of this API Resource.
+                        properties:
+                          lastTransitionTime:
+                            description: |-
+                              lastTransitionTime is the last time the condition transitioned from one status to another.
+                              This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                            format: date-time
+                            type: string
+                          message:
+                            description: |-
+                              message is a human readable message indicating details about the transition.
+                              This may be an empty string.
+                            maxLength: 32768
+                            type: string
+                          observedGeneration:
+                            description: |-
+                              observedGeneration represents the .metadata.generation that the condition was set based upon.
+                              For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                              with respect to the current state of the instance.
+                            format: int64
+                            minimum: 0
+                            type: integer
+                          reason:
+                            description: |-
+                              reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                              Producers of specific condition types may define expected values and meanings for this field,
+                              and whether the values are considered a guaranteed API.
+                              The value should be a CamelCase string.
+                              This field may not be empty.
+                            maxLength: 1024
+                            minLength: 1
+                            pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                            type: string
+                          status:
+                            description: status of the condition, one of True, False,
+                              Unknown.
+                            enum:
+                            - "True"
+                            - "False"
+                            - Unknown
+                            type: string
+                          type:
+                            description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                            maxLength: 316
+                            pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                            type: string
+                        required:
+                        - lastTransitionTime
+                        - message
+                        - reason
+                        - status
+                        - type
+                        type: object
+                      maxItems: 8
+                      type: array
+                      x-kubernetes-list-map-keys:
+                      - type
+                      x-kubernetes-list-type: map
+                    name:
+                      description: Name is the name of the Listener that this status
+                        corresponds to.
+                      maxLength: 253
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                      type: string
+                    supportedKinds:
+                      description: |-
+                        SupportedKinds is the list indicating the Kinds supported by this
+                        listener. This MUST represent the kinds an implementation supports for
+                        that Listener configuration.
+
+                        If kinds are specified in Spec that are not supported, they MUST NOT
+                        appear in this list and an implementation MUST set the "ResolvedRefs"
+                        condition to "False" with the "InvalidRouteKinds" reason. If both valid
+                        and invalid Route kinds are specified, the implementation MUST
+                        reference the valid Route kinds that have been specified.
+                      items:
+                        description: RouteGroupKind indicates the group and kind of
+                          a Route resource.
+                        properties:
+                          group:
+                            default: gateway.networking.k8s.io
+                            description: Group is the group of the Route.
+                            maxLength: 253
+                            pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                            type: string
+                          kind:
+                            description: Kind is the kind of the Route.
+                            maxLength: 63
+                            minLength: 1
+                            pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                            type: string
+                        required:
+                        - kind
+                        type: object
+                      maxItems: 8
+                      type: array
+                  required:
+                  - attachedRoutes
+                  - conditions
+                  - name
+                  - supportedKinds
+                  type: object
+                maxItems: 64
+                type: array
+                x-kubernetes-list-map-keys:
+                - name
+                x-kubernetes-list-type: map
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - jsonPath: .spec.gatewayClassName
+      name: Class
+      type: string
+    - jsonPath: .status.addresses[*].value
+      name: Address
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Programmed")].status
+      name: Programmed
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: |-
+          Gateway represents an instance of a service-traffic handling infrastructure
+          by binding Listeners to a set of IP addresses.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec defines the desired state of Gateway.
+            properties:
+              addresses:
+                description: |+
+                  Addresses requested for this Gateway. This is optional and behavior can
+                  depend on the implementation. If a value is set in the spec and the
+                  requested address is invalid or unavailable, the implementation MUST
+                  indicate this in the associated entry in GatewayStatus.Addresses.
+
+                  The Addresses field represents a request for the address(es) on the
+                  "outside of the Gateway", that traffic bound for this Gateway will use.
+                  This could be the IP address or hostname of an external load balancer or
+                  other networking infrastructure, or some other address that traffic will
+                  be sent to.
+
+                  If no Addresses are specified, the implementation MAY schedule the
+                  Gateway in an implementation-specific manner, assigning an appropriate
+                  set of Addresses.
+
+                  The implementation MUST bind all Listeners to every GatewayAddress that
+                  it assigns to the Gateway and add a corresponding entry in
+                  GatewayStatus.Addresses.
+
+                  Support: Extended
+
+                items:
+                  description: GatewayAddress describes an address that can be bound
+                    to a Gateway.
+                  oneOf:
+                  - properties:
+                      type:
+                        enum:
+                        - IPAddress
+                      value:
+                        anyOf:
+                        - format: ipv4
+                        - format: ipv6
+                  - properties:
+                      type:
+                        not:
+                          enum:
+                          - IPAddress
+                  properties:
+                    type:
+                      default: IPAddress
+                      description: Type of the address.
+                      maxLength: 253
+                      minLength: 1
+                      pattern: ^Hostname|IPAddress|NamedAddress|[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\/[A-Za-z0-9\/\-._~%!$&'()*+,;=:]+$
+                      type: string
+                    value:
+                      description: |-
+                        Value of the address. The validity of the values will depend
+                        on the type and support by the controller.
+
+                        Examples: `1.2.3.4`, `128::1`, `my-ip-address`.
+                      maxLength: 253
+                      minLength: 1
+                      type: string
+                  required:
+                  - value
+                  type: object
+                  x-kubernetes-validations:
+                  - message: Hostname value must only contain valid characters (matching
+                      ^(\*\.)?[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$)
+                    rule: 'self.type == ''Hostname'' ? self.value.matches(r"""^(\*\.)?[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$"""):
+                      true'
+                maxItems: 16
+                type: array
+                x-kubernetes-validations:
+                - message: IPAddress values must be unique
+                  rule: 'self.all(a1, a1.type == ''IPAddress'' ? self.exists_one(a2,
+                    a2.type == a1.type && a2.value == a1.value) : true )'
+                - message: Hostname values must be unique
+                  rule: 'self.all(a1, a1.type == ''Hostname'' ? self.exists_one(a2,
+                    a2.type == a1.type && a2.value == a1.value) : true )'
+              gatewayClassName:
+                description: |-
+                  GatewayClassName used for this Gateway. This is the name of a
+                  GatewayClass resource.
+                maxLength: 253
+                minLength: 1
+                type: string
+              infrastructure:
+                description: |-
+                  Infrastructure defines infrastructure level attributes about this Gateway instance.
+
+                  Support: Extended
+                properties:
+                  annotations:
+                    additionalProperties:
+                      description: |-
+                        AnnotationValue is the value of an annotation in Gateway API. This is used
+                        for validation of maps such as TLS options. This roughly matches Kubernetes
+                        annotation validation, although the length validation in that case is based
+                        on the entire size of the annotations struct.
+                      maxLength: 4096
+                      minLength: 0
+                      type: string
+                    description: |-
+                      Annotations that SHOULD be applied to any resources created in response to this Gateway.
+
+                      For implementations creating other Kubernetes objects, this should be the `metadata.annotations` field on resources.
+                      For other implementations, this refers to any relevant (implementation specific) "annotations" concepts.
+
+                      An implementation may chose to add additional implementation-specific annotations as they see fit.
+
+                      Support: Extended
+                    maxProperties: 8
+                    type: object
+                    x-kubernetes-validations:
+                    - message: Annotation keys must be in the form of an optional
+                        DNS subdomain prefix followed by a required name segment of
+                        up to 63 characters.
+                      rule: self.all(key, key.matches(r"""^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?([A-Za-z0-9][-A-Za-z0-9_.]{0,61})?[A-Za-z0-9]$"""))
+                    - message: If specified, the annotation key's prefix must be a
+                        DNS subdomain not longer than 253 characters in total.
+                      rule: self.all(key, key.split("/")[0].size() < 253)
+                  labels:
+                    additionalProperties:
+                      description: |-
+                        LabelValue is the value of a label in the Gateway API. This is used for validation
+                        of maps such as Gateway infrastructure labels. This matches the Kubernetes
+                        label validation rules:
+                        * must be 63 characters or less (can be empty),
+                        * unless empty, must begin and end with an alphanumeric character ([a-z0-9A-Z]),
+                        * could contain dashes (-), underscores (_), dots (.), and alphanumerics between.
+
+                        Valid values include:
+
+                        * MyValue
+                        * my.name
+                        * 123-my-value
+                      maxLength: 63
+                      minLength: 0
+                      pattern: ^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$
+                      type: string
+                    description: |-
+                      Labels that SHOULD be applied to any resources created in response to this Gateway.
+
+                      For implementations creating other Kubernetes objects, this should be the `metadata.labels` field on resources.
+                      For other implementations, this refers to any relevant (implementation specific) "labels" concepts.
+
+                      An implementation may chose to add additional implementation-specific labels as they see fit.
+
+                      If an implementation maps these labels to Pods, or any other resource that would need to be recreated when labels
+                      change, it SHOULD clearly warn about this behavior in documentation.
+
+                      Support: Extended
+                    maxProperties: 8
+                    type: object
+                    x-kubernetes-validations:
+                    - message: Label keys must be in the form of an optional DNS subdomain
+                        prefix followed by a required name segment of up to 63 characters.
+                      rule: self.all(key, key.matches(r"""^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?([A-Za-z0-9][-A-Za-z0-9_.]{0,61})?[A-Za-z0-9]$"""))
+                    - message: If specified, the label key's prefix must be a DNS
+                        subdomain not longer than 253 characters in total.
+                      rule: self.all(key, key.split("/")[0].size() < 253)
+                  parametersRef:
+                    description: |-
+                      ParametersRef is a reference to a resource that contains the configuration
+                      parameters corresponding to the Gateway. This is optional if the
+                      controller does not require any additional configuration.
+
+                      This follows the same semantics as GatewayClass's `parametersRef`, but on a per-Gateway basis
+
+                      The Gateway's GatewayClass may provide its own `parametersRef`. When both are specified,
+                      the merging behavior is implementation specific.
+                      It is generally recommended that GatewayClass provides defaults that can be overridden by a Gateway.
+
+                      Support: Implementation-specific
+                    properties:
+                      group:
+                        description: Group is the group of the referent.
+                        maxLength: 253
+                        pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                        type: string
+                      kind:
+                        description: Kind is kind of the referent.
+                        maxLength: 63
+                        minLength: 1
+                        pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                        type: string
+                      name:
+                        description: Name is the name of the referent.
+                        maxLength: 253
+                        minLength: 1
+                        type: string
+                    required:
+                    - group
+                    - kind
+                    - name
+                    type: object
+                type: object
+              listeners:
+                description: |-
+                  Listeners associated with this Gateway. Listeners define
+                  logical endpoints that are bound on this Gateway's addresses.
+                  At least one Listener MUST be specified.
+
+                  Each Listener in a set of Listeners (for example, in a single Gateway)
+                  MUST be _distinct_, in that a traffic flow MUST be able to be assigned to
+                  exactly one listener. (This section uses "set of Listeners" rather than
+                  "Listeners in a single Gateway" because implementations MAY merge configuration
+                  from multiple Gateways onto a single data plane, and these rules _also_
+                  apply in that case).
+
+                  Practically, this means that each listener in a set MUST have a unique
+                  combination of Port, Protocol, and, if supported by the protocol, Hostname.
+
+                  Some combinations of port, protocol, and TLS settings are considered
+                  Core support and MUST be supported by implementations based on their
+                  targeted conformance profile:
+
+                  HTTP Profile
+
+                  1. HTTPRoute, Port: 80, Protocol: HTTP
+                  2. HTTPRoute, Port: 443, Protocol: HTTPS, TLS Mode: Terminate, TLS keypair provided
+
+                  TLS Profile
+
+                  1. TLSRoute, Port: 443, Protocol: TLS, TLS Mode: Passthrough
+
+                  "Distinct" Listeners have the following property:
+
+                  The implementation can match inbound requests to a single distinct
+                  Listener. When multiple Listeners share values for fields (for
+                  example, two Listeners with the same Port value), the implementation
+                  can match requests to only one of the Listeners using other
+                  Listener fields.
+
+                  For example, the following Listener scenarios are distinct:
+
+                  1. Multiple Listeners with the same Port that all use the "HTTP"
+                     Protocol that all have unique Hostname values.
+                  2. Multiple Listeners with the same Port that use either the "HTTPS" or
+                     "TLS" Protocol that all have unique Hostname values.
+                  3. A mixture of "TCP" and "UDP" Protocol Listeners, where no Listener
+                     with the same Protocol has the same Port value.
+
+                  Some fields in the Listener struct have possible values that affect
+                  whether the Listener is distinct. Hostname is particularly relevant
+                  for HTTP or HTTPS protocols.
+
+                  When using the Hostname value to select between same-Port, same-Protocol
+                  Listeners, the Hostname value must be different on each Listener for the
+                  Listener to be distinct.
+
+                  When the Listeners are distinct based on Hostname, inbound request
+                  hostnames MUST match from the most specific to least specific Hostname
+                  values to choose the correct Listener and its associated set of Routes.
+
+                  Exact matches must be processed before wildcard matches, and wildcard
+                  matches must be processed before fallback (empty Hostname value)
+                  matches. For example, `"foo.example.com"` takes precedence over
+                  `"*.example.com"`, and `"*.example.com"` takes precedence over `""`.
+
+                  Additionally, if there are multiple wildcard entries, more specific
+                  wildcard entries must be processed before less specific wildcard entries.
+                  For example, `"*.foo.example.com"` takes precedence over `"*.example.com"`.
+                  The precise definition here is that the higher the number of dots in the
+                  hostname to the right of the wildcard character, the higher the precedence.
+
+                  The wildcard character will match any number of characters _and dots_ to
+                  the left, however, so `"*.example.com"` will match both
+                  `"foo.bar.example.com"` _and_ `"bar.example.com"`.
+
+                  If a set of Listeners contains Listeners that are not distinct, then those
+                  Listeners are Conflicted, and the implementation MUST set the "Conflicted"
+                  condition in the Listener Status to "True".
+
+                  Implementations MAY choose to accept a Gateway with some Conflicted
+                  Listeners only if they only accept the partial Listener set that contains
+                  no Conflicted Listeners. To put this another way, implementations may
+                  accept a partial Listener set only if they throw out *all* the conflicting
+                  Listeners. No picking one of the conflicting listeners as the winner.
+                  This also means that the Gateway must have at least one non-conflicting
+                  Listener in this case, otherwise it violates the requirement that at
+                  least one Listener must be present.
+
+                  The implementation MUST set a "ListenersNotValid" condition on the
+                  Gateway Status when the Gateway contains Conflicted Listeners whether or
+                  not they accept the Gateway. That Condition SHOULD clearly
+                  indicate in the Message which Listeners are conflicted, and which are
+                  Accepted. Additionally, the Listener status for those listeners SHOULD
+                  indicate which Listeners are conflicted and not Accepted.
+
+                  A Gateway's Listeners are considered "compatible" if:
+
+                  1. They are distinct.
+                  2. The implementation can serve them in compliance with the Addresses
+                     requirement that all Listeners are available on all assigned
+                     addresses.
+
+                  Compatible combinations in Extended support are expected to vary across
+                  implementations. A combination that is compatible for one implementation
+                  may not be compatible for another.
+
+                  For example, an implementation that cannot serve both TCP and UDP listeners
+                  on the same address, or cannot mix HTTPS and generic TLS listens on the same port
+                  would not consider those cases compatible, even though they are distinct.
+
+                  Note that requests SHOULD match at most one Listener. For example, if
+                  Listeners are defined for "foo.example.com" and "*.example.com", a
+                  request to "foo.example.com" SHOULD only be routed using routes attached
+                  to the "foo.example.com" Listener (and not the "*.example.com" Listener).
+                  This concept is known as "Listener Isolation". Implementations that do
+                  not support Listener Isolation MUST clearly document this.
+
+                  Implementations MAY merge separate Gateways onto a single set of
+                  Addresses if all Listeners across all Gateways are compatible.
+
+                  Support: Core
+                items:
+                  description: |-
+                    Listener embodies the concept of a logical endpoint where a Gateway accepts
+                    network connections.
+                  properties:
+                    allowedRoutes:
+                      default:
+                        namespaces:
+                          from: Same
+                      description: |-
+                        AllowedRoutes defines the types of routes that MAY be attached to a
+                        Listener and the trusted namespaces where those Route resources MAY be
+                        present.
+
+                        Although a client request may match multiple route rules, only one rule
+                        may ultimately receive the request. Matching precedence MUST be
+                        determined in order of the following criteria:
+
+                        * The most specific match as defined by the Route type.
+                        * The oldest Route based on creation timestamp. For example, a Route with
+                          a creation timestamp of "2020-09-08 01:02:03" is given precedence over
+                          a Route with a creation timestamp of "2020-09-08 01:02:04".
+                        * If everything else is equivalent, the Route appearing first in
+                          alphabetical order (namespace/name) should be given precedence. For
+                          example, foo/bar is given precedence over foo/baz.
+
+                        All valid rules within a Route attached to this Listener should be
+                        implemented. Invalid Route rules can be ignored (sometimes that will mean
+                        the full Route). If a Route rule transitions from valid to invalid,
+                        support for that Route rule should be dropped to ensure consistency. For
+                        example, even if a filter specified by a Route rule is invalid, the rest
+                        of the rules within that Route should still be supported.
+
+                        Support: Core
+                      properties:
+                        kinds:
+                          description: |-
+                            Kinds specifies the groups and kinds of Routes that are allowed to bind
+                            to this Gateway Listener. When unspecified or empty, the kinds of Routes
+                            selected are determined using the Listener protocol.
+
+                            A RouteGroupKind MUST correspond to kinds of Routes that are compatible
+                            with the application protocol specified in the Listener's Protocol field.
+                            If an implementation does not support or recognize this resource type, it
+                            MUST set the "ResolvedRefs" condition to False for this Listener with the
+                            "InvalidRouteKinds" reason.
+
+                            Support: Core
+                          items:
+                            description: RouteGroupKind indicates the group and kind
+                              of a Route resource.
+                            properties:
+                              group:
+                                default: gateway.networking.k8s.io
+                                description: Group is the group of the Route.
+                                maxLength: 253
+                                pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                type: string
+                              kind:
+                                description: Kind is the kind of the Route.
+                                maxLength: 63
+                                minLength: 1
+                                pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                                type: string
+                            required:
+                            - kind
+                            type: object
+                          maxItems: 8
+                          type: array
+                        namespaces:
+                          default:
+                            from: Same
+                          description: |-
+                            Namespaces indicates namespaces from which Routes may be attached to this
+                            Listener. This is restricted to the namespace of this Gateway by default.
+
+                            Support: Core
+                          properties:
+                            from:
+                              default: Same
+                              description: |-
+                                From indicates where Routes will be selected for this Gateway. Possible
+                                values are:
+
+                                * All: Routes in all namespaces may be used by this Gateway.
+                                * Selector: Routes in namespaces selected by the selector may be used by
+                                  this Gateway.
+                                * Same: Only Routes in the same namespace may be used by this Gateway.
+
+                                Support: Core
+                              enum:
+                              - All
+                              - Selector
+                              - Same
+                              type: string
+                            selector:
+                              description: |-
+                                Selector must be specified when From is set to "Selector". In that case,
+                                only Routes in Namespaces matching this Selector will be selected by this
+                                Gateway. This field is ignored for other values of "From".
+
+                                Support: Core
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
+                                  items:
+                                    description: |-
+                                      A label selector requirement is a selector that contains values, a key, and an operator that
+                                      relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the
+                                          selector applies to.
+                                        type: string
+                                      operator:
+                                        description: |-
+                                          operator represents a key's relationship to a set of values.
+                                          Valid operators are In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: |-
+                                          values is an array of string values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                          the values array must be empty. This array is replaced during a strategic
+                                          merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: |-
+                                    matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                    operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                  type: object
+                              type: object
+                              x-kubernetes-map-type: atomic
+                          type: object
+                      type: object
+                    hostname:
+                      description: |-
+                        Hostname specifies the virtual hostname to match for protocol types that
+                        define this concept. When unspecified, all hostnames are matched. This
+                        field is ignored for protocols that don't require hostname based
+                        matching.
+
+                        Implementations MUST apply Hostname matching appropriately for each of
+                        the following protocols:
+
+                        * TLS: The Listener Hostname MUST match the SNI.
+                        * HTTP: The Listener Hostname MUST match the Host header of the request.
+                        * HTTPS: The Listener Hostname SHOULD match at both the TLS and HTTP
+                          protocol layers as described above. If an implementation does not
+                          ensure that both the SNI and Host header match the Listener hostname,
+                          it MUST clearly document that.
+
+                        For HTTPRoute and TLSRoute resources, there is an interaction with the
+                        `spec.hostnames` array. When both listener and route specify hostnames,
+                        there MUST be an intersection between the values for a Route to be
+                        accepted. For more information, refer to the Route specific Hostnames
+                        documentation.
+
+                        Hostnames that are prefixed with a wildcard label (`*.`) are interpreted
+                        as a suffix match. That means that a match for `*.example.com` would match
+                        both `test.example.com`, and `foo.test.example.com`, but not `example.com`.
+
+                        Support: Core
+                      maxLength: 253
+                      minLength: 1
+                      pattern: ^(\*\.)?[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                      type: string
+                    name:
+                      description: |-
+                        Name is the name of the Listener. This name MUST be unique within a
+                        Gateway.
+
+                        Support: Core
+                      maxLength: 253
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                      type: string
+                    port:
+                      description: |-
+                        Port is the network port. Multiple listeners may use the
+                        same port, subject to the Listener compatibility rules.
+
+                        Support: Core
+                      format: int32
+                      maximum: 65535
+                      minimum: 1
+                      type: integer
+                    protocol:
+                      description: |-
+                        Protocol specifies the network protocol this listener expects to receive.
+
+                        Support: Core
+                      maxLength: 255
+                      minLength: 1
+                      pattern: ^[a-zA-Z0-9]([-a-zA-Z0-9]*[a-zA-Z0-9])?$|[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\/[A-Za-z0-9]+$
+                      type: string
+                    tls:
+                      description: |-
+                        TLS is the TLS configuration for the Listener. This field is required if
+                        the Protocol field is "HTTPS" or "TLS". It is invalid to set this field
+                        if the Protocol field is "HTTP", "TCP", or "UDP".
+
+                        The association of SNIs to Certificate defined in GatewayTLSConfig is
+                        defined based on the Hostname field for this listener.
+
+                        The GatewayClass MUST use the longest matching SNI out of all
+                        available certificates for any TLS handshake.
+
+                        Support: Core
+                      properties:
+                        certificateRefs:
+                          description: |-
+                            CertificateRefs contains a series of references to Kubernetes objects that
+                            contains TLS certificates and private keys. These certificates are used to
+                            establish a TLS handshake for requests that match the hostname of the
+                            associated listener.
+
+                            A single CertificateRef to a Kubernetes Secret has "Core" support.
+                            Implementations MAY choose to support attaching multiple certificates to
+                            a Listener, but this behavior is implementation-specific.
+
+                            References to a resource in different namespace are invalid UNLESS there
+                            is a ReferenceGrant in the target namespace that allows the certificate
+                            to be attached. If a ReferenceGrant does not allow this reference, the
+                            "ResolvedRefs" condition MUST be set to False for this listener with the
+                            "RefNotPermitted" reason.
+
+                            This field is required to have at least one element when the mode is set
+                            to "Terminate" (default) and is optional otherwise.
+
+                            CertificateRefs can reference to standard Kubernetes resources, i.e.
+                            Secret, or implementation-specific custom resources.
+
+                            Support: Core - A single reference to a Kubernetes Secret of type kubernetes.io/tls
+
+                            Support: Implementation-specific (More than one reference or other resource types)
+                          items:
+                            description: |-
+                              SecretObjectReference identifies an API object including its namespace,
+                              defaulting to Secret.
+
+                              The API object must be valid in the cluster; the Group and Kind must
+                              be registered in the cluster for this reference to be valid.
+
+                              References to objects with invalid Group and Kind are not valid, and must
+                              be rejected by the implementation, with appropriate Conditions set
+                              on the containing object.
+                            properties:
+                              group:
+                                default: ""
+                                description: |-
+                                  Group is the group of the referent. For example, "gateway.networking.k8s.io".
+                                  When unspecified or empty string, core API group is inferred.
+                                maxLength: 253
+                                pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                type: string
+                              kind:
+                                default: Secret
+                                description: Kind is kind of the referent. For example
+                                  "Secret".
+                                maxLength: 63
+                                minLength: 1
+                                pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                                type: string
+                              name:
+                                description: Name is the name of the referent.
+                                maxLength: 253
+                                minLength: 1
+                                type: string
+                              namespace:
+                                description: |-
+                                  Namespace is the namespace of the referenced object. When unspecified, the local
+                                  namespace is inferred.
+
+                                  Note that when a namespace different than the local namespace is specified,
+                                  a ReferenceGrant object is required in the referent namespace to allow that
+                                  namespace's owner to accept the reference. See the ReferenceGrant
+                                  documentation for details.
+
+                                  Support: Core
+                                maxLength: 63
+                                minLength: 1
+                                pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                type: string
+                            required:
+                            - name
+                            type: object
+                          maxItems: 64
+                          type: array
+                        mode:
+                          default: Terminate
+                          description: |-
+                            Mode defines the TLS behavior for the TLS session initiated by the client.
+                            There are two possible modes:
+
+                            - Terminate: The TLS session between the downstream client and the
+                              Gateway is terminated at the Gateway. This mode requires certificates
+                              to be specified in some way, such as populating the certificateRefs
+                              field.
+                            - Passthrough: The TLS session is NOT terminated by the Gateway. This
+                              implies that the Gateway can't decipher the TLS stream except for
+                              the ClientHello message of the TLS protocol. The certificateRefs field
+                              is ignored in this mode.
+
+                            Support: Core
+                          enum:
+                          - Terminate
+                          - Passthrough
+                          type: string
+                        options:
+                          additionalProperties:
+                            description: |-
+                              AnnotationValue is the value of an annotation in Gateway API. This is used
+                              for validation of maps such as TLS options. This roughly matches Kubernetes
+                              annotation validation, although the length validation in that case is based
+                              on the entire size of the annotations struct.
+                            maxLength: 4096
+                            minLength: 0
+                            type: string
+                          description: |-
+                            Options are a list of key/value pairs to enable extended TLS
+                            configuration for each implementation. For example, configuring the
+                            minimum TLS version or supported cipher suites.
+
+                            A set of common keys MAY be defined by the API in the future. To avoid
+                            any ambiguity, implementation-specific definitions MUST use
+                            domain-prefixed names, such as `example.com/my-custom-option`.
+                            Un-prefixed names are reserved for key names defined by Gateway API.
+
+                            Support: Implementation-specific
+                          maxProperties: 16
+                          type: object
+                      type: object
+                      x-kubernetes-validations:
+                      - message: certificateRefs or options must be specified when
+                          mode is Terminate
+                        rule: 'self.mode == ''Terminate'' ? size(self.certificateRefs)
+                          > 0 || size(self.options) > 0 : true'
+                  required:
+                  - name
+                  - port
+                  - protocol
+                  type: object
+                maxItems: 64
+                minItems: 1
+                type: array
+                x-kubernetes-list-map-keys:
+                - name
+                x-kubernetes-list-type: map
+                x-kubernetes-validations:
+                - message: tls must not be specified for protocols ['HTTP', 'TCP',
+                    'UDP']
+                  rule: 'self.all(l, l.protocol in [''HTTP'', ''TCP'', ''UDP''] ?
+                    !has(l.tls) : true)'
+                - message: tls mode must be Terminate for protocol HTTPS
+                  rule: 'self.all(l, (l.protocol == ''HTTPS'' && has(l.tls)) ? (l.tls.mode
+                    == '''' || l.tls.mode == ''Terminate'') : true)'
+                - message: hostname must not be specified for protocols ['TCP', 'UDP']
+                  rule: 'self.all(l, l.protocol in [''TCP'', ''UDP'']  ? (!has(l.hostname)
+                    || l.hostname == '''') : true)'
+                - message: Listener name must be unique within the Gateway
+                  rule: self.all(l1, self.exists_one(l2, l1.name == l2.name))
+                - message: Combination of port, protocol and hostname must be unique
+                    for each listener
+                  rule: 'self.all(l1, self.exists_one(l2, l1.port == l2.port && l1.protocol
+                    == l2.protocol && (has(l1.hostname) && has(l2.hostname) ? l1.hostname
+                    == l2.hostname : !has(l1.hostname) && !has(l2.hostname))))'
+            required:
+            - gatewayClassName
+            - listeners
+            type: object
+          status:
+            default:
+              conditions:
+              - lastTransitionTime: "1970-01-01T00:00:00Z"
+                message: Waiting for controller
+                reason: Pending
+                status: Unknown
+                type: Accepted
+              - lastTransitionTime: "1970-01-01T00:00:00Z"
+                message: Waiting for controller
+                reason: Pending
+                status: Unknown
+                type: Programmed
+            description: Status defines the current state of Gateway.
+            properties:
+              addresses:
+                description: |+
+                  Addresses lists the network addresses that have been bound to the
+                  Gateway.
+
+                  This list may differ from the addresses provided in the spec under some
+                  conditions:
+
+                    * no addresses are specified, all addresses are dynamically assigned
+                    * a combination of specified and dynamic addresses are assigned
+                    * a specified address was unusable (e.g. already in use)
+
+                items:
+                  description: GatewayStatusAddress describes a network address that
+                    is bound to a Gateway.
+                  oneOf:
+                  - properties:
+                      type:
+                        enum:
+                        - IPAddress
+                      value:
+                        anyOf:
+                        - format: ipv4
+                        - format: ipv6
+                  - properties:
+                      type:
+                        not:
+                          enum:
+                          - IPAddress
+                  properties:
+                    type:
+                      default: IPAddress
+                      description: Type of the address.
+                      maxLength: 253
+                      minLength: 1
+                      pattern: ^Hostname|IPAddress|NamedAddress|[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\/[A-Za-z0-9\/\-._~%!$&'()*+,;=:]+$
+                      type: string
+                    value:
+                      description: |-
+                        Value of the address. The validity of the values will depend
+                        on the type and support by the controller.
+
+                        Examples: `1.2.3.4`, `128::1`, `my-ip-address`.
+                      maxLength: 253
+                      minLength: 1
+                      type: string
+                  required:
+                  - value
+                  type: object
+                  x-kubernetes-validations:
+                  - message: Hostname value must only contain valid characters (matching
+                      ^(\*\.)?[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$)
+                    rule: 'self.type == ''Hostname'' ? self.value.matches(r"""^(\*\.)?[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$"""):
+                      true'
+                maxItems: 16
+                type: array
+              conditions:
+                default:
+                - lastTransitionTime: "1970-01-01T00:00:00Z"
+                  message: Waiting for controller
+                  reason: Pending
+                  status: Unknown
+                  type: Accepted
+                - lastTransitionTime: "1970-01-01T00:00:00Z"
+                  message: Waiting for controller
+                  reason: Pending
+                  status: Unknown
+                  type: Programmed
+                description: |-
+                  Conditions describe the current conditions of the Gateway.
+
+                  Implementations should prefer to express Gateway conditions
+                  using the `GatewayConditionType` and `GatewayConditionReason`
+                  constants so that operators and tools can converge on a common
+                  vocabulary to describe Gateway state.
+
+                  Known condition types are:
+
+                  * "Accepted"
+                  * "Programmed"
+                  * "Ready"
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                maxItems: 8
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              listeners:
+                description: Listeners provide status for each unique listener port
+                  defined in the Spec.
+                items:
+                  description: ListenerStatus is the status associated with a Listener.
+                  properties:
+                    attachedRoutes:
+                      description: |-
+                        AttachedRoutes represents the total number of Routes that have been
+                        successfully attached to this Listener.
+
+                        Successful attachment of a Route to a Listener is based solely on the
+                        combination of the AllowedRoutes field on the corresponding Listener
+                        and the Route's ParentRefs field. A Route is successfully attached to
+                        a Listener when it is selected by the Listener's AllowedRoutes field
+                        AND the Route has a valid ParentRef selecting the whole Gateway
+                        resource or a specific Listener as a parent resource (more detail on
+                        attachment semantics can be found in the documentation on the various
+                        Route kinds ParentRefs fields). Listener or Route status does not impact
+                        successful attachment, i.e. the AttachedRoutes field count MUST be set
+                        for Listeners with condition Accepted: false and MUST count successfully
+                        attached Routes that may themselves have Accepted: false conditions.
+
+                        Uses for this field include troubleshooting Route attachment and
+                        measuring blast radius/impact of changes to a Listener.
+                      format: int32
+                      type: integer
+                    conditions:
+                      description: Conditions describe the current condition of this
+                        listener.
+                      items:
+                        description: Condition contains details for one aspect of
+                          the current state of this API Resource.
+                        properties:
+                          lastTransitionTime:
+                            description: |-
+                              lastTransitionTime is the last time the condition transitioned from one status to another.
+                              This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                            format: date-time
+                            type: string
+                          message:
+                            description: |-
+                              message is a human readable message indicating details about the transition.
+                              This may be an empty string.
+                            maxLength: 32768
+                            type: string
+                          observedGeneration:
+                            description: |-
+                              observedGeneration represents the .metadata.generation that the condition was set based upon.
+                              For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                              with respect to the current state of the instance.
+                            format: int64
+                            minimum: 0
+                            type: integer
+                          reason:
+                            description: |-
+                              reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                              Producers of specific condition types may define expected values and meanings for this field,
+                              and whether the values are considered a guaranteed API.
+                              The value should be a CamelCase string.
+                              This field may not be empty.
+                            maxLength: 1024
+                            minLength: 1
+                            pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                            type: string
+                          status:
+                            description: status of the condition, one of True, False,
+                              Unknown.
+                            enum:
+                            - "True"
+                            - "False"
+                            - Unknown
+                            type: string
+                          type:
+                            description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                            maxLength: 316
+                            pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                            type: string
+                        required:
+                        - lastTransitionTime
+                        - message
+                        - reason
+                        - status
+                        - type
+                        type: object
+                      maxItems: 8
+                      type: array
+                      x-kubernetes-list-map-keys:
+                      - type
+                      x-kubernetes-list-type: map
+                    name:
+                      description: Name is the name of the Listener that this status
+                        corresponds to.
+                      maxLength: 253
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                      type: string
+                    supportedKinds:
+                      description: |-
+                        SupportedKinds is the list indicating the Kinds supported by this
+                        listener. This MUST represent the kinds an implementation supports for
+                        that Listener configuration.
+
+                        If kinds are specified in Spec that are not supported, they MUST NOT
+                        appear in this list and an implementation MUST set the "ResolvedRefs"
+                        condition to "False" with the "InvalidRouteKinds" reason. If both valid
+                        and invalid Route kinds are specified, the implementation MUST
+                        reference the valid Route kinds that have been specified.
+                      items:
+                        description: RouteGroupKind indicates the group and kind of
+                          a Route resource.
+                        properties:
+                          group:
+                            default: gateway.networking.k8s.io
+                            description: Group is the group of the Route.
+                            maxLength: 253
+                            pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                            type: string
+                          kind:
+                            description: Kind is the kind of the Route.
+                            maxLength: 63
+                            minLength: 1
+                            pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                            type: string
+                        required:
+                        - kind
+                        type: object
+                      maxItems: 8
+                      type: array
+                  required:
+                  - attachedRoutes
+                  - conditions
+                  - name
+                  - supportedKinds
+                  type: object
+                maxItems: 64
+                type: array
+                x-kubernetes-list-map-keys:
+                - name
+                x-kubernetes-list-type: map
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/3328
+    gateway.networking.k8s.io/bundle-version: v1.2.1
+    gateway.networking.k8s.io/channel: standard
+  creationTimestamp: null
+  name: grpcroutes.gateway.networking.k8s.io
+spec:
+  group: gateway.networking.k8s.io
+  names:
+    categories:
+    - gateway-api
+    kind: GRPCRoute
+    listKind: GRPCRouteList
+    plural: grpcroutes
+    singular: grpcroute
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.hostnames
+      name: Hostnames
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: |-
+          GRPCRoute provides a way to route gRPC requests. This includes the capability
+          to match requests by hostname, gRPC service, gRPC method, or HTTP/2 header.
+          Filters can be used to specify additional processing steps. Backends specify
+          where matching requests will be routed.
+
+          GRPCRoute falls under extended support within the Gateway API. Within the
+          following specification, the word "MUST" indicates that an implementation
+          supporting GRPCRoute must conform to the indicated requirement, but an
+          implementation not supporting this route type need not follow the requirement
+          unless explicitly indicated.
+
+          Implementations supporting `GRPCRoute` with the `HTTPS` `ProtocolType` MUST
+          accept HTTP/2 connections without an initial upgrade from HTTP/1.1, i.e. via
+          ALPN. If the implementation does not support this, then it MUST set the
+          "Accepted" condition to "False" for the affected listener with a reason of
+          "UnsupportedProtocol".  Implementations MAY also accept HTTP/2 connections
+          with an upgrade from HTTP/1.
+
+          Implementations supporting `GRPCRoute` with the `HTTP` `ProtocolType` MUST
+          support HTTP/2 over cleartext TCP (h2c,
+          https://www.rfc-editor.org/rfc/rfc7540#section-3.1) without an initial
+          upgrade from HTTP/1.1, i.e. with prior knowledge
+          (https://www.rfc-editor.org/rfc/rfc7540#section-3.4). If the implementation
+          does not support this, then it MUST set the "Accepted" condition to "False"
+          for the affected listener with a reason of "UnsupportedProtocol".
+          Implementations MAY also accept HTTP/2 connections with an upgrade from
+          HTTP/1, i.e. without prior knowledge.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec defines the desired state of GRPCRoute.
+            properties:
+              hostnames:
+                description: |-
+                  Hostnames defines a set of hostnames to match against the GRPC
+                  Host header to select a GRPCRoute to process the request. This matches
+                  the RFC 1123 definition of a hostname with 2 notable exceptions:
+
+                  1. IPs are not allowed.
+                  2. A hostname may be prefixed with a wildcard label (`*.`). The wildcard
+                     label MUST appear by itself as the first label.
+
+                  If a hostname is specified by both the Listener and GRPCRoute, there
+                  MUST be at least one intersecting hostname for the GRPCRoute to be
+                  attached to the Listener. For example:
+
+                  * A Listener with `test.example.com` as the hostname matches GRPCRoutes
+                    that have either not specified any hostnames, or have specified at
+                    least one of `test.example.com` or `*.example.com`.
+                  * A Listener with `*.example.com` as the hostname matches GRPCRoutes
+                    that have either not specified any hostnames or have specified at least
+                    one hostname that matches the Listener hostname. For example,
+                    `test.example.com` and `*.example.com` would both match. On the other
+                    hand, `example.com` and `test.example.net` would not match.
+
+                  Hostnames that are prefixed with a wildcard label (`*.`) are interpreted
+                  as a suffix match. That means that a match for `*.example.com` would match
+                  both `test.example.com`, and `foo.test.example.com`, but not `example.com`.
+
+                  If both the Listener and GRPCRoute have specified hostnames, any
+                  GRPCRoute hostnames that do not match the Listener hostname MUST be
+                  ignored. For example, if a Listener specified `*.example.com`, and the
+                  GRPCRoute specified `test.example.com` and `test.example.net`,
+                  `test.example.net` MUST NOT be considered for a match.
+
+                  If both the Listener and GRPCRoute have specified hostnames, and none
+                  match with the criteria above, then the GRPCRoute MUST NOT be accepted by
+                  the implementation. The implementation MUST raise an 'Accepted' Condition
+                  with a status of `False` in the corresponding RouteParentStatus.
+
+                  If a Route (A) of type HTTPRoute or GRPCRoute is attached to a
+                  Listener and that listener already has another Route (B) of the other
+                  type attached and the intersection of the hostnames of A and B is
+                  non-empty, then the implementation MUST accept exactly one of these two
+                  routes, determined by the following criteria, in order:
+
+                  * The oldest Route based on creation timestamp.
+                  * The Route appearing first in alphabetical order by
+                    "{namespace}/{name}".
+
+                  The rejected Route MUST raise an 'Accepted' condition with a status of
+                  'False' in the corresponding RouteParentStatus.
+
+                  Support: Core
+                items:
+                  description: |-
+                    Hostname is the fully qualified domain name of a network host. This matches
+                    the RFC 1123 definition of a hostname with 2 notable exceptions:
+
+                     1. IPs are not allowed.
+                     2. A hostname may be prefixed with a wildcard label (`*.`). The wildcard
+                        label must appear by itself as the first label.
+
+                    Hostname can be "precise" which is a domain name without the terminating
+                    dot of a network host (e.g. "foo.example.com") or "wildcard", which is a
+                    domain name prefixed with a single wildcard label (e.g. `*.example.com`).
+
+                    Note that as per RFC1035 and RFC1123, a *label* must consist of lower case
+                    alphanumeric characters or '-', and must start and end with an alphanumeric
+                    character. No other punctuation is allowed.
+                  maxLength: 253
+                  minLength: 1
+                  pattern: ^(\*\.)?[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                  type: string
+                maxItems: 16
+                type: array
+              parentRefs:
+                description: |+
+                  ParentRefs references the resources (usually Gateways) that a Route wants
+                  to be attached to. Note that the referenced parent resource needs to
+                  allow this for the attachment to be complete. For Gateways, that means
+                  the Gateway needs to allow attachment from Routes of this kind and
+                  namespace. For Services, that means the Service must either be in the same
+                  namespace for a "producer" route, or the mesh implementation must support
+                  and allow "consumer" routes for the referenced Service. ReferenceGrant is
+                  not applicable for governing ParentRefs to Services - it is not possible to
+                  create a "producer" route for a Service in a different namespace from the
+                  Route.
+
+                  There are two kinds of parent resources with "Core" support:
+
+                  * Gateway (Gateway conformance profile)
+                  * Service (Mesh conformance profile, ClusterIP Services only)
+
+                  This API may be extended in the future to support additional kinds of parent
+                  resources.
+
+                  ParentRefs must be _distinct_. This means either that:
+
+                  * They select different objects.  If this is the case, then parentRef
+                    entries are distinct. In terms of fields, this means that the
+                    multi-part key defined by `group`, `kind`, `namespace`, and `name` must
+                    be unique across all parentRef entries in the Route.
+                  * They do not select different objects, but for each optional field used,
+                    each ParentRef that selects the same object must set the same set of
+                    optional fields to different values. If one ParentRef sets a
+                    combination of optional fields, all must set the same combination.
+
+                  Some examples:
+
+                  * If one ParentRef sets `sectionName`, all ParentRefs referencing the
+                    same object must also set `sectionName`.
+                  * If one ParentRef sets `port`, all ParentRefs referencing the same
+                    object must also set `port`.
+                  * If one ParentRef sets `sectionName` and `port`, all ParentRefs
+                    referencing the same object must also set `sectionName` and `port`.
+
+                  It is possible to separately reference multiple distinct objects that may
+                  be collapsed by an implementation. For example, some implementations may
+                  choose to merge compatible Gateway Listeners together. If that is the
+                  case, the list of routes attached to those resources should also be
+                  merged.
+
+                  Note that for ParentRefs that cross namespace boundaries, there are specific
+                  rules. Cross-namespace references are only valid if they are explicitly
+                  allowed by something in the namespace they are referring to. For example,
+                  Gateway has the AllowedRoutes field, and ReferenceGrant provides a
+                  generic way to enable other kinds of cross-namespace reference.
+
+
+
+
+
+
+                items:
+                  description: |-
+                    ParentReference identifies an API object (usually a Gateway) that can be considered
+                    a parent of this resource (usually a route). There are two kinds of parent resources
+                    with "Core" support:
+
+                    * Gateway (Gateway conformance profile)
+                    * Service (Mesh conformance profile, ClusterIP Services only)
+
+                    This API may be extended in the future to support additional kinds of parent
+                    resources.
+
+                    The API object must be valid in the cluster; the Group and Kind must
+                    be registered in the cluster for this reference to be valid.
+                  properties:
+                    group:
+                      default: gateway.networking.k8s.io
+                      description: |-
+                        Group is the group of the referent.
+                        When unspecified, "gateway.networking.k8s.io" is inferred.
+                        To set the core API group (such as for a "Service" kind referent),
+                        Group must be explicitly set to "" (empty string).
+
+                        Support: Core
+                      maxLength: 253
+                      pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                      type: string
+                    kind:
+                      default: Gateway
+                      description: |-
+                        Kind is kind of the referent.
+
+                        There are two kinds of parent resources with "Core" support:
+
+                        * Gateway (Gateway conformance profile)
+                        * Service (Mesh conformance profile, ClusterIP Services only)
+
+                        Support for other resources is Implementation-Specific.
+                      maxLength: 63
+                      minLength: 1
+                      pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                      type: string
+                    name:
+                      description: |-
+                        Name is the name of the referent.
+
+                        Support: Core
+                      maxLength: 253
+                      minLength: 1
+                      type: string
+                    namespace:
+                      description: |-
+                        Namespace is the namespace of the referent. When unspecified, this refers
+                        to the local namespace of the Route.
+
+                        Note that there are specific rules for ParentRefs which cross namespace
+                        boundaries. Cross-namespace references are only valid if they are explicitly
+                        allowed by something in the namespace they are referring to. For example:
+                        Gateway has the AllowedRoutes field, and ReferenceGrant provides a
+                        generic way to enable any other kind of cross-namespace reference.
+
+
+
+                        Support: Core
+                      maxLength: 63
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                      type: string
+                    port:
+                      description: |-
+                        Port is the network port this Route targets. It can be interpreted
+                        differently based on the type of parent resource.
+
+                        When the parent resource is a Gateway, this targets all listeners
+                        listening on the specified port that also support this kind of Route(and
+                        select this Route). It's not recommended to set `Port` unless the
+                        networking behaviors specified in a Route must apply to a specific port
+                        as opposed to a listener(s) whose port(s) may be changed. When both Port
+                        and SectionName are specified, the name and port of the selected listener
+                        must match both specified values.
+
+
+
+                        Implementations MAY choose to support other parent resources.
+                        Implementations supporting other types of parent resources MUST clearly
+                        document how/if Port is interpreted.
+
+                        For the purpose of status, an attachment is considered successful as
+                        long as the parent resource accepts it partially. For example, Gateway
+                        listeners can restrict which Routes can attach to them by Route kind,
+                        namespace, or hostname. If 1 of 2 Gateway listeners accept attachment
+                        from the referencing Route, the Route MUST be considered successfully
+                        attached. If no Gateway listeners accept attachment from this Route,
+                        the Route MUST be considered detached from the Gateway.
+
+                        Support: Extended
+                      format: int32
+                      maximum: 65535
+                      minimum: 1
+                      type: integer
+                    sectionName:
+                      description: |-
+                        SectionName is the name of a section within the target resource. In the
+                        following resources, SectionName is interpreted as the following:
+
+                        * Gateway: Listener name. When both Port (experimental) and SectionName
+                        are specified, the name and port of the selected listener must match
+                        both specified values.
+                        * Service: Port name. When both Port (experimental) and SectionName
+                        are specified, the name and port of the selected listener must match
+                        both specified values.
+
+                        Implementations MAY choose to support attaching Routes to other resources.
+                        If that is the case, they MUST clearly document how SectionName is
+                        interpreted.
+
+                        When unspecified (empty string), this will reference the entire resource.
+                        For the purpose of status, an attachment is considered successful if at
+                        least one section in the parent resource accepts it. For example, Gateway
+                        listeners can restrict which Routes can attach to them by Route kind,
+                        namespace, or hostname. If 1 of 2 Gateway listeners accept attachment from
+                        the referencing Route, the Route MUST be considered successfully
+                        attached. If no Gateway listeners accept attachment from this Route, the
+                        Route MUST be considered detached from the Gateway.
+
+                        Support: Core
+                      maxLength: 253
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                      type: string
+                  required:
+                  - name
+                  type: object
+                maxItems: 32
+                type: array
+                x-kubernetes-validations:
+                - message: sectionName must be specified when parentRefs includes
+                    2 or more references to the same parent
+                  rule: 'self.all(p1, self.all(p2, p1.group == p2.group && p1.kind
+                    == p2.kind && p1.name == p2.name && (((!has(p1.__namespace__)
+                    || p1.__namespace__ == '''') && (!has(p2.__namespace__) || p2.__namespace__
+                    == '''')) || (has(p1.__namespace__) && has(p2.__namespace__) &&
+                    p1.__namespace__ == p2.__namespace__ )) ? ((!has(p1.sectionName)
+                    || p1.sectionName == '''') == (!has(p2.sectionName) || p2.sectionName
+                    == '''')) : true))'
+                - message: sectionName must be unique when parentRefs includes 2 or
+                    more references to the same parent
+                  rule: self.all(p1, self.exists_one(p2, p1.group == p2.group && p1.kind
+                    == p2.kind && p1.name == p2.name && (((!has(p1.__namespace__)
+                    || p1.__namespace__ == '') && (!has(p2.__namespace__) || p2.__namespace__
+                    == '')) || (has(p1.__namespace__) && has(p2.__namespace__) &&
+                    p1.__namespace__ == p2.__namespace__ )) && (((!has(p1.sectionName)
+                    || p1.sectionName == '') && (!has(p2.sectionName) || p2.sectionName
+                    == '')) || (has(p1.sectionName) && has(p2.sectionName) && p1.sectionName
+                    == p2.sectionName))))
+              rules:
+                description: |+
+                  Rules are a list of GRPC matchers, filters and actions.
+
+                items:
+                  description: |-
+                    GRPCRouteRule defines the semantics for matching a gRPC request based on
+                    conditions (matches), processing it (filters), and forwarding the request to
+                    an API object (backendRefs).
+                  properties:
+                    backendRefs:
+                      description: |-
+                        BackendRefs defines the backend(s) where matching requests should be
+                        sent.
+
+                        Failure behavior here depends on how many BackendRefs are specified and
+                        how many are invalid.
+
+                        If *all* entries in BackendRefs are invalid, and there are also no filters
+                        specified in this route rule, *all* traffic which matches this rule MUST
+                        receive an `UNAVAILABLE` status.
+
+                        See the GRPCBackendRef definition for the rules about what makes a single
+                        GRPCBackendRef invalid.
+
+                        When a GRPCBackendRef is invalid, `UNAVAILABLE` statuses MUST be returned for
+                        requests that would have otherwise been routed to an invalid backend. If
+                        multiple backends are specified, and some are invalid, the proportion of
+                        requests that would otherwise have been routed to an invalid backend
+                        MUST receive an `UNAVAILABLE` status.
+
+                        For example, if two backends are specified with equal weights, and one is
+                        invalid, 50 percent of traffic MUST receive an `UNAVAILABLE` status.
+                        Implementations may choose how that 50 percent is determined.
+
+                        Support: Core for Kubernetes Service
+
+                        Support: Implementation-specific for any other resource
+
+                        Support for weight: Core
+                      items:
+                        description: |-
+                          GRPCBackendRef defines how a GRPCRoute forwards a gRPC request.
+
+                          Note that when a namespace different than the local namespace is specified, a
+                          ReferenceGrant object is required in the referent namespace to allow that
+                          namespace's owner to accept the reference. See the ReferenceGrant
+                          documentation for details.
+
+                          <gateway:experimental:description>
+
+                          When the BackendRef points to a Kubernetes Service, implementations SHOULD
+                          honor the appProtocol field if it is set for the target Service Port.
+
+                          Implementations supporting appProtocol SHOULD recognize the Kubernetes
+                          Standard Application Protocols defined in KEP-3726.
+
+                          If a Service appProtocol isn't specified, an implementation MAY infer the
+                          backend protocol through its own means. Implementations MAY infer the
+                          protocol from the Route type referring to the backend Service.
+
+                          If a Route is not able to send traffic to the backend using the specified
+                          protocol then the backend is considered invalid. Implementations MUST set the
+                          "ResolvedRefs" condition to "False" with the "UnsupportedProtocol" reason.
+
+                          </gateway:experimental:description>
+                        properties:
+                          filters:
+                            description: |-
+                              Filters defined at this level MUST be executed if and only if the
+                              request is being forwarded to the backend defined here.
+
+                              Support: Implementation-specific (For broader support of filters, use the
+                              Filters field in GRPCRouteRule.)
+                            items:
+                              description: |-
+                                GRPCRouteFilter defines processing steps that must be completed during the
+                                request or response lifecycle. GRPCRouteFilters are meant as an extension
+                                point to express processing that may be done in Gateway implementations. Some
+                                examples include request or response modification, implementing
+                                authentication strategies, rate-limiting, and traffic shaping. API
+                                guarantee/conformance is defined based on the type of the filter.
+                              properties:
+                                extensionRef:
+                                  description: |-
+                                    ExtensionRef is an optional, implementation-specific extension to the
+                                    "filter" behavior.  For example, resource "myroutefilter" in group
+                                    "networking.example.net"). ExtensionRef MUST NOT be used for core and
+                                    extended filters.
+
+                                    Support: Implementation-specific
+
+                                    This filter can be used multiple times within the same rule.
+                                  properties:
+                                    group:
+                                      description: |-
+                                        Group is the group of the referent. For example, "gateway.networking.k8s.io".
+                                        When unspecified or empty string, core API group is inferred.
+                                      maxLength: 253
+                                      pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    kind:
+                                      description: Kind is kind of the referent. For
+                                        example "HTTPRoute" or "Service".
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                                      type: string
+                                    name:
+                                      description: Name is the name of the referent.
+                                      maxLength: 253
+                                      minLength: 1
+                                      type: string
+                                  required:
+                                  - group
+                                  - kind
+                                  - name
+                                  type: object
+                                requestHeaderModifier:
+                                  description: |-
+                                    RequestHeaderModifier defines a schema for a filter that modifies request
+                                    headers.
+
+                                    Support: Core
+                                  properties:
+                                    add:
+                                      description: |-
+                                        Add adds the given header(s) (name, value) to the request
+                                        before the action. It appends to any existing values associated
+                                        with the header name.
+
+                                        Input:
+                                          GET /foo HTTP/1.1
+                                          my-header: foo
+
+                                        Config:
+                                          add:
+                                          - name: "my-header"
+                                            value: "bar,baz"
+
+                                        Output:
+                                          GET /foo HTTP/1.1
+                                          my-header: foo,bar,baz
+                                      items:
+                                        description: HTTPHeader represents an HTTP
+                                          Header name and value as defined by RFC
+                                          7230.
+                                        properties:
+                                          name:
+                                            description: |-
+                                              Name is the name of the HTTP Header to be matched. Name matching MUST be
+                                              case insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
+
+                                              If multiple entries specify equivalent header names, the first entry with
+                                              an equivalent name MUST be considered for a match. Subsequent entries
+                                              with an equivalent header name MUST be ignored. Due to the
+                                              case-insensitivity of header names, "foo" and "Foo" are considered
+                                              equivalent.
+                                            maxLength: 256
+                                            minLength: 1
+                                            pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                            type: string
+                                          value:
+                                            description: Value is the value of HTTP
+                                              Header to be matched.
+                                            maxLength: 4096
+                                            minLength: 1
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                        type: object
+                                      maxItems: 16
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                      - name
+                                      x-kubernetes-list-type: map
+                                    remove:
+                                      description: |-
+                                        Remove the given header(s) from the HTTP request before the action. The
+                                        value of Remove is a list of HTTP header names. Note that the header
+                                        names are case-insensitive (see
+                                        https://datatracker.ietf.org/doc/html/rfc2616#section-4.2).
+
+                                        Input:
+                                          GET /foo HTTP/1.1
+                                          my-header1: foo
+                                          my-header2: bar
+                                          my-header3: baz
+
+                                        Config:
+                                          remove: ["my-header1", "my-header3"]
+
+                                        Output:
+                                          GET /foo HTTP/1.1
+                                          my-header2: bar
+                                      items:
+                                        type: string
+                                      maxItems: 16
+                                      type: array
+                                      x-kubernetes-list-type: set
+                                    set:
+                                      description: |-
+                                        Set overwrites the request with the given header (name, value)
+                                        before the action.
+
+                                        Input:
+                                          GET /foo HTTP/1.1
+                                          my-header: foo
+
+                                        Config:
+                                          set:
+                                          - name: "my-header"
+                                            value: "bar"
+
+                                        Output:
+                                          GET /foo HTTP/1.1
+                                          my-header: bar
+                                      items:
+                                        description: HTTPHeader represents an HTTP
+                                          Header name and value as defined by RFC
+                                          7230.
+                                        properties:
+                                          name:
+                                            description: |-
+                                              Name is the name of the HTTP Header to be matched. Name matching MUST be
+                                              case insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
+
+                                              If multiple entries specify equivalent header names, the first entry with
+                                              an equivalent name MUST be considered for a match. Subsequent entries
+                                              with an equivalent header name MUST be ignored. Due to the
+                                              case-insensitivity of header names, "foo" and "Foo" are considered
+                                              equivalent.
+                                            maxLength: 256
+                                            minLength: 1
+                                            pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                            type: string
+                                          value:
+                                            description: Value is the value of HTTP
+                                              Header to be matched.
+                                            maxLength: 4096
+                                            minLength: 1
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                        type: object
+                                      maxItems: 16
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                      - name
+                                      x-kubernetes-list-type: map
+                                  type: object
+                                requestMirror:
+                                  description: |+
+                                    RequestMirror defines a schema for a filter that mirrors requests.
+                                    Requests are sent to the specified destination, but responses from
+                                    that destination are ignored.
+
+                                    This filter can be used multiple times within the same rule. Note that
+                                    not all implementations will be able to support mirroring to multiple
+                                    backends.
+
+                                    Support: Extended
+
+                                  properties:
+                                    backendRef:
+                                      description: |-
+                                        BackendRef references a resource where mirrored requests are sent.
+
+                                        Mirrored requests must be sent only to a single destination endpoint
+                                        within this BackendRef, irrespective of how many endpoints are present
+                                        within this BackendRef.
+
+                                        If the referent cannot be found, this BackendRef is invalid and must be
+                                        dropped from the Gateway. The controller must ensure the "ResolvedRefs"
+                                        condition on the Route status is set to `status: False` and not configure
+                                        this backend in the underlying implementation.
+
+                                        If there is a cross-namespace reference to an *existing* object
+                                        that is not allowed by a ReferenceGrant, the controller must ensure the
+                                        "ResolvedRefs"  condition on the Route is set to `status: False`,
+                                        with the "RefNotPermitted" reason and not configure this backend in the
+                                        underlying implementation.
+
+                                        In either error case, the Message of the `ResolvedRefs` Condition
+                                        should be used to provide more detail about the problem.
+
+                                        Support: Extended for Kubernetes Service
+
+                                        Support: Implementation-specific for any other resource
+                                      properties:
+                                        group:
+                                          default: ""
+                                          description: |-
+                                            Group is the group of the referent. For example, "gateway.networking.k8s.io".
+                                            When unspecified or empty string, core API group is inferred.
+                                          maxLength: 253
+                                          pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                          type: string
+                                        kind:
+                                          default: Service
+                                          description: |-
+                                            Kind is the Kubernetes resource kind of the referent. For example
+                                            "Service".
+
+                                            Defaults to "Service" when not specified.
+
+                                            ExternalName services can refer to CNAME DNS records that may live
+                                            outside of the cluster and as such are difficult to reason about in
+                                            terms of conformance. They also may not be safe to forward to (see
+                                            CVE-2021-25740 for more information). Implementations SHOULD NOT
+                                            support ExternalName Services.
+
+                                            Support: Core (Services with a type other than ExternalName)
+
+                                            Support: Implementation-specific (Services with type ExternalName)
+                                          maxLength: 63
+                                          minLength: 1
+                                          pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                                          type: string
+                                        name:
+                                          description: Name is the name of the referent.
+                                          maxLength: 253
+                                          minLength: 1
+                                          type: string
+                                        namespace:
+                                          description: |-
+                                            Namespace is the namespace of the backend. When unspecified, the local
+                                            namespace is inferred.
+
+                                            Note that when a namespace different than the local namespace is specified,
+                                            a ReferenceGrant object is required in the referent namespace to allow that
+                                            namespace's owner to accept the reference. See the ReferenceGrant
+                                            documentation for details.
+
+                                            Support: Core
+                                          maxLength: 63
+                                          minLength: 1
+                                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                          type: string
+                                        port:
+                                          description: |-
+                                            Port specifies the destination port number to use for this resource.
+                                            Port is required when the referent is a Kubernetes Service. In this
+                                            case, the port number is the service port number, not the target port.
+                                            For other resources, destination port might be derived from the referent
+                                            resource or this field.
+                                          format: int32
+                                          maximum: 65535
+                                          minimum: 1
+                                          type: integer
+                                      required:
+                                      - name
+                                      type: object
+                                      x-kubernetes-validations:
+                                      - message: Must have port for Service reference
+                                        rule: '(size(self.group) == 0 && self.kind
+                                          == ''Service'') ? has(self.port) : true'
+                                  required:
+                                  - backendRef
+                                  type: object
+                                responseHeaderModifier:
+                                  description: |-
+                                    ResponseHeaderModifier defines a schema for a filter that modifies response
+                                    headers.
+
+                                    Support: Extended
+                                  properties:
+                                    add:
+                                      description: |-
+                                        Add adds the given header(s) (name, value) to the request
+                                        before the action. It appends to any existing values associated
+                                        with the header name.
+
+                                        Input:
+                                          GET /foo HTTP/1.1
+                                          my-header: foo
+
+                                        Config:
+                                          add:
+                                          - name: "my-header"
+                                            value: "bar,baz"
+
+                                        Output:
+                                          GET /foo HTTP/1.1
+                                          my-header: foo,bar,baz
+                                      items:
+                                        description: HTTPHeader represents an HTTP
+                                          Header name and value as defined by RFC
+                                          7230.
+                                        properties:
+                                          name:
+                                            description: |-
+                                              Name is the name of the HTTP Header to be matched. Name matching MUST be
+                                              case insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
+
+                                              If multiple entries specify equivalent header names, the first entry with
+                                              an equivalent name MUST be considered for a match. Subsequent entries
+                                              with an equivalent header name MUST be ignored. Due to the
+                                              case-insensitivity of header names, "foo" and "Foo" are considered
+                                              equivalent.
+                                            maxLength: 256
+                                            minLength: 1
+                                            pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                            type: string
+                                          value:
+                                            description: Value is the value of HTTP
+                                              Header to be matched.
+                                            maxLength: 4096
+                                            minLength: 1
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                        type: object
+                                      maxItems: 16
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                      - name
+                                      x-kubernetes-list-type: map
+                                    remove:
+                                      description: |-
+                                        Remove the given header(s) from the HTTP request before the action. The
+                                        value of Remove is a list of HTTP header names. Note that the header
+                                        names are case-insensitive (see
+                                        https://datatracker.ietf.org/doc/html/rfc2616#section-4.2).
+
+                                        Input:
+                                          GET /foo HTTP/1.1
+                                          my-header1: foo
+                                          my-header2: bar
+                                          my-header3: baz
+
+                                        Config:
+                                          remove: ["my-header1", "my-header3"]
+
+                                        Output:
+                                          GET /foo HTTP/1.1
+                                          my-header2: bar
+                                      items:
+                                        type: string
+                                      maxItems: 16
+                                      type: array
+                                      x-kubernetes-list-type: set
+                                    set:
+                                      description: |-
+                                        Set overwrites the request with the given header (name, value)
+                                        before the action.
+
+                                        Input:
+                                          GET /foo HTTP/1.1
+                                          my-header: foo
+
+                                        Config:
+                                          set:
+                                          - name: "my-header"
+                                            value: "bar"
+
+                                        Output:
+                                          GET /foo HTTP/1.1
+                                          my-header: bar
+                                      items:
+                                        description: HTTPHeader represents an HTTP
+                                          Header name and value as defined by RFC
+                                          7230.
+                                        properties:
+                                          name:
+                                            description: |-
+                                              Name is the name of the HTTP Header to be matched. Name matching MUST be
+                                              case insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
+
+                                              If multiple entries specify equivalent header names, the first entry with
+                                              an equivalent name MUST be considered for a match. Subsequent entries
+                                              with an equivalent header name MUST be ignored. Due to the
+                                              case-insensitivity of header names, "foo" and "Foo" are considered
+                                              equivalent.
+                                            maxLength: 256
+                                            minLength: 1
+                                            pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                            type: string
+                                          value:
+                                            description: Value is the value of HTTP
+                                              Header to be matched.
+                                            maxLength: 4096
+                                            minLength: 1
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                        type: object
+                                      maxItems: 16
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                      - name
+                                      x-kubernetes-list-type: map
+                                  type: object
+                                type:
+                                  description: |+
+                                    Type identifies the type of filter to apply. As with other API fields,
+                                    types are classified into three conformance levels:
+
+                                    - Core: Filter types and their corresponding configuration defined by
+                                      "Support: Core" in this package, e.g. "RequestHeaderModifier". All
+                                      implementations supporting GRPCRoute MUST support core filters.
+
+                                    - Extended: Filter types and their corresponding configuration defined by
+                                      "Support: Extended" in this package, e.g. "RequestMirror". Implementers
+                                      are encouraged to support extended filters.
+
+                                    - Implementation-specific: Filters that are defined and supported by specific vendors.
+                                      In the future, filters showing convergence in behavior across multiple
+                                      implementations will be considered for inclusion in extended or core
+                                      conformance levels. Filter-specific configuration for such filters
+                                      is specified using the ExtensionRef field. `Type` MUST be set to
+                                      "ExtensionRef" for custom filters.
+
+                                    Implementers are encouraged to define custom implementation types to
+                                    extend the core API with implementation-specific behavior.
+
+                                    If a reference to a custom filter type cannot be resolved, the filter
+                                    MUST NOT be skipped. Instead, requests that would have been processed by
+                                    that filter MUST receive a HTTP error response.
+
+                                  enum:
+                                  - ResponseHeaderModifier
+                                  - RequestHeaderModifier
+                                  - RequestMirror
+                                  - ExtensionRef
+                                  type: string
+                              required:
+                              - type
+                              type: object
+                              x-kubernetes-validations:
+                              - message: filter.requestHeaderModifier must be nil
+                                  if the filter.type is not RequestHeaderModifier
+                                rule: '!(has(self.requestHeaderModifier) && self.type
+                                  != ''RequestHeaderModifier'')'
+                              - message: filter.requestHeaderModifier must be specified
+                                  for RequestHeaderModifier filter.type
+                                rule: '!(!has(self.requestHeaderModifier) && self.type
+                                  == ''RequestHeaderModifier'')'
+                              - message: filter.responseHeaderModifier must be nil
+                                  if the filter.type is not ResponseHeaderModifier
+                                rule: '!(has(self.responseHeaderModifier) && self.type
+                                  != ''ResponseHeaderModifier'')'
+                              - message: filter.responseHeaderModifier must be specified
+                                  for ResponseHeaderModifier filter.type
+                                rule: '!(!has(self.responseHeaderModifier) && self.type
+                                  == ''ResponseHeaderModifier'')'
+                              - message: filter.requestMirror must be nil if the filter.type
+                                  is not RequestMirror
+                                rule: '!(has(self.requestMirror) && self.type != ''RequestMirror'')'
+                              - message: filter.requestMirror must be specified for
+                                  RequestMirror filter.type
+                                rule: '!(!has(self.requestMirror) && self.type ==
+                                  ''RequestMirror'')'
+                              - message: filter.extensionRef must be nil if the filter.type
+                                  is not ExtensionRef
+                                rule: '!(has(self.extensionRef) && self.type != ''ExtensionRef'')'
+                              - message: filter.extensionRef must be specified for
+                                  ExtensionRef filter.type
+                                rule: '!(!has(self.extensionRef) && self.type == ''ExtensionRef'')'
+                            maxItems: 16
+                            type: array
+                            x-kubernetes-validations:
+                            - message: RequestHeaderModifier filter cannot be repeated
+                              rule: self.filter(f, f.type == 'RequestHeaderModifier').size()
+                                <= 1
+                            - message: ResponseHeaderModifier filter cannot be repeated
+                              rule: self.filter(f, f.type == 'ResponseHeaderModifier').size()
+                                <= 1
+                          group:
+                            default: ""
+                            description: |-
+                              Group is the group of the referent. For example, "gateway.networking.k8s.io".
+                              When unspecified or empty string, core API group is inferred.
+                            maxLength: 253
+                            pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                            type: string
+                          kind:
+                            default: Service
+                            description: |-
+                              Kind is the Kubernetes resource kind of the referent. For example
+                              "Service".
+
+                              Defaults to "Service" when not specified.
+
+                              ExternalName services can refer to CNAME DNS records that may live
+                              outside of the cluster and as such are difficult to reason about in
+                              terms of conformance. They also may not be safe to forward to (see
+                              CVE-2021-25740 for more information). Implementations SHOULD NOT
+                              support ExternalName Services.
+
+                              Support: Core (Services with a type other than ExternalName)
+
+                              Support: Implementation-specific (Services with type ExternalName)
+                            maxLength: 63
+                            minLength: 1
+                            pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                            type: string
+                          name:
+                            description: Name is the name of the referent.
+                            maxLength: 253
+                            minLength: 1
+                            type: string
+                          namespace:
+                            description: |-
+                              Namespace is the namespace of the backend. When unspecified, the local
+                              namespace is inferred.
+
+                              Note that when a namespace different than the local namespace is specified,
+                              a ReferenceGrant object is required in the referent namespace to allow that
+                              namespace's owner to accept the reference. See the ReferenceGrant
+                              documentation for details.
+
+                              Support: Core
+                            maxLength: 63
+                            minLength: 1
+                            pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                            type: string
+                          port:
+                            description: |-
+                              Port specifies the destination port number to use for this resource.
+                              Port is required when the referent is a Kubernetes Service. In this
+                              case, the port number is the service port number, not the target port.
+                              For other resources, destination port might be derived from the referent
+                              resource or this field.
+                            format: int32
+                            maximum: 65535
+                            minimum: 1
+                            type: integer
+                          weight:
+                            default: 1
+                            description: |-
+                              Weight specifies the proportion of requests forwarded to the referenced
+                              backend. This is computed as weight/(sum of all weights in this
+                              BackendRefs list). For non-zero values, there may be some epsilon from
+                              the exact proportion defined here depending on the precision an
+                              implementation supports. Weight is not a percentage and the sum of
+                              weights does not need to equal 100.
+
+                              If only one backend is specified and it has a weight greater than 0, 100%
+                              of the traffic is forwarded to that backend. If weight is set to 0, no
+                              traffic should be forwarded for this entry. If unspecified, weight
+                              defaults to 1.
+
+                              Support for this field varies based on the context where used.
+                            format: int32
+                            maximum: 1000000
+                            minimum: 0
+                            type: integer
+                        required:
+                        - name
+                        type: object
+                        x-kubernetes-validations:
+                        - message: Must have port for Service reference
+                          rule: '(size(self.group) == 0 && self.kind == ''Service'')
+                            ? has(self.port) : true'
+                      maxItems: 16
+                      type: array
+                    filters:
+                      description: |-
+                        Filters define the filters that are applied to requests that match
+                        this rule.
+
+                        The effects of ordering of multiple behaviors are currently unspecified.
+                        This can change in the future based on feedback during the alpha stage.
+
+                        Conformance-levels at this level are defined based on the type of filter:
+
+                        - ALL core filters MUST be supported by all implementations that support
+                          GRPCRoute.
+                        - Implementers are encouraged to support extended filters.
+                        - Implementation-specific custom filters have no API guarantees across
+                          implementations.
+
+                        Specifying the same filter multiple times is not supported unless explicitly
+                        indicated in the filter.
+
+                        If an implementation can not support a combination of filters, it must clearly
+                        document that limitation. In cases where incompatible or unsupported
+                        filters are specified and cause the `Accepted` condition to be set to status
+                        `False`, implementations may use the `IncompatibleFilters` reason to specify
+                        this configuration error.
+
+                        Support: Core
+                      items:
+                        description: |-
+                          GRPCRouteFilter defines processing steps that must be completed during the
+                          request or response lifecycle. GRPCRouteFilters are meant as an extension
+                          point to express processing that may be done in Gateway implementations. Some
+                          examples include request or response modification, implementing
+                          authentication strategies, rate-limiting, and traffic shaping. API
+                          guarantee/conformance is defined based on the type of the filter.
+                        properties:
+                          extensionRef:
+                            description: |-
+                              ExtensionRef is an optional, implementation-specific extension to the
+                              "filter" behavior.  For example, resource "myroutefilter" in group
+                              "networking.example.net"). ExtensionRef MUST NOT be used for core and
+                              extended filters.
+
+                              Support: Implementation-specific
+
+                              This filter can be used multiple times within the same rule.
+                            properties:
+                              group:
+                                description: |-
+                                  Group is the group of the referent. For example, "gateway.networking.k8s.io".
+                                  When unspecified or empty string, core API group is inferred.
+                                maxLength: 253
+                                pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                type: string
+                              kind:
+                                description: Kind is kind of the referent. For example
+                                  "HTTPRoute" or "Service".
+                                maxLength: 63
+                                minLength: 1
+                                pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                                type: string
+                              name:
+                                description: Name is the name of the referent.
+                                maxLength: 253
+                                minLength: 1
+                                type: string
+                            required:
+                            - group
+                            - kind
+                            - name
+                            type: object
+                          requestHeaderModifier:
+                            description: |-
+                              RequestHeaderModifier defines a schema for a filter that modifies request
+                              headers.
+
+                              Support: Core
+                            properties:
+                              add:
+                                description: |-
+                                  Add adds the given header(s) (name, value) to the request
+                                  before the action. It appends to any existing values associated
+                                  with the header name.
+
+                                  Input:
+                                    GET /foo HTTP/1.1
+                                    my-header: foo
+
+                                  Config:
+                                    add:
+                                    - name: "my-header"
+                                      value: "bar,baz"
+
+                                  Output:
+                                    GET /foo HTTP/1.1
+                                    my-header: foo,bar,baz
+                                items:
+                                  description: HTTPHeader represents an HTTP Header
+                                    name and value as defined by RFC 7230.
+                                  properties:
+                                    name:
+                                      description: |-
+                                        Name is the name of the HTTP Header to be matched. Name matching MUST be
+                                        case insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
+
+                                        If multiple entries specify equivalent header names, the first entry with
+                                        an equivalent name MUST be considered for a match. Subsequent entries
+                                        with an equivalent header name MUST be ignored. Due to the
+                                        case-insensitivity of header names, "foo" and "Foo" are considered
+                                        equivalent.
+                                      maxLength: 256
+                                      minLength: 1
+                                      pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                      type: string
+                                    value:
+                                      description: Value is the value of HTTP Header
+                                        to be matched.
+                                      maxLength: 4096
+                                      minLength: 1
+                                      type: string
+                                  required:
+                                  - name
+                                  - value
+                                  type: object
+                                maxItems: 16
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                - name
+                                x-kubernetes-list-type: map
+                              remove:
+                                description: |-
+                                  Remove the given header(s) from the HTTP request before the action. The
+                                  value of Remove is a list of HTTP header names. Note that the header
+                                  names are case-insensitive (see
+                                  https://datatracker.ietf.org/doc/html/rfc2616#section-4.2).
+
+                                  Input:
+                                    GET /foo HTTP/1.1
+                                    my-header1: foo
+                                    my-header2: bar
+                                    my-header3: baz
+
+                                  Config:
+                                    remove: ["my-header1", "my-header3"]
+
+                                  Output:
+                                    GET /foo HTTP/1.1
+                                    my-header2: bar
+                                items:
+                                  type: string
+                                maxItems: 16
+                                type: array
+                                x-kubernetes-list-type: set
+                              set:
+                                description: |-
+                                  Set overwrites the request with the given header (name, value)
+                                  before the action.
+
+                                  Input:
+                                    GET /foo HTTP/1.1
+                                    my-header: foo
+
+                                  Config:
+                                    set:
+                                    - name: "my-header"
+                                      value: "bar"
+
+                                  Output:
+                                    GET /foo HTTP/1.1
+                                    my-header: bar
+                                items:
+                                  description: HTTPHeader represents an HTTP Header
+                                    name and value as defined by RFC 7230.
+                                  properties:
+                                    name:
+                                      description: |-
+                                        Name is the name of the HTTP Header to be matched. Name matching MUST be
+                                        case insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
+
+                                        If multiple entries specify equivalent header names, the first entry with
+                                        an equivalent name MUST be considered for a match. Subsequent entries
+                                        with an equivalent header name MUST be ignored. Due to the
+                                        case-insensitivity of header names, "foo" and "Foo" are considered
+                                        equivalent.
+                                      maxLength: 256
+                                      minLength: 1
+                                      pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                      type: string
+                                    value:
+                                      description: Value is the value of HTTP Header
+                                        to be matched.
+                                      maxLength: 4096
+                                      minLength: 1
+                                      type: string
+                                  required:
+                                  - name
+                                  - value
+                                  type: object
+                                maxItems: 16
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                - name
+                                x-kubernetes-list-type: map
+                            type: object
+                          requestMirror:
+                            description: |+
+                              RequestMirror defines a schema for a filter that mirrors requests.
+                              Requests are sent to the specified destination, but responses from
+                              that destination are ignored.
+
+                              This filter can be used multiple times within the same rule. Note that
+                              not all implementations will be able to support mirroring to multiple
+                              backends.
+
+                              Support: Extended
+
+                            properties:
+                              backendRef:
+                                description: |-
+                                  BackendRef references a resource where mirrored requests are sent.
+
+                                  Mirrored requests must be sent only to a single destination endpoint
+                                  within this BackendRef, irrespective of how many endpoints are present
+                                  within this BackendRef.
+
+                                  If the referent cannot be found, this BackendRef is invalid and must be
+                                  dropped from the Gateway. The controller must ensure the "ResolvedRefs"
+                                  condition on the Route status is set to `status: False` and not configure
+                                  this backend in the underlying implementation.
+
+                                  If there is a cross-namespace reference to an *existing* object
+                                  that is not allowed by a ReferenceGrant, the controller must ensure the
+                                  "ResolvedRefs"  condition on the Route is set to `status: False`,
+                                  with the "RefNotPermitted" reason and not configure this backend in the
+                                  underlying implementation.
+
+                                  In either error case, the Message of the `ResolvedRefs` Condition
+                                  should be used to provide more detail about the problem.
+
+                                  Support: Extended for Kubernetes Service
+
+                                  Support: Implementation-specific for any other resource
+                                properties:
+                                  group:
+                                    default: ""
+                                    description: |-
+                                      Group is the group of the referent. For example, "gateway.networking.k8s.io".
+                                      When unspecified or empty string, core API group is inferred.
+                                    maxLength: 253
+                                    pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                    type: string
+                                  kind:
+                                    default: Service
+                                    description: |-
+                                      Kind is the Kubernetes resource kind of the referent. For example
+                                      "Service".
+
+                                      Defaults to "Service" when not specified.
+
+                                      ExternalName services can refer to CNAME DNS records that may live
+                                      outside of the cluster and as such are difficult to reason about in
+                                      terms of conformance. They also may not be safe to forward to (see
+                                      CVE-2021-25740 for more information). Implementations SHOULD NOT
+                                      support ExternalName Services.
+
+                                      Support: Core (Services with a type other than ExternalName)
+
+                                      Support: Implementation-specific (Services with type ExternalName)
+                                    maxLength: 63
+                                    minLength: 1
+                                    pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                                    type: string
+                                  name:
+                                    description: Name is the name of the referent.
+                                    maxLength: 253
+                                    minLength: 1
+                                    type: string
+                                  namespace:
+                                    description: |-
+                                      Namespace is the namespace of the backend. When unspecified, the local
+                                      namespace is inferred.
+
+                                      Note that when a namespace different than the local namespace is specified,
+                                      a ReferenceGrant object is required in the referent namespace to allow that
+                                      namespace's owner to accept the reference. See the ReferenceGrant
+                                      documentation for details.
+
+                                      Support: Core
+                                    maxLength: 63
+                                    minLength: 1
+                                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                    type: string
+                                  port:
+                                    description: |-
+                                      Port specifies the destination port number to use for this resource.
+                                      Port is required when the referent is a Kubernetes Service. In this
+                                      case, the port number is the service port number, not the target port.
+                                      For other resources, destination port might be derived from the referent
+                                      resource or this field.
+                                    format: int32
+                                    maximum: 65535
+                                    minimum: 1
+                                    type: integer
+                                required:
+                                - name
+                                type: object
+                                x-kubernetes-validations:
+                                - message: Must have port for Service reference
+                                  rule: '(size(self.group) == 0 && self.kind == ''Service'')
+                                    ? has(self.port) : true'
+                            required:
+                            - backendRef
+                            type: object
+                          responseHeaderModifier:
+                            description: |-
+                              ResponseHeaderModifier defines a schema for a filter that modifies response
+                              headers.
+
+                              Support: Extended
+                            properties:
+                              add:
+                                description: |-
+                                  Add adds the given header(s) (name, value) to the request
+                                  before the action. It appends to any existing values associated
+                                  with the header name.
+
+                                  Input:
+                                    GET /foo HTTP/1.1
+                                    my-header: foo
+
+                                  Config:
+                                    add:
+                                    - name: "my-header"
+                                      value: "bar,baz"
+
+                                  Output:
+                                    GET /foo HTTP/1.1
+                                    my-header: foo,bar,baz
+                                items:
+                                  description: HTTPHeader represents an HTTP Header
+                                    name and value as defined by RFC 7230.
+                                  properties:
+                                    name:
+                                      description: |-
+                                        Name is the name of the HTTP Header to be matched. Name matching MUST be
+                                        case insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
+
+                                        If multiple entries specify equivalent header names, the first entry with
+                                        an equivalent name MUST be considered for a match. Subsequent entries
+                                        with an equivalent header name MUST be ignored. Due to the
+                                        case-insensitivity of header names, "foo" and "Foo" are considered
+                                        equivalent.
+                                      maxLength: 256
+                                      minLength: 1
+                                      pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                      type: string
+                                    value:
+                                      description: Value is the value of HTTP Header
+                                        to be matched.
+                                      maxLength: 4096
+                                      minLength: 1
+                                      type: string
+                                  required:
+                                  - name
+                                  - value
+                                  type: object
+                                maxItems: 16
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                - name
+                                x-kubernetes-list-type: map
+                              remove:
+                                description: |-
+                                  Remove the given header(s) from the HTTP request before the action. The
+                                  value of Remove is a list of HTTP header names. Note that the header
+                                  names are case-insensitive (see
+                                  https://datatracker.ietf.org/doc/html/rfc2616#section-4.2).
+
+                                  Input:
+                                    GET /foo HTTP/1.1
+                                    my-header1: foo
+                                    my-header2: bar
+                                    my-header3: baz
+
+                                  Config:
+                                    remove: ["my-header1", "my-header3"]
+
+                                  Output:
+                                    GET /foo HTTP/1.1
+                                    my-header2: bar
+                                items:
+                                  type: string
+                                maxItems: 16
+                                type: array
+                                x-kubernetes-list-type: set
+                              set:
+                                description: |-
+                                  Set overwrites the request with the given header (name, value)
+                                  before the action.
+
+                                  Input:
+                                    GET /foo HTTP/1.1
+                                    my-header: foo
+
+                                  Config:
+                                    set:
+                                    - name: "my-header"
+                                      value: "bar"
+
+                                  Output:
+                                    GET /foo HTTP/1.1
+                                    my-header: bar
+                                items:
+                                  description: HTTPHeader represents an HTTP Header
+                                    name and value as defined by RFC 7230.
+                                  properties:
+                                    name:
+                                      description: |-
+                                        Name is the name of the HTTP Header to be matched. Name matching MUST be
+                                        case insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
+
+                                        If multiple entries specify equivalent header names, the first entry with
+                                        an equivalent name MUST be considered for a match. Subsequent entries
+                                        with an equivalent header name MUST be ignored. Due to the
+                                        case-insensitivity of header names, "foo" and "Foo" are considered
+                                        equivalent.
+                                      maxLength: 256
+                                      minLength: 1
+                                      pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                      type: string
+                                    value:
+                                      description: Value is the value of HTTP Header
+                                        to be matched.
+                                      maxLength: 4096
+                                      minLength: 1
+                                      type: string
+                                  required:
+                                  - name
+                                  - value
+                                  type: object
+                                maxItems: 16
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                - name
+                                x-kubernetes-list-type: map
+                            type: object
+                          type:
+                            description: |+
+                              Type identifies the type of filter to apply. As with other API fields,
+                              types are classified into three conformance levels:
+
+                              - Core: Filter types and their corresponding configuration defined by
+                                "Support: Core" in this package, e.g. "RequestHeaderModifier". All
+                                implementations supporting GRPCRoute MUST support core filters.
+
+                              - Extended: Filter types and their corresponding configuration defined by
+                                "Support: Extended" in this package, e.g. "RequestMirror". Implementers
+                                are encouraged to support extended filters.
+
+                              - Implementation-specific: Filters that are defined and supported by specific vendors.
+                                In the future, filters showing convergence in behavior across multiple
+                                implementations will be considered for inclusion in extended or core
+                                conformance levels. Filter-specific configuration for such filters
+                                is specified using the ExtensionRef field. `Type` MUST be set to
+                                "ExtensionRef" for custom filters.
+
+                              Implementers are encouraged to define custom implementation types to
+                              extend the core API with implementation-specific behavior.
+
+                              If a reference to a custom filter type cannot be resolved, the filter
+                              MUST NOT be skipped. Instead, requests that would have been processed by
+                              that filter MUST receive a HTTP error response.
+
+                            enum:
+                            - ResponseHeaderModifier
+                            - RequestHeaderModifier
+                            - RequestMirror
+                            - ExtensionRef
+                            type: string
+                        required:
+                        - type
+                        type: object
+                        x-kubernetes-validations:
+                        - message: filter.requestHeaderModifier must be nil if the
+                            filter.type is not RequestHeaderModifier
+                          rule: '!(has(self.requestHeaderModifier) && self.type !=
+                            ''RequestHeaderModifier'')'
+                        - message: filter.requestHeaderModifier must be specified
+                            for RequestHeaderModifier filter.type
+                          rule: '!(!has(self.requestHeaderModifier) && self.type ==
+                            ''RequestHeaderModifier'')'
+                        - message: filter.responseHeaderModifier must be nil if the
+                            filter.type is not ResponseHeaderModifier
+                          rule: '!(has(self.responseHeaderModifier) && self.type !=
+                            ''ResponseHeaderModifier'')'
+                        - message: filter.responseHeaderModifier must be specified
+                            for ResponseHeaderModifier filter.type
+                          rule: '!(!has(self.responseHeaderModifier) && self.type
+                            == ''ResponseHeaderModifier'')'
+                        - message: filter.requestMirror must be nil if the filter.type
+                            is not RequestMirror
+                          rule: '!(has(self.requestMirror) && self.type != ''RequestMirror'')'
+                        - message: filter.requestMirror must be specified for RequestMirror
+                            filter.type
+                          rule: '!(!has(self.requestMirror) && self.type == ''RequestMirror'')'
+                        - message: filter.extensionRef must be nil if the filter.type
+                            is not ExtensionRef
+                          rule: '!(has(self.extensionRef) && self.type != ''ExtensionRef'')'
+                        - message: filter.extensionRef must be specified for ExtensionRef
+                            filter.type
+                          rule: '!(!has(self.extensionRef) && self.type == ''ExtensionRef'')'
+                      maxItems: 16
+                      type: array
+                      x-kubernetes-validations:
+                      - message: RequestHeaderModifier filter cannot be repeated
+                        rule: self.filter(f, f.type == 'RequestHeaderModifier').size()
+                          <= 1
+                      - message: ResponseHeaderModifier filter cannot be repeated
+                        rule: self.filter(f, f.type == 'ResponseHeaderModifier').size()
+                          <= 1
+                    matches:
+                      description: |-
+                        Matches define conditions used for matching the rule against incoming
+                        gRPC requests. Each match is independent, i.e. this rule will be matched
+                        if **any** one of the matches is satisfied.
+
+                        For example, take the following matches configuration:
+
+                        ```
+                        matches:
+                        - method:
+                            service: foo.bar
+                          headers:
+                            values:
+                              version: 2
+                        - method:
+                            service: foo.bar.v2
+                        ```
+
+                        For a request to match against this rule, it MUST satisfy
+                        EITHER of the two conditions:
+
+                        - service of foo.bar AND contains the header `version: 2`
+                        - service of foo.bar.v2
+
+                        See the documentation for GRPCRouteMatch on how to specify multiple
+                        match conditions to be ANDed together.
+
+                        If no matches are specified, the implementation MUST match every gRPC request.
+
+                        Proxy or Load Balancer routing configuration generated from GRPCRoutes
+                        MUST prioritize rules based on the following criteria, continuing on
+                        ties. Merging MUST not be done between GRPCRoutes and HTTPRoutes.
+                        Precedence MUST be given to the rule with the largest number of:
+
+                        * Characters in a matching non-wildcard hostname.
+                        * Characters in a matching hostname.
+                        * Characters in a matching service.
+                        * Characters in a matching method.
+                        * Header matches.
+
+                        If ties still exist across multiple Routes, matching precedence MUST be
+                        determined in order of the following criteria, continuing on ties:
+
+                        * The oldest Route based on creation timestamp.
+                        * The Route appearing first in alphabetical order by
+                          "{namespace}/{name}".
+
+                        If ties still exist within the Route that has been given precedence,
+                        matching precedence MUST be granted to the first matching rule meeting
+                        the above criteria.
+                      items:
+                        description: |-
+                          GRPCRouteMatch defines the predicate used to match requests to a given
+                          action. Multiple match types are ANDed together, i.e. the match will
+                          evaluate to true only if all conditions are satisfied.
+
+                          For example, the match below will match a gRPC request only if its service
+                          is `foo` AND it contains the `version: v1` header:
+
+                          ```
+                          matches:
+                            - method:
+                              type: Exact
+                              service: "foo"
+                              headers:
+                            - name: "version"
+                              value "v1"
+
+                          ```
+                        properties:
+                          headers:
+                            description: |-
+                              Headers specifies gRPC request header matchers. Multiple match values are
+                              ANDed together, meaning, a request MUST match all the specified headers
+                              to select the route.
+                            items:
+                              description: |-
+                                GRPCHeaderMatch describes how to select a gRPC route by matching gRPC request
+                                headers.
+                              properties:
+                                name:
+                                  description: |-
+                                    Name is the name of the gRPC Header to be matched.
+
+                                    If multiple entries specify equivalent header names, only the first
+                                    entry with an equivalent name MUST be considered for a match. Subsequent
+                                    entries with an equivalent header name MUST be ignored. Due to the
+                                    case-insensitivity of header names, "foo" and "Foo" are considered
+                                    equivalent.
+                                  maxLength: 256
+                                  minLength: 1
+                                  pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                  type: string
+                                type:
+                                  default: Exact
+                                  description: Type specifies how to match against
+                                    the value of the header.
+                                  enum:
+                                  - Exact
+                                  - RegularExpression
+                                  type: string
+                                value:
+                                  description: Value is the value of the gRPC Header
+                                    to be matched.
+                                  maxLength: 4096
+                                  minLength: 1
+                                  type: string
+                              required:
+                              - name
+                              - value
+                              type: object
+                            maxItems: 16
+                            type: array
+                            x-kubernetes-list-map-keys:
+                            - name
+                            x-kubernetes-list-type: map
+                          method:
+                            description: |-
+                              Method specifies a gRPC request service/method matcher. If this field is
+                              not specified, all services and methods will match.
+                            properties:
+                              method:
+                                description: |-
+                                  Value of the method to match against. If left empty or omitted, will
+                                  match all services.
+
+                                  At least one of Service and Method MUST be a non-empty string.
+                                maxLength: 1024
+                                type: string
+                              service:
+                                description: |-
+                                  Value of the service to match against. If left empty or omitted, will
+                                  match any service.
+
+                                  At least one of Service and Method MUST be a non-empty string.
+                                maxLength: 1024
+                                type: string
+                              type:
+                                default: Exact
+                                description: |-
+                                  Type specifies how to match against the service and/or method.
+                                  Support: Core (Exact with service and method specified)
+
+                                  Support: Implementation-specific (Exact with method specified but no service specified)
+
+                                  Support: Implementation-specific (RegularExpression)
+                                enum:
+                                - Exact
+                                - RegularExpression
+                                type: string
+                            type: object
+                            x-kubernetes-validations:
+                            - message: One or both of 'service' or 'method' must be
+                                specified
+                              rule: 'has(self.type) ? has(self.service) || has(self.method)
+                                : true'
+                            - message: service must only contain valid characters
+                                (matching ^(?i)\.?[a-z_][a-z_0-9]*(\.[a-z_][a-z_0-9]*)*$)
+                              rule: '(!has(self.type) || self.type == ''Exact'') &&
+                                has(self.service) ? self.service.matches(r"""^(?i)\.?[a-z_][a-z_0-9]*(\.[a-z_][a-z_0-9]*)*$"""):
+                                true'
+                            - message: method must only contain valid characters (matching
+                                ^[A-Za-z_][A-Za-z_0-9]*$)
+                              rule: '(!has(self.type) || self.type == ''Exact'') &&
+                                has(self.method) ? self.method.matches(r"""^[A-Za-z_][A-Za-z_0-9]*$"""):
+                                true'
+                        type: object
+                      maxItems: 8
+                      type: array
+                  type: object
+                maxItems: 16
+                type: array
+                x-kubernetes-validations:
+                - message: While 16 rules and 64 matches per rule are allowed, the
+                    total number of matches across all rules in a route must be less
+                    than 128
+                  rule: '(self.size() > 0 ? (has(self[0].matches) ? self[0].matches.size()
+                    : 0) : 0) + (self.size() > 1 ? (has(self[1].matches) ? self[1].matches.size()
+                    : 0) : 0) + (self.size() > 2 ? (has(self[2].matches) ? self[2].matches.size()
+                    : 0) : 0) + (self.size() > 3 ? (has(self[3].matches) ? self[3].matches.size()
+                    : 0) : 0) + (self.size() > 4 ? (has(self[4].matches) ? self[4].matches.size()
+                    : 0) : 0) + (self.size() > 5 ? (has(self[5].matches) ? self[5].matches.size()
+                    : 0) : 0) + (self.size() > 6 ? (has(self[6].matches) ? self[6].matches.size()
+                    : 0) : 0) + (self.size() > 7 ? (has(self[7].matches) ? self[7].matches.size()
+                    : 0) : 0) + (self.size() > 8 ? (has(self[8].matches) ? self[8].matches.size()
+                    : 0) : 0) + (self.size() > 9 ? (has(self[9].matches) ? self[9].matches.size()
+                    : 0) : 0) + (self.size() > 10 ? (has(self[10].matches) ? self[10].matches.size()
+                    : 0) : 0) + (self.size() > 11 ? (has(self[11].matches) ? self[11].matches.size()
+                    : 0) : 0) + (self.size() > 12 ? (has(self[12].matches) ? self[12].matches.size()
+                    : 0) : 0) + (self.size() > 13 ? (has(self[13].matches) ? self[13].matches.size()
+                    : 0) : 0) + (self.size() > 14 ? (has(self[14].matches) ? self[14].matches.size()
+                    : 0) : 0) + (self.size() > 15 ? (has(self[15].matches) ? self[15].matches.size()
+                    : 0) : 0) <= 128'
+            type: object
+          status:
+            description: Status defines the current state of GRPCRoute.
+            properties:
+              parents:
+                description: |-
+                  Parents is a list of parent resources (usually Gateways) that are
+                  associated with the route, and the status of the route with respect to
+                  each parent. When this route attaches to a parent, the controller that
+                  manages the parent must add an entry to this list when the controller
+                  first sees the route and should update the entry as appropriate when the
+                  route or gateway is modified.
+
+                  Note that parent references that cannot be resolved by an implementation
+                  of this API will not be added to this list. Implementations of this API
+                  can only populate Route status for the Gateways/parent resources they are
+                  responsible for.
+
+                  A maximum of 32 Gateways will be represented in this list. An empty list
+                  means the route has not been attached to any Gateway.
+                items:
+                  description: |-
+                    RouteParentStatus describes the status of a route with respect to an
+                    associated Parent.
+                  properties:
+                    conditions:
+                      description: |-
+                        Conditions describes the status of the route with respect to the Gateway.
+                        Note that the route's availability is also subject to the Gateway's own
+                        status conditions and listener status.
+
+                        If the Route's ParentRef specifies an existing Gateway that supports
+                        Routes of this kind AND that Gateway's controller has sufficient access,
+                        then that Gateway's controller MUST set the "Accepted" condition on the
+                        Route, to indicate whether the route has been accepted or rejected by the
+                        Gateway, and why.
+
+                        A Route MUST be considered "Accepted" if at least one of the Route's
+                        rules is implemented by the Gateway.
+
+                        There are a number of cases where the "Accepted" condition may not be set
+                        due to lack of controller visibility, that includes when:
+
+                        * The Route refers to a non-existent parent.
+                        * The Route is of a type that the controller does not support.
+                        * The Route is in a namespace the controller does not have access to.
+                      items:
+                        description: Condition contains details for one aspect of
+                          the current state of this API Resource.
+                        properties:
+                          lastTransitionTime:
+                            description: |-
+                              lastTransitionTime is the last time the condition transitioned from one status to another.
+                              This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                            format: date-time
+                            type: string
+                          message:
+                            description: |-
+                              message is a human readable message indicating details about the transition.
+                              This may be an empty string.
+                            maxLength: 32768
+                            type: string
+                          observedGeneration:
+                            description: |-
+                              observedGeneration represents the .metadata.generation that the condition was set based upon.
+                              For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                              with respect to the current state of the instance.
+                            format: int64
+                            minimum: 0
+                            type: integer
+                          reason:
+                            description: |-
+                              reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                              Producers of specific condition types may define expected values and meanings for this field,
+                              and whether the values are considered a guaranteed API.
+                              The value should be a CamelCase string.
+                              This field may not be empty.
+                            maxLength: 1024
+                            minLength: 1
+                            pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                            type: string
+                          status:
+                            description: status of the condition, one of True, False,
+                              Unknown.
+                            enum:
+                            - "True"
+                            - "False"
+                            - Unknown
+                            type: string
+                          type:
+                            description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                            maxLength: 316
+                            pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                            type: string
+                        required:
+                        - lastTransitionTime
+                        - message
+                        - reason
+                        - status
+                        - type
+                        type: object
+                      maxItems: 8
+                      minItems: 1
+                      type: array
+                      x-kubernetes-list-map-keys:
+                      - type
+                      x-kubernetes-list-type: map
+                    controllerName:
+                      description: |-
+                        ControllerName is a domain/path string that indicates the name of the
+                        controller that wrote this status. This corresponds with the
+                        controllerName field on GatewayClass.
+
+                        Example: "example.net/gateway-controller".
+
+                        The format of this field is DOMAIN "/" PATH, where DOMAIN and PATH are
+                        valid Kubernetes names
+                        (https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names).
+
+                        Controllers MUST populate this field when writing status. Controllers should ensure that
+                        entries to status populated with their ControllerName are cleaned up when they are no
+                        longer necessary.
+                      maxLength: 253
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\/[A-Za-z0-9\/\-._~%!$&'()*+,;=:]+$
+                      type: string
+                    parentRef:
+                      description: |-
+                        ParentRef corresponds with a ParentRef in the spec that this
+                        RouteParentStatus struct describes the status of.
+                      properties:
+                        group:
+                          default: gateway.networking.k8s.io
+                          description: |-
+                            Group is the group of the referent.
+                            When unspecified, "gateway.networking.k8s.io" is inferred.
+                            To set the core API group (such as for a "Service" kind referent),
+                            Group must be explicitly set to "" (empty string).
+
+                            Support: Core
+                          maxLength: 253
+                          pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                          type: string
+                        kind:
+                          default: Gateway
+                          description: |-
+                            Kind is kind of the referent.
+
+                            There are two kinds of parent resources with "Core" support:
+
+                            * Gateway (Gateway conformance profile)
+                            * Service (Mesh conformance profile, ClusterIP Services only)
+
+                            Support for other resources is Implementation-Specific.
+                          maxLength: 63
+                          minLength: 1
+                          pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                          type: string
+                        name:
+                          description: |-
+                            Name is the name of the referent.
+
+                            Support: Core
+                          maxLength: 253
+                          minLength: 1
+                          type: string
+                        namespace:
+                          description: |-
+                            Namespace is the namespace of the referent. When unspecified, this refers
+                            to the local namespace of the Route.
+
+                            Note that there are specific rules for ParentRefs which cross namespace
+                            boundaries. Cross-namespace references are only valid if they are explicitly
+                            allowed by something in the namespace they are referring to. For example:
+                            Gateway has the AllowedRoutes field, and ReferenceGrant provides a
+                            generic way to enable any other kind of cross-namespace reference.
+
+
+
+                            Support: Core
+                          maxLength: 63
+                          minLength: 1
+                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                          type: string
+                        port:
+                          description: |-
+                            Port is the network port this Route targets. It can be interpreted
+                            differently based on the type of parent resource.
+
+                            When the parent resource is a Gateway, this targets all listeners
+                            listening on the specified port that also support this kind of Route(and
+                            select this Route). It's not recommended to set `Port` unless the
+                            networking behaviors specified in a Route must apply to a specific port
+                            as opposed to a listener(s) whose port(s) may be changed. When both Port
+                            and SectionName are specified, the name and port of the selected listener
+                            must match both specified values.
+
+
+
+                            Implementations MAY choose to support other parent resources.
+                            Implementations supporting other types of parent resources MUST clearly
+                            document how/if Port is interpreted.
+
+                            For the purpose of status, an attachment is considered successful as
+                            long as the parent resource accepts it partially. For example, Gateway
+                            listeners can restrict which Routes can attach to them by Route kind,
+                            namespace, or hostname. If 1 of 2 Gateway listeners accept attachment
+                            from the referencing Route, the Route MUST be considered successfully
+                            attached. If no Gateway listeners accept attachment from this Route,
+                            the Route MUST be considered detached from the Gateway.
+
+                            Support: Extended
+                          format: int32
+                          maximum: 65535
+                          minimum: 1
+                          type: integer
+                        sectionName:
+                          description: |-
+                            SectionName is the name of a section within the target resource. In the
+                            following resources, SectionName is interpreted as the following:
+
+                            * Gateway: Listener name. When both Port (experimental) and SectionName
+                            are specified, the name and port of the selected listener must match
+                            both specified values.
+                            * Service: Port name. When both Port (experimental) and SectionName
+                            are specified, the name and port of the selected listener must match
+                            both specified values.
+
+                            Implementations MAY choose to support attaching Routes to other resources.
+                            If that is the case, they MUST clearly document how SectionName is
+                            interpreted.
+
+                            When unspecified (empty string), this will reference the entire resource.
+                            For the purpose of status, an attachment is considered successful if at
+                            least one section in the parent resource accepts it. For example, Gateway
+                            listeners can restrict which Routes can attach to them by Route kind,
+                            namespace, or hostname. If 1 of 2 Gateway listeners accept attachment from
+                            the referencing Route, the Route MUST be considered successfully
+                            attached. If no Gateway listeners accept attachment from this Route, the
+                            Route MUST be considered detached from the Gateway.
+
+                            Support: Core
+                          maxLength: 253
+                          minLength: 1
+                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                          type: string
+                      required:
+                      - name
+                      type: object
+                  required:
+                  - controllerName
+                  - parentRef
+                  type: object
+                maxItems: 32
+                type: array
+            required:
+            - parents
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/3328
+    gateway.networking.k8s.io/bundle-version: v1.2.1
+    gateway.networking.k8s.io/channel: standard
+  creationTimestamp: null
+  name: httproutes.gateway.networking.k8s.io
+spec:
+  group: gateway.networking.k8s.io
+  names:
+    categories:
+    - gateway-api
+    kind: HTTPRoute
+    listKind: HTTPRouteList
+    plural: httproutes
+    singular: httproute
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.hostnames
+      name: Hostnames
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: |-
+          HTTPRoute provides a way to route HTTP requests. This includes the capability
+          to match requests by hostname, path, header, or query param. Filters can be
+          used to specify additional processing steps. Backends specify where matching
+          requests should be routed.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec defines the desired state of HTTPRoute.
+            properties:
+              hostnames:
+                description: |-
+                  Hostnames defines a set of hostnames that should match against the HTTP Host
+                  header to select a HTTPRoute used to process the request. Implementations
+                  MUST ignore any port value specified in the HTTP Host header while
+                  performing a match and (absent of any applicable header modification
+                  configuration) MUST forward this header unmodified to the backend.
+
+                  Valid values for Hostnames are determined by RFC 1123 definition of a
+                  hostname with 2 notable exceptions:
+
+                  1. IPs are not allowed.
+                  2. A hostname may be prefixed with a wildcard label (`*.`). The wildcard
+                     label must appear by itself as the first label.
+
+                  If a hostname is specified by both the Listener and HTTPRoute, there
+                  must be at least one intersecting hostname for the HTTPRoute to be
+                  attached to the Listener. For example:
+
+                  * A Listener with `test.example.com` as the hostname matches HTTPRoutes
+                    that have either not specified any hostnames, or have specified at
+                    least one of `test.example.com` or `*.example.com`.
+                  * A Listener with `*.example.com` as the hostname matches HTTPRoutes
+                    that have either not specified any hostnames or have specified at least
+                    one hostname that matches the Listener hostname. For example,
+                    `*.example.com`, `test.example.com`, and `foo.test.example.com` would
+                    all match. On the other hand, `example.com` and `test.example.net` would
+                    not match.
+
+                  Hostnames that are prefixed with a wildcard label (`*.`) are interpreted
+                  as a suffix match. That means that a match for `*.example.com` would match
+                  both `test.example.com`, and `foo.test.example.com`, but not `example.com`.
+
+                  If both the Listener and HTTPRoute have specified hostnames, any
+                  HTTPRoute hostnames that do not match the Listener hostname MUST be
+                  ignored. For example, if a Listener specified `*.example.com`, and the
+                  HTTPRoute specified `test.example.com` and `test.example.net`,
+                  `test.example.net` must not be considered for a match.
+
+                  If both the Listener and HTTPRoute have specified hostnames, and none
+                  match with the criteria above, then the HTTPRoute is not accepted. The
+                  implementation must raise an 'Accepted' Condition with a status of
+                  `False` in the corresponding RouteParentStatus.
+
+                  In the event that multiple HTTPRoutes specify intersecting hostnames (e.g.
+                  overlapping wildcard matching and exact matching hostnames), precedence must
+                  be given to rules from the HTTPRoute with the largest number of:
+
+                  * Characters in a matching non-wildcard hostname.
+                  * Characters in a matching hostname.
+
+                  If ties exist across multiple Routes, the matching precedence rules for
+                  HTTPRouteMatches takes over.
+
+                  Support: Core
+                items:
+                  description: |-
+                    Hostname is the fully qualified domain name of a network host. This matches
+                    the RFC 1123 definition of a hostname with 2 notable exceptions:
+
+                     1. IPs are not allowed.
+                     2. A hostname may be prefixed with a wildcard label (`*.`). The wildcard
+                        label must appear by itself as the first label.
+
+                    Hostname can be "precise" which is a domain name without the terminating
+                    dot of a network host (e.g. "foo.example.com") or "wildcard", which is a
+                    domain name prefixed with a single wildcard label (e.g. `*.example.com`).
+
+                    Note that as per RFC1035 and RFC1123, a *label* must consist of lower case
+                    alphanumeric characters or '-', and must start and end with an alphanumeric
+                    character. No other punctuation is allowed.
+                  maxLength: 253
+                  minLength: 1
+                  pattern: ^(\*\.)?[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                  type: string
+                maxItems: 16
+                type: array
+              parentRefs:
+                description: |+
+                  ParentRefs references the resources (usually Gateways) that a Route wants
+                  to be attached to. Note that the referenced parent resource needs to
+                  allow this for the attachment to be complete. For Gateways, that means
+                  the Gateway needs to allow attachment from Routes of this kind and
+                  namespace. For Services, that means the Service must either be in the same
+                  namespace for a "producer" route, or the mesh implementation must support
+                  and allow "consumer" routes for the referenced Service. ReferenceGrant is
+                  not applicable for governing ParentRefs to Services - it is not possible to
+                  create a "producer" route for a Service in a different namespace from the
+                  Route.
+
+                  There are two kinds of parent resources with "Core" support:
+
+                  * Gateway (Gateway conformance profile)
+                  * Service (Mesh conformance profile, ClusterIP Services only)
+
+                  This API may be extended in the future to support additional kinds of parent
+                  resources.
+
+                  ParentRefs must be _distinct_. This means either that:
+
+                  * They select different objects.  If this is the case, then parentRef
+                    entries are distinct. In terms of fields, this means that the
+                    multi-part key defined by `group`, `kind`, `namespace`, and `name` must
+                    be unique across all parentRef entries in the Route.
+                  * They do not select different objects, but for each optional field used,
+                    each ParentRef that selects the same object must set the same set of
+                    optional fields to different values. If one ParentRef sets a
+                    combination of optional fields, all must set the same combination.
+
+                  Some examples:
+
+                  * If one ParentRef sets `sectionName`, all ParentRefs referencing the
+                    same object must also set `sectionName`.
+                  * If one ParentRef sets `port`, all ParentRefs referencing the same
+                    object must also set `port`.
+                  * If one ParentRef sets `sectionName` and `port`, all ParentRefs
+                    referencing the same object must also set `sectionName` and `port`.
+
+                  It is possible to separately reference multiple distinct objects that may
+                  be collapsed by an implementation. For example, some implementations may
+                  choose to merge compatible Gateway Listeners together. If that is the
+                  case, the list of routes attached to those resources should also be
+                  merged.
+
+                  Note that for ParentRefs that cross namespace boundaries, there are specific
+                  rules. Cross-namespace references are only valid if they are explicitly
+                  allowed by something in the namespace they are referring to. For example,
+                  Gateway has the AllowedRoutes field, and ReferenceGrant provides a
+                  generic way to enable other kinds of cross-namespace reference.
+
+
+
+
+
+
+                items:
+                  description: |-
+                    ParentReference identifies an API object (usually a Gateway) that can be considered
+                    a parent of this resource (usually a route). There are two kinds of parent resources
+                    with "Core" support:
+
+                    * Gateway (Gateway conformance profile)
+                    * Service (Mesh conformance profile, ClusterIP Services only)
+
+                    This API may be extended in the future to support additional kinds of parent
+                    resources.
+
+                    The API object must be valid in the cluster; the Group and Kind must
+                    be registered in the cluster for this reference to be valid.
+                  properties:
+                    group:
+                      default: gateway.networking.k8s.io
+                      description: |-
+                        Group is the group of the referent.
+                        When unspecified, "gateway.networking.k8s.io" is inferred.
+                        To set the core API group (such as for a "Service" kind referent),
+                        Group must be explicitly set to "" (empty string).
+
+                        Support: Core
+                      maxLength: 253
+                      pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                      type: string
+                    kind:
+                      default: Gateway
+                      description: |-
+                        Kind is kind of the referent.
+
+                        There are two kinds of parent resources with "Core" support:
+
+                        * Gateway (Gateway conformance profile)
+                        * Service (Mesh conformance profile, ClusterIP Services only)
+
+                        Support for other resources is Implementation-Specific.
+                      maxLength: 63
+                      minLength: 1
+                      pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                      type: string
+                    name:
+                      description: |-
+                        Name is the name of the referent.
+
+                        Support: Core
+                      maxLength: 253
+                      minLength: 1
+                      type: string
+                    namespace:
+                      description: |-
+                        Namespace is the namespace of the referent. When unspecified, this refers
+                        to the local namespace of the Route.
+
+                        Note that there are specific rules for ParentRefs which cross namespace
+                        boundaries. Cross-namespace references are only valid if they are explicitly
+                        allowed by something in the namespace they are referring to. For example:
+                        Gateway has the AllowedRoutes field, and ReferenceGrant provides a
+                        generic way to enable any other kind of cross-namespace reference.
+
+
+
+                        Support: Core
+                      maxLength: 63
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                      type: string
+                    port:
+                      description: |-
+                        Port is the network port this Route targets. It can be interpreted
+                        differently based on the type of parent resource.
+
+                        When the parent resource is a Gateway, this targets all listeners
+                        listening on the specified port that also support this kind of Route(and
+                        select this Route). It's not recommended to set `Port` unless the
+                        networking behaviors specified in a Route must apply to a specific port
+                        as opposed to a listener(s) whose port(s) may be changed. When both Port
+                        and SectionName are specified, the name and port of the selected listener
+                        must match both specified values.
+
+
+
+                        Implementations MAY choose to support other parent resources.
+                        Implementations supporting other types of parent resources MUST clearly
+                        document how/if Port is interpreted.
+
+                        For the purpose of status, an attachment is considered successful as
+                        long as the parent resource accepts it partially. For example, Gateway
+                        listeners can restrict which Routes can attach to them by Route kind,
+                        namespace, or hostname. If 1 of 2 Gateway listeners accept attachment
+                        from the referencing Route, the Route MUST be considered successfully
+                        attached. If no Gateway listeners accept attachment from this Route,
+                        the Route MUST be considered detached from the Gateway.
+
+                        Support: Extended
+                      format: int32
+                      maximum: 65535
+                      minimum: 1
+                      type: integer
+                    sectionName:
+                      description: |-
+                        SectionName is the name of a section within the target resource. In the
+                        following resources, SectionName is interpreted as the following:
+
+                        * Gateway: Listener name. When both Port (experimental) and SectionName
+                        are specified, the name and port of the selected listener must match
+                        both specified values.
+                        * Service: Port name. When both Port (experimental) and SectionName
+                        are specified, the name and port of the selected listener must match
+                        both specified values.
+
+                        Implementations MAY choose to support attaching Routes to other resources.
+                        If that is the case, they MUST clearly document how SectionName is
+                        interpreted.
+
+                        When unspecified (empty string), this will reference the entire resource.
+                        For the purpose of status, an attachment is considered successful if at
+                        least one section in the parent resource accepts it. For example, Gateway
+                        listeners can restrict which Routes can attach to them by Route kind,
+                        namespace, or hostname. If 1 of 2 Gateway listeners accept attachment from
+                        the referencing Route, the Route MUST be considered successfully
+                        attached. If no Gateway listeners accept attachment from this Route, the
+                        Route MUST be considered detached from the Gateway.
+
+                        Support: Core
+                      maxLength: 253
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                      type: string
+                  required:
+                  - name
+                  type: object
+                maxItems: 32
+                type: array
+                x-kubernetes-validations:
+                - message: sectionName must be specified when parentRefs includes
+                    2 or more references to the same parent
+                  rule: 'self.all(p1, self.all(p2, p1.group == p2.group && p1.kind
+                    == p2.kind && p1.name == p2.name && (((!has(p1.__namespace__)
+                    || p1.__namespace__ == '''') && (!has(p2.__namespace__) || p2.__namespace__
+                    == '''')) || (has(p1.__namespace__) && has(p2.__namespace__) &&
+                    p1.__namespace__ == p2.__namespace__ )) ? ((!has(p1.sectionName)
+                    || p1.sectionName == '''') == (!has(p2.sectionName) || p2.sectionName
+                    == '''')) : true))'
+                - message: sectionName must be unique when parentRefs includes 2 or
+                    more references to the same parent
+                  rule: self.all(p1, self.exists_one(p2, p1.group == p2.group && p1.kind
+                    == p2.kind && p1.name == p2.name && (((!has(p1.__namespace__)
+                    || p1.__namespace__ == '') && (!has(p2.__namespace__) || p2.__namespace__
+                    == '')) || (has(p1.__namespace__) && has(p2.__namespace__) &&
+                    p1.__namespace__ == p2.__namespace__ )) && (((!has(p1.sectionName)
+                    || p1.sectionName == '') && (!has(p2.sectionName) || p2.sectionName
+                    == '')) || (has(p1.sectionName) && has(p2.sectionName) && p1.sectionName
+                    == p2.sectionName))))
+              rules:
+                default:
+                - matches:
+                  - path:
+                      type: PathPrefix
+                      value: /
+                description: |+
+                  Rules are a list of HTTP matchers, filters and actions.
+
+                items:
+                  description: |-
+                    HTTPRouteRule defines semantics for matching an HTTP request based on
+                    conditions (matches), processing it (filters), and forwarding the request to
+                    an API object (backendRefs).
+                  properties:
+                    backendRefs:
+                      description: |-
+                        BackendRefs defines the backend(s) where matching requests should be
+                        sent.
+
+                        Failure behavior here depends on how many BackendRefs are specified and
+                        how many are invalid.
+
+                        If *all* entries in BackendRefs are invalid, and there are also no filters
+                        specified in this route rule, *all* traffic which matches this rule MUST
+                        receive a 500 status code.
+
+                        See the HTTPBackendRef definition for the rules about what makes a single
+                        HTTPBackendRef invalid.
+
+                        When a HTTPBackendRef is invalid, 500 status codes MUST be returned for
+                        requests that would have otherwise been routed to an invalid backend. If
+                        multiple backends are specified, and some are invalid, the proportion of
+                        requests that would otherwise have been routed to an invalid backend
+                        MUST receive a 500 status code.
+
+                        For example, if two backends are specified with equal weights, and one is
+                        invalid, 50 percent of traffic must receive a 500. Implementations may
+                        choose how that 50 percent is determined.
+
+                        When a HTTPBackendRef refers to a Service that has no ready endpoints,
+                        implementations SHOULD return a 503 for requests to that backend instead.
+                        If an implementation chooses to do this, all of the above rules for 500 responses
+                        MUST also apply for responses that return a 503.
+
+                        Support: Core for Kubernetes Service
+
+                        Support: Extended for Kubernetes ServiceImport
+
+                        Support: Implementation-specific for any other resource
+
+                        Support for weight: Core
+                      items:
+                        description: |-
+                          HTTPBackendRef defines how a HTTPRoute forwards a HTTP request.
+
+                          Note that when a namespace different than the local namespace is specified, a
+                          ReferenceGrant object is required in the referent namespace to allow that
+                          namespace's owner to accept the reference. See the ReferenceGrant
+                          documentation for details.
+
+                          <gateway:experimental:description>
+
+                          When the BackendRef points to a Kubernetes Service, implementations SHOULD
+                          honor the appProtocol field if it is set for the target Service Port.
+
+                          Implementations supporting appProtocol SHOULD recognize the Kubernetes
+                          Standard Application Protocols defined in KEP-3726.
+
+                          If a Service appProtocol isn't specified, an implementation MAY infer the
+                          backend protocol through its own means. Implementations MAY infer the
+                          protocol from the Route type referring to the backend Service.
+
+                          If a Route is not able to send traffic to the backend using the specified
+                          protocol then the backend is considered invalid. Implementations MUST set the
+                          "ResolvedRefs" condition to "False" with the "UnsupportedProtocol" reason.
+
+                          </gateway:experimental:description>
+                        properties:
+                          filters:
+                            description: |-
+                              Filters defined at this level should be executed if and only if the
+                              request is being forwarded to the backend defined here.
+
+                              Support: Implementation-specific (For broader support of filters, use the
+                              Filters field in HTTPRouteRule.)
+                            items:
+                              description: |-
+                                HTTPRouteFilter defines processing steps that must be completed during the
+                                request or response lifecycle. HTTPRouteFilters are meant as an extension
+                                point to express processing that may be done in Gateway implementations. Some
+                                examples include request or response modification, implementing
+                                authentication strategies, rate-limiting, and traffic shaping. API
+                                guarantee/conformance is defined based on the type of the filter.
+                              properties:
+                                extensionRef:
+                                  description: |-
+                                    ExtensionRef is an optional, implementation-specific extension to the
+                                    "filter" behavior.  For example, resource "myroutefilter" in group
+                                    "networking.example.net"). ExtensionRef MUST NOT be used for core and
+                                    extended filters.
+
+                                    This filter can be used multiple times within the same rule.
+
+                                    Support: Implementation-specific
+                                  properties:
+                                    group:
+                                      description: |-
+                                        Group is the group of the referent. For example, "gateway.networking.k8s.io".
+                                        When unspecified or empty string, core API group is inferred.
+                                      maxLength: 253
+                                      pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    kind:
+                                      description: Kind is kind of the referent. For
+                                        example "HTTPRoute" or "Service".
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                                      type: string
+                                    name:
+                                      description: Name is the name of the referent.
+                                      maxLength: 253
+                                      minLength: 1
+                                      type: string
+                                  required:
+                                  - group
+                                  - kind
+                                  - name
+                                  type: object
+                                requestHeaderModifier:
+                                  description: |-
+                                    RequestHeaderModifier defines a schema for a filter that modifies request
+                                    headers.
+
+                                    Support: Core
+                                  properties:
+                                    add:
+                                      description: |-
+                                        Add adds the given header(s) (name, value) to the request
+                                        before the action. It appends to any existing values associated
+                                        with the header name.
+
+                                        Input:
+                                          GET /foo HTTP/1.1
+                                          my-header: foo
+
+                                        Config:
+                                          add:
+                                          - name: "my-header"
+                                            value: "bar,baz"
+
+                                        Output:
+                                          GET /foo HTTP/1.1
+                                          my-header: foo,bar,baz
+                                      items:
+                                        description: HTTPHeader represents an HTTP
+                                          Header name and value as defined by RFC
+                                          7230.
+                                        properties:
+                                          name:
+                                            description: |-
+                                              Name is the name of the HTTP Header to be matched. Name matching MUST be
+                                              case insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
+
+                                              If multiple entries specify equivalent header names, the first entry with
+                                              an equivalent name MUST be considered for a match. Subsequent entries
+                                              with an equivalent header name MUST be ignored. Due to the
+                                              case-insensitivity of header names, "foo" and "Foo" are considered
+                                              equivalent.
+                                            maxLength: 256
+                                            minLength: 1
+                                            pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                            type: string
+                                          value:
+                                            description: Value is the value of HTTP
+                                              Header to be matched.
+                                            maxLength: 4096
+                                            minLength: 1
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                        type: object
+                                      maxItems: 16
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                      - name
+                                      x-kubernetes-list-type: map
+                                    remove:
+                                      description: |-
+                                        Remove the given header(s) from the HTTP request before the action. The
+                                        value of Remove is a list of HTTP header names. Note that the header
+                                        names are case-insensitive (see
+                                        https://datatracker.ietf.org/doc/html/rfc2616#section-4.2).
+
+                                        Input:
+                                          GET /foo HTTP/1.1
+                                          my-header1: foo
+                                          my-header2: bar
+                                          my-header3: baz
+
+                                        Config:
+                                          remove: ["my-header1", "my-header3"]
+
+                                        Output:
+                                          GET /foo HTTP/1.1
+                                          my-header2: bar
+                                      items:
+                                        type: string
+                                      maxItems: 16
+                                      type: array
+                                      x-kubernetes-list-type: set
+                                    set:
+                                      description: |-
+                                        Set overwrites the request with the given header (name, value)
+                                        before the action.
+
+                                        Input:
+                                          GET /foo HTTP/1.1
+                                          my-header: foo
+
+                                        Config:
+                                          set:
+                                          - name: "my-header"
+                                            value: "bar"
+
+                                        Output:
+                                          GET /foo HTTP/1.1
+                                          my-header: bar
+                                      items:
+                                        description: HTTPHeader represents an HTTP
+                                          Header name and value as defined by RFC
+                                          7230.
+                                        properties:
+                                          name:
+                                            description: |-
+                                              Name is the name of the HTTP Header to be matched. Name matching MUST be
+                                              case insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
+
+                                              If multiple entries specify equivalent header names, the first entry with
+                                              an equivalent name MUST be considered for a match. Subsequent entries
+                                              with an equivalent header name MUST be ignored. Due to the
+                                              case-insensitivity of header names, "foo" and "Foo" are considered
+                                              equivalent.
+                                            maxLength: 256
+                                            minLength: 1
+                                            pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                            type: string
+                                          value:
+                                            description: Value is the value of HTTP
+                                              Header to be matched.
+                                            maxLength: 4096
+                                            minLength: 1
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                        type: object
+                                      maxItems: 16
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                      - name
+                                      x-kubernetes-list-type: map
+                                  type: object
+                                requestMirror:
+                                  description: |+
+                                    RequestMirror defines a schema for a filter that mirrors requests.
+                                    Requests are sent to the specified destination, but responses from
+                                    that destination are ignored.
+
+                                    This filter can be used multiple times within the same rule. Note that
+                                    not all implementations will be able to support mirroring to multiple
+                                    backends.
+
+                                    Support: Extended
+
+                                  properties:
+                                    backendRef:
+                                      description: |-
+                                        BackendRef references a resource where mirrored requests are sent.
+
+                                        Mirrored requests must be sent only to a single destination endpoint
+                                        within this BackendRef, irrespective of how many endpoints are present
+                                        within this BackendRef.
+
+                                        If the referent cannot be found, this BackendRef is invalid and must be
+                                        dropped from the Gateway. The controller must ensure the "ResolvedRefs"
+                                        condition on the Route status is set to `status: False` and not configure
+                                        this backend in the underlying implementation.
+
+                                        If there is a cross-namespace reference to an *existing* object
+                                        that is not allowed by a ReferenceGrant, the controller must ensure the
+                                        "ResolvedRefs"  condition on the Route is set to `status: False`,
+                                        with the "RefNotPermitted" reason and not configure this backend in the
+                                        underlying implementation.
+
+                                        In either error case, the Message of the `ResolvedRefs` Condition
+                                        should be used to provide more detail about the problem.
+
+                                        Support: Extended for Kubernetes Service
+
+                                        Support: Implementation-specific for any other resource
+                                      properties:
+                                        group:
+                                          default: ""
+                                          description: |-
+                                            Group is the group of the referent. For example, "gateway.networking.k8s.io".
+                                            When unspecified or empty string, core API group is inferred.
+                                          maxLength: 253
+                                          pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                          type: string
+                                        kind:
+                                          default: Service
+                                          description: |-
+                                            Kind is the Kubernetes resource kind of the referent. For example
+                                            "Service".
+
+                                            Defaults to "Service" when not specified.
+
+                                            ExternalName services can refer to CNAME DNS records that may live
+                                            outside of the cluster and as such are difficult to reason about in
+                                            terms of conformance. They also may not be safe to forward to (see
+                                            CVE-2021-25740 for more information). Implementations SHOULD NOT
+                                            support ExternalName Services.
+
+                                            Support: Core (Services with a type other than ExternalName)
+
+                                            Support: Implementation-specific (Services with type ExternalName)
+                                          maxLength: 63
+                                          minLength: 1
+                                          pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                                          type: string
+                                        name:
+                                          description: Name is the name of the referent.
+                                          maxLength: 253
+                                          minLength: 1
+                                          type: string
+                                        namespace:
+                                          description: |-
+                                            Namespace is the namespace of the backend. When unspecified, the local
+                                            namespace is inferred.
+
+                                            Note that when a namespace different than the local namespace is specified,
+                                            a ReferenceGrant object is required in the referent namespace to allow that
+                                            namespace's owner to accept the reference. See the ReferenceGrant
+                                            documentation for details.
+
+                                            Support: Core
+                                          maxLength: 63
+                                          minLength: 1
+                                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                          type: string
+                                        port:
+                                          description: |-
+                                            Port specifies the destination port number to use for this resource.
+                                            Port is required when the referent is a Kubernetes Service. In this
+                                            case, the port number is the service port number, not the target port.
+                                            For other resources, destination port might be derived from the referent
+                                            resource or this field.
+                                          format: int32
+                                          maximum: 65535
+                                          minimum: 1
+                                          type: integer
+                                      required:
+                                      - name
+                                      type: object
+                                      x-kubernetes-validations:
+                                      - message: Must have port for Service reference
+                                        rule: '(size(self.group) == 0 && self.kind
+                                          == ''Service'') ? has(self.port) : true'
+                                  required:
+                                  - backendRef
+                                  type: object
+                                requestRedirect:
+                                  description: |-
+                                    RequestRedirect defines a schema for a filter that responds to the
+                                    request with an HTTP redirection.
+
+                                    Support: Core
+                                  properties:
+                                    hostname:
+                                      description: |-
+                                        Hostname is the hostname to be used in the value of the `Location`
+                                        header in the response.
+                                        When empty, the hostname in the `Host` header of the request is used.
+
+                                        Support: Core
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    path:
+                                      description: |-
+                                        Path defines parameters used to modify the path of the incoming request.
+                                        The modified path is then used to construct the `Location` header. When
+                                        empty, the request path is used as-is.
+
+                                        Support: Extended
+                                      properties:
+                                        replaceFullPath:
+                                          description: |-
+                                            ReplaceFullPath specifies the value with which to replace the full path
+                                            of a request during a rewrite or redirect.
+                                          maxLength: 1024
+                                          type: string
+                                        replacePrefixMatch:
+                                          description: |-
+                                            ReplacePrefixMatch specifies the value with which to replace the prefix
+                                            match of a request during a rewrite or redirect. For example, a request
+                                            to "/foo/bar" with a prefix match of "/foo" and a ReplacePrefixMatch
+                                            of "/xyz" would be modified to "/xyz/bar".
+
+                                            Note that this matches the behavior of the PathPrefix match type. This
+                                            matches full path elements. A path element refers to the list of labels
+                                            in the path split by the `/` separator. When specified, a trailing `/` is
+                                            ignored. For example, the paths `/abc`, `/abc/`, and `/abc/def` would all
+                                            match the prefix `/abc`, but the path `/abcd` would not.
+
+                                            ReplacePrefixMatch is only compatible with a `PathPrefix` HTTPRouteMatch.
+                                            Using any other HTTPRouteMatch type on the same HTTPRouteRule will result in
+                                            the implementation setting the Accepted Condition for the Route to `status: False`.
+
+                                            Request Path | Prefix Match | Replace Prefix | Modified Path
+                                          maxLength: 1024
+                                          type: string
+                                        type:
+                                          description: |-
+                                            Type defines the type of path modifier. Additional types may be
+                                            added in a future release of the API.
+
+                                            Note that values may be added to this enum, implementations
+                                            must ensure that unknown values will not cause a crash.
+
+                                            Unknown values here must result in the implementation setting the
+                                            Accepted Condition for the Route to `status: False`, with a
+                                            Reason of `UnsupportedValue`.
+                                          enum:
+                                          - ReplaceFullPath
+                                          - ReplacePrefixMatch
+                                          type: string
+                                      required:
+                                      - type
+                                      type: object
+                                      x-kubernetes-validations:
+                                      - message: replaceFullPath must be specified
+                                          when type is set to 'ReplaceFullPath'
+                                        rule: 'self.type == ''ReplaceFullPath'' ?
+                                          has(self.replaceFullPath) : true'
+                                      - message: type must be 'ReplaceFullPath' when
+                                          replaceFullPath is set
+                                        rule: 'has(self.replaceFullPath) ? self.type
+                                          == ''ReplaceFullPath'' : true'
+                                      - message: replacePrefixMatch must be specified
+                                          when type is set to 'ReplacePrefixMatch'
+                                        rule: 'self.type == ''ReplacePrefixMatch''
+                                          ? has(self.replacePrefixMatch) : true'
+                                      - message: type must be 'ReplacePrefixMatch'
+                                          when replacePrefixMatch is set
+                                        rule: 'has(self.replacePrefixMatch) ? self.type
+                                          == ''ReplacePrefixMatch'' : true'
+                                    port:
+                                      description: |-
+                                        Port is the port to be used in the value of the `Location`
+                                        header in the response.
+
+                                        If no port is specified, the redirect port MUST be derived using the
+                                        following rules:
+
+                                        * If redirect scheme is not-empty, the redirect port MUST be the well-known
+                                          port associated with the redirect scheme. Specifically "http" to port 80
+                                          and "https" to port 443. If the redirect scheme does not have a
+                                          well-known port, the listener port of the Gateway SHOULD be used.
+                                        * If redirect scheme is empty, the redirect port MUST be the Gateway
+                                          Listener port.
+
+                                        Implementations SHOULD NOT add the port number in the 'Location'
+                                        header in the following cases:
+
+                                        * A Location header that will use HTTP (whether that is determined via
+                                          the Listener protocol or the Scheme field) _and_ use port 80.
+                                        * A Location header that will use HTTPS (whether that is determined via
+                                          the Listener protocol or the Scheme field) _and_ use port 443.
+
+                                        Support: Extended
+                                      format: int32
+                                      maximum: 65535
+                                      minimum: 1
+                                      type: integer
+                                    scheme:
+                                      description: |-
+                                        Scheme is the scheme to be used in the value of the `Location` header in
+                                        the response. When empty, the scheme of the request is used.
+
+                                        Scheme redirects can affect the port of the redirect, for more information,
+                                        refer to the documentation for the port field of this filter.
+
+                                        Note that values may be added to this enum, implementations
+                                        must ensure that unknown values will not cause a crash.
+
+                                        Unknown values here must result in the implementation setting the
+                                        Accepted Condition for the Route to `status: False`, with a
+                                        Reason of `UnsupportedValue`.
+
+                                        Support: Extended
+                                      enum:
+                                      - http
+                                      - https
+                                      type: string
+                                    statusCode:
+                                      default: 302
+                                      description: |-
+                                        StatusCode is the HTTP status code to be used in response.
+
+                                        Note that values may be added to this enum, implementations
+                                        must ensure that unknown values will not cause a crash.
+
+                                        Unknown values here must result in the implementation setting the
+                                        Accepted Condition for the Route to `status: False`, with a
+                                        Reason of `UnsupportedValue`.
+
+                                        Support: Core
+                                      enum:
+                                      - 301
+                                      - 302
+                                      type: integer
+                                  type: object
+                                responseHeaderModifier:
+                                  description: |-
+                                    ResponseHeaderModifier defines a schema for a filter that modifies response
+                                    headers.
+
+                                    Support: Extended
+                                  properties:
+                                    add:
+                                      description: |-
+                                        Add adds the given header(s) (name, value) to the request
+                                        before the action. It appends to any existing values associated
+                                        with the header name.
+
+                                        Input:
+                                          GET /foo HTTP/1.1
+                                          my-header: foo
+
+                                        Config:
+                                          add:
+                                          - name: "my-header"
+                                            value: "bar,baz"
+
+                                        Output:
+                                          GET /foo HTTP/1.1
+                                          my-header: foo,bar,baz
+                                      items:
+                                        description: HTTPHeader represents an HTTP
+                                          Header name and value as defined by RFC
+                                          7230.
+                                        properties:
+                                          name:
+                                            description: |-
+                                              Name is the name of the HTTP Header to be matched. Name matching MUST be
+                                              case insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
+
+                                              If multiple entries specify equivalent header names, the first entry with
+                                              an equivalent name MUST be considered for a match. Subsequent entries
+                                              with an equivalent header name MUST be ignored. Due to the
+                                              case-insensitivity of header names, "foo" and "Foo" are considered
+                                              equivalent.
+                                            maxLength: 256
+                                            minLength: 1
+                                            pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                            type: string
+                                          value:
+                                            description: Value is the value of HTTP
+                                              Header to be matched.
+                                            maxLength: 4096
+                                            minLength: 1
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                        type: object
+                                      maxItems: 16
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                      - name
+                                      x-kubernetes-list-type: map
+                                    remove:
+                                      description: |-
+                                        Remove the given header(s) from the HTTP request before the action. The
+                                        value of Remove is a list of HTTP header names. Note that the header
+                                        names are case-insensitive (see
+                                        https://datatracker.ietf.org/doc/html/rfc2616#section-4.2).
+
+                                        Input:
+                                          GET /foo HTTP/1.1
+                                          my-header1: foo
+                                          my-header2: bar
+                                          my-header3: baz
+
+                                        Config:
+                                          remove: ["my-header1", "my-header3"]
+
+                                        Output:
+                                          GET /foo HTTP/1.1
+                                          my-header2: bar
+                                      items:
+                                        type: string
+                                      maxItems: 16
+                                      type: array
+                                      x-kubernetes-list-type: set
+                                    set:
+                                      description: |-
+                                        Set overwrites the request with the given header (name, value)
+                                        before the action.
+
+                                        Input:
+                                          GET /foo HTTP/1.1
+                                          my-header: foo
+
+                                        Config:
+                                          set:
+                                          - name: "my-header"
+                                            value: "bar"
+
+                                        Output:
+                                          GET /foo HTTP/1.1
+                                          my-header: bar
+                                      items:
+                                        description: HTTPHeader represents an HTTP
+                                          Header name and value as defined by RFC
+                                          7230.
+                                        properties:
+                                          name:
+                                            description: |-
+                                              Name is the name of the HTTP Header to be matched. Name matching MUST be
+                                              case insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
+
+                                              If multiple entries specify equivalent header names, the first entry with
+                                              an equivalent name MUST be considered for a match. Subsequent entries
+                                              with an equivalent header name MUST be ignored. Due to the
+                                              case-insensitivity of header names, "foo" and "Foo" are considered
+                                              equivalent.
+                                            maxLength: 256
+                                            minLength: 1
+                                            pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                            type: string
+                                          value:
+                                            description: Value is the value of HTTP
+                                              Header to be matched.
+                                            maxLength: 4096
+                                            minLength: 1
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                        type: object
+                                      maxItems: 16
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                      - name
+                                      x-kubernetes-list-type: map
+                                  type: object
+                                type:
+                                  description: |-
+                                    Type identifies the type of filter to apply. As with other API fields,
+                                    types are classified into three conformance levels:
+
+                                    - Core: Filter types and their corresponding configuration defined by
+                                      "Support: Core" in this package, e.g. "RequestHeaderModifier". All
+                                      implementations must support core filters.
+
+                                    - Extended: Filter types and their corresponding configuration defined by
+                                      "Support: Extended" in this package, e.g. "RequestMirror". Implementers
+                                      are encouraged to support extended filters.
+
+                                    - Implementation-specific: Filters that are defined and supported by
+                                      specific vendors.
+                                      In the future, filters showing convergence in behavior across multiple
+                                      implementations will be considered for inclusion in extended or core
+                                      conformance levels. Filter-specific configuration for such filters
+                                      is specified using the ExtensionRef field. `Type` should be set to
+                                      "ExtensionRef" for custom filters.
+
+                                    Implementers are encouraged to define custom implementation types to
+                                    extend the core API with implementation-specific behavior.
+
+                                    If a reference to a custom filter type cannot be resolved, the filter
+                                    MUST NOT be skipped. Instead, requests that would have been processed by
+                                    that filter MUST receive a HTTP error response.
+
+                                    Note that values may be added to this enum, implementations
+                                    must ensure that unknown values will not cause a crash.
+
+                                    Unknown values here must result in the implementation setting the
+                                    Accepted Condition for the Route to `status: False`, with a
+                                    Reason of `UnsupportedValue`.
+                                  enum:
+                                  - RequestHeaderModifier
+                                  - ResponseHeaderModifier
+                                  - RequestMirror
+                                  - RequestRedirect
+                                  - URLRewrite
+                                  - ExtensionRef
+                                  type: string
+                                urlRewrite:
+                                  description: |-
+                                    URLRewrite defines a schema for a filter that modifies a request during forwarding.
+
+                                    Support: Extended
+                                  properties:
+                                    hostname:
+                                      description: |-
+                                        Hostname is the value to be used to replace the Host header value during
+                                        forwarding.
+
+                                        Support: Extended
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    path:
+                                      description: |-
+                                        Path defines a path rewrite.
+
+                                        Support: Extended
+                                      properties:
+                                        replaceFullPath:
+                                          description: |-
+                                            ReplaceFullPath specifies the value with which to replace the full path
+                                            of a request during a rewrite or redirect.
+                                          maxLength: 1024
+                                          type: string
+                                        replacePrefixMatch:
+                                          description: |-
+                                            ReplacePrefixMatch specifies the value with which to replace the prefix
+                                            match of a request during a rewrite or redirect. For example, a request
+                                            to "/foo/bar" with a prefix match of "/foo" and a ReplacePrefixMatch
+                                            of "/xyz" would be modified to "/xyz/bar".
+
+                                            Note that this matches the behavior of the PathPrefix match type. This
+                                            matches full path elements. A path element refers to the list of labels
+                                            in the path split by the `/` separator. When specified, a trailing `/` is
+                                            ignored. For example, the paths `/abc`, `/abc/`, and `/abc/def` would all
+                                            match the prefix `/abc`, but the path `/abcd` would not.
+
+                                            ReplacePrefixMatch is only compatible with a `PathPrefix` HTTPRouteMatch.
+                                            Using any other HTTPRouteMatch type on the same HTTPRouteRule will result in
+                                            the implementation setting the Accepted Condition for the Route to `status: False`.
+
+                                            Request Path | Prefix Match | Replace Prefix | Modified Path
+                                          maxLength: 1024
+                                          type: string
+                                        type:
+                                          description: |-
+                                            Type defines the type of path modifier. Additional types may be
+                                            added in a future release of the API.
+
+                                            Note that values may be added to this enum, implementations
+                                            must ensure that unknown values will not cause a crash.
+
+                                            Unknown values here must result in the implementation setting the
+                                            Accepted Condition for the Route to `status: False`, with a
+                                            Reason of `UnsupportedValue`.
+                                          enum:
+                                          - ReplaceFullPath
+                                          - ReplacePrefixMatch
+                                          type: string
+                                      required:
+                                      - type
+                                      type: object
+                                      x-kubernetes-validations:
+                                      - message: replaceFullPath must be specified
+                                          when type is set to 'ReplaceFullPath'
+                                        rule: 'self.type == ''ReplaceFullPath'' ?
+                                          has(self.replaceFullPath) : true'
+                                      - message: type must be 'ReplaceFullPath' when
+                                          replaceFullPath is set
+                                        rule: 'has(self.replaceFullPath) ? self.type
+                                          == ''ReplaceFullPath'' : true'
+                                      - message: replacePrefixMatch must be specified
+                                          when type is set to 'ReplacePrefixMatch'
+                                        rule: 'self.type == ''ReplacePrefixMatch''
+                                          ? has(self.replacePrefixMatch) : true'
+                                      - message: type must be 'ReplacePrefixMatch'
+                                          when replacePrefixMatch is set
+                                        rule: 'has(self.replacePrefixMatch) ? self.type
+                                          == ''ReplacePrefixMatch'' : true'
+                                  type: object
+                              required:
+                              - type
+                              type: object
+                              x-kubernetes-validations:
+                              - message: filter.requestHeaderModifier must be nil
+                                  if the filter.type is not RequestHeaderModifier
+                                rule: '!(has(self.requestHeaderModifier) && self.type
+                                  != ''RequestHeaderModifier'')'
+                              - message: filter.requestHeaderModifier must be specified
+                                  for RequestHeaderModifier filter.type
+                                rule: '!(!has(self.requestHeaderModifier) && self.type
+                                  == ''RequestHeaderModifier'')'
+                              - message: filter.responseHeaderModifier must be nil
+                                  if the filter.type is not ResponseHeaderModifier
+                                rule: '!(has(self.responseHeaderModifier) && self.type
+                                  != ''ResponseHeaderModifier'')'
+                              - message: filter.responseHeaderModifier must be specified
+                                  for ResponseHeaderModifier filter.type
+                                rule: '!(!has(self.responseHeaderModifier) && self.type
+                                  == ''ResponseHeaderModifier'')'
+                              - message: filter.requestMirror must be nil if the filter.type
+                                  is not RequestMirror
+                                rule: '!(has(self.requestMirror) && self.type != ''RequestMirror'')'
+                              - message: filter.requestMirror must be specified for
+                                  RequestMirror filter.type
+                                rule: '!(!has(self.requestMirror) && self.type ==
+                                  ''RequestMirror'')'
+                              - message: filter.requestRedirect must be nil if the
+                                  filter.type is not RequestRedirect
+                                rule: '!(has(self.requestRedirect) && self.type !=
+                                  ''RequestRedirect'')'
+                              - message: filter.requestRedirect must be specified
+                                  for RequestRedirect filter.type
+                                rule: '!(!has(self.requestRedirect) && self.type ==
+                                  ''RequestRedirect'')'
+                              - message: filter.urlRewrite must be nil if the filter.type
+                                  is not URLRewrite
+                                rule: '!(has(self.urlRewrite) && self.type != ''URLRewrite'')'
+                              - message: filter.urlRewrite must be specified for URLRewrite
+                                  filter.type
+                                rule: '!(!has(self.urlRewrite) && self.type == ''URLRewrite'')'
+                              - message: filter.extensionRef must be nil if the filter.type
+                                  is not ExtensionRef
+                                rule: '!(has(self.extensionRef) && self.type != ''ExtensionRef'')'
+                              - message: filter.extensionRef must be specified for
+                                  ExtensionRef filter.type
+                                rule: '!(!has(self.extensionRef) && self.type == ''ExtensionRef'')'
+                            maxItems: 16
+                            type: array
+                            x-kubernetes-validations:
+                            - message: May specify either httpRouteFilterRequestRedirect
+                                or httpRouteFilterRequestRewrite, but not both
+                              rule: '!(self.exists(f, f.type == ''RequestRedirect'')
+                                && self.exists(f, f.type == ''URLRewrite''))'
+                            - message: May specify either httpRouteFilterRequestRedirect
+                                or httpRouteFilterRequestRewrite, but not both
+                              rule: '!(self.exists(f, f.type == ''RequestRedirect'')
+                                && self.exists(f, f.type == ''URLRewrite''))'
+                            - message: RequestHeaderModifier filter cannot be repeated
+                              rule: self.filter(f, f.type == 'RequestHeaderModifier').size()
+                                <= 1
+                            - message: ResponseHeaderModifier filter cannot be repeated
+                              rule: self.filter(f, f.type == 'ResponseHeaderModifier').size()
+                                <= 1
+                            - message: RequestRedirect filter cannot be repeated
+                              rule: self.filter(f, f.type == 'RequestRedirect').size()
+                                <= 1
+                            - message: URLRewrite filter cannot be repeated
+                              rule: self.filter(f, f.type == 'URLRewrite').size()
+                                <= 1
+                          group:
+                            default: ""
+                            description: |-
+                              Group is the group of the referent. For example, "gateway.networking.k8s.io".
+                              When unspecified or empty string, core API group is inferred.
+                            maxLength: 253
+                            pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                            type: string
+                          kind:
+                            default: Service
+                            description: |-
+                              Kind is the Kubernetes resource kind of the referent. For example
+                              "Service".
+
+                              Defaults to "Service" when not specified.
+
+                              ExternalName services can refer to CNAME DNS records that may live
+                              outside of the cluster and as such are difficult to reason about in
+                              terms of conformance. They also may not be safe to forward to (see
+                              CVE-2021-25740 for more information). Implementations SHOULD NOT
+                              support ExternalName Services.
+
+                              Support: Core (Services with a type other than ExternalName)
+
+                              Support: Implementation-specific (Services with type ExternalName)
+                            maxLength: 63
+                            minLength: 1
+                            pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                            type: string
+                          name:
+                            description: Name is the name of the referent.
+                            maxLength: 253
+                            minLength: 1
+                            type: string
+                          namespace:
+                            description: |-
+                              Namespace is the namespace of the backend. When unspecified, the local
+                              namespace is inferred.
+
+                              Note that when a namespace different than the local namespace is specified,
+                              a ReferenceGrant object is required in the referent namespace to allow that
+                              namespace's owner to accept the reference. See the ReferenceGrant
+                              documentation for details.
+
+                              Support: Core
+                            maxLength: 63
+                            minLength: 1
+                            pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                            type: string
+                          port:
+                            description: |-
+                              Port specifies the destination port number to use for this resource.
+                              Port is required when the referent is a Kubernetes Service. In this
+                              case, the port number is the service port number, not the target port.
+                              For other resources, destination port might be derived from the referent
+                              resource or this field.
+                            format: int32
+                            maximum: 65535
+                            minimum: 1
+                            type: integer
+                          weight:
+                            default: 1
+                            description: |-
+                              Weight specifies the proportion of requests forwarded to the referenced
+                              backend. This is computed as weight/(sum of all weights in this
+                              BackendRefs list). For non-zero values, there may be some epsilon from
+                              the exact proportion defined here depending on the precision an
+                              implementation supports. Weight is not a percentage and the sum of
+                              weights does not need to equal 100.
+
+                              If only one backend is specified and it has a weight greater than 0, 100%
+                              of the traffic is forwarded to that backend. If weight is set to 0, no
+                              traffic should be forwarded for this entry. If unspecified, weight
+                              defaults to 1.
+
+                              Support for this field varies based on the context where used.
+                            format: int32
+                            maximum: 1000000
+                            minimum: 0
+                            type: integer
+                        required:
+                        - name
+                        type: object
+                        x-kubernetes-validations:
+                        - message: Must have port for Service reference
+                          rule: '(size(self.group) == 0 && self.kind == ''Service'')
+                            ? has(self.port) : true'
+                      maxItems: 16
+                      type: array
+                    filters:
+                      description: |-
+                        Filters define the filters that are applied to requests that match
+                        this rule.
+
+                        Wherever possible, implementations SHOULD implement filters in the order
+                        they are specified.
+
+                        Implementations MAY choose to implement this ordering strictly, rejecting
+                        any combination or order of filters that can not be supported. If implementations
+                        choose a strict interpretation of filter ordering, they MUST clearly document
+                        that behavior.
+
+                        To reject an invalid combination or order of filters, implementations SHOULD
+                        consider the Route Rules with this configuration invalid. If all Route Rules
+                        in a Route are invalid, the entire Route would be considered invalid. If only
+                        a portion of Route Rules are invalid, implementations MUST set the
+                        "PartiallyInvalid" condition for the Route.
+
+                        Conformance-levels at this level are defined based on the type of filter:
+
+                        - ALL core filters MUST be supported by all implementations.
+                        - Implementers are encouraged to support extended filters.
+                        - Implementation-specific custom filters have no API guarantees across
+                          implementations.
+
+                        Specifying the same filter multiple times is not supported unless explicitly
+                        indicated in the filter.
+
+                        All filters are expected to be compatible with each other except for the
+                        URLRewrite and RequestRedirect filters, which may not be combined. If an
+                        implementation can not support other combinations of filters, they must clearly
+                        document that limitation. In cases where incompatible or unsupported
+                        filters are specified and cause the `Accepted` condition to be set to status
+                        `False`, implementations may use the `IncompatibleFilters` reason to specify
+                        this configuration error.
+
+                        Support: Core
+                      items:
+                        description: |-
+                          HTTPRouteFilter defines processing steps that must be completed during the
+                          request or response lifecycle. HTTPRouteFilters are meant as an extension
+                          point to express processing that may be done in Gateway implementations. Some
+                          examples include request or response modification, implementing
+                          authentication strategies, rate-limiting, and traffic shaping. API
+                          guarantee/conformance is defined based on the type of the filter.
+                        properties:
+                          extensionRef:
+                            description: |-
+                              ExtensionRef is an optional, implementation-specific extension to the
+                              "filter" behavior.  For example, resource "myroutefilter" in group
+                              "networking.example.net"). ExtensionRef MUST NOT be used for core and
+                              extended filters.
+
+                              This filter can be used multiple times within the same rule.
+
+                              Support: Implementation-specific
+                            properties:
+                              group:
+                                description: |-
+                                  Group is the group of the referent. For example, "gateway.networking.k8s.io".
+                                  When unspecified or empty string, core API group is inferred.
+                                maxLength: 253
+                                pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                type: string
+                              kind:
+                                description: Kind is kind of the referent. For example
+                                  "HTTPRoute" or "Service".
+                                maxLength: 63
+                                minLength: 1
+                                pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                                type: string
+                              name:
+                                description: Name is the name of the referent.
+                                maxLength: 253
+                                minLength: 1
+                                type: string
+                            required:
+                            - group
+                            - kind
+                            - name
+                            type: object
+                          requestHeaderModifier:
+                            description: |-
+                              RequestHeaderModifier defines a schema for a filter that modifies request
+                              headers.
+
+                              Support: Core
+                            properties:
+                              add:
+                                description: |-
+                                  Add adds the given header(s) (name, value) to the request
+                                  before the action. It appends to any existing values associated
+                                  with the header name.
+
+                                  Input:
+                                    GET /foo HTTP/1.1
+                                    my-header: foo
+
+                                  Config:
+                                    add:
+                                    - name: "my-header"
+                                      value: "bar,baz"
+
+                                  Output:
+                                    GET /foo HTTP/1.1
+                                    my-header: foo,bar,baz
+                                items:
+                                  description: HTTPHeader represents an HTTP Header
+                                    name and value as defined by RFC 7230.
+                                  properties:
+                                    name:
+                                      description: |-
+                                        Name is the name of the HTTP Header to be matched. Name matching MUST be
+                                        case insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
+
+                                        If multiple entries specify equivalent header names, the first entry with
+                                        an equivalent name MUST be considered for a match. Subsequent entries
+                                        with an equivalent header name MUST be ignored. Due to the
+                                        case-insensitivity of header names, "foo" and "Foo" are considered
+                                        equivalent.
+                                      maxLength: 256
+                                      minLength: 1
+                                      pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                      type: string
+                                    value:
+                                      description: Value is the value of HTTP Header
+                                        to be matched.
+                                      maxLength: 4096
+                                      minLength: 1
+                                      type: string
+                                  required:
+                                  - name
+                                  - value
+                                  type: object
+                                maxItems: 16
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                - name
+                                x-kubernetes-list-type: map
+                              remove:
+                                description: |-
+                                  Remove the given header(s) from the HTTP request before the action. The
+                                  value of Remove is a list of HTTP header names. Note that the header
+                                  names are case-insensitive (see
+                                  https://datatracker.ietf.org/doc/html/rfc2616#section-4.2).
+
+                                  Input:
+                                    GET /foo HTTP/1.1
+                                    my-header1: foo
+                                    my-header2: bar
+                                    my-header3: baz
+
+                                  Config:
+                                    remove: ["my-header1", "my-header3"]
+
+                                  Output:
+                                    GET /foo HTTP/1.1
+                                    my-header2: bar
+                                items:
+                                  type: string
+                                maxItems: 16
+                                type: array
+                                x-kubernetes-list-type: set
+                              set:
+                                description: |-
+                                  Set overwrites the request with the given header (name, value)
+                                  before the action.
+
+                                  Input:
+                                    GET /foo HTTP/1.1
+                                    my-header: foo
+
+                                  Config:
+                                    set:
+                                    - name: "my-header"
+                                      value: "bar"
+
+                                  Output:
+                                    GET /foo HTTP/1.1
+                                    my-header: bar
+                                items:
+                                  description: HTTPHeader represents an HTTP Header
+                                    name and value as defined by RFC 7230.
+                                  properties:
+                                    name:
+                                      description: |-
+                                        Name is the name of the HTTP Header to be matched. Name matching MUST be
+                                        case insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
+
+                                        If multiple entries specify equivalent header names, the first entry with
+                                        an equivalent name MUST be considered for a match. Subsequent entries
+                                        with an equivalent header name MUST be ignored. Due to the
+                                        case-insensitivity of header names, "foo" and "Foo" are considered
+                                        equivalent.
+                                      maxLength: 256
+                                      minLength: 1
+                                      pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                      type: string
+                                    value:
+                                      description: Value is the value of HTTP Header
+                                        to be matched.
+                                      maxLength: 4096
+                                      minLength: 1
+                                      type: string
+                                  required:
+                                  - name
+                                  - value
+                                  type: object
+                                maxItems: 16
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                - name
+                                x-kubernetes-list-type: map
+                            type: object
+                          requestMirror:
+                            description: |+
+                              RequestMirror defines a schema for a filter that mirrors requests.
+                              Requests are sent to the specified destination, but responses from
+                              that destination are ignored.
+
+                              This filter can be used multiple times within the same rule. Note that
+                              not all implementations will be able to support mirroring to multiple
+                              backends.
+
+                              Support: Extended
+
+                            properties:
+                              backendRef:
+                                description: |-
+                                  BackendRef references a resource where mirrored requests are sent.
+
+                                  Mirrored requests must be sent only to a single destination endpoint
+                                  within this BackendRef, irrespective of how many endpoints are present
+                                  within this BackendRef.
+
+                                  If the referent cannot be found, this BackendRef is invalid and must be
+                                  dropped from the Gateway. The controller must ensure the "ResolvedRefs"
+                                  condition on the Route status is set to `status: False` and not configure
+                                  this backend in the underlying implementation.
+
+                                  If there is a cross-namespace reference to an *existing* object
+                                  that is not allowed by a ReferenceGrant, the controller must ensure the
+                                  "ResolvedRefs"  condition on the Route is set to `status: False`,
+                                  with the "RefNotPermitted" reason and not configure this backend in the
+                                  underlying implementation.
+
+                                  In either error case, the Message of the `ResolvedRefs` Condition
+                                  should be used to provide more detail about the problem.
+
+                                  Support: Extended for Kubernetes Service
+
+                                  Support: Implementation-specific for any other resource
+                                properties:
+                                  group:
+                                    default: ""
+                                    description: |-
+                                      Group is the group of the referent. For example, "gateway.networking.k8s.io".
+                                      When unspecified or empty string, core API group is inferred.
+                                    maxLength: 253
+                                    pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                    type: string
+                                  kind:
+                                    default: Service
+                                    description: |-
+                                      Kind is the Kubernetes resource kind of the referent. For example
+                                      "Service".
+
+                                      Defaults to "Service" when not specified.
+
+                                      ExternalName services can refer to CNAME DNS records that may live
+                                      outside of the cluster and as such are difficult to reason about in
+                                      terms of conformance. They also may not be safe to forward to (see
+                                      CVE-2021-25740 for more information). Implementations SHOULD NOT
+                                      support ExternalName Services.
+
+                                      Support: Core (Services with a type other than ExternalName)
+
+                                      Support: Implementation-specific (Services with type ExternalName)
+                                    maxLength: 63
+                                    minLength: 1
+                                    pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                                    type: string
+                                  name:
+                                    description: Name is the name of the referent.
+                                    maxLength: 253
+                                    minLength: 1
+                                    type: string
+                                  namespace:
+                                    description: |-
+                                      Namespace is the namespace of the backend. When unspecified, the local
+                                      namespace is inferred.
+
+                                      Note that when a namespace different than the local namespace is specified,
+                                      a ReferenceGrant object is required in the referent namespace to allow that
+                                      namespace's owner to accept the reference. See the ReferenceGrant
+                                      documentation for details.
+
+                                      Support: Core
+                                    maxLength: 63
+                                    minLength: 1
+                                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                    type: string
+                                  port:
+                                    description: |-
+                                      Port specifies the destination port number to use for this resource.
+                                      Port is required when the referent is a Kubernetes Service. In this
+                                      case, the port number is the service port number, not the target port.
+                                      For other resources, destination port might be derived from the referent
+                                      resource or this field.
+                                    format: int32
+                                    maximum: 65535
+                                    minimum: 1
+                                    type: integer
+                                required:
+                                - name
+                                type: object
+                                x-kubernetes-validations:
+                                - message: Must have port for Service reference
+                                  rule: '(size(self.group) == 0 && self.kind == ''Service'')
+                                    ? has(self.port) : true'
+                            required:
+                            - backendRef
+                            type: object
+                          requestRedirect:
+                            description: |-
+                              RequestRedirect defines a schema for a filter that responds to the
+                              request with an HTTP redirection.
+
+                              Support: Core
+                            properties:
+                              hostname:
+                                description: |-
+                                  Hostname is the hostname to be used in the value of the `Location`
+                                  header in the response.
+                                  When empty, the hostname in the `Host` header of the request is used.
+
+                                  Support: Core
+                                maxLength: 253
+                                minLength: 1
+                                pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                type: string
+                              path:
+                                description: |-
+                                  Path defines parameters used to modify the path of the incoming request.
+                                  The modified path is then used to construct the `Location` header. When
+                                  empty, the request path is used as-is.
+
+                                  Support: Extended
+                                properties:
+                                  replaceFullPath:
+                                    description: |-
+                                      ReplaceFullPath specifies the value with which to replace the full path
+                                      of a request during a rewrite or redirect.
+                                    maxLength: 1024
+                                    type: string
+                                  replacePrefixMatch:
+                                    description: |-
+                                      ReplacePrefixMatch specifies the value with which to replace the prefix
+                                      match of a request during a rewrite or redirect. For example, a request
+                                      to "/foo/bar" with a prefix match of "/foo" and a ReplacePrefixMatch
+                                      of "/xyz" would be modified to "/xyz/bar".
+
+                                      Note that this matches the behavior of the PathPrefix match type. This
+                                      matches full path elements. A path element refers to the list of labels
+                                      in the path split by the `/` separator. When specified, a trailing `/` is
+                                      ignored. For example, the paths `/abc`, `/abc/`, and `/abc/def` would all
+                                      match the prefix `/abc`, but the path `/abcd` would not.
+
+                                      ReplacePrefixMatch is only compatible with a `PathPrefix` HTTPRouteMatch.
+                                      Using any other HTTPRouteMatch type on the same HTTPRouteRule will result in
+                                      the implementation setting the Accepted Condition for the Route to `status: False`.
+
+                                      Request Path | Prefix Match | Replace Prefix | Modified Path
+                                    maxLength: 1024
+                                    type: string
+                                  type:
+                                    description: |-
+                                      Type defines the type of path modifier. Additional types may be
+                                      added in a future release of the API.
+
+                                      Note that values may be added to this enum, implementations
+                                      must ensure that unknown values will not cause a crash.
+
+                                      Unknown values here must result in the implementation setting the
+                                      Accepted Condition for the Route to `status: False`, with a
+                                      Reason of `UnsupportedValue`.
+                                    enum:
+                                    - ReplaceFullPath
+                                    - ReplacePrefixMatch
+                                    type: string
+                                required:
+                                - type
+                                type: object
+                                x-kubernetes-validations:
+                                - message: replaceFullPath must be specified when
+                                    type is set to 'ReplaceFullPath'
+                                  rule: 'self.type == ''ReplaceFullPath'' ? has(self.replaceFullPath)
+                                    : true'
+                                - message: type must be 'ReplaceFullPath' when replaceFullPath
+                                    is set
+                                  rule: 'has(self.replaceFullPath) ? self.type ==
+                                    ''ReplaceFullPath'' : true'
+                                - message: replacePrefixMatch must be specified when
+                                    type is set to 'ReplacePrefixMatch'
+                                  rule: 'self.type == ''ReplacePrefixMatch'' ? has(self.replacePrefixMatch)
+                                    : true'
+                                - message: type must be 'ReplacePrefixMatch' when
+                                    replacePrefixMatch is set
+                                  rule: 'has(self.replacePrefixMatch) ? self.type
+                                    == ''ReplacePrefixMatch'' : true'
+                              port:
+                                description: |-
+                                  Port is the port to be used in the value of the `Location`
+                                  header in the response.
+
+                                  If no port is specified, the redirect port MUST be derived using the
+                                  following rules:
+
+                                  * If redirect scheme is not-empty, the redirect port MUST be the well-known
+                                    port associated with the redirect scheme. Specifically "http" to port 80
+                                    and "https" to port 443. If the redirect scheme does not have a
+                                    well-known port, the listener port of the Gateway SHOULD be used.
+                                  * If redirect scheme is empty, the redirect port MUST be the Gateway
+                                    Listener port.
+
+                                  Implementations SHOULD NOT add the port number in the 'Location'
+                                  header in the following cases:
+
+                                  * A Location header that will use HTTP (whether that is determined via
+                                    the Listener protocol or the Scheme field) _and_ use port 80.
+                                  * A Location header that will use HTTPS (whether that is determined via
+                                    the Listener protocol or the Scheme field) _and_ use port 443.
+
+                                  Support: Extended
+                                format: int32
+                                maximum: 65535
+                                minimum: 1
+                                type: integer
+                              scheme:
+                                description: |-
+                                  Scheme is the scheme to be used in the value of the `Location` header in
+                                  the response. When empty, the scheme of the request is used.
+
+                                  Scheme redirects can affect the port of the redirect, for more information,
+                                  refer to the documentation for the port field of this filter.
+
+                                  Note that values may be added to this enum, implementations
+                                  must ensure that unknown values will not cause a crash.
+
+                                  Unknown values here must result in the implementation setting the
+                                  Accepted Condition for the Route to `status: False`, with a
+                                  Reason of `UnsupportedValue`.
+
+                                  Support: Extended
+                                enum:
+                                - http
+                                - https
+                                type: string
+                              statusCode:
+                                default: 302
+                                description: |-
+                                  StatusCode is the HTTP status code to be used in response.
+
+                                  Note that values may be added to this enum, implementations
+                                  must ensure that unknown values will not cause a crash.
+
+                                  Unknown values here must result in the implementation setting the
+                                  Accepted Condition for the Route to `status: False`, with a
+                                  Reason of `UnsupportedValue`.
+
+                                  Support: Core
+                                enum:
+                                - 301
+                                - 302
+                                type: integer
+                            type: object
+                          responseHeaderModifier:
+                            description: |-
+                              ResponseHeaderModifier defines a schema for a filter that modifies response
+                              headers.
+
+                              Support: Extended
+                            properties:
+                              add:
+                                description: |-
+                                  Add adds the given header(s) (name, value) to the request
+                                  before the action. It appends to any existing values associated
+                                  with the header name.
+
+                                  Input:
+                                    GET /foo HTTP/1.1
+                                    my-header: foo
+
+                                  Config:
+                                    add:
+                                    - name: "my-header"
+                                      value: "bar,baz"
+
+                                  Output:
+                                    GET /foo HTTP/1.1
+                                    my-header: foo,bar,baz
+                                items:
+                                  description: HTTPHeader represents an HTTP Header
+                                    name and value as defined by RFC 7230.
+                                  properties:
+                                    name:
+                                      description: |-
+                                        Name is the name of the HTTP Header to be matched. Name matching MUST be
+                                        case insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
+
+                                        If multiple entries specify equivalent header names, the first entry with
+                                        an equivalent name MUST be considered for a match. Subsequent entries
+                                        with an equivalent header name MUST be ignored. Due to the
+                                        case-insensitivity of header names, "foo" and "Foo" are considered
+                                        equivalent.
+                                      maxLength: 256
+                                      minLength: 1
+                                      pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                      type: string
+                                    value:
+                                      description: Value is the value of HTTP Header
+                                        to be matched.
+                                      maxLength: 4096
+                                      minLength: 1
+                                      type: string
+                                  required:
+                                  - name
+                                  - value
+                                  type: object
+                                maxItems: 16
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                - name
+                                x-kubernetes-list-type: map
+                              remove:
+                                description: |-
+                                  Remove the given header(s) from the HTTP request before the action. The
+                                  value of Remove is a list of HTTP header names. Note that the header
+                                  names are case-insensitive (see
+                                  https://datatracker.ietf.org/doc/html/rfc2616#section-4.2).
+
+                                  Input:
+                                    GET /foo HTTP/1.1
+                                    my-header1: foo
+                                    my-header2: bar
+                                    my-header3: baz
+
+                                  Config:
+                                    remove: ["my-header1", "my-header3"]
+
+                                  Output:
+                                    GET /foo HTTP/1.1
+                                    my-header2: bar
+                                items:
+                                  type: string
+                                maxItems: 16
+                                type: array
+                                x-kubernetes-list-type: set
+                              set:
+                                description: |-
+                                  Set overwrites the request with the given header (name, value)
+                                  before the action.
+
+                                  Input:
+                                    GET /foo HTTP/1.1
+                                    my-header: foo
+
+                                  Config:
+                                    set:
+                                    - name: "my-header"
+                                      value: "bar"
+
+                                  Output:
+                                    GET /foo HTTP/1.1
+                                    my-header: bar
+                                items:
+                                  description: HTTPHeader represents an HTTP Header
+                                    name and value as defined by RFC 7230.
+                                  properties:
+                                    name:
+                                      description: |-
+                                        Name is the name of the HTTP Header to be matched. Name matching MUST be
+                                        case insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
+
+                                        If multiple entries specify equivalent header names, the first entry with
+                                        an equivalent name MUST be considered for a match. Subsequent entries
+                                        with an equivalent header name MUST be ignored. Due to the
+                                        case-insensitivity of header names, "foo" and "Foo" are considered
+                                        equivalent.
+                                      maxLength: 256
+                                      minLength: 1
+                                      pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                      type: string
+                                    value:
+                                      description: Value is the value of HTTP Header
+                                        to be matched.
+                                      maxLength: 4096
+                                      minLength: 1
+                                      type: string
+                                  required:
+                                  - name
+                                  - value
+                                  type: object
+                                maxItems: 16
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                - name
+                                x-kubernetes-list-type: map
+                            type: object
+                          type:
+                            description: |-
+                              Type identifies the type of filter to apply. As with other API fields,
+                              types are classified into three conformance levels:
+
+                              - Core: Filter types and their corresponding configuration defined by
+                                "Support: Core" in this package, e.g. "RequestHeaderModifier". All
+                                implementations must support core filters.
+
+                              - Extended: Filter types and their corresponding configuration defined by
+                                "Support: Extended" in this package, e.g. "RequestMirror". Implementers
+                                are encouraged to support extended filters.
+
+                              - Implementation-specific: Filters that are defined and supported by
+                                specific vendors.
+                                In the future, filters showing convergence in behavior across multiple
+                                implementations will be considered for inclusion in extended or core
+                                conformance levels. Filter-specific configuration for such filters
+                                is specified using the ExtensionRef field. `Type` should be set to
+                                "ExtensionRef" for custom filters.
+
+                              Implementers are encouraged to define custom implementation types to
+                              extend the core API with implementation-specific behavior.
+
+                              If a reference to a custom filter type cannot be resolved, the filter
+                              MUST NOT be skipped. Instead, requests that would have been processed by
+                              that filter MUST receive a HTTP error response.
+
+                              Note that values may be added to this enum, implementations
+                              must ensure that unknown values will not cause a crash.
+
+                              Unknown values here must result in the implementation setting the
+                              Accepted Condition for the Route to `status: False`, with a
+                              Reason of `UnsupportedValue`.
+                            enum:
+                            - RequestHeaderModifier
+                            - ResponseHeaderModifier
+                            - RequestMirror
+                            - RequestRedirect
+                            - URLRewrite
+                            - ExtensionRef
+                            type: string
+                          urlRewrite:
+                            description: |-
+                              URLRewrite defines a schema for a filter that modifies a request during forwarding.
+
+                              Support: Extended
+                            properties:
+                              hostname:
+                                description: |-
+                                  Hostname is the value to be used to replace the Host header value during
+                                  forwarding.
+
+                                  Support: Extended
+                                maxLength: 253
+                                minLength: 1
+                                pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                type: string
+                              path:
+                                description: |-
+                                  Path defines a path rewrite.
+
+                                  Support: Extended
+                                properties:
+                                  replaceFullPath:
+                                    description: |-
+                                      ReplaceFullPath specifies the value with which to replace the full path
+                                      of a request during a rewrite or redirect.
+                                    maxLength: 1024
+                                    type: string
+                                  replacePrefixMatch:
+                                    description: |-
+                                      ReplacePrefixMatch specifies the value with which to replace the prefix
+                                      match of a request during a rewrite or redirect. For example, a request
+                                      to "/foo/bar" with a prefix match of "/foo" and a ReplacePrefixMatch
+                                      of "/xyz" would be modified to "/xyz/bar".
+
+                                      Note that this matches the behavior of the PathPrefix match type. This
+                                      matches full path elements. A path element refers to the list of labels
+                                      in the path split by the `/` separator. When specified, a trailing `/` is
+                                      ignored. For example, the paths `/abc`, `/abc/`, and `/abc/def` would all
+                                      match the prefix `/abc`, but the path `/abcd` would not.
+
+                                      ReplacePrefixMatch is only compatible with a `PathPrefix` HTTPRouteMatch.
+                                      Using any other HTTPRouteMatch type on the same HTTPRouteRule will result in
+                                      the implementation setting the Accepted Condition for the Route to `status: False`.
+
+                                      Request Path | Prefix Match | Replace Prefix | Modified Path
+                                    maxLength: 1024
+                                    type: string
+                                  type:
+                                    description: |-
+                                      Type defines the type of path modifier. Additional types may be
+                                      added in a future release of the API.
+
+                                      Note that values may be added to this enum, implementations
+                                      must ensure that unknown values will not cause a crash.
+
+                                      Unknown values here must result in the implementation setting the
+                                      Accepted Condition for the Route to `status: False`, with a
+                                      Reason of `UnsupportedValue`.
+                                    enum:
+                                    - ReplaceFullPath
+                                    - ReplacePrefixMatch
+                                    type: string
+                                required:
+                                - type
+                                type: object
+                                x-kubernetes-validations:
+                                - message: replaceFullPath must be specified when
+                                    type is set to 'ReplaceFullPath'
+                                  rule: 'self.type == ''ReplaceFullPath'' ? has(self.replaceFullPath)
+                                    : true'
+                                - message: type must be 'ReplaceFullPath' when replaceFullPath
+                                    is set
+                                  rule: 'has(self.replaceFullPath) ? self.type ==
+                                    ''ReplaceFullPath'' : true'
+                                - message: replacePrefixMatch must be specified when
+                                    type is set to 'ReplacePrefixMatch'
+                                  rule: 'self.type == ''ReplacePrefixMatch'' ? has(self.replacePrefixMatch)
+                                    : true'
+                                - message: type must be 'ReplacePrefixMatch' when
+                                    replacePrefixMatch is set
+                                  rule: 'has(self.replacePrefixMatch) ? self.type
+                                    == ''ReplacePrefixMatch'' : true'
+                            type: object
+                        required:
+                        - type
+                        type: object
+                        x-kubernetes-validations:
+                        - message: filter.requestHeaderModifier must be nil if the
+                            filter.type is not RequestHeaderModifier
+                          rule: '!(has(self.requestHeaderModifier) && self.type !=
+                            ''RequestHeaderModifier'')'
+                        - message: filter.requestHeaderModifier must be specified
+                            for RequestHeaderModifier filter.type
+                          rule: '!(!has(self.requestHeaderModifier) && self.type ==
+                            ''RequestHeaderModifier'')'
+                        - message: filter.responseHeaderModifier must be nil if the
+                            filter.type is not ResponseHeaderModifier
+                          rule: '!(has(self.responseHeaderModifier) && self.type !=
+                            ''ResponseHeaderModifier'')'
+                        - message: filter.responseHeaderModifier must be specified
+                            for ResponseHeaderModifier filter.type
+                          rule: '!(!has(self.responseHeaderModifier) && self.type
+                            == ''ResponseHeaderModifier'')'
+                        - message: filter.requestMirror must be nil if the filter.type
+                            is not RequestMirror
+                          rule: '!(has(self.requestMirror) && self.type != ''RequestMirror'')'
+                        - message: filter.requestMirror must be specified for RequestMirror
+                            filter.type
+                          rule: '!(!has(self.requestMirror) && self.type == ''RequestMirror'')'
+                        - message: filter.requestRedirect must be nil if the filter.type
+                            is not RequestRedirect
+                          rule: '!(has(self.requestRedirect) && self.type != ''RequestRedirect'')'
+                        - message: filter.requestRedirect must be specified for RequestRedirect
+                            filter.type
+                          rule: '!(!has(self.requestRedirect) && self.type == ''RequestRedirect'')'
+                        - message: filter.urlRewrite must be nil if the filter.type
+                            is not URLRewrite
+                          rule: '!(has(self.urlRewrite) && self.type != ''URLRewrite'')'
+                        - message: filter.urlRewrite must be specified for URLRewrite
+                            filter.type
+                          rule: '!(!has(self.urlRewrite) && self.type == ''URLRewrite'')'
+                        - message: filter.extensionRef must be nil if the filter.type
+                            is not ExtensionRef
+                          rule: '!(has(self.extensionRef) && self.type != ''ExtensionRef'')'
+                        - message: filter.extensionRef must be specified for ExtensionRef
+                            filter.type
+                          rule: '!(!has(self.extensionRef) && self.type == ''ExtensionRef'')'
+                      maxItems: 16
+                      type: array
+                      x-kubernetes-validations:
+                      - message: May specify either httpRouteFilterRequestRedirect
+                          or httpRouteFilterRequestRewrite, but not both
+                        rule: '!(self.exists(f, f.type == ''RequestRedirect'') &&
+                          self.exists(f, f.type == ''URLRewrite''))'
+                      - message: RequestHeaderModifier filter cannot be repeated
+                        rule: self.filter(f, f.type == 'RequestHeaderModifier').size()
+                          <= 1
+                      - message: ResponseHeaderModifier filter cannot be repeated
+                        rule: self.filter(f, f.type == 'ResponseHeaderModifier').size()
+                          <= 1
+                      - message: RequestRedirect filter cannot be repeated
+                        rule: self.filter(f, f.type == 'RequestRedirect').size() <=
+                          1
+                      - message: URLRewrite filter cannot be repeated
+                        rule: self.filter(f, f.type == 'URLRewrite').size() <= 1
+                    matches:
+                      default:
+                      - path:
+                          type: PathPrefix
+                          value: /
+                      description: |-
+                        Matches define conditions used for matching the rule against incoming
+                        HTTP requests. Each match is independent, i.e. this rule will be matched
+                        if **any** one of the matches is satisfied.
+
+                        For example, take the following matches configuration:
+
+                        ```
+                        matches:
+                        - path:
+                            value: "/foo"
+                          headers:
+                          - name: "version"
+                            value: "v2"
+                        - path:
+                            value: "/v2/foo"
+                        ```
+
+                        For a request to match against this rule, a request must satisfy
+                        EITHER of the two conditions:
+
+                        - path prefixed with `/foo` AND contains the header `version: v2`
+                        - path prefix of `/v2/foo`
+
+                        See the documentation for HTTPRouteMatch on how to specify multiple
+                        match conditions that should be ANDed together.
+
+                        If no matches are specified, the default is a prefix
+                        path match on "/", which has the effect of matching every
+                        HTTP request.
+
+                        Proxy or Load Balancer routing configuration generated from HTTPRoutes
+                        MUST prioritize matches based on the following criteria, continuing on
+                        ties. Across all rules specified on applicable Routes, precedence must be
+                        given to the match having:
+
+                        * "Exact" path match.
+                        * "Prefix" path match with largest number of characters.
+                        * Method match.
+                        * Largest number of header matches.
+                        * Largest number of query param matches.
+
+                        Note: The precedence of RegularExpression path matches are implementation-specific.
+
+                        If ties still exist across multiple Routes, matching precedence MUST be
+                        determined in order of the following criteria, continuing on ties:
+
+                        * The oldest Route based on creation timestamp.
+                        * The Route appearing first in alphabetical order by
+                          "{namespace}/{name}".
+
+                        If ties still exist within an HTTPRoute, matching precedence MUST be granted
+                        to the FIRST matching rule (in list order) with a match meeting the above
+                        criteria.
+
+                        When no rules matching a request have been successfully attached to the
+                        parent a request is coming from, a HTTP 404 status code MUST be returned.
+                      items:
+                        description: "HTTPRouteMatch defines the predicate used to
+                          match requests to a given\naction. Multiple match types
+                          are ANDed together, i.e. the match will\nevaluate to true
+                          only if all conditions are satisfied.\n\nFor example, the
+                          match below will match a HTTP request only if its path\nstarts
+                          with `/foo` AND it contains the `version: v1` header:\n\n```\nmatch:\n\n\tpath:\n\t
+                          \ value: \"/foo\"\n\theaders:\n\t- name: \"version\"\n\t
+                          \ value \"v1\"\n\n```"
+                        properties:
+                          headers:
+                            description: |-
+                              Headers specifies HTTP request header matchers. Multiple match values are
+                              ANDed together, meaning, a request must match all the specified headers
+                              to select the route.
+                            items:
+                              description: |-
+                                HTTPHeaderMatch describes how to select a HTTP route by matching HTTP request
+                                headers.
+                              properties:
+                                name:
+                                  description: |-
+                                    Name is the name of the HTTP Header to be matched. Name matching MUST be
+                                    case insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
+
+                                    If multiple entries specify equivalent header names, only the first
+                                    entry with an equivalent name MUST be considered for a match. Subsequent
+                                    entries with an equivalent header name MUST be ignored. Due to the
+                                    case-insensitivity of header names, "foo" and "Foo" are considered
+                                    equivalent.
+
+                                    When a header is repeated in an HTTP request, it is
+                                    implementation-specific behavior as to how this is represented.
+                                    Generally, proxies should follow the guidance from the RFC:
+                                    https://www.rfc-editor.org/rfc/rfc7230.html#section-3.2.2 regarding
+                                    processing a repeated header, with special handling for "Set-Cookie".
+                                  maxLength: 256
+                                  minLength: 1
+                                  pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                  type: string
+                                type:
+                                  default: Exact
+                                  description: |-
+                                    Type specifies how to match against the value of the header.
+
+                                    Support: Core (Exact)
+
+                                    Support: Implementation-specific (RegularExpression)
+
+                                    Since RegularExpression HeaderMatchType has implementation-specific
+                                    conformance, implementations can support POSIX, PCRE or any other dialects
+                                    of regular expressions. Please read the implementation's documentation to
+                                    determine the supported dialect.
+                                  enum:
+                                  - Exact
+                                  - RegularExpression
+                                  type: string
+                                value:
+                                  description: Value is the value of HTTP Header to
+                                    be matched.
+                                  maxLength: 4096
+                                  minLength: 1
+                                  type: string
+                              required:
+                              - name
+                              - value
+                              type: object
+                            maxItems: 16
+                            type: array
+                            x-kubernetes-list-map-keys:
+                            - name
+                            x-kubernetes-list-type: map
+                          method:
+                            description: |-
+                              Method specifies HTTP method matcher.
+                              When specified, this route will be matched only if the request has the
+                              specified method.
+
+                              Support: Extended
+                            enum:
+                            - GET
+                            - HEAD
+                            - POST
+                            - PUT
+                            - DELETE
+                            - CONNECT
+                            - OPTIONS
+                            - TRACE
+                            - PATCH
+                            type: string
+                          path:
+                            default:
+                              type: PathPrefix
+                              value: /
+                            description: |-
+                              Path specifies a HTTP request path matcher. If this field is not
+                              specified, a default prefix match on the "/" path is provided.
+                            properties:
+                              type:
+                                default: PathPrefix
+                                description: |-
+                                  Type specifies how to match against the path Value.
+
+                                  Support: Core (Exact, PathPrefix)
+
+                                  Support: Implementation-specific (RegularExpression)
+                                enum:
+                                - Exact
+                                - PathPrefix
+                                - RegularExpression
+                                type: string
+                              value:
+                                default: /
+                                description: Value of the HTTP path to match against.
+                                maxLength: 1024
+                                type: string
+                            type: object
+                            x-kubernetes-validations:
+                            - message: value must be an absolute path and start with
+                                '/' when type one of ['Exact', 'PathPrefix']
+                              rule: '(self.type in [''Exact'',''PathPrefix'']) ? self.value.startsWith(''/'')
+                                : true'
+                            - message: must not contain '//' when type one of ['Exact',
+                                'PathPrefix']
+                              rule: '(self.type in [''Exact'',''PathPrefix'']) ? !self.value.contains(''//'')
+                                : true'
+                            - message: must not contain '/./' when type one of ['Exact',
+                                'PathPrefix']
+                              rule: '(self.type in [''Exact'',''PathPrefix'']) ? !self.value.contains(''/./'')
+                                : true'
+                            - message: must not contain '/../' when type one of ['Exact',
+                                'PathPrefix']
+                              rule: '(self.type in [''Exact'',''PathPrefix'']) ? !self.value.contains(''/../'')
+                                : true'
+                            - message: must not contain '%2f' when type one of ['Exact',
+                                'PathPrefix']
+                              rule: '(self.type in [''Exact'',''PathPrefix'']) ? !self.value.contains(''%2f'')
+                                : true'
+                            - message: must not contain '%2F' when type one of ['Exact',
+                                'PathPrefix']
+                              rule: '(self.type in [''Exact'',''PathPrefix'']) ? !self.value.contains(''%2F'')
+                                : true'
+                            - message: must not contain '#' when type one of ['Exact',
+                                'PathPrefix']
+                              rule: '(self.type in [''Exact'',''PathPrefix'']) ? !self.value.contains(''#'')
+                                : true'
+                            - message: must not end with '/..' when type one of ['Exact',
+                                'PathPrefix']
+                              rule: '(self.type in [''Exact'',''PathPrefix'']) ? !self.value.endsWith(''/..'')
+                                : true'
+                            - message: must not end with '/.' when type one of ['Exact',
+                                'PathPrefix']
+                              rule: '(self.type in [''Exact'',''PathPrefix'']) ? !self.value.endsWith(''/.'')
+                                : true'
+                            - message: type must be one of ['Exact', 'PathPrefix',
+                                'RegularExpression']
+                              rule: self.type in ['Exact','PathPrefix'] || self.type
+                                == 'RegularExpression'
+                            - message: must only contain valid characters (matching
+                                ^(?:[-A-Za-z0-9/._~!$&'()*+,;=:@]|[%][0-9a-fA-F]{2})+$)
+                                for types ['Exact', 'PathPrefix']
+                              rule: '(self.type in [''Exact'',''PathPrefix'']) ? self.value.matches(r"""^(?:[-A-Za-z0-9/._~!$&''()*+,;=:@]|[%][0-9a-fA-F]{2})+$""")
+                                : true'
+                          queryParams:
+                            description: |-
+                              QueryParams specifies HTTP query parameter matchers. Multiple match
+                              values are ANDed together, meaning, a request must match all the
+                              specified query parameters to select the route.
+
+                              Support: Extended
+                            items:
+                              description: |-
+                                HTTPQueryParamMatch describes how to select a HTTP route by matching HTTP
+                                query parameters.
+                              properties:
+                                name:
+                                  description: |-
+                                    Name is the name of the HTTP query param to be matched. This must be an
+                                    exact string match. (See
+                                    https://tools.ietf.org/html/rfc7230#section-2.7.3).
+
+                                    If multiple entries specify equivalent query param names, only the first
+                                    entry with an equivalent name MUST be considered for a match. Subsequent
+                                    entries with an equivalent query param name MUST be ignored.
+
+                                    If a query param is repeated in an HTTP request, the behavior is
+                                    purposely left undefined, since different data planes have different
+                                    capabilities. However, it is *recommended* that implementations should
+                                    match against the first value of the param if the data plane supports it,
+                                    as this behavior is expected in other load balancing contexts outside of
+                                    the Gateway API.
+
+                                    Users SHOULD NOT route traffic based on repeated query params to guard
+                                    themselves against potential differences in the implementations.
+                                  maxLength: 256
+                                  minLength: 1
+                                  pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                  type: string
+                                type:
+                                  default: Exact
+                                  description: |-
+                                    Type specifies how to match against the value of the query parameter.
+
+                                    Support: Extended (Exact)
+
+                                    Support: Implementation-specific (RegularExpression)
+
+                                    Since RegularExpression QueryParamMatchType has Implementation-specific
+                                    conformance, implementations can support POSIX, PCRE or any other
+                                    dialects of regular expressions. Please read the implementation's
+                                    documentation to determine the supported dialect.
+                                  enum:
+                                  - Exact
+                                  - RegularExpression
+                                  type: string
+                                value:
+                                  description: Value is the value of HTTP query param
+                                    to be matched.
+                                  maxLength: 1024
+                                  minLength: 1
+                                  type: string
+                              required:
+                              - name
+                              - value
+                              type: object
+                            maxItems: 16
+                            type: array
+                            x-kubernetes-list-map-keys:
+                            - name
+                            x-kubernetes-list-type: map
+                        type: object
+                      maxItems: 64
+                      type: array
+                    timeouts:
+                      description: |-
+                        Timeouts defines the timeouts that can be configured for an HTTP request.
+
+                        Support: Extended
+                      properties:
+                        backendRequest:
+                          description: |-
+                            BackendRequest specifies a timeout for an individual request from the gateway
+                            to a backend. This covers the time from when the request first starts being
+                            sent from the gateway to when the full response has been received from the backend.
+
+                            Setting a timeout to the zero duration (e.g. "0s") SHOULD disable the timeout
+                            completely. Implementations that cannot completely disable the timeout MUST
+                            instead interpret the zero duration as the longest possible value to which
+                            the timeout can be set.
+
+                            An entire client HTTP transaction with a gateway, covered by the Request timeout,
+                            may result in more than one call from the gateway to the destination backend,
+                            for example, if automatic retries are supported.
+
+                            The value of BackendRequest must be a Gateway API Duration string as defined by
+                            GEP-2257.  When this field is unspecified, its behavior is implementation-specific;
+                            when specified, the value of BackendRequest must be no more than the value of the
+                            Request timeout (since the Request timeout encompasses the BackendRequest timeout).
+
+                            Support: Extended
+                          pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
+                          type: string
+                        request:
+                          description: |-
+                            Request specifies the maximum duration for a gateway to respond to an HTTP request.
+                            If the gateway has not been able to respond before this deadline is met, the gateway
+                            MUST return a timeout error.
+
+                            For example, setting the `rules.timeouts.request` field to the value `10s` in an
+                            `HTTPRoute` will cause a timeout if a client request is taking longer than 10 seconds
+                            to complete.
+
+                            Setting a timeout to the zero duration (e.g. "0s") SHOULD disable the timeout
+                            completely. Implementations that cannot completely disable the timeout MUST
+                            instead interpret the zero duration as the longest possible value to which
+                            the timeout can be set.
+
+                            This timeout is intended to cover as close to the whole request-response transaction
+                            as possible although an implementation MAY choose to start the timeout after the entire
+                            request stream has been received instead of immediately after the transaction is
+                            initiated by the client.
+
+                            The value of Request is a Gateway API Duration string as defined by GEP-2257. When this
+                            field is unspecified, request timeout behavior is implementation-specific.
+
+                            Support: Extended
+                          pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
+                          type: string
+                      type: object
+                      x-kubernetes-validations:
+                      - message: backendRequest timeout cannot be longer than request
+                          timeout
+                        rule: '!(has(self.request) && has(self.backendRequest) &&
+                          duration(self.request) != duration(''0s'') && duration(self.backendRequest)
+                          > duration(self.request))'
+                  type: object
+                  x-kubernetes-validations:
+                  - message: RequestRedirect filter must not be used together with
+                      backendRefs
+                    rule: '(has(self.backendRefs) && size(self.backendRefs) > 0) ?
+                      (!has(self.filters) || self.filters.all(f, !has(f.requestRedirect))):
+                      true'
+                  - message: When using RequestRedirect filter with path.replacePrefixMatch,
+                      exactly one PathPrefix match must be specified
+                    rule: '(has(self.filters) && self.filters.exists_one(f, has(f.requestRedirect)
+                      && has(f.requestRedirect.path) && f.requestRedirect.path.type
+                      == ''ReplacePrefixMatch'' && has(f.requestRedirect.path.replacePrefixMatch)))
+                      ? ((size(self.matches) != 1 || !has(self.matches[0].path) ||
+                      self.matches[0].path.type != ''PathPrefix'') ? false : true)
+                      : true'
+                  - message: When using URLRewrite filter with path.replacePrefixMatch,
+                      exactly one PathPrefix match must be specified
+                    rule: '(has(self.filters) && self.filters.exists_one(f, has(f.urlRewrite)
+                      && has(f.urlRewrite.path) && f.urlRewrite.path.type == ''ReplacePrefixMatch''
+                      && has(f.urlRewrite.path.replacePrefixMatch))) ? ((size(self.matches)
+                      != 1 || !has(self.matches[0].path) || self.matches[0].path.type
+                      != ''PathPrefix'') ? false : true) : true'
+                  - message: Within backendRefs, when using RequestRedirect filter
+                      with path.replacePrefixMatch, exactly one PathPrefix match must
+                      be specified
+                    rule: '(has(self.backendRefs) && self.backendRefs.exists_one(b,
+                      (has(b.filters) && b.filters.exists_one(f, has(f.requestRedirect)
+                      && has(f.requestRedirect.path) && f.requestRedirect.path.type
+                      == ''ReplacePrefixMatch'' && has(f.requestRedirect.path.replacePrefixMatch)))
+                      )) ? ((size(self.matches) != 1 || !has(self.matches[0].path)
+                      || self.matches[0].path.type != ''PathPrefix'') ? false : true)
+                      : true'
+                  - message: Within backendRefs, When using URLRewrite filter with
+                      path.replacePrefixMatch, exactly one PathPrefix match must be
+                      specified
+                    rule: '(has(self.backendRefs) && self.backendRefs.exists_one(b,
+                      (has(b.filters) && b.filters.exists_one(f, has(f.urlRewrite)
+                      && has(f.urlRewrite.path) && f.urlRewrite.path.type == ''ReplacePrefixMatch''
+                      && has(f.urlRewrite.path.replacePrefixMatch))) )) ? ((size(self.matches)
+                      != 1 || !has(self.matches[0].path) || self.matches[0].path.type
+                      != ''PathPrefix'') ? false : true) : true'
+                maxItems: 16
+                type: array
+                x-kubernetes-validations:
+                - message: While 16 rules and 64 matches per rule are allowed, the
+                    total number of matches across all rules in a route must be less
+                    than 128
+                  rule: '(self.size() > 0 ? self[0].matches.size() : 0) + (self.size()
+                    > 1 ? self[1].matches.size() : 0) + (self.size() > 2 ? self[2].matches.size()
+                    : 0) + (self.size() > 3 ? self[3].matches.size() : 0) + (self.size()
+                    > 4 ? self[4].matches.size() : 0) + (self.size() > 5 ? self[5].matches.size()
+                    : 0) + (self.size() > 6 ? self[6].matches.size() : 0) + (self.size()
+                    > 7 ? self[7].matches.size() : 0) + (self.size() > 8 ? self[8].matches.size()
+                    : 0) + (self.size() > 9 ? self[9].matches.size() : 0) + (self.size()
+                    > 10 ? self[10].matches.size() : 0) + (self.size() > 11 ? self[11].matches.size()
+                    : 0) + (self.size() > 12 ? self[12].matches.size() : 0) + (self.size()
+                    > 13 ? self[13].matches.size() : 0) + (self.size() > 14 ? self[14].matches.size()
+                    : 0) + (self.size() > 15 ? self[15].matches.size() : 0) <= 128'
+            type: object
+          status:
+            description: Status defines the current state of HTTPRoute.
+            properties:
+              parents:
+                description: |-
+                  Parents is a list of parent resources (usually Gateways) that are
+                  associated with the route, and the status of the route with respect to
+                  each parent. When this route attaches to a parent, the controller that
+                  manages the parent must add an entry to this list when the controller
+                  first sees the route and should update the entry as appropriate when the
+                  route or gateway is modified.
+
+                  Note that parent references that cannot be resolved by an implementation
+                  of this API will not be added to this list. Implementations of this API
+                  can only populate Route status for the Gateways/parent resources they are
+                  responsible for.
+
+                  A maximum of 32 Gateways will be represented in this list. An empty list
+                  means the route has not been attached to any Gateway.
+                items:
+                  description: |-
+                    RouteParentStatus describes the status of a route with respect to an
+                    associated Parent.
+                  properties:
+                    conditions:
+                      description: |-
+                        Conditions describes the status of the route with respect to the Gateway.
+                        Note that the route's availability is also subject to the Gateway's own
+                        status conditions and listener status.
+
+                        If the Route's ParentRef specifies an existing Gateway that supports
+                        Routes of this kind AND that Gateway's controller has sufficient access,
+                        then that Gateway's controller MUST set the "Accepted" condition on the
+                        Route, to indicate whether the route has been accepted or rejected by the
+                        Gateway, and why.
+
+                        A Route MUST be considered "Accepted" if at least one of the Route's
+                        rules is implemented by the Gateway.
+
+                        There are a number of cases where the "Accepted" condition may not be set
+                        due to lack of controller visibility, that includes when:
+
+                        * The Route refers to a non-existent parent.
+                        * The Route is of a type that the controller does not support.
+                        * The Route is in a namespace the controller does not have access to.
+                      items:
+                        description: Condition contains details for one aspect of
+                          the current state of this API Resource.
+                        properties:
+                          lastTransitionTime:
+                            description: |-
+                              lastTransitionTime is the last time the condition transitioned from one status to another.
+                              This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                            format: date-time
+                            type: string
+                          message:
+                            description: |-
+                              message is a human readable message indicating details about the transition.
+                              This may be an empty string.
+                            maxLength: 32768
+                            type: string
+                          observedGeneration:
+                            description: |-
+                              observedGeneration represents the .metadata.generation that the condition was set based upon.
+                              For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                              with respect to the current state of the instance.
+                            format: int64
+                            minimum: 0
+                            type: integer
+                          reason:
+                            description: |-
+                              reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                              Producers of specific condition types may define expected values and meanings for this field,
+                              and whether the values are considered a guaranteed API.
+                              The value should be a CamelCase string.
+                              This field may not be empty.
+                            maxLength: 1024
+                            minLength: 1
+                            pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                            type: string
+                          status:
+                            description: status of the condition, one of True, False,
+                              Unknown.
+                            enum:
+                            - "True"
+                            - "False"
+                            - Unknown
+                            type: string
+                          type:
+                            description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                            maxLength: 316
+                            pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                            type: string
+                        required:
+                        - lastTransitionTime
+                        - message
+                        - reason
+                        - status
+                        - type
+                        type: object
+                      maxItems: 8
+                      minItems: 1
+                      type: array
+                      x-kubernetes-list-map-keys:
+                      - type
+                      x-kubernetes-list-type: map
+                    controllerName:
+                      description: |-
+                        ControllerName is a domain/path string that indicates the name of the
+                        controller that wrote this status. This corresponds with the
+                        controllerName field on GatewayClass.
+
+                        Example: "example.net/gateway-controller".
+
+                        The format of this field is DOMAIN "/" PATH, where DOMAIN and PATH are
+                        valid Kubernetes names
+                        (https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names).
+
+                        Controllers MUST populate this field when writing status. Controllers should ensure that
+                        entries to status populated with their ControllerName are cleaned up when they are no
+                        longer necessary.
+                      maxLength: 253
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\/[A-Za-z0-9\/\-._~%!$&'()*+,;=:]+$
+                      type: string
+                    parentRef:
+                      description: |-
+                        ParentRef corresponds with a ParentRef in the spec that this
+                        RouteParentStatus struct describes the status of.
+                      properties:
+                        group:
+                          default: gateway.networking.k8s.io
+                          description: |-
+                            Group is the group of the referent.
+                            When unspecified, "gateway.networking.k8s.io" is inferred.
+                            To set the core API group (such as for a "Service" kind referent),
+                            Group must be explicitly set to "" (empty string).
+
+                            Support: Core
+                          maxLength: 253
+                          pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                          type: string
+                        kind:
+                          default: Gateway
+                          description: |-
+                            Kind is kind of the referent.
+
+                            There are two kinds of parent resources with "Core" support:
+
+                            * Gateway (Gateway conformance profile)
+                            * Service (Mesh conformance profile, ClusterIP Services only)
+
+                            Support for other resources is Implementation-Specific.
+                          maxLength: 63
+                          minLength: 1
+                          pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                          type: string
+                        name:
+                          description: |-
+                            Name is the name of the referent.
+
+                            Support: Core
+                          maxLength: 253
+                          minLength: 1
+                          type: string
+                        namespace:
+                          description: |-
+                            Namespace is the namespace of the referent. When unspecified, this refers
+                            to the local namespace of the Route.
+
+                            Note that there are specific rules for ParentRefs which cross namespace
+                            boundaries. Cross-namespace references are only valid if they are explicitly
+                            allowed by something in the namespace they are referring to. For example:
+                            Gateway has the AllowedRoutes field, and ReferenceGrant provides a
+                            generic way to enable any other kind of cross-namespace reference.
+
+
+
+                            Support: Core
+                          maxLength: 63
+                          minLength: 1
+                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                          type: string
+                        port:
+                          description: |-
+                            Port is the network port this Route targets. It can be interpreted
+                            differently based on the type of parent resource.
+
+                            When the parent resource is a Gateway, this targets all listeners
+                            listening on the specified port that also support this kind of Route(and
+                            select this Route). It's not recommended to set `Port` unless the
+                            networking behaviors specified in a Route must apply to a specific port
+                            as opposed to a listener(s) whose port(s) may be changed. When both Port
+                            and SectionName are specified, the name and port of the selected listener
+                            must match both specified values.
+
+
+
+                            Implementations MAY choose to support other parent resources.
+                            Implementations supporting other types of parent resources MUST clearly
+                            document how/if Port is interpreted.
+
+                            For the purpose of status, an attachment is considered successful as
+                            long as the parent resource accepts it partially. For example, Gateway
+                            listeners can restrict which Routes can attach to them by Route kind,
+                            namespace, or hostname. If 1 of 2 Gateway listeners accept attachment
+                            from the referencing Route, the Route MUST be considered successfully
+                            attached. If no Gateway listeners accept attachment from this Route,
+                            the Route MUST be considered detached from the Gateway.
+
+                            Support: Extended
+                          format: int32
+                          maximum: 65535
+                          minimum: 1
+                          type: integer
+                        sectionName:
+                          description: |-
+                            SectionName is the name of a section within the target resource. In the
+                            following resources, SectionName is interpreted as the following:
+
+                            * Gateway: Listener name. When both Port (experimental) and SectionName
+                            are specified, the name and port of the selected listener must match
+                            both specified values.
+                            * Service: Port name. When both Port (experimental) and SectionName
+                            are specified, the name and port of the selected listener must match
+                            both specified values.
+
+                            Implementations MAY choose to support attaching Routes to other resources.
+                            If that is the case, they MUST clearly document how SectionName is
+                            interpreted.
+
+                            When unspecified (empty string), this will reference the entire resource.
+                            For the purpose of status, an attachment is considered successful if at
+                            least one section in the parent resource accepts it. For example, Gateway
+                            listeners can restrict which Routes can attach to them by Route kind,
+                            namespace, or hostname. If 1 of 2 Gateway listeners accept attachment from
+                            the referencing Route, the Route MUST be considered successfully
+                            attached. If no Gateway listeners accept attachment from this Route, the
+                            Route MUST be considered detached from the Gateway.
+
+                            Support: Core
+                          maxLength: 253
+                          minLength: 1
+                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                          type: string
+                      required:
+                      - name
+                      type: object
+                  required:
+                  - controllerName
+                  - parentRef
+                  type: object
+                maxItems: 32
+                type: array
+            required:
+            - parents
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - jsonPath: .spec.hostnames
+      name: Hostnames
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: |-
+          HTTPRoute provides a way to route HTTP requests. This includes the capability
+          to match requests by hostname, path, header, or query param. Filters can be
+          used to specify additional processing steps. Backends specify where matching
+          requests should be routed.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec defines the desired state of HTTPRoute.
+            properties:
+              hostnames:
+                description: |-
+                  Hostnames defines a set of hostnames that should match against the HTTP Host
+                  header to select a HTTPRoute used to process the request. Implementations
+                  MUST ignore any port value specified in the HTTP Host header while
+                  performing a match and (absent of any applicable header modification
+                  configuration) MUST forward this header unmodified to the backend.
+
+                  Valid values for Hostnames are determined by RFC 1123 definition of a
+                  hostname with 2 notable exceptions:
+
+                  1. IPs are not allowed.
+                  2. A hostname may be prefixed with a wildcard label (`*.`). The wildcard
+                     label must appear by itself as the first label.
+
+                  If a hostname is specified by both the Listener and HTTPRoute, there
+                  must be at least one intersecting hostname for the HTTPRoute to be
+                  attached to the Listener. For example:
+
+                  * A Listener with `test.example.com` as the hostname matches HTTPRoutes
+                    that have either not specified any hostnames, or have specified at
+                    least one of `test.example.com` or `*.example.com`.
+                  * A Listener with `*.example.com` as the hostname matches HTTPRoutes
+                    that have either not specified any hostnames or have specified at least
+                    one hostname that matches the Listener hostname. For example,
+                    `*.example.com`, `test.example.com`, and `foo.test.example.com` would
+                    all match. On the other hand, `example.com` and `test.example.net` would
+                    not match.
+
+                  Hostnames that are prefixed with a wildcard label (`*.`) are interpreted
+                  as a suffix match. That means that a match for `*.example.com` would match
+                  both `test.example.com`, and `foo.test.example.com`, but not `example.com`.
+
+                  If both the Listener and HTTPRoute have specified hostnames, any
+                  HTTPRoute hostnames that do not match the Listener hostname MUST be
+                  ignored. For example, if a Listener specified `*.example.com`, and the
+                  HTTPRoute specified `test.example.com` and `test.example.net`,
+                  `test.example.net` must not be considered for a match.
+
+                  If both the Listener and HTTPRoute have specified hostnames, and none
+                  match with the criteria above, then the HTTPRoute is not accepted. The
+                  implementation must raise an 'Accepted' Condition with a status of
+                  `False` in the corresponding RouteParentStatus.
+
+                  In the event that multiple HTTPRoutes specify intersecting hostnames (e.g.
+                  overlapping wildcard matching and exact matching hostnames), precedence must
+                  be given to rules from the HTTPRoute with the largest number of:
+
+                  * Characters in a matching non-wildcard hostname.
+                  * Characters in a matching hostname.
+
+                  If ties exist across multiple Routes, the matching precedence rules for
+                  HTTPRouteMatches takes over.
+
+                  Support: Core
+                items:
+                  description: |-
+                    Hostname is the fully qualified domain name of a network host. This matches
+                    the RFC 1123 definition of a hostname with 2 notable exceptions:
+
+                     1. IPs are not allowed.
+                     2. A hostname may be prefixed with a wildcard label (`*.`). The wildcard
+                        label must appear by itself as the first label.
+
+                    Hostname can be "precise" which is a domain name without the terminating
+                    dot of a network host (e.g. "foo.example.com") or "wildcard", which is a
+                    domain name prefixed with a single wildcard label (e.g. `*.example.com`).
+
+                    Note that as per RFC1035 and RFC1123, a *label* must consist of lower case
+                    alphanumeric characters or '-', and must start and end with an alphanumeric
+                    character. No other punctuation is allowed.
+                  maxLength: 253
+                  minLength: 1
+                  pattern: ^(\*\.)?[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                  type: string
+                maxItems: 16
+                type: array
+              parentRefs:
+                description: |+
+                  ParentRefs references the resources (usually Gateways) that a Route wants
+                  to be attached to. Note that the referenced parent resource needs to
+                  allow this for the attachment to be complete. For Gateways, that means
+                  the Gateway needs to allow attachment from Routes of this kind and
+                  namespace. For Services, that means the Service must either be in the same
+                  namespace for a "producer" route, or the mesh implementation must support
+                  and allow "consumer" routes for the referenced Service. ReferenceGrant is
+                  not applicable for governing ParentRefs to Services - it is not possible to
+                  create a "producer" route for a Service in a different namespace from the
+                  Route.
+
+                  There are two kinds of parent resources with "Core" support:
+
+                  * Gateway (Gateway conformance profile)
+                  * Service (Mesh conformance profile, ClusterIP Services only)
+
+                  This API may be extended in the future to support additional kinds of parent
+                  resources.
+
+                  ParentRefs must be _distinct_. This means either that:
+
+                  * They select different objects.  If this is the case, then parentRef
+                    entries are distinct. In terms of fields, this means that the
+                    multi-part key defined by `group`, `kind`, `namespace`, and `name` must
+                    be unique across all parentRef entries in the Route.
+                  * They do not select different objects, but for each optional field used,
+                    each ParentRef that selects the same object must set the same set of
+                    optional fields to different values. If one ParentRef sets a
+                    combination of optional fields, all must set the same combination.
+
+                  Some examples:
+
+                  * If one ParentRef sets `sectionName`, all ParentRefs referencing the
+                    same object must also set `sectionName`.
+                  * If one ParentRef sets `port`, all ParentRefs referencing the same
+                    object must also set `port`.
+                  * If one ParentRef sets `sectionName` and `port`, all ParentRefs
+                    referencing the same object must also set `sectionName` and `port`.
+
+                  It is possible to separately reference multiple distinct objects that may
+                  be collapsed by an implementation. For example, some implementations may
+                  choose to merge compatible Gateway Listeners together. If that is the
+                  case, the list of routes attached to those resources should also be
+                  merged.
+
+                  Note that for ParentRefs that cross namespace boundaries, there are specific
+                  rules. Cross-namespace references are only valid if they are explicitly
+                  allowed by something in the namespace they are referring to. For example,
+                  Gateway has the AllowedRoutes field, and ReferenceGrant provides a
+                  generic way to enable other kinds of cross-namespace reference.
+
+
+
+
+
+
+                items:
+                  description: |-
+                    ParentReference identifies an API object (usually a Gateway) that can be considered
+                    a parent of this resource (usually a route). There are two kinds of parent resources
+                    with "Core" support:
+
+                    * Gateway (Gateway conformance profile)
+                    * Service (Mesh conformance profile, ClusterIP Services only)
+
+                    This API may be extended in the future to support additional kinds of parent
+                    resources.
+
+                    The API object must be valid in the cluster; the Group and Kind must
+                    be registered in the cluster for this reference to be valid.
+                  properties:
+                    group:
+                      default: gateway.networking.k8s.io
+                      description: |-
+                        Group is the group of the referent.
+                        When unspecified, "gateway.networking.k8s.io" is inferred.
+                        To set the core API group (such as for a "Service" kind referent),
+                        Group must be explicitly set to "" (empty string).
+
+                        Support: Core
+                      maxLength: 253
+                      pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                      type: string
+                    kind:
+                      default: Gateway
+                      description: |-
+                        Kind is kind of the referent.
+
+                        There are two kinds of parent resources with "Core" support:
+
+                        * Gateway (Gateway conformance profile)
+                        * Service (Mesh conformance profile, ClusterIP Services only)
+
+                        Support for other resources is Implementation-Specific.
+                      maxLength: 63
+                      minLength: 1
+                      pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                      type: string
+                    name:
+                      description: |-
+                        Name is the name of the referent.
+
+                        Support: Core
+                      maxLength: 253
+                      minLength: 1
+                      type: string
+                    namespace:
+                      description: |-
+                        Namespace is the namespace of the referent. When unspecified, this refers
+                        to the local namespace of the Route.
+
+                        Note that there are specific rules for ParentRefs which cross namespace
+                        boundaries. Cross-namespace references are only valid if they are explicitly
+                        allowed by something in the namespace they are referring to. For example:
+                        Gateway has the AllowedRoutes field, and ReferenceGrant provides a
+                        generic way to enable any other kind of cross-namespace reference.
+
+
+
+                        Support: Core
+                      maxLength: 63
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                      type: string
+                    port:
+                      description: |-
+                        Port is the network port this Route targets. It can be interpreted
+                        differently based on the type of parent resource.
+
+                        When the parent resource is a Gateway, this targets all listeners
+                        listening on the specified port that also support this kind of Route(and
+                        select this Route). It's not recommended to set `Port` unless the
+                        networking behaviors specified in a Route must apply to a specific port
+                        as opposed to a listener(s) whose port(s) may be changed. When both Port
+                        and SectionName are specified, the name and port of the selected listener
+                        must match both specified values.
+
+
+
+                        Implementations MAY choose to support other parent resources.
+                        Implementations supporting other types of parent resources MUST clearly
+                        document how/if Port is interpreted.
+
+                        For the purpose of status, an attachment is considered successful as
+                        long as the parent resource accepts it partially. For example, Gateway
+                        listeners can restrict which Routes can attach to them by Route kind,
+                        namespace, or hostname. If 1 of 2 Gateway listeners accept attachment
+                        from the referencing Route, the Route MUST be considered successfully
+                        attached. If no Gateway listeners accept attachment from this Route,
+                        the Route MUST be considered detached from the Gateway.
+
+                        Support: Extended
+                      format: int32
+                      maximum: 65535
+                      minimum: 1
+                      type: integer
+                    sectionName:
+                      description: |-
+                        SectionName is the name of a section within the target resource. In the
+                        following resources, SectionName is interpreted as the following:
+
+                        * Gateway: Listener name. When both Port (experimental) and SectionName
+                        are specified, the name and port of the selected listener must match
+                        both specified values.
+                        * Service: Port name. When both Port (experimental) and SectionName
+                        are specified, the name and port of the selected listener must match
+                        both specified values.
+
+                        Implementations MAY choose to support attaching Routes to other resources.
+                        If that is the case, they MUST clearly document how SectionName is
+                        interpreted.
+
+                        When unspecified (empty string), this will reference the entire resource.
+                        For the purpose of status, an attachment is considered successful if at
+                        least one section in the parent resource accepts it. For example, Gateway
+                        listeners can restrict which Routes can attach to them by Route kind,
+                        namespace, or hostname. If 1 of 2 Gateway listeners accept attachment from
+                        the referencing Route, the Route MUST be considered successfully
+                        attached. If no Gateway listeners accept attachment from this Route, the
+                        Route MUST be considered detached from the Gateway.
+
+                        Support: Core
+                      maxLength: 253
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                      type: string
+                  required:
+                  - name
+                  type: object
+                maxItems: 32
+                type: array
+                x-kubernetes-validations:
+                - message: sectionName must be specified when parentRefs includes
+                    2 or more references to the same parent
+                  rule: 'self.all(p1, self.all(p2, p1.group == p2.group && p1.kind
+                    == p2.kind && p1.name == p2.name && (((!has(p1.__namespace__)
+                    || p1.__namespace__ == '''') && (!has(p2.__namespace__) || p2.__namespace__
+                    == '''')) || (has(p1.__namespace__) && has(p2.__namespace__) &&
+                    p1.__namespace__ == p2.__namespace__ )) ? ((!has(p1.sectionName)
+                    || p1.sectionName == '''') == (!has(p2.sectionName) || p2.sectionName
+                    == '''')) : true))'
+                - message: sectionName must be unique when parentRefs includes 2 or
+                    more references to the same parent
+                  rule: self.all(p1, self.exists_one(p2, p1.group == p2.group && p1.kind
+                    == p2.kind && p1.name == p2.name && (((!has(p1.__namespace__)
+                    || p1.__namespace__ == '') && (!has(p2.__namespace__) || p2.__namespace__
+                    == '')) || (has(p1.__namespace__) && has(p2.__namespace__) &&
+                    p1.__namespace__ == p2.__namespace__ )) && (((!has(p1.sectionName)
+                    || p1.sectionName == '') && (!has(p2.sectionName) || p2.sectionName
+                    == '')) || (has(p1.sectionName) && has(p2.sectionName) && p1.sectionName
+                    == p2.sectionName))))
+              rules:
+                default:
+                - matches:
+                  - path:
+                      type: PathPrefix
+                      value: /
+                description: |+
+                  Rules are a list of HTTP matchers, filters and actions.
+
+                items:
+                  description: |-
+                    HTTPRouteRule defines semantics for matching an HTTP request based on
+                    conditions (matches), processing it (filters), and forwarding the request to
+                    an API object (backendRefs).
+                  properties:
+                    backendRefs:
+                      description: |-
+                        BackendRefs defines the backend(s) where matching requests should be
+                        sent.
+
+                        Failure behavior here depends on how many BackendRefs are specified and
+                        how many are invalid.
+
+                        If *all* entries in BackendRefs are invalid, and there are also no filters
+                        specified in this route rule, *all* traffic which matches this rule MUST
+                        receive a 500 status code.
+
+                        See the HTTPBackendRef definition for the rules about what makes a single
+                        HTTPBackendRef invalid.
+
+                        When a HTTPBackendRef is invalid, 500 status codes MUST be returned for
+                        requests that would have otherwise been routed to an invalid backend. If
+                        multiple backends are specified, and some are invalid, the proportion of
+                        requests that would otherwise have been routed to an invalid backend
+                        MUST receive a 500 status code.
+
+                        For example, if two backends are specified with equal weights, and one is
+                        invalid, 50 percent of traffic must receive a 500. Implementations may
+                        choose how that 50 percent is determined.
+
+                        When a HTTPBackendRef refers to a Service that has no ready endpoints,
+                        implementations SHOULD return a 503 for requests to that backend instead.
+                        If an implementation chooses to do this, all of the above rules for 500 responses
+                        MUST also apply for responses that return a 503.
+
+                        Support: Core for Kubernetes Service
+
+                        Support: Extended for Kubernetes ServiceImport
+
+                        Support: Implementation-specific for any other resource
+
+                        Support for weight: Core
+                      items:
+                        description: |-
+                          HTTPBackendRef defines how a HTTPRoute forwards a HTTP request.
+
+                          Note that when a namespace different than the local namespace is specified, a
+                          ReferenceGrant object is required in the referent namespace to allow that
+                          namespace's owner to accept the reference. See the ReferenceGrant
+                          documentation for details.
+
+                          <gateway:experimental:description>
+
+                          When the BackendRef points to a Kubernetes Service, implementations SHOULD
+                          honor the appProtocol field if it is set for the target Service Port.
+
+                          Implementations supporting appProtocol SHOULD recognize the Kubernetes
+                          Standard Application Protocols defined in KEP-3726.
+
+                          If a Service appProtocol isn't specified, an implementation MAY infer the
+                          backend protocol through its own means. Implementations MAY infer the
+                          protocol from the Route type referring to the backend Service.
+
+                          If a Route is not able to send traffic to the backend using the specified
+                          protocol then the backend is considered invalid. Implementations MUST set the
+                          "ResolvedRefs" condition to "False" with the "UnsupportedProtocol" reason.
+
+                          </gateway:experimental:description>
+                        properties:
+                          filters:
+                            description: |-
+                              Filters defined at this level should be executed if and only if the
+                              request is being forwarded to the backend defined here.
+
+                              Support: Implementation-specific (For broader support of filters, use the
+                              Filters field in HTTPRouteRule.)
+                            items:
+                              description: |-
+                                HTTPRouteFilter defines processing steps that must be completed during the
+                                request or response lifecycle. HTTPRouteFilters are meant as an extension
+                                point to express processing that may be done in Gateway implementations. Some
+                                examples include request or response modification, implementing
+                                authentication strategies, rate-limiting, and traffic shaping. API
+                                guarantee/conformance is defined based on the type of the filter.
+                              properties:
+                                extensionRef:
+                                  description: |-
+                                    ExtensionRef is an optional, implementation-specific extension to the
+                                    "filter" behavior.  For example, resource "myroutefilter" in group
+                                    "networking.example.net"). ExtensionRef MUST NOT be used for core and
+                                    extended filters.
+
+                                    This filter can be used multiple times within the same rule.
+
+                                    Support: Implementation-specific
+                                  properties:
+                                    group:
+                                      description: |-
+                                        Group is the group of the referent. For example, "gateway.networking.k8s.io".
+                                        When unspecified or empty string, core API group is inferred.
+                                      maxLength: 253
+                                      pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    kind:
+                                      description: Kind is kind of the referent. For
+                                        example "HTTPRoute" or "Service".
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                                      type: string
+                                    name:
+                                      description: Name is the name of the referent.
+                                      maxLength: 253
+                                      minLength: 1
+                                      type: string
+                                  required:
+                                  - group
+                                  - kind
+                                  - name
+                                  type: object
+                                requestHeaderModifier:
+                                  description: |-
+                                    RequestHeaderModifier defines a schema for a filter that modifies request
+                                    headers.
+
+                                    Support: Core
+                                  properties:
+                                    add:
+                                      description: |-
+                                        Add adds the given header(s) (name, value) to the request
+                                        before the action. It appends to any existing values associated
+                                        with the header name.
+
+                                        Input:
+                                          GET /foo HTTP/1.1
+                                          my-header: foo
+
+                                        Config:
+                                          add:
+                                          - name: "my-header"
+                                            value: "bar,baz"
+
+                                        Output:
+                                          GET /foo HTTP/1.1
+                                          my-header: foo,bar,baz
+                                      items:
+                                        description: HTTPHeader represents an HTTP
+                                          Header name and value as defined by RFC
+                                          7230.
+                                        properties:
+                                          name:
+                                            description: |-
+                                              Name is the name of the HTTP Header to be matched. Name matching MUST be
+                                              case insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
+
+                                              If multiple entries specify equivalent header names, the first entry with
+                                              an equivalent name MUST be considered for a match. Subsequent entries
+                                              with an equivalent header name MUST be ignored. Due to the
+                                              case-insensitivity of header names, "foo" and "Foo" are considered
+                                              equivalent.
+                                            maxLength: 256
+                                            minLength: 1
+                                            pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                            type: string
+                                          value:
+                                            description: Value is the value of HTTP
+                                              Header to be matched.
+                                            maxLength: 4096
+                                            minLength: 1
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                        type: object
+                                      maxItems: 16
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                      - name
+                                      x-kubernetes-list-type: map
+                                    remove:
+                                      description: |-
+                                        Remove the given header(s) from the HTTP request before the action. The
+                                        value of Remove is a list of HTTP header names. Note that the header
+                                        names are case-insensitive (see
+                                        https://datatracker.ietf.org/doc/html/rfc2616#section-4.2).
+
+                                        Input:
+                                          GET /foo HTTP/1.1
+                                          my-header1: foo
+                                          my-header2: bar
+                                          my-header3: baz
+
+                                        Config:
+                                          remove: ["my-header1", "my-header3"]
+
+                                        Output:
+                                          GET /foo HTTP/1.1
+                                          my-header2: bar
+                                      items:
+                                        type: string
+                                      maxItems: 16
+                                      type: array
+                                      x-kubernetes-list-type: set
+                                    set:
+                                      description: |-
+                                        Set overwrites the request with the given header (name, value)
+                                        before the action.
+
+                                        Input:
+                                          GET /foo HTTP/1.1
+                                          my-header: foo
+
+                                        Config:
+                                          set:
+                                          - name: "my-header"
+                                            value: "bar"
+
+                                        Output:
+                                          GET /foo HTTP/1.1
+                                          my-header: bar
+                                      items:
+                                        description: HTTPHeader represents an HTTP
+                                          Header name and value as defined by RFC
+                                          7230.
+                                        properties:
+                                          name:
+                                            description: |-
+                                              Name is the name of the HTTP Header to be matched. Name matching MUST be
+                                              case insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
+
+                                              If multiple entries specify equivalent header names, the first entry with
+                                              an equivalent name MUST be considered for a match. Subsequent entries
+                                              with an equivalent header name MUST be ignored. Due to the
+                                              case-insensitivity of header names, "foo" and "Foo" are considered
+                                              equivalent.
+                                            maxLength: 256
+                                            minLength: 1
+                                            pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                            type: string
+                                          value:
+                                            description: Value is the value of HTTP
+                                              Header to be matched.
+                                            maxLength: 4096
+                                            minLength: 1
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                        type: object
+                                      maxItems: 16
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                      - name
+                                      x-kubernetes-list-type: map
+                                  type: object
+                                requestMirror:
+                                  description: |+
+                                    RequestMirror defines a schema for a filter that mirrors requests.
+                                    Requests are sent to the specified destination, but responses from
+                                    that destination are ignored.
+
+                                    This filter can be used multiple times within the same rule. Note that
+                                    not all implementations will be able to support mirroring to multiple
+                                    backends.
+
+                                    Support: Extended
+
+                                  properties:
+                                    backendRef:
+                                      description: |-
+                                        BackendRef references a resource where mirrored requests are sent.
+
+                                        Mirrored requests must be sent only to a single destination endpoint
+                                        within this BackendRef, irrespective of how many endpoints are present
+                                        within this BackendRef.
+
+                                        If the referent cannot be found, this BackendRef is invalid and must be
+                                        dropped from the Gateway. The controller must ensure the "ResolvedRefs"
+                                        condition on the Route status is set to `status: False` and not configure
+                                        this backend in the underlying implementation.
+
+                                        If there is a cross-namespace reference to an *existing* object
+                                        that is not allowed by a ReferenceGrant, the controller must ensure the
+                                        "ResolvedRefs"  condition on the Route is set to `status: False`,
+                                        with the "RefNotPermitted" reason and not configure this backend in the
+                                        underlying implementation.
+
+                                        In either error case, the Message of the `ResolvedRefs` Condition
+                                        should be used to provide more detail about the problem.
+
+                                        Support: Extended for Kubernetes Service
+
+                                        Support: Implementation-specific for any other resource
+                                      properties:
+                                        group:
+                                          default: ""
+                                          description: |-
+                                            Group is the group of the referent. For example, "gateway.networking.k8s.io".
+                                            When unspecified or empty string, core API group is inferred.
+                                          maxLength: 253
+                                          pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                          type: string
+                                        kind:
+                                          default: Service
+                                          description: |-
+                                            Kind is the Kubernetes resource kind of the referent. For example
+                                            "Service".
+
+                                            Defaults to "Service" when not specified.
+
+                                            ExternalName services can refer to CNAME DNS records that may live
+                                            outside of the cluster and as such are difficult to reason about in
+                                            terms of conformance. They also may not be safe to forward to (see
+                                            CVE-2021-25740 for more information). Implementations SHOULD NOT
+                                            support ExternalName Services.
+
+                                            Support: Core (Services with a type other than ExternalName)
+
+                                            Support: Implementation-specific (Services with type ExternalName)
+                                          maxLength: 63
+                                          minLength: 1
+                                          pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                                          type: string
+                                        name:
+                                          description: Name is the name of the referent.
+                                          maxLength: 253
+                                          minLength: 1
+                                          type: string
+                                        namespace:
+                                          description: |-
+                                            Namespace is the namespace of the backend. When unspecified, the local
+                                            namespace is inferred.
+
+                                            Note that when a namespace different than the local namespace is specified,
+                                            a ReferenceGrant object is required in the referent namespace to allow that
+                                            namespace's owner to accept the reference. See the ReferenceGrant
+                                            documentation for details.
+
+                                            Support: Core
+                                          maxLength: 63
+                                          minLength: 1
+                                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                          type: string
+                                        port:
+                                          description: |-
+                                            Port specifies the destination port number to use for this resource.
+                                            Port is required when the referent is a Kubernetes Service. In this
+                                            case, the port number is the service port number, not the target port.
+                                            For other resources, destination port might be derived from the referent
+                                            resource or this field.
+                                          format: int32
+                                          maximum: 65535
+                                          minimum: 1
+                                          type: integer
+                                      required:
+                                      - name
+                                      type: object
+                                      x-kubernetes-validations:
+                                      - message: Must have port for Service reference
+                                        rule: '(size(self.group) == 0 && self.kind
+                                          == ''Service'') ? has(self.port) : true'
+                                  required:
+                                  - backendRef
+                                  type: object
+                                requestRedirect:
+                                  description: |-
+                                    RequestRedirect defines a schema for a filter that responds to the
+                                    request with an HTTP redirection.
+
+                                    Support: Core
+                                  properties:
+                                    hostname:
+                                      description: |-
+                                        Hostname is the hostname to be used in the value of the `Location`
+                                        header in the response.
+                                        When empty, the hostname in the `Host` header of the request is used.
+
+                                        Support: Core
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    path:
+                                      description: |-
+                                        Path defines parameters used to modify the path of the incoming request.
+                                        The modified path is then used to construct the `Location` header. When
+                                        empty, the request path is used as-is.
+
+                                        Support: Extended
+                                      properties:
+                                        replaceFullPath:
+                                          description: |-
+                                            ReplaceFullPath specifies the value with which to replace the full path
+                                            of a request during a rewrite or redirect.
+                                          maxLength: 1024
+                                          type: string
+                                        replacePrefixMatch:
+                                          description: |-
+                                            ReplacePrefixMatch specifies the value with which to replace the prefix
+                                            match of a request during a rewrite or redirect. For example, a request
+                                            to "/foo/bar" with a prefix match of "/foo" and a ReplacePrefixMatch
+                                            of "/xyz" would be modified to "/xyz/bar".
+
+                                            Note that this matches the behavior of the PathPrefix match type. This
+                                            matches full path elements. A path element refers to the list of labels
+                                            in the path split by the `/` separator. When specified, a trailing `/` is
+                                            ignored. For example, the paths `/abc`, `/abc/`, and `/abc/def` would all
+                                            match the prefix `/abc`, but the path `/abcd` would not.
+
+                                            ReplacePrefixMatch is only compatible with a `PathPrefix` HTTPRouteMatch.
+                                            Using any other HTTPRouteMatch type on the same HTTPRouteRule will result in
+                                            the implementation setting the Accepted Condition for the Route to `status: False`.
+
+                                            Request Path | Prefix Match | Replace Prefix | Modified Path
+                                          maxLength: 1024
+                                          type: string
+                                        type:
+                                          description: |-
+                                            Type defines the type of path modifier. Additional types may be
+                                            added in a future release of the API.
+
+                                            Note that values may be added to this enum, implementations
+                                            must ensure that unknown values will not cause a crash.
+
+                                            Unknown values here must result in the implementation setting the
+                                            Accepted Condition for the Route to `status: False`, with a
+                                            Reason of `UnsupportedValue`.
+                                          enum:
+                                          - ReplaceFullPath
+                                          - ReplacePrefixMatch
+                                          type: string
+                                      required:
+                                      - type
+                                      type: object
+                                      x-kubernetes-validations:
+                                      - message: replaceFullPath must be specified
+                                          when type is set to 'ReplaceFullPath'
+                                        rule: 'self.type == ''ReplaceFullPath'' ?
+                                          has(self.replaceFullPath) : true'
+                                      - message: type must be 'ReplaceFullPath' when
+                                          replaceFullPath is set
+                                        rule: 'has(self.replaceFullPath) ? self.type
+                                          == ''ReplaceFullPath'' : true'
+                                      - message: replacePrefixMatch must be specified
+                                          when type is set to 'ReplacePrefixMatch'
+                                        rule: 'self.type == ''ReplacePrefixMatch''
+                                          ? has(self.replacePrefixMatch) : true'
+                                      - message: type must be 'ReplacePrefixMatch'
+                                          when replacePrefixMatch is set
+                                        rule: 'has(self.replacePrefixMatch) ? self.type
+                                          == ''ReplacePrefixMatch'' : true'
+                                    port:
+                                      description: |-
+                                        Port is the port to be used in the value of the `Location`
+                                        header in the response.
+
+                                        If no port is specified, the redirect port MUST be derived using the
+                                        following rules:
+
+                                        * If redirect scheme is not-empty, the redirect port MUST be the well-known
+                                          port associated with the redirect scheme. Specifically "http" to port 80
+                                          and "https" to port 443. If the redirect scheme does not have a
+                                          well-known port, the listener port of the Gateway SHOULD be used.
+                                        * If redirect scheme is empty, the redirect port MUST be the Gateway
+                                          Listener port.
+
+                                        Implementations SHOULD NOT add the port number in the 'Location'
+                                        header in the following cases:
+
+                                        * A Location header that will use HTTP (whether that is determined via
+                                          the Listener protocol or the Scheme field) _and_ use port 80.
+                                        * A Location header that will use HTTPS (whether that is determined via
+                                          the Listener protocol or the Scheme field) _and_ use port 443.
+
+                                        Support: Extended
+                                      format: int32
+                                      maximum: 65535
+                                      minimum: 1
+                                      type: integer
+                                    scheme:
+                                      description: |-
+                                        Scheme is the scheme to be used in the value of the `Location` header in
+                                        the response. When empty, the scheme of the request is used.
+
+                                        Scheme redirects can affect the port of the redirect, for more information,
+                                        refer to the documentation for the port field of this filter.
+
+                                        Note that values may be added to this enum, implementations
+                                        must ensure that unknown values will not cause a crash.
+
+                                        Unknown values here must result in the implementation setting the
+                                        Accepted Condition for the Route to `status: False`, with a
+                                        Reason of `UnsupportedValue`.
+
+                                        Support: Extended
+                                      enum:
+                                      - http
+                                      - https
+                                      type: string
+                                    statusCode:
+                                      default: 302
+                                      description: |-
+                                        StatusCode is the HTTP status code to be used in response.
+
+                                        Note that values may be added to this enum, implementations
+                                        must ensure that unknown values will not cause a crash.
+
+                                        Unknown values here must result in the implementation setting the
+                                        Accepted Condition for the Route to `status: False`, with a
+                                        Reason of `UnsupportedValue`.
+
+                                        Support: Core
+                                      enum:
+                                      - 301
+                                      - 302
+                                      type: integer
+                                  type: object
+                                responseHeaderModifier:
+                                  description: |-
+                                    ResponseHeaderModifier defines a schema for a filter that modifies response
+                                    headers.
+
+                                    Support: Extended
+                                  properties:
+                                    add:
+                                      description: |-
+                                        Add adds the given header(s) (name, value) to the request
+                                        before the action. It appends to any existing values associated
+                                        with the header name.
+
+                                        Input:
+                                          GET /foo HTTP/1.1
+                                          my-header: foo
+
+                                        Config:
+                                          add:
+                                          - name: "my-header"
+                                            value: "bar,baz"
+
+                                        Output:
+                                          GET /foo HTTP/1.1
+                                          my-header: foo,bar,baz
+                                      items:
+                                        description: HTTPHeader represents an HTTP
+                                          Header name and value as defined by RFC
+                                          7230.
+                                        properties:
+                                          name:
+                                            description: |-
+                                              Name is the name of the HTTP Header to be matched. Name matching MUST be
+                                              case insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
+
+                                              If multiple entries specify equivalent header names, the first entry with
+                                              an equivalent name MUST be considered for a match. Subsequent entries
+                                              with an equivalent header name MUST be ignored. Due to the
+                                              case-insensitivity of header names, "foo" and "Foo" are considered
+                                              equivalent.
+                                            maxLength: 256
+                                            minLength: 1
+                                            pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                            type: string
+                                          value:
+                                            description: Value is the value of HTTP
+                                              Header to be matched.
+                                            maxLength: 4096
+                                            minLength: 1
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                        type: object
+                                      maxItems: 16
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                      - name
+                                      x-kubernetes-list-type: map
+                                    remove:
+                                      description: |-
+                                        Remove the given header(s) from the HTTP request before the action. The
+                                        value of Remove is a list of HTTP header names. Note that the header
+                                        names are case-insensitive (see
+                                        https://datatracker.ietf.org/doc/html/rfc2616#section-4.2).
+
+                                        Input:
+                                          GET /foo HTTP/1.1
+                                          my-header1: foo
+                                          my-header2: bar
+                                          my-header3: baz
+
+                                        Config:
+                                          remove: ["my-header1", "my-header3"]
+
+                                        Output:
+                                          GET /foo HTTP/1.1
+                                          my-header2: bar
+                                      items:
+                                        type: string
+                                      maxItems: 16
+                                      type: array
+                                      x-kubernetes-list-type: set
+                                    set:
+                                      description: |-
+                                        Set overwrites the request with the given header (name, value)
+                                        before the action.
+
+                                        Input:
+                                          GET /foo HTTP/1.1
+                                          my-header: foo
+
+                                        Config:
+                                          set:
+                                          - name: "my-header"
+                                            value: "bar"
+
+                                        Output:
+                                          GET /foo HTTP/1.1
+                                          my-header: bar
+                                      items:
+                                        description: HTTPHeader represents an HTTP
+                                          Header name and value as defined by RFC
+                                          7230.
+                                        properties:
+                                          name:
+                                            description: |-
+                                              Name is the name of the HTTP Header to be matched. Name matching MUST be
+                                              case insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
+
+                                              If multiple entries specify equivalent header names, the first entry with
+                                              an equivalent name MUST be considered for a match. Subsequent entries
+                                              with an equivalent header name MUST be ignored. Due to the
+                                              case-insensitivity of header names, "foo" and "Foo" are considered
+                                              equivalent.
+                                            maxLength: 256
+                                            minLength: 1
+                                            pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                            type: string
+                                          value:
+                                            description: Value is the value of HTTP
+                                              Header to be matched.
+                                            maxLength: 4096
+                                            minLength: 1
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                        type: object
+                                      maxItems: 16
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                      - name
+                                      x-kubernetes-list-type: map
+                                  type: object
+                                type:
+                                  description: |-
+                                    Type identifies the type of filter to apply. As with other API fields,
+                                    types are classified into three conformance levels:
+
+                                    - Core: Filter types and their corresponding configuration defined by
+                                      "Support: Core" in this package, e.g. "RequestHeaderModifier". All
+                                      implementations must support core filters.
+
+                                    - Extended: Filter types and their corresponding configuration defined by
+                                      "Support: Extended" in this package, e.g. "RequestMirror". Implementers
+                                      are encouraged to support extended filters.
+
+                                    - Implementation-specific: Filters that are defined and supported by
+                                      specific vendors.
+                                      In the future, filters showing convergence in behavior across multiple
+                                      implementations will be considered for inclusion in extended or core
+                                      conformance levels. Filter-specific configuration for such filters
+                                      is specified using the ExtensionRef field. `Type` should be set to
+                                      "ExtensionRef" for custom filters.
+
+                                    Implementers are encouraged to define custom implementation types to
+                                    extend the core API with implementation-specific behavior.
+
+                                    If a reference to a custom filter type cannot be resolved, the filter
+                                    MUST NOT be skipped. Instead, requests that would have been processed by
+                                    that filter MUST receive a HTTP error response.
+
+                                    Note that values may be added to this enum, implementations
+                                    must ensure that unknown values will not cause a crash.
+
+                                    Unknown values here must result in the implementation setting the
+                                    Accepted Condition for the Route to `status: False`, with a
+                                    Reason of `UnsupportedValue`.
+                                  enum:
+                                  - RequestHeaderModifier
+                                  - ResponseHeaderModifier
+                                  - RequestMirror
+                                  - RequestRedirect
+                                  - URLRewrite
+                                  - ExtensionRef
+                                  type: string
+                                urlRewrite:
+                                  description: |-
+                                    URLRewrite defines a schema for a filter that modifies a request during forwarding.
+
+                                    Support: Extended
+                                  properties:
+                                    hostname:
+                                      description: |-
+                                        Hostname is the value to be used to replace the Host header value during
+                                        forwarding.
+
+                                        Support: Extended
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    path:
+                                      description: |-
+                                        Path defines a path rewrite.
+
+                                        Support: Extended
+                                      properties:
+                                        replaceFullPath:
+                                          description: |-
+                                            ReplaceFullPath specifies the value with which to replace the full path
+                                            of a request during a rewrite or redirect.
+                                          maxLength: 1024
+                                          type: string
+                                        replacePrefixMatch:
+                                          description: |-
+                                            ReplacePrefixMatch specifies the value with which to replace the prefix
+                                            match of a request during a rewrite or redirect. For example, a request
+                                            to "/foo/bar" with a prefix match of "/foo" and a ReplacePrefixMatch
+                                            of "/xyz" would be modified to "/xyz/bar".
+
+                                            Note that this matches the behavior of the PathPrefix match type. This
+                                            matches full path elements. A path element refers to the list of labels
+                                            in the path split by the `/` separator. When specified, a trailing `/` is
+                                            ignored. For example, the paths `/abc`, `/abc/`, and `/abc/def` would all
+                                            match the prefix `/abc`, but the path `/abcd` would not.
+
+                                            ReplacePrefixMatch is only compatible with a `PathPrefix` HTTPRouteMatch.
+                                            Using any other HTTPRouteMatch type on the same HTTPRouteRule will result in
+                                            the implementation setting the Accepted Condition for the Route to `status: False`.
+
+                                            Request Path | Prefix Match | Replace Prefix | Modified Path
+                                          maxLength: 1024
+                                          type: string
+                                        type:
+                                          description: |-
+                                            Type defines the type of path modifier. Additional types may be
+                                            added in a future release of the API.
+
+                                            Note that values may be added to this enum, implementations
+                                            must ensure that unknown values will not cause a crash.
+
+                                            Unknown values here must result in the implementation setting the
+                                            Accepted Condition for the Route to `status: False`, with a
+                                            Reason of `UnsupportedValue`.
+                                          enum:
+                                          - ReplaceFullPath
+                                          - ReplacePrefixMatch
+                                          type: string
+                                      required:
+                                      - type
+                                      type: object
+                                      x-kubernetes-validations:
+                                      - message: replaceFullPath must be specified
+                                          when type is set to 'ReplaceFullPath'
+                                        rule: 'self.type == ''ReplaceFullPath'' ?
+                                          has(self.replaceFullPath) : true'
+                                      - message: type must be 'ReplaceFullPath' when
+                                          replaceFullPath is set
+                                        rule: 'has(self.replaceFullPath) ? self.type
+                                          == ''ReplaceFullPath'' : true'
+                                      - message: replacePrefixMatch must be specified
+                                          when type is set to 'ReplacePrefixMatch'
+                                        rule: 'self.type == ''ReplacePrefixMatch''
+                                          ? has(self.replacePrefixMatch) : true'
+                                      - message: type must be 'ReplacePrefixMatch'
+                                          when replacePrefixMatch is set
+                                        rule: 'has(self.replacePrefixMatch) ? self.type
+                                          == ''ReplacePrefixMatch'' : true'
+                                  type: object
+                              required:
+                              - type
+                              type: object
+                              x-kubernetes-validations:
+                              - message: filter.requestHeaderModifier must be nil
+                                  if the filter.type is not RequestHeaderModifier
+                                rule: '!(has(self.requestHeaderModifier) && self.type
+                                  != ''RequestHeaderModifier'')'
+                              - message: filter.requestHeaderModifier must be specified
+                                  for RequestHeaderModifier filter.type
+                                rule: '!(!has(self.requestHeaderModifier) && self.type
+                                  == ''RequestHeaderModifier'')'
+                              - message: filter.responseHeaderModifier must be nil
+                                  if the filter.type is not ResponseHeaderModifier
+                                rule: '!(has(self.responseHeaderModifier) && self.type
+                                  != ''ResponseHeaderModifier'')'
+                              - message: filter.responseHeaderModifier must be specified
+                                  for ResponseHeaderModifier filter.type
+                                rule: '!(!has(self.responseHeaderModifier) && self.type
+                                  == ''ResponseHeaderModifier'')'
+                              - message: filter.requestMirror must be nil if the filter.type
+                                  is not RequestMirror
+                                rule: '!(has(self.requestMirror) && self.type != ''RequestMirror'')'
+                              - message: filter.requestMirror must be specified for
+                                  RequestMirror filter.type
+                                rule: '!(!has(self.requestMirror) && self.type ==
+                                  ''RequestMirror'')'
+                              - message: filter.requestRedirect must be nil if the
+                                  filter.type is not RequestRedirect
+                                rule: '!(has(self.requestRedirect) && self.type !=
+                                  ''RequestRedirect'')'
+                              - message: filter.requestRedirect must be specified
+                                  for RequestRedirect filter.type
+                                rule: '!(!has(self.requestRedirect) && self.type ==
+                                  ''RequestRedirect'')'
+                              - message: filter.urlRewrite must be nil if the filter.type
+                                  is not URLRewrite
+                                rule: '!(has(self.urlRewrite) && self.type != ''URLRewrite'')'
+                              - message: filter.urlRewrite must be specified for URLRewrite
+                                  filter.type
+                                rule: '!(!has(self.urlRewrite) && self.type == ''URLRewrite'')'
+                              - message: filter.extensionRef must be nil if the filter.type
+                                  is not ExtensionRef
+                                rule: '!(has(self.extensionRef) && self.type != ''ExtensionRef'')'
+                              - message: filter.extensionRef must be specified for
+                                  ExtensionRef filter.type
+                                rule: '!(!has(self.extensionRef) && self.type == ''ExtensionRef'')'
+                            maxItems: 16
+                            type: array
+                            x-kubernetes-validations:
+                            - message: May specify either httpRouteFilterRequestRedirect
+                                or httpRouteFilterRequestRewrite, but not both
+                              rule: '!(self.exists(f, f.type == ''RequestRedirect'')
+                                && self.exists(f, f.type == ''URLRewrite''))'
+                            - message: May specify either httpRouteFilterRequestRedirect
+                                or httpRouteFilterRequestRewrite, but not both
+                              rule: '!(self.exists(f, f.type == ''RequestRedirect'')
+                                && self.exists(f, f.type == ''URLRewrite''))'
+                            - message: RequestHeaderModifier filter cannot be repeated
+                              rule: self.filter(f, f.type == 'RequestHeaderModifier').size()
+                                <= 1
+                            - message: ResponseHeaderModifier filter cannot be repeated
+                              rule: self.filter(f, f.type == 'ResponseHeaderModifier').size()
+                                <= 1
+                            - message: RequestRedirect filter cannot be repeated
+                              rule: self.filter(f, f.type == 'RequestRedirect').size()
+                                <= 1
+                            - message: URLRewrite filter cannot be repeated
+                              rule: self.filter(f, f.type == 'URLRewrite').size()
+                                <= 1
+                          group:
+                            default: ""
+                            description: |-
+                              Group is the group of the referent. For example, "gateway.networking.k8s.io".
+                              When unspecified or empty string, core API group is inferred.
+                            maxLength: 253
+                            pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                            type: string
+                          kind:
+                            default: Service
+                            description: |-
+                              Kind is the Kubernetes resource kind of the referent. For example
+                              "Service".
+
+                              Defaults to "Service" when not specified.
+
+                              ExternalName services can refer to CNAME DNS records that may live
+                              outside of the cluster and as such are difficult to reason about in
+                              terms of conformance. They also may not be safe to forward to (see
+                              CVE-2021-25740 for more information). Implementations SHOULD NOT
+                              support ExternalName Services.
+
+                              Support: Core (Services with a type other than ExternalName)
+
+                              Support: Implementation-specific (Services with type ExternalName)
+                            maxLength: 63
+                            minLength: 1
+                            pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                            type: string
+                          name:
+                            description: Name is the name of the referent.
+                            maxLength: 253
+                            minLength: 1
+                            type: string
+                          namespace:
+                            description: |-
+                              Namespace is the namespace of the backend. When unspecified, the local
+                              namespace is inferred.
+
+                              Note that when a namespace different than the local namespace is specified,
+                              a ReferenceGrant object is required in the referent namespace to allow that
+                              namespace's owner to accept the reference. See the ReferenceGrant
+                              documentation for details.
+
+                              Support: Core
+                            maxLength: 63
+                            minLength: 1
+                            pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                            type: string
+                          port:
+                            description: |-
+                              Port specifies the destination port number to use for this resource.
+                              Port is required when the referent is a Kubernetes Service. In this
+                              case, the port number is the service port number, not the target port.
+                              For other resources, destination port might be derived from the referent
+                              resource or this field.
+                            format: int32
+                            maximum: 65535
+                            minimum: 1
+                            type: integer
+                          weight:
+                            default: 1
+                            description: |-
+                              Weight specifies the proportion of requests forwarded to the referenced
+                              backend. This is computed as weight/(sum of all weights in this
+                              BackendRefs list). For non-zero values, there may be some epsilon from
+                              the exact proportion defined here depending on the precision an
+                              implementation supports. Weight is not a percentage and the sum of
+                              weights does not need to equal 100.
+
+                              If only one backend is specified and it has a weight greater than 0, 100%
+                              of the traffic is forwarded to that backend. If weight is set to 0, no
+                              traffic should be forwarded for this entry. If unspecified, weight
+                              defaults to 1.
+
+                              Support for this field varies based on the context where used.
+                            format: int32
+                            maximum: 1000000
+                            minimum: 0
+                            type: integer
+                        required:
+                        - name
+                        type: object
+                        x-kubernetes-validations:
+                        - message: Must have port for Service reference
+                          rule: '(size(self.group) == 0 && self.kind == ''Service'')
+                            ? has(self.port) : true'
+                      maxItems: 16
+                      type: array
+                    filters:
+                      description: |-
+                        Filters define the filters that are applied to requests that match
+                        this rule.
+
+                        Wherever possible, implementations SHOULD implement filters in the order
+                        they are specified.
+
+                        Implementations MAY choose to implement this ordering strictly, rejecting
+                        any combination or order of filters that can not be supported. If implementations
+                        choose a strict interpretation of filter ordering, they MUST clearly document
+                        that behavior.
+
+                        To reject an invalid combination or order of filters, implementations SHOULD
+                        consider the Route Rules with this configuration invalid. If all Route Rules
+                        in a Route are invalid, the entire Route would be considered invalid. If only
+                        a portion of Route Rules are invalid, implementations MUST set the
+                        "PartiallyInvalid" condition for the Route.
+
+                        Conformance-levels at this level are defined based on the type of filter:
+
+                        - ALL core filters MUST be supported by all implementations.
+                        - Implementers are encouraged to support extended filters.
+                        - Implementation-specific custom filters have no API guarantees across
+                          implementations.
+
+                        Specifying the same filter multiple times is not supported unless explicitly
+                        indicated in the filter.
+
+                        All filters are expected to be compatible with each other except for the
+                        URLRewrite and RequestRedirect filters, which may not be combined. If an
+                        implementation can not support other combinations of filters, they must clearly
+                        document that limitation. In cases where incompatible or unsupported
+                        filters are specified and cause the `Accepted` condition to be set to status
+                        `False`, implementations may use the `IncompatibleFilters` reason to specify
+                        this configuration error.
+
+                        Support: Core
+                      items:
+                        description: |-
+                          HTTPRouteFilter defines processing steps that must be completed during the
+                          request or response lifecycle. HTTPRouteFilters are meant as an extension
+                          point to express processing that may be done in Gateway implementations. Some
+                          examples include request or response modification, implementing
+                          authentication strategies, rate-limiting, and traffic shaping. API
+                          guarantee/conformance is defined based on the type of the filter.
+                        properties:
+                          extensionRef:
+                            description: |-
+                              ExtensionRef is an optional, implementation-specific extension to the
+                              "filter" behavior.  For example, resource "myroutefilter" in group
+                              "networking.example.net"). ExtensionRef MUST NOT be used for core and
+                              extended filters.
+
+                              This filter can be used multiple times within the same rule.
+
+                              Support: Implementation-specific
+                            properties:
+                              group:
+                                description: |-
+                                  Group is the group of the referent. For example, "gateway.networking.k8s.io".
+                                  When unspecified or empty string, core API group is inferred.
+                                maxLength: 253
+                                pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                type: string
+                              kind:
+                                description: Kind is kind of the referent. For example
+                                  "HTTPRoute" or "Service".
+                                maxLength: 63
+                                minLength: 1
+                                pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                                type: string
+                              name:
+                                description: Name is the name of the referent.
+                                maxLength: 253
+                                minLength: 1
+                                type: string
+                            required:
+                            - group
+                            - kind
+                            - name
+                            type: object
+                          requestHeaderModifier:
+                            description: |-
+                              RequestHeaderModifier defines a schema for a filter that modifies request
+                              headers.
+
+                              Support: Core
+                            properties:
+                              add:
+                                description: |-
+                                  Add adds the given header(s) (name, value) to the request
+                                  before the action. It appends to any existing values associated
+                                  with the header name.
+
+                                  Input:
+                                    GET /foo HTTP/1.1
+                                    my-header: foo
+
+                                  Config:
+                                    add:
+                                    - name: "my-header"
+                                      value: "bar,baz"
+
+                                  Output:
+                                    GET /foo HTTP/1.1
+                                    my-header: foo,bar,baz
+                                items:
+                                  description: HTTPHeader represents an HTTP Header
+                                    name and value as defined by RFC 7230.
+                                  properties:
+                                    name:
+                                      description: |-
+                                        Name is the name of the HTTP Header to be matched. Name matching MUST be
+                                        case insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
+
+                                        If multiple entries specify equivalent header names, the first entry with
+                                        an equivalent name MUST be considered for a match. Subsequent entries
+                                        with an equivalent header name MUST be ignored. Due to the
+                                        case-insensitivity of header names, "foo" and "Foo" are considered
+                                        equivalent.
+                                      maxLength: 256
+                                      minLength: 1
+                                      pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                      type: string
+                                    value:
+                                      description: Value is the value of HTTP Header
+                                        to be matched.
+                                      maxLength: 4096
+                                      minLength: 1
+                                      type: string
+                                  required:
+                                  - name
+                                  - value
+                                  type: object
+                                maxItems: 16
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                - name
+                                x-kubernetes-list-type: map
+                              remove:
+                                description: |-
+                                  Remove the given header(s) from the HTTP request before the action. The
+                                  value of Remove is a list of HTTP header names. Note that the header
+                                  names are case-insensitive (see
+                                  https://datatracker.ietf.org/doc/html/rfc2616#section-4.2).
+
+                                  Input:
+                                    GET /foo HTTP/1.1
+                                    my-header1: foo
+                                    my-header2: bar
+                                    my-header3: baz
+
+                                  Config:
+                                    remove: ["my-header1", "my-header3"]
+
+                                  Output:
+                                    GET /foo HTTP/1.1
+                                    my-header2: bar
+                                items:
+                                  type: string
+                                maxItems: 16
+                                type: array
+                                x-kubernetes-list-type: set
+                              set:
+                                description: |-
+                                  Set overwrites the request with the given header (name, value)
+                                  before the action.
+
+                                  Input:
+                                    GET /foo HTTP/1.1
+                                    my-header: foo
+
+                                  Config:
+                                    set:
+                                    - name: "my-header"
+                                      value: "bar"
+
+                                  Output:
+                                    GET /foo HTTP/1.1
+                                    my-header: bar
+                                items:
+                                  description: HTTPHeader represents an HTTP Header
+                                    name and value as defined by RFC 7230.
+                                  properties:
+                                    name:
+                                      description: |-
+                                        Name is the name of the HTTP Header to be matched. Name matching MUST be
+                                        case insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
+
+                                        If multiple entries specify equivalent header names, the first entry with
+                                        an equivalent name MUST be considered for a match. Subsequent entries
+                                        with an equivalent header name MUST be ignored. Due to the
+                                        case-insensitivity of header names, "foo" and "Foo" are considered
+                                        equivalent.
+                                      maxLength: 256
+                                      minLength: 1
+                                      pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                      type: string
+                                    value:
+                                      description: Value is the value of HTTP Header
+                                        to be matched.
+                                      maxLength: 4096
+                                      minLength: 1
+                                      type: string
+                                  required:
+                                  - name
+                                  - value
+                                  type: object
+                                maxItems: 16
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                - name
+                                x-kubernetes-list-type: map
+                            type: object
+                          requestMirror:
+                            description: |+
+                              RequestMirror defines a schema for a filter that mirrors requests.
+                              Requests are sent to the specified destination, but responses from
+                              that destination are ignored.
+
+                              This filter can be used multiple times within the same rule. Note that
+                              not all implementations will be able to support mirroring to multiple
+                              backends.
+
+                              Support: Extended
+
+                            properties:
+                              backendRef:
+                                description: |-
+                                  BackendRef references a resource where mirrored requests are sent.
+
+                                  Mirrored requests must be sent only to a single destination endpoint
+                                  within this BackendRef, irrespective of how many endpoints are present
+                                  within this BackendRef.
+
+                                  If the referent cannot be found, this BackendRef is invalid and must be
+                                  dropped from the Gateway. The controller must ensure the "ResolvedRefs"
+                                  condition on the Route status is set to `status: False` and not configure
+                                  this backend in the underlying implementation.
+
+                                  If there is a cross-namespace reference to an *existing* object
+                                  that is not allowed by a ReferenceGrant, the controller must ensure the
+                                  "ResolvedRefs"  condition on the Route is set to `status: False`,
+                                  with the "RefNotPermitted" reason and not configure this backend in the
+                                  underlying implementation.
+
+                                  In either error case, the Message of the `ResolvedRefs` Condition
+                                  should be used to provide more detail about the problem.
+
+                                  Support: Extended for Kubernetes Service
+
+                                  Support: Implementation-specific for any other resource
+                                properties:
+                                  group:
+                                    default: ""
+                                    description: |-
+                                      Group is the group of the referent. For example, "gateway.networking.k8s.io".
+                                      When unspecified or empty string, core API group is inferred.
+                                    maxLength: 253
+                                    pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                    type: string
+                                  kind:
+                                    default: Service
+                                    description: |-
+                                      Kind is the Kubernetes resource kind of the referent. For example
+                                      "Service".
+
+                                      Defaults to "Service" when not specified.
+
+                                      ExternalName services can refer to CNAME DNS records that may live
+                                      outside of the cluster and as such are difficult to reason about in
+                                      terms of conformance. They also may not be safe to forward to (see
+                                      CVE-2021-25740 for more information). Implementations SHOULD NOT
+                                      support ExternalName Services.
+
+                                      Support: Core (Services with a type other than ExternalName)
+
+                                      Support: Implementation-specific (Services with type ExternalName)
+                                    maxLength: 63
+                                    minLength: 1
+                                    pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                                    type: string
+                                  name:
+                                    description: Name is the name of the referent.
+                                    maxLength: 253
+                                    minLength: 1
+                                    type: string
+                                  namespace:
+                                    description: |-
+                                      Namespace is the namespace of the backend. When unspecified, the local
+                                      namespace is inferred.
+
+                                      Note that when a namespace different than the local namespace is specified,
+                                      a ReferenceGrant object is required in the referent namespace to allow that
+                                      namespace's owner to accept the reference. See the ReferenceGrant
+                                      documentation for details.
+
+                                      Support: Core
+                                    maxLength: 63
+                                    minLength: 1
+                                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                    type: string
+                                  port:
+                                    description: |-
+                                      Port specifies the destination port number to use for this resource.
+                                      Port is required when the referent is a Kubernetes Service. In this
+                                      case, the port number is the service port number, not the target port.
+                                      For other resources, destination port might be derived from the referent
+                                      resource or this field.
+                                    format: int32
+                                    maximum: 65535
+                                    minimum: 1
+                                    type: integer
+                                required:
+                                - name
+                                type: object
+                                x-kubernetes-validations:
+                                - message: Must have port for Service reference
+                                  rule: '(size(self.group) == 0 && self.kind == ''Service'')
+                                    ? has(self.port) : true'
+                            required:
+                            - backendRef
+                            type: object
+                          requestRedirect:
+                            description: |-
+                              RequestRedirect defines a schema for a filter that responds to the
+                              request with an HTTP redirection.
+
+                              Support: Core
+                            properties:
+                              hostname:
+                                description: |-
+                                  Hostname is the hostname to be used in the value of the `Location`
+                                  header in the response.
+                                  When empty, the hostname in the `Host` header of the request is used.
+
+                                  Support: Core
+                                maxLength: 253
+                                minLength: 1
+                                pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                type: string
+                              path:
+                                description: |-
+                                  Path defines parameters used to modify the path of the incoming request.
+                                  The modified path is then used to construct the `Location` header. When
+                                  empty, the request path is used as-is.
+
+                                  Support: Extended
+                                properties:
+                                  replaceFullPath:
+                                    description: |-
+                                      ReplaceFullPath specifies the value with which to replace the full path
+                                      of a request during a rewrite or redirect.
+                                    maxLength: 1024
+                                    type: string
+                                  replacePrefixMatch:
+                                    description: |-
+                                      ReplacePrefixMatch specifies the value with which to replace the prefix
+                                      match of a request during a rewrite or redirect. For example, a request
+                                      to "/foo/bar" with a prefix match of "/foo" and a ReplacePrefixMatch
+                                      of "/xyz" would be modified to "/xyz/bar".
+
+                                      Note that this matches the behavior of the PathPrefix match type. This
+                                      matches full path elements. A path element refers to the list of labels
+                                      in the path split by the `/` separator. When specified, a trailing `/` is
+                                      ignored. For example, the paths `/abc`, `/abc/`, and `/abc/def` would all
+                                      match the prefix `/abc`, but the path `/abcd` would not.
+
+                                      ReplacePrefixMatch is only compatible with a `PathPrefix` HTTPRouteMatch.
+                                      Using any other HTTPRouteMatch type on the same HTTPRouteRule will result in
+                                      the implementation setting the Accepted Condition for the Route to `status: False`.
+
+                                      Request Path | Prefix Match | Replace Prefix | Modified Path
+                                    maxLength: 1024
+                                    type: string
+                                  type:
+                                    description: |-
+                                      Type defines the type of path modifier. Additional types may be
+                                      added in a future release of the API.
+
+                                      Note that values may be added to this enum, implementations
+                                      must ensure that unknown values will not cause a crash.
+
+                                      Unknown values here must result in the implementation setting the
+                                      Accepted Condition for the Route to `status: False`, with a
+                                      Reason of `UnsupportedValue`.
+                                    enum:
+                                    - ReplaceFullPath
+                                    - ReplacePrefixMatch
+                                    type: string
+                                required:
+                                - type
+                                type: object
+                                x-kubernetes-validations:
+                                - message: replaceFullPath must be specified when
+                                    type is set to 'ReplaceFullPath'
+                                  rule: 'self.type == ''ReplaceFullPath'' ? has(self.replaceFullPath)
+                                    : true'
+                                - message: type must be 'ReplaceFullPath' when replaceFullPath
+                                    is set
+                                  rule: 'has(self.replaceFullPath) ? self.type ==
+                                    ''ReplaceFullPath'' : true'
+                                - message: replacePrefixMatch must be specified when
+                                    type is set to 'ReplacePrefixMatch'
+                                  rule: 'self.type == ''ReplacePrefixMatch'' ? has(self.replacePrefixMatch)
+                                    : true'
+                                - message: type must be 'ReplacePrefixMatch' when
+                                    replacePrefixMatch is set
+                                  rule: 'has(self.replacePrefixMatch) ? self.type
+                                    == ''ReplacePrefixMatch'' : true'
+                              port:
+                                description: |-
+                                  Port is the port to be used in the value of the `Location`
+                                  header in the response.
+
+                                  If no port is specified, the redirect port MUST be derived using the
+                                  following rules:
+
+                                  * If redirect scheme is not-empty, the redirect port MUST be the well-known
+                                    port associated with the redirect scheme. Specifically "http" to port 80
+                                    and "https" to port 443. If the redirect scheme does not have a
+                                    well-known port, the listener port of the Gateway SHOULD be used.
+                                  * If redirect scheme is empty, the redirect port MUST be the Gateway
+                                    Listener port.
+
+                                  Implementations SHOULD NOT add the port number in the 'Location'
+                                  header in the following cases:
+
+                                  * A Location header that will use HTTP (whether that is determined via
+                                    the Listener protocol or the Scheme field) _and_ use port 80.
+                                  * A Location header that will use HTTPS (whether that is determined via
+                                    the Listener protocol or the Scheme field) _and_ use port 443.
+
+                                  Support: Extended
+                                format: int32
+                                maximum: 65535
+                                minimum: 1
+                                type: integer
+                              scheme:
+                                description: |-
+                                  Scheme is the scheme to be used in the value of the `Location` header in
+                                  the response. When empty, the scheme of the request is used.
+
+                                  Scheme redirects can affect the port of the redirect, for more information,
+                                  refer to the documentation for the port field of this filter.
+
+                                  Note that values may be added to this enum, implementations
+                                  must ensure that unknown values will not cause a crash.
+
+                                  Unknown values here must result in the implementation setting the
+                                  Accepted Condition for the Route to `status: False`, with a
+                                  Reason of `UnsupportedValue`.
+
+                                  Support: Extended
+                                enum:
+                                - http
+                                - https
+                                type: string
+                              statusCode:
+                                default: 302
+                                description: |-
+                                  StatusCode is the HTTP status code to be used in response.
+
+                                  Note that values may be added to this enum, implementations
+                                  must ensure that unknown values will not cause a crash.
+
+                                  Unknown values here must result in the implementation setting the
+                                  Accepted Condition for the Route to `status: False`, with a
+                                  Reason of `UnsupportedValue`.
+
+                                  Support: Core
+                                enum:
+                                - 301
+                                - 302
+                                type: integer
+                            type: object
+                          responseHeaderModifier:
+                            description: |-
+                              ResponseHeaderModifier defines a schema for a filter that modifies response
+                              headers.
+
+                              Support: Extended
+                            properties:
+                              add:
+                                description: |-
+                                  Add adds the given header(s) (name, value) to the request
+                                  before the action. It appends to any existing values associated
+                                  with the header name.
+
+                                  Input:
+                                    GET /foo HTTP/1.1
+                                    my-header: foo
+
+                                  Config:
+                                    add:
+                                    - name: "my-header"
+                                      value: "bar,baz"
+
+                                  Output:
+                                    GET /foo HTTP/1.1
+                                    my-header: foo,bar,baz
+                                items:
+                                  description: HTTPHeader represents an HTTP Header
+                                    name and value as defined by RFC 7230.
+                                  properties:
+                                    name:
+                                      description: |-
+                                        Name is the name of the HTTP Header to be matched. Name matching MUST be
+                                        case insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
+
+                                        If multiple entries specify equivalent header names, the first entry with
+                                        an equivalent name MUST be considered for a match. Subsequent entries
+                                        with an equivalent header name MUST be ignored. Due to the
+                                        case-insensitivity of header names, "foo" and "Foo" are considered
+                                        equivalent.
+                                      maxLength: 256
+                                      minLength: 1
+                                      pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                      type: string
+                                    value:
+                                      description: Value is the value of HTTP Header
+                                        to be matched.
+                                      maxLength: 4096
+                                      minLength: 1
+                                      type: string
+                                  required:
+                                  - name
+                                  - value
+                                  type: object
+                                maxItems: 16
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                - name
+                                x-kubernetes-list-type: map
+                              remove:
+                                description: |-
+                                  Remove the given header(s) from the HTTP request before the action. The
+                                  value of Remove is a list of HTTP header names. Note that the header
+                                  names are case-insensitive (see
+                                  https://datatracker.ietf.org/doc/html/rfc2616#section-4.2).
+
+                                  Input:
+                                    GET /foo HTTP/1.1
+                                    my-header1: foo
+                                    my-header2: bar
+                                    my-header3: baz
+
+                                  Config:
+                                    remove: ["my-header1", "my-header3"]
+
+                                  Output:
+                                    GET /foo HTTP/1.1
+                                    my-header2: bar
+                                items:
+                                  type: string
+                                maxItems: 16
+                                type: array
+                                x-kubernetes-list-type: set
+                              set:
+                                description: |-
+                                  Set overwrites the request with the given header (name, value)
+                                  before the action.
+
+                                  Input:
+                                    GET /foo HTTP/1.1
+                                    my-header: foo
+
+                                  Config:
+                                    set:
+                                    - name: "my-header"
+                                      value: "bar"
+
+                                  Output:
+                                    GET /foo HTTP/1.1
+                                    my-header: bar
+                                items:
+                                  description: HTTPHeader represents an HTTP Header
+                                    name and value as defined by RFC 7230.
+                                  properties:
+                                    name:
+                                      description: |-
+                                        Name is the name of the HTTP Header to be matched. Name matching MUST be
+                                        case insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
+
+                                        If multiple entries specify equivalent header names, the first entry with
+                                        an equivalent name MUST be considered for a match. Subsequent entries
+                                        with an equivalent header name MUST be ignored. Due to the
+                                        case-insensitivity of header names, "foo" and "Foo" are considered
+                                        equivalent.
+                                      maxLength: 256
+                                      minLength: 1
+                                      pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                      type: string
+                                    value:
+                                      description: Value is the value of HTTP Header
+                                        to be matched.
+                                      maxLength: 4096
+                                      minLength: 1
+                                      type: string
+                                  required:
+                                  - name
+                                  - value
+                                  type: object
+                                maxItems: 16
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                - name
+                                x-kubernetes-list-type: map
+                            type: object
+                          type:
+                            description: |-
+                              Type identifies the type of filter to apply. As with other API fields,
+                              types are classified into three conformance levels:
+
+                              - Core: Filter types and their corresponding configuration defined by
+                                "Support: Core" in this package, e.g. "RequestHeaderModifier". All
+                                implementations must support core filters.
+
+                              - Extended: Filter types and their corresponding configuration defined by
+                                "Support: Extended" in this package, e.g. "RequestMirror". Implementers
+                                are encouraged to support extended filters.
+
+                              - Implementation-specific: Filters that are defined and supported by
+                                specific vendors.
+                                In the future, filters showing convergence in behavior across multiple
+                                implementations will be considered for inclusion in extended or core
+                                conformance levels. Filter-specific configuration for such filters
+                                is specified using the ExtensionRef field. `Type` should be set to
+                                "ExtensionRef" for custom filters.
+
+                              Implementers are encouraged to define custom implementation types to
+                              extend the core API with implementation-specific behavior.
+
+                              If a reference to a custom filter type cannot be resolved, the filter
+                              MUST NOT be skipped. Instead, requests that would have been processed by
+                              that filter MUST receive a HTTP error response.
+
+                              Note that values may be added to this enum, implementations
+                              must ensure that unknown values will not cause a crash.
+
+                              Unknown values here must result in the implementation setting the
+                              Accepted Condition for the Route to `status: False`, with a
+                              Reason of `UnsupportedValue`.
+                            enum:
+                            - RequestHeaderModifier
+                            - ResponseHeaderModifier
+                            - RequestMirror
+                            - RequestRedirect
+                            - URLRewrite
+                            - ExtensionRef
+                            type: string
+                          urlRewrite:
+                            description: |-
+                              URLRewrite defines a schema for a filter that modifies a request during forwarding.
+
+                              Support: Extended
+                            properties:
+                              hostname:
+                                description: |-
+                                  Hostname is the value to be used to replace the Host header value during
+                                  forwarding.
+
+                                  Support: Extended
+                                maxLength: 253
+                                minLength: 1
+                                pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                type: string
+                              path:
+                                description: |-
+                                  Path defines a path rewrite.
+
+                                  Support: Extended
+                                properties:
+                                  replaceFullPath:
+                                    description: |-
+                                      ReplaceFullPath specifies the value with which to replace the full path
+                                      of a request during a rewrite or redirect.
+                                    maxLength: 1024
+                                    type: string
+                                  replacePrefixMatch:
+                                    description: |-
+                                      ReplacePrefixMatch specifies the value with which to replace the prefix
+                                      match of a request during a rewrite or redirect. For example, a request
+                                      to "/foo/bar" with a prefix match of "/foo" and a ReplacePrefixMatch
+                                      of "/xyz" would be modified to "/xyz/bar".
+
+                                      Note that this matches the behavior of the PathPrefix match type. This
+                                      matches full path elements. A path element refers to the list of labels
+                                      in the path split by the `/` separator. When specified, a trailing `/` is
+                                      ignored. For example, the paths `/abc`, `/abc/`, and `/abc/def` would all
+                                      match the prefix `/abc`, but the path `/abcd` would not.
+
+                                      ReplacePrefixMatch is only compatible with a `PathPrefix` HTTPRouteMatch.
+                                      Using any other HTTPRouteMatch type on the same HTTPRouteRule will result in
+                                      the implementation setting the Accepted Condition for the Route to `status: False`.
+
+                                      Request Path | Prefix Match | Replace Prefix | Modified Path
+                                    maxLength: 1024
+                                    type: string
+                                  type:
+                                    description: |-
+                                      Type defines the type of path modifier. Additional types may be
+                                      added in a future release of the API.
+
+                                      Note that values may be added to this enum, implementations
+                                      must ensure that unknown values will not cause a crash.
+
+                                      Unknown values here must result in the implementation setting the
+                                      Accepted Condition for the Route to `status: False`, with a
+                                      Reason of `UnsupportedValue`.
+                                    enum:
+                                    - ReplaceFullPath
+                                    - ReplacePrefixMatch
+                                    type: string
+                                required:
+                                - type
+                                type: object
+                                x-kubernetes-validations:
+                                - message: replaceFullPath must be specified when
+                                    type is set to 'ReplaceFullPath'
+                                  rule: 'self.type == ''ReplaceFullPath'' ? has(self.replaceFullPath)
+                                    : true'
+                                - message: type must be 'ReplaceFullPath' when replaceFullPath
+                                    is set
+                                  rule: 'has(self.replaceFullPath) ? self.type ==
+                                    ''ReplaceFullPath'' : true'
+                                - message: replacePrefixMatch must be specified when
+                                    type is set to 'ReplacePrefixMatch'
+                                  rule: 'self.type == ''ReplacePrefixMatch'' ? has(self.replacePrefixMatch)
+                                    : true'
+                                - message: type must be 'ReplacePrefixMatch' when
+                                    replacePrefixMatch is set
+                                  rule: 'has(self.replacePrefixMatch) ? self.type
+                                    == ''ReplacePrefixMatch'' : true'
+                            type: object
+                        required:
+                        - type
+                        type: object
+                        x-kubernetes-validations:
+                        - message: filter.requestHeaderModifier must be nil if the
+                            filter.type is not RequestHeaderModifier
+                          rule: '!(has(self.requestHeaderModifier) && self.type !=
+                            ''RequestHeaderModifier'')'
+                        - message: filter.requestHeaderModifier must be specified
+                            for RequestHeaderModifier filter.type
+                          rule: '!(!has(self.requestHeaderModifier) && self.type ==
+                            ''RequestHeaderModifier'')'
+                        - message: filter.responseHeaderModifier must be nil if the
+                            filter.type is not ResponseHeaderModifier
+                          rule: '!(has(self.responseHeaderModifier) && self.type !=
+                            ''ResponseHeaderModifier'')'
+                        - message: filter.responseHeaderModifier must be specified
+                            for ResponseHeaderModifier filter.type
+                          rule: '!(!has(self.responseHeaderModifier) && self.type
+                            == ''ResponseHeaderModifier'')'
+                        - message: filter.requestMirror must be nil if the filter.type
+                            is not RequestMirror
+                          rule: '!(has(self.requestMirror) && self.type != ''RequestMirror'')'
+                        - message: filter.requestMirror must be specified for RequestMirror
+                            filter.type
+                          rule: '!(!has(self.requestMirror) && self.type == ''RequestMirror'')'
+                        - message: filter.requestRedirect must be nil if the filter.type
+                            is not RequestRedirect
+                          rule: '!(has(self.requestRedirect) && self.type != ''RequestRedirect'')'
+                        - message: filter.requestRedirect must be specified for RequestRedirect
+                            filter.type
+                          rule: '!(!has(self.requestRedirect) && self.type == ''RequestRedirect'')'
+                        - message: filter.urlRewrite must be nil if the filter.type
+                            is not URLRewrite
+                          rule: '!(has(self.urlRewrite) && self.type != ''URLRewrite'')'
+                        - message: filter.urlRewrite must be specified for URLRewrite
+                            filter.type
+                          rule: '!(!has(self.urlRewrite) && self.type == ''URLRewrite'')'
+                        - message: filter.extensionRef must be nil if the filter.type
+                            is not ExtensionRef
+                          rule: '!(has(self.extensionRef) && self.type != ''ExtensionRef'')'
+                        - message: filter.extensionRef must be specified for ExtensionRef
+                            filter.type
+                          rule: '!(!has(self.extensionRef) && self.type == ''ExtensionRef'')'
+                      maxItems: 16
+                      type: array
+                      x-kubernetes-validations:
+                      - message: May specify either httpRouteFilterRequestRedirect
+                          or httpRouteFilterRequestRewrite, but not both
+                        rule: '!(self.exists(f, f.type == ''RequestRedirect'') &&
+                          self.exists(f, f.type == ''URLRewrite''))'
+                      - message: RequestHeaderModifier filter cannot be repeated
+                        rule: self.filter(f, f.type == 'RequestHeaderModifier').size()
+                          <= 1
+                      - message: ResponseHeaderModifier filter cannot be repeated
+                        rule: self.filter(f, f.type == 'ResponseHeaderModifier').size()
+                          <= 1
+                      - message: RequestRedirect filter cannot be repeated
+                        rule: self.filter(f, f.type == 'RequestRedirect').size() <=
+                          1
+                      - message: URLRewrite filter cannot be repeated
+                        rule: self.filter(f, f.type == 'URLRewrite').size() <= 1
+                    matches:
+                      default:
+                      - path:
+                          type: PathPrefix
+                          value: /
+                      description: |-
+                        Matches define conditions used for matching the rule against incoming
+                        HTTP requests. Each match is independent, i.e. this rule will be matched
+                        if **any** one of the matches is satisfied.
+
+                        For example, take the following matches configuration:
+
+                        ```
+                        matches:
+                        - path:
+                            value: "/foo"
+                          headers:
+                          - name: "version"
+                            value: "v2"
+                        - path:
+                            value: "/v2/foo"
+                        ```
+
+                        For a request to match against this rule, a request must satisfy
+                        EITHER of the two conditions:
+
+                        - path prefixed with `/foo` AND contains the header `version: v2`
+                        - path prefix of `/v2/foo`
+
+                        See the documentation for HTTPRouteMatch on how to specify multiple
+                        match conditions that should be ANDed together.
+
+                        If no matches are specified, the default is a prefix
+                        path match on "/", which has the effect of matching every
+                        HTTP request.
+
+                        Proxy or Load Balancer routing configuration generated from HTTPRoutes
+                        MUST prioritize matches based on the following criteria, continuing on
+                        ties. Across all rules specified on applicable Routes, precedence must be
+                        given to the match having:
+
+                        * "Exact" path match.
+                        * "Prefix" path match with largest number of characters.
+                        * Method match.
+                        * Largest number of header matches.
+                        * Largest number of query param matches.
+
+                        Note: The precedence of RegularExpression path matches are implementation-specific.
+
+                        If ties still exist across multiple Routes, matching precedence MUST be
+                        determined in order of the following criteria, continuing on ties:
+
+                        * The oldest Route based on creation timestamp.
+                        * The Route appearing first in alphabetical order by
+                          "{namespace}/{name}".
+
+                        If ties still exist within an HTTPRoute, matching precedence MUST be granted
+                        to the FIRST matching rule (in list order) with a match meeting the above
+                        criteria.
+
+                        When no rules matching a request have been successfully attached to the
+                        parent a request is coming from, a HTTP 404 status code MUST be returned.
+                      items:
+                        description: "HTTPRouteMatch defines the predicate used to
+                          match requests to a given\naction. Multiple match types
+                          are ANDed together, i.e. the match will\nevaluate to true
+                          only if all conditions are satisfied.\n\nFor example, the
+                          match below will match a HTTP request only if its path\nstarts
+                          with `/foo` AND it contains the `version: v1` header:\n\n```\nmatch:\n\n\tpath:\n\t
+                          \ value: \"/foo\"\n\theaders:\n\t- name: \"version\"\n\t
+                          \ value \"v1\"\n\n```"
+                        properties:
+                          headers:
+                            description: |-
+                              Headers specifies HTTP request header matchers. Multiple match values are
+                              ANDed together, meaning, a request must match all the specified headers
+                              to select the route.
+                            items:
+                              description: |-
+                                HTTPHeaderMatch describes how to select a HTTP route by matching HTTP request
+                                headers.
+                              properties:
+                                name:
+                                  description: |-
+                                    Name is the name of the HTTP Header to be matched. Name matching MUST be
+                                    case insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
+
+                                    If multiple entries specify equivalent header names, only the first
+                                    entry with an equivalent name MUST be considered for a match. Subsequent
+                                    entries with an equivalent header name MUST be ignored. Due to the
+                                    case-insensitivity of header names, "foo" and "Foo" are considered
+                                    equivalent.
+
+                                    When a header is repeated in an HTTP request, it is
+                                    implementation-specific behavior as to how this is represented.
+                                    Generally, proxies should follow the guidance from the RFC:
+                                    https://www.rfc-editor.org/rfc/rfc7230.html#section-3.2.2 regarding
+                                    processing a repeated header, with special handling for "Set-Cookie".
+                                  maxLength: 256
+                                  minLength: 1
+                                  pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                  type: string
+                                type:
+                                  default: Exact
+                                  description: |-
+                                    Type specifies how to match against the value of the header.
+
+                                    Support: Core (Exact)
+
+                                    Support: Implementation-specific (RegularExpression)
+
+                                    Since RegularExpression HeaderMatchType has implementation-specific
+                                    conformance, implementations can support POSIX, PCRE or any other dialects
+                                    of regular expressions. Please read the implementation's documentation to
+                                    determine the supported dialect.
+                                  enum:
+                                  - Exact
+                                  - RegularExpression
+                                  type: string
+                                value:
+                                  description: Value is the value of HTTP Header to
+                                    be matched.
+                                  maxLength: 4096
+                                  minLength: 1
+                                  type: string
+                              required:
+                              - name
+                              - value
+                              type: object
+                            maxItems: 16
+                            type: array
+                            x-kubernetes-list-map-keys:
+                            - name
+                            x-kubernetes-list-type: map
+                          method:
+                            description: |-
+                              Method specifies HTTP method matcher.
+                              When specified, this route will be matched only if the request has the
+                              specified method.
+
+                              Support: Extended
+                            enum:
+                            - GET
+                            - HEAD
+                            - POST
+                            - PUT
+                            - DELETE
+                            - CONNECT
+                            - OPTIONS
+                            - TRACE
+                            - PATCH
+                            type: string
+                          path:
+                            default:
+                              type: PathPrefix
+                              value: /
+                            description: |-
+                              Path specifies a HTTP request path matcher. If this field is not
+                              specified, a default prefix match on the "/" path is provided.
+                            properties:
+                              type:
+                                default: PathPrefix
+                                description: |-
+                                  Type specifies how to match against the path Value.
+
+                                  Support: Core (Exact, PathPrefix)
+
+                                  Support: Implementation-specific (RegularExpression)
+                                enum:
+                                - Exact
+                                - PathPrefix
+                                - RegularExpression
+                                type: string
+                              value:
+                                default: /
+                                description: Value of the HTTP path to match against.
+                                maxLength: 1024
+                                type: string
+                            type: object
+                            x-kubernetes-validations:
+                            - message: value must be an absolute path and start with
+                                '/' when type one of ['Exact', 'PathPrefix']
+                              rule: '(self.type in [''Exact'',''PathPrefix'']) ? self.value.startsWith(''/'')
+                                : true'
+                            - message: must not contain '//' when type one of ['Exact',
+                                'PathPrefix']
+                              rule: '(self.type in [''Exact'',''PathPrefix'']) ? !self.value.contains(''//'')
+                                : true'
+                            - message: must not contain '/./' when type one of ['Exact',
+                                'PathPrefix']
+                              rule: '(self.type in [''Exact'',''PathPrefix'']) ? !self.value.contains(''/./'')
+                                : true'
+                            - message: must not contain '/../' when type one of ['Exact',
+                                'PathPrefix']
+                              rule: '(self.type in [''Exact'',''PathPrefix'']) ? !self.value.contains(''/../'')
+                                : true'
+                            - message: must not contain '%2f' when type one of ['Exact',
+                                'PathPrefix']
+                              rule: '(self.type in [''Exact'',''PathPrefix'']) ? !self.value.contains(''%2f'')
+                                : true'
+                            - message: must not contain '%2F' when type one of ['Exact',
+                                'PathPrefix']
+                              rule: '(self.type in [''Exact'',''PathPrefix'']) ? !self.value.contains(''%2F'')
+                                : true'
+                            - message: must not contain '#' when type one of ['Exact',
+                                'PathPrefix']
+                              rule: '(self.type in [''Exact'',''PathPrefix'']) ? !self.value.contains(''#'')
+                                : true'
+                            - message: must not end with '/..' when type one of ['Exact',
+                                'PathPrefix']
+                              rule: '(self.type in [''Exact'',''PathPrefix'']) ? !self.value.endsWith(''/..'')
+                                : true'
+                            - message: must not end with '/.' when type one of ['Exact',
+                                'PathPrefix']
+                              rule: '(self.type in [''Exact'',''PathPrefix'']) ? !self.value.endsWith(''/.'')
+                                : true'
+                            - message: type must be one of ['Exact', 'PathPrefix',
+                                'RegularExpression']
+                              rule: self.type in ['Exact','PathPrefix'] || self.type
+                                == 'RegularExpression'
+                            - message: must only contain valid characters (matching
+                                ^(?:[-A-Za-z0-9/._~!$&'()*+,;=:@]|[%][0-9a-fA-F]{2})+$)
+                                for types ['Exact', 'PathPrefix']
+                              rule: '(self.type in [''Exact'',''PathPrefix'']) ? self.value.matches(r"""^(?:[-A-Za-z0-9/._~!$&''()*+,;=:@]|[%][0-9a-fA-F]{2})+$""")
+                                : true'
+                          queryParams:
+                            description: |-
+                              QueryParams specifies HTTP query parameter matchers. Multiple match
+                              values are ANDed together, meaning, a request must match all the
+                              specified query parameters to select the route.
+
+                              Support: Extended
+                            items:
+                              description: |-
+                                HTTPQueryParamMatch describes how to select a HTTP route by matching HTTP
+                                query parameters.
+                              properties:
+                                name:
+                                  description: |-
+                                    Name is the name of the HTTP query param to be matched. This must be an
+                                    exact string match. (See
+                                    https://tools.ietf.org/html/rfc7230#section-2.7.3).
+
+                                    If multiple entries specify equivalent query param names, only the first
+                                    entry with an equivalent name MUST be considered for a match. Subsequent
+                                    entries with an equivalent query param name MUST be ignored.
+
+                                    If a query param is repeated in an HTTP request, the behavior is
+                                    purposely left undefined, since different data planes have different
+                                    capabilities. However, it is *recommended* that implementations should
+                                    match against the first value of the param if the data plane supports it,
+                                    as this behavior is expected in other load balancing contexts outside of
+                                    the Gateway API.
+
+                                    Users SHOULD NOT route traffic based on repeated query params to guard
+                                    themselves against potential differences in the implementations.
+                                  maxLength: 256
+                                  minLength: 1
+                                  pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                  type: string
+                                type:
+                                  default: Exact
+                                  description: |-
+                                    Type specifies how to match against the value of the query parameter.
+
+                                    Support: Extended (Exact)
+
+                                    Support: Implementation-specific (RegularExpression)
+
+                                    Since RegularExpression QueryParamMatchType has Implementation-specific
+                                    conformance, implementations can support POSIX, PCRE or any other
+                                    dialects of regular expressions. Please read the implementation's
+                                    documentation to determine the supported dialect.
+                                  enum:
+                                  - Exact
+                                  - RegularExpression
+                                  type: string
+                                value:
+                                  description: Value is the value of HTTP query param
+                                    to be matched.
+                                  maxLength: 1024
+                                  minLength: 1
+                                  type: string
+                              required:
+                              - name
+                              - value
+                              type: object
+                            maxItems: 16
+                            type: array
+                            x-kubernetes-list-map-keys:
+                            - name
+                            x-kubernetes-list-type: map
+                        type: object
+                      maxItems: 64
+                      type: array
+                    timeouts:
+                      description: |-
+                        Timeouts defines the timeouts that can be configured for an HTTP request.
+
+                        Support: Extended
+                      properties:
+                        backendRequest:
+                          description: |-
+                            BackendRequest specifies a timeout for an individual request from the gateway
+                            to a backend. This covers the time from when the request first starts being
+                            sent from the gateway to when the full response has been received from the backend.
+
+                            Setting a timeout to the zero duration (e.g. "0s") SHOULD disable the timeout
+                            completely. Implementations that cannot completely disable the timeout MUST
+                            instead interpret the zero duration as the longest possible value to which
+                            the timeout can be set.
+
+                            An entire client HTTP transaction with a gateway, covered by the Request timeout,
+                            may result in more than one call from the gateway to the destination backend,
+                            for example, if automatic retries are supported.
+
+                            The value of BackendRequest must be a Gateway API Duration string as defined by
+                            GEP-2257.  When this field is unspecified, its behavior is implementation-specific;
+                            when specified, the value of BackendRequest must be no more than the value of the
+                            Request timeout (since the Request timeout encompasses the BackendRequest timeout).
+
+                            Support: Extended
+                          pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
+                          type: string
+                        request:
+                          description: |-
+                            Request specifies the maximum duration for a gateway to respond to an HTTP request.
+                            If the gateway has not been able to respond before this deadline is met, the gateway
+                            MUST return a timeout error.
+
+                            For example, setting the `rules.timeouts.request` field to the value `10s` in an
+                            `HTTPRoute` will cause a timeout if a client request is taking longer than 10 seconds
+                            to complete.
+
+                            Setting a timeout to the zero duration (e.g. "0s") SHOULD disable the timeout
+                            completely. Implementations that cannot completely disable the timeout MUST
+                            instead interpret the zero duration as the longest possible value to which
+                            the timeout can be set.
+
+                            This timeout is intended to cover as close to the whole request-response transaction
+                            as possible although an implementation MAY choose to start the timeout after the entire
+                            request stream has been received instead of immediately after the transaction is
+                            initiated by the client.
+
+                            The value of Request is a Gateway API Duration string as defined by GEP-2257. When this
+                            field is unspecified, request timeout behavior is implementation-specific.
+
+                            Support: Extended
+                          pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
+                          type: string
+                      type: object
+                      x-kubernetes-validations:
+                      - message: backendRequest timeout cannot be longer than request
+                          timeout
+                        rule: '!(has(self.request) && has(self.backendRequest) &&
+                          duration(self.request) != duration(''0s'') && duration(self.backendRequest)
+                          > duration(self.request))'
+                  type: object
+                  x-kubernetes-validations:
+                  - message: RequestRedirect filter must not be used together with
+                      backendRefs
+                    rule: '(has(self.backendRefs) && size(self.backendRefs) > 0) ?
+                      (!has(self.filters) || self.filters.all(f, !has(f.requestRedirect))):
+                      true'
+                  - message: When using RequestRedirect filter with path.replacePrefixMatch,
+                      exactly one PathPrefix match must be specified
+                    rule: '(has(self.filters) && self.filters.exists_one(f, has(f.requestRedirect)
+                      && has(f.requestRedirect.path) && f.requestRedirect.path.type
+                      == ''ReplacePrefixMatch'' && has(f.requestRedirect.path.replacePrefixMatch)))
+                      ? ((size(self.matches) != 1 || !has(self.matches[0].path) ||
+                      self.matches[0].path.type != ''PathPrefix'') ? false : true)
+                      : true'
+                  - message: When using URLRewrite filter with path.replacePrefixMatch,
+                      exactly one PathPrefix match must be specified
+                    rule: '(has(self.filters) && self.filters.exists_one(f, has(f.urlRewrite)
+                      && has(f.urlRewrite.path) && f.urlRewrite.path.type == ''ReplacePrefixMatch''
+                      && has(f.urlRewrite.path.replacePrefixMatch))) ? ((size(self.matches)
+                      != 1 || !has(self.matches[0].path) || self.matches[0].path.type
+                      != ''PathPrefix'') ? false : true) : true'
+                  - message: Within backendRefs, when using RequestRedirect filter
+                      with path.replacePrefixMatch, exactly one PathPrefix match must
+                      be specified
+                    rule: '(has(self.backendRefs) && self.backendRefs.exists_one(b,
+                      (has(b.filters) && b.filters.exists_one(f, has(f.requestRedirect)
+                      && has(f.requestRedirect.path) && f.requestRedirect.path.type
+                      == ''ReplacePrefixMatch'' && has(f.requestRedirect.path.replacePrefixMatch)))
+                      )) ? ((size(self.matches) != 1 || !has(self.matches[0].path)
+                      || self.matches[0].path.type != ''PathPrefix'') ? false : true)
+                      : true'
+                  - message: Within backendRefs, When using URLRewrite filter with
+                      path.replacePrefixMatch, exactly one PathPrefix match must be
+                      specified
+                    rule: '(has(self.backendRefs) && self.backendRefs.exists_one(b,
+                      (has(b.filters) && b.filters.exists_one(f, has(f.urlRewrite)
+                      && has(f.urlRewrite.path) && f.urlRewrite.path.type == ''ReplacePrefixMatch''
+                      && has(f.urlRewrite.path.replacePrefixMatch))) )) ? ((size(self.matches)
+                      != 1 || !has(self.matches[0].path) || self.matches[0].path.type
+                      != ''PathPrefix'') ? false : true) : true'
+                maxItems: 16
+                type: array
+                x-kubernetes-validations:
+                - message: While 16 rules and 64 matches per rule are allowed, the
+                    total number of matches across all rules in a route must be less
+                    than 128
+                  rule: '(self.size() > 0 ? self[0].matches.size() : 0) + (self.size()
+                    > 1 ? self[1].matches.size() : 0) + (self.size() > 2 ? self[2].matches.size()
+                    : 0) + (self.size() > 3 ? self[3].matches.size() : 0) + (self.size()
+                    > 4 ? self[4].matches.size() : 0) + (self.size() > 5 ? self[5].matches.size()
+                    : 0) + (self.size() > 6 ? self[6].matches.size() : 0) + (self.size()
+                    > 7 ? self[7].matches.size() : 0) + (self.size() > 8 ? self[8].matches.size()
+                    : 0) + (self.size() > 9 ? self[9].matches.size() : 0) + (self.size()
+                    > 10 ? self[10].matches.size() : 0) + (self.size() > 11 ? self[11].matches.size()
+                    : 0) + (self.size() > 12 ? self[12].matches.size() : 0) + (self.size()
+                    > 13 ? self[13].matches.size() : 0) + (self.size() > 14 ? self[14].matches.size()
+                    : 0) + (self.size() > 15 ? self[15].matches.size() : 0) <= 128'
+            type: object
+          status:
+            description: Status defines the current state of HTTPRoute.
+            properties:
+              parents:
+                description: |-
+                  Parents is a list of parent resources (usually Gateways) that are
+                  associated with the route, and the status of the route with respect to
+                  each parent. When this route attaches to a parent, the controller that
+                  manages the parent must add an entry to this list when the controller
+                  first sees the route and should update the entry as appropriate when the
+                  route or gateway is modified.
+
+                  Note that parent references that cannot be resolved by an implementation
+                  of this API will not be added to this list. Implementations of this API
+                  can only populate Route status for the Gateways/parent resources they are
+                  responsible for.
+
+                  A maximum of 32 Gateways will be represented in this list. An empty list
+                  means the route has not been attached to any Gateway.
+                items:
+                  description: |-
+                    RouteParentStatus describes the status of a route with respect to an
+                    associated Parent.
+                  properties:
+                    conditions:
+                      description: |-
+                        Conditions describes the status of the route with respect to the Gateway.
+                        Note that the route's availability is also subject to the Gateway's own
+                        status conditions and listener status.
+
+                        If the Route's ParentRef specifies an existing Gateway that supports
+                        Routes of this kind AND that Gateway's controller has sufficient access,
+                        then that Gateway's controller MUST set the "Accepted" condition on the
+                        Route, to indicate whether the route has been accepted or rejected by the
+                        Gateway, and why.
+
+                        A Route MUST be considered "Accepted" if at least one of the Route's
+                        rules is implemented by the Gateway.
+
+                        There are a number of cases where the "Accepted" condition may not be set
+                        due to lack of controller visibility, that includes when:
+
+                        * The Route refers to a non-existent parent.
+                        * The Route is of a type that the controller does not support.
+                        * The Route is in a namespace the controller does not have access to.
+                      items:
+                        description: Condition contains details for one aspect of
+                          the current state of this API Resource.
+                        properties:
+                          lastTransitionTime:
+                            description: |-
+                              lastTransitionTime is the last time the condition transitioned from one status to another.
+                              This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                            format: date-time
+                            type: string
+                          message:
+                            description: |-
+                              message is a human readable message indicating details about the transition.
+                              This may be an empty string.
+                            maxLength: 32768
+                            type: string
+                          observedGeneration:
+                            description: |-
+                              observedGeneration represents the .metadata.generation that the condition was set based upon.
+                              For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                              with respect to the current state of the instance.
+                            format: int64
+                            minimum: 0
+                            type: integer
+                          reason:
+                            description: |-
+                              reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                              Producers of specific condition types may define expected values and meanings for this field,
+                              and whether the values are considered a guaranteed API.
+                              The value should be a CamelCase string.
+                              This field may not be empty.
+                            maxLength: 1024
+                            minLength: 1
+                            pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                            type: string
+                          status:
+                            description: status of the condition, one of True, False,
+                              Unknown.
+                            enum:
+                            - "True"
+                            - "False"
+                            - Unknown
+                            type: string
+                          type:
+                            description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                            maxLength: 316
+                            pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                            type: string
+                        required:
+                        - lastTransitionTime
+                        - message
+                        - reason
+                        - status
+                        - type
+                        type: object
+                      maxItems: 8
+                      minItems: 1
+                      type: array
+                      x-kubernetes-list-map-keys:
+                      - type
+                      x-kubernetes-list-type: map
+                    controllerName:
+                      description: |-
+                        ControllerName is a domain/path string that indicates the name of the
+                        controller that wrote this status. This corresponds with the
+                        controllerName field on GatewayClass.
+
+                        Example: "example.net/gateway-controller".
+
+                        The format of this field is DOMAIN "/" PATH, where DOMAIN and PATH are
+                        valid Kubernetes names
+                        (https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names).
+
+                        Controllers MUST populate this field when writing status. Controllers should ensure that
+                        entries to status populated with their ControllerName are cleaned up when they are no
+                        longer necessary.
+                      maxLength: 253
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\/[A-Za-z0-9\/\-._~%!$&'()*+,;=:]+$
+                      type: string
+                    parentRef:
+                      description: |-
+                        ParentRef corresponds with a ParentRef in the spec that this
+                        RouteParentStatus struct describes the status of.
+                      properties:
+                        group:
+                          default: gateway.networking.k8s.io
+                          description: |-
+                            Group is the group of the referent.
+                            When unspecified, "gateway.networking.k8s.io" is inferred.
+                            To set the core API group (such as for a "Service" kind referent),
+                            Group must be explicitly set to "" (empty string).
+
+                            Support: Core
+                          maxLength: 253
+                          pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                          type: string
+                        kind:
+                          default: Gateway
+                          description: |-
+                            Kind is kind of the referent.
+
+                            There are two kinds of parent resources with "Core" support:
+
+                            * Gateway (Gateway conformance profile)
+                            * Service (Mesh conformance profile, ClusterIP Services only)
+
+                            Support for other resources is Implementation-Specific.
+                          maxLength: 63
+                          minLength: 1
+                          pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                          type: string
+                        name:
+                          description: |-
+                            Name is the name of the referent.
+
+                            Support: Core
+                          maxLength: 253
+                          minLength: 1
+                          type: string
+                        namespace:
+                          description: |-
+                            Namespace is the namespace of the referent. When unspecified, this refers
+                            to the local namespace of the Route.
+
+                            Note that there are specific rules for ParentRefs which cross namespace
+                            boundaries. Cross-namespace references are only valid if they are explicitly
+                            allowed by something in the namespace they are referring to. For example:
+                            Gateway has the AllowedRoutes field, and ReferenceGrant provides a
+                            generic way to enable any other kind of cross-namespace reference.
+
+
+
+                            Support: Core
+                          maxLength: 63
+                          minLength: 1
+                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                          type: string
+                        port:
+                          description: |-
+                            Port is the network port this Route targets. It can be interpreted
+                            differently based on the type of parent resource.
+
+                            When the parent resource is a Gateway, this targets all listeners
+                            listening on the specified port that also support this kind of Route(and
+                            select this Route). It's not recommended to set `Port` unless the
+                            networking behaviors specified in a Route must apply to a specific port
+                            as opposed to a listener(s) whose port(s) may be changed. When both Port
+                            and SectionName are specified, the name and port of the selected listener
+                            must match both specified values.
+
+
+
+                            Implementations MAY choose to support other parent resources.
+                            Implementations supporting other types of parent resources MUST clearly
+                            document how/if Port is interpreted.
+
+                            For the purpose of status, an attachment is considered successful as
+                            long as the parent resource accepts it partially. For example, Gateway
+                            listeners can restrict which Routes can attach to them by Route kind,
+                            namespace, or hostname. If 1 of 2 Gateway listeners accept attachment
+                            from the referencing Route, the Route MUST be considered successfully
+                            attached. If no Gateway listeners accept attachment from this Route,
+                            the Route MUST be considered detached from the Gateway.
+
+                            Support: Extended
+                          format: int32
+                          maximum: 65535
+                          minimum: 1
+                          type: integer
+                        sectionName:
+                          description: |-
+                            SectionName is the name of a section within the target resource. In the
+                            following resources, SectionName is interpreted as the following:
+
+                            * Gateway: Listener name. When both Port (experimental) and SectionName
+                            are specified, the name and port of the selected listener must match
+                            both specified values.
+                            * Service: Port name. When both Port (experimental) and SectionName
+                            are specified, the name and port of the selected listener must match
+                            both specified values.
+
+                            Implementations MAY choose to support attaching Routes to other resources.
+                            If that is the case, they MUST clearly document how SectionName is
+                            interpreted.
+
+                            When unspecified (empty string), this will reference the entire resource.
+                            For the purpose of status, an attachment is considered successful if at
+                            least one section in the parent resource accepts it. For example, Gateway
+                            listeners can restrict which Routes can attach to them by Route kind,
+                            namespace, or hostname. If 1 of 2 Gateway listeners accept attachment from
+                            the referencing Route, the Route MUST be considered successfully
+                            attached. If no Gateway listeners accept attachment from this Route, the
+                            Route MUST be considered detached from the Gateway.
+
+                            Support: Core
+                          maxLength: 253
+                          minLength: 1
+                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                          type: string
+                      required:
+                      - name
+                      type: object
+                  required:
+                  - controllerName
+                  - parentRef
+                  type: object
+                maxItems: 32
+                type: array
+            required:
+            - parents
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/3328
+    gateway.networking.k8s.io/bundle-version: v1.2.1
+    gateway.networking.k8s.io/channel: standard
+  creationTimestamp: null
+  name: referencegrants.gateway.networking.k8s.io
+spec:
+  group: gateway.networking.k8s.io
+  names:
+    categories:
+    - gateway-api
+    kind: ReferenceGrant
+    listKind: ReferenceGrantList
+    plural: referencegrants
+    shortNames:
+    - refgrant
+    singular: referencegrant
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: |-
+          ReferenceGrant identifies kinds of resources in other namespaces that are
+          trusted to reference the specified kinds of resources in the same namespace
+          as the policy.
+
+          Each ReferenceGrant can be used to represent a unique trust relationship.
+          Additional Reference Grants can be used to add to the set of trusted
+          sources of inbound references for the namespace they are defined within.
+
+          All cross-namespace references in Gateway API (with the exception of cross-namespace
+          Gateway-route attachment) require a ReferenceGrant.
+
+          ReferenceGrant is a form of runtime verification allowing users to assert
+          which cross-namespace object references are permitted. Implementations that
+          support ReferenceGrant MUST NOT permit cross-namespace references which have
+          no grant, and MUST respond to the removal of a grant by revoking the access
+          that the grant allowed.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec defines the desired state of ReferenceGrant.
+            properties:
+              from:
+                description: |-
+                  From describes the trusted namespaces and kinds that can reference the
+                  resources described in "To". Each entry in this list MUST be considered
+                  to be an additional place that references can be valid from, or to put
+                  this another way, entries MUST be combined using OR.
+
+                  Support: Core
+                items:
+                  description: ReferenceGrantFrom describes trusted namespaces and
+                    kinds.
+                  properties:
+                    group:
+                      description: |-
+                        Group is the group of the referent.
+                        When empty, the Kubernetes core API group is inferred.
+
+                        Support: Core
+                      maxLength: 253
+                      pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                      type: string
+                    kind:
+                      description: |-
+                        Kind is the kind of the referent. Although implementations may support
+                        additional resources, the following types are part of the "Core"
+                        support level for this field.
+
+                        When used to permit a SecretObjectReference:
+
+                        * Gateway
+
+                        When used to permit a BackendObjectReference:
+
+                        * GRPCRoute
+                        * HTTPRoute
+                        * TCPRoute
+                        * TLSRoute
+                        * UDPRoute
+                      maxLength: 63
+                      minLength: 1
+                      pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                      type: string
+                    namespace:
+                      description: |-
+                        Namespace is the namespace of the referent.
+
+                        Support: Core
+                      maxLength: 63
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                      type: string
+                  required:
+                  - group
+                  - kind
+                  - namespace
+                  type: object
+                maxItems: 16
+                minItems: 1
+                type: array
+              to:
+                description: |-
+                  To describes the resources that may be referenced by the resources
+                  described in "From". Each entry in this list MUST be considered to be an
+                  additional place that references can be valid to, or to put this another
+                  way, entries MUST be combined using OR.
+
+                  Support: Core
+                items:
+                  description: |-
+                    ReferenceGrantTo describes what Kinds are allowed as targets of the
+                    references.
+                  properties:
+                    group:
+                      description: |-
+                        Group is the group of the referent.
+                        When empty, the Kubernetes core API group is inferred.
+
+                        Support: Core
+                      maxLength: 253
+                      pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                      type: string
+                    kind:
+                      description: |-
+                        Kind is the kind of the referent. Although implementations may support
+                        additional resources, the following types are part of the "Core"
+                        support level for this field:
+
+                        * Secret when used to permit a SecretObjectReference
+                        * Service when used to permit a BackendObjectReference
+                      maxLength: 63
+                      minLength: 1
+                      pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                      type: string
+                    name:
+                      description: |-
+                        Name is the name of the referent. When unspecified, this policy
+                        refers to all resources of the specified Group and Kind in the local
+                        namespace.
+                      maxLength: 253
+                      minLength: 1
+                      type: string
+                  required:
+                  - group
+                  - kind
+                  type: object
+                maxItems: 16
+                minItems: 1
+                type: array
+            required:
+            - from
+            - to
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null

--- a/kubernetes/manifests/production/keda/kustomization.yaml
+++ b/kubernetes/manifests/production/keda/kustomization.yaml
@@ -1,0 +1,2 @@
+resources:
+  - manifest.yaml

--- a/kubernetes/manifests/production/keda/manifest.yaml
+++ b/kubernetes/manifests/production/keda/manifest.yaml
@@ -1,0 +1,12259 @@
+---
+# Source: keda/templates/manager/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/name: keda-operator
+    
+    helm.sh/chart: keda-2.19.0
+    app.kubernetes.io/component: operator
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: keda-operator
+    app.kubernetes.io/version: 2.19.0
+    app.kubernetes.io/instance: keda
+  name: keda-operator
+  namespace: keda
+automountServiceAccountToken: true
+---
+# Source: keda/templates/metrics-server/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/name: keda-metrics-server
+    
+    helm.sh/chart: keda-2.19.0
+    app.kubernetes.io/component: operator
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: keda-operator
+    app.kubernetes.io/version: 2.19.0
+    app.kubernetes.io/instance: keda
+  annotations:
+  name: keda-metrics-server
+  namespace: keda
+automountServiceAccountToken: true
+---
+# Source: keda/templates/webhooks/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/name: keda-webhook
+    
+    helm.sh/chart: keda-2.19.0
+    app.kubernetes.io/component: operator
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: keda-operator
+    app.kubernetes.io/version: 2.19.0
+    app.kubernetes.io/instance: keda
+  annotations:
+  name: keda-webhook
+  namespace: keda
+automountServiceAccountToken: true
+---
+# Source: keda/templates/crds/crd-cloudeventsources.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.20.0
+  labels:
+    app.kubernetes.io/name: keda-operator    
+    helm.sh/chart: keda-2.19.0
+    app.kubernetes.io/component: operator
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: keda-operator
+    app.kubernetes.io/version: 2.19.0
+  name: cloudeventsources.eventing.keda.sh
+spec:
+  group: eventing.keda.sh
+  names:
+    kind: CloudEventSource
+    listKind: CloudEventSourceList
+    plural: cloudeventsources
+    singular: cloudeventsource
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.conditions[?(@.type=="Active")].status
+      name: Active
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: CloudEventSource defines how a KEDA event will be sent to event
+          sink
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: CloudEventSourceSpec defines the spec of CloudEventSource
+            properties:
+              authenticationRef:
+                description: |-
+                  AuthenticationRef points to the TriggerAuthentication or ClusterTriggerAuthentication object that
+                  is used to authenticate the scaler with the environment
+                properties:
+                  kind:
+                    description: Kind of the resource being referred to. Defaults
+                      to TriggerAuthentication.
+                    type: string
+                  name:
+                    type: string
+                required:
+                - name
+                type: object
+              clusterName:
+                type: string
+              destination:
+                description: Destination defines the various ways to emit events
+                properties:
+                  azureEventGridTopic:
+                    properties:
+                      endpoint:
+                        type: string
+                    required:
+                    - endpoint
+                    type: object
+                  http:
+                    properties:
+                      uri:
+                        type: string
+                    required:
+                    - uri
+                    type: object
+                type: object
+              eventSubscription:
+                description: EventSubscription defines filters for events
+                properties:
+                  excludedEventTypes:
+                    items:
+                      enum:
+                      - keda.scaledobject.ready.v1
+                      - keda.scaledobject.failed.v1
+                      - keda.scaledobject.removed.v1
+                      - keda.scaledobject.paused.v1
+                      - keda.scaledobject.unpaused.v1
+                      - keda.scaledjob.ready.v1
+                      - keda.scaledjob.failed.v1
+                      - keda.scaledjob.removed.v1
+                      - keda.scaledjob.paused.v1
+                      - keda.scaledjob.unpaused.v1
+                      - keda.scaledjob.rolloutcleanup.started.v1
+                      - keda.scaledjob.rolloutcleanup.completed.v1
+                      - keda.scaledjob.rolloutcleanup.failed.v1
+                      - keda.authentication.triggerauthentication.created.v1
+                      - keda.authentication.triggerauthentication.updated.v1
+                      - keda.authentication.triggerauthentication.removed.v1
+                      - keda.authentication.clustertriggerauthentication.created.v1
+                      - keda.authentication.clustertriggerauthentication.updated.v1
+                      - keda.authentication.clustertriggerauthentication.removed.v1
+                      type: string
+                    type: array
+                  includedEventTypes:
+                    items:
+                      enum:
+                      - keda.scaledobject.ready.v1
+                      - keda.scaledobject.failed.v1
+                      - keda.scaledobject.removed.v1
+                      - keda.scaledobject.paused.v1
+                      - keda.scaledobject.unpaused.v1
+                      - keda.scaledjob.ready.v1
+                      - keda.scaledjob.failed.v1
+                      - keda.scaledjob.removed.v1
+                      - keda.scaledjob.paused.v1
+                      - keda.scaledjob.unpaused.v1
+                      - keda.scaledjob.rolloutcleanup.started.v1
+                      - keda.scaledjob.rolloutcleanup.completed.v1
+                      - keda.scaledjob.rolloutcleanup.failed.v1
+                      - keda.authentication.triggerauthentication.created.v1
+                      - keda.authentication.triggerauthentication.updated.v1
+                      - keda.authentication.triggerauthentication.removed.v1
+                      - keda.authentication.clustertriggerauthentication.created.v1
+                      - keda.authentication.clustertriggerauthentication.updated.v1
+                      - keda.authentication.clustertriggerauthentication.removed.v1
+                      type: string
+                    type: array
+                type: object
+            required:
+            - destination
+            type: object
+          status:
+            description: CloudEventSourceStatus defines the observed state of CloudEventSource
+            properties:
+              conditions:
+                description: Conditions an array representation to store multiple
+                  Conditions
+                items:
+                  description: Condition to store the condition state
+                  properties:
+                    message:
+                      description: A human readable message indicating details about
+                        the transition.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of condition
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+# Source: keda/templates/crds/crd-clustercloudeventsources.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.20.0
+  labels:
+    app.kubernetes.io/name: keda-operator    
+    helm.sh/chart: keda-2.19.0
+    app.kubernetes.io/component: operator
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: keda-operator
+    app.kubernetes.io/version: 2.19.0
+  name: clustercloudeventsources.eventing.keda.sh
+spec:
+  group: eventing.keda.sh
+  names:
+    kind: ClusterCloudEventSource
+    listKind: ClusterCloudEventSourceList
+    plural: clustercloudeventsources
+    singular: clustercloudeventsource
+  scope: Cluster
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.conditions[?(@.type=="Active")].status
+      name: Active
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: CloudEventSourceSpec defines the spec of CloudEventSource
+            properties:
+              authenticationRef:
+                description: |-
+                  AuthenticationRef points to the TriggerAuthentication or ClusterTriggerAuthentication object that
+                  is used to authenticate the scaler with the environment
+                properties:
+                  kind:
+                    description: Kind of the resource being referred to. Defaults
+                      to TriggerAuthentication.
+                    type: string
+                  name:
+                    type: string
+                required:
+                - name
+                type: object
+              clusterName:
+                type: string
+              destination:
+                description: Destination defines the various ways to emit events
+                properties:
+                  azureEventGridTopic:
+                    properties:
+                      endpoint:
+                        type: string
+                    required:
+                    - endpoint
+                    type: object
+                  http:
+                    properties:
+                      uri:
+                        type: string
+                    required:
+                    - uri
+                    type: object
+                type: object
+              eventSubscription:
+                description: EventSubscription defines filters for events
+                properties:
+                  excludedEventTypes:
+                    items:
+                      enum:
+                      - keda.scaledobject.ready.v1
+                      - keda.scaledobject.failed.v1
+                      - keda.scaledobject.removed.v1
+                      - keda.scaledobject.paused.v1
+                      - keda.scaledobject.unpaused.v1
+                      - keda.scaledjob.ready.v1
+                      - keda.scaledjob.failed.v1
+                      - keda.scaledjob.removed.v1
+                      - keda.scaledjob.paused.v1
+                      - keda.scaledjob.unpaused.v1
+                      - keda.scaledjob.rolloutcleanup.started.v1
+                      - keda.scaledjob.rolloutcleanup.completed.v1
+                      - keda.scaledjob.rolloutcleanup.failed.v1
+                      - keda.authentication.triggerauthentication.created.v1
+                      - keda.authentication.triggerauthentication.updated.v1
+                      - keda.authentication.triggerauthentication.removed.v1
+                      - keda.authentication.clustertriggerauthentication.created.v1
+                      - keda.authentication.clustertriggerauthentication.updated.v1
+                      - keda.authentication.clustertriggerauthentication.removed.v1
+                      type: string
+                    type: array
+                  includedEventTypes:
+                    items:
+                      enum:
+                      - keda.scaledobject.ready.v1
+                      - keda.scaledobject.failed.v1
+                      - keda.scaledobject.removed.v1
+                      - keda.scaledobject.paused.v1
+                      - keda.scaledobject.unpaused.v1
+                      - keda.scaledjob.ready.v1
+                      - keda.scaledjob.failed.v1
+                      - keda.scaledjob.removed.v1
+                      - keda.scaledjob.paused.v1
+                      - keda.scaledjob.unpaused.v1
+                      - keda.scaledjob.rolloutcleanup.started.v1
+                      - keda.scaledjob.rolloutcleanup.completed.v1
+                      - keda.scaledjob.rolloutcleanup.failed.v1
+                      - keda.authentication.triggerauthentication.created.v1
+                      - keda.authentication.triggerauthentication.updated.v1
+                      - keda.authentication.triggerauthentication.removed.v1
+                      - keda.authentication.clustertriggerauthentication.created.v1
+                      - keda.authentication.clustertriggerauthentication.updated.v1
+                      - keda.authentication.clustertriggerauthentication.removed.v1
+                      type: string
+                    type: array
+                type: object
+            required:
+            - destination
+            type: object
+          status:
+            description: CloudEventSourceStatus defines the observed state of CloudEventSource
+            properties:
+              conditions:
+                description: Conditions an array representation to store multiple
+                  Conditions
+                items:
+                  description: Condition to store the condition state
+                  properties:
+                    message:
+                      description: A human readable message indicating details about
+                        the transition.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of condition
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+# Source: keda/templates/crds/crd-clustertriggerauthentications.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.20.0
+  labels:
+    app.kubernetes.io/name: keda-operator    
+    helm.sh/chart: keda-2.19.0
+    app.kubernetes.io/component: operator
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: keda-operator
+    app.kubernetes.io/version: 2.19.0
+  name: clustertriggerauthentications.keda.sh
+spec:
+  group: keda.sh
+  names:
+    kind: ClusterTriggerAuthentication
+    listKind: ClusterTriggerAuthenticationList
+    plural: clustertriggerauthentications
+    shortNames:
+    - cta
+    - clustertriggerauth
+    singular: clustertriggerauthentication
+  scope: Cluster
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.podIdentity.provider
+      name: PodIdentity
+      type: string
+    - jsonPath: .spec.secretTargetRef[*].name
+      name: Secret
+      type: string
+    - jsonPath: .spec.env[*].name
+      name: Env
+      type: string
+    - jsonPath: .spec.filePath
+      name: FilePath
+      type: string
+    - jsonPath: .spec.hashiCorpVault.address
+      name: VaultAddress
+      type: string
+    - jsonPath: .status.scaledobjects
+      name: ScaledObjects
+      priority: 1
+      type: string
+    - jsonPath: .status.scaledjobs
+      name: ScaledJobs
+      priority: 1
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: ClusterTriggerAuthentication defines how a trigger can authenticate
+          globally
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: TriggerAuthenticationSpec defines the various ways to authenticate
+            properties:
+              awsSecretManager:
+                description: AwsSecretManager is used to authenticate using AwsSecretManager
+                properties:
+                  credentials:
+                    properties:
+                      accessKey:
+                        properties:
+                          valueFrom:
+                            properties:
+                              secretKeyRef:
+                                properties:
+                                  key:
+                                    type: string
+                                  name:
+                                    type: string
+                                required:
+                                - key
+                                - name
+                                type: object
+                            required:
+                            - secretKeyRef
+                            type: object
+                        required:
+                        - valueFrom
+                        type: object
+                      accessSecretKey:
+                        properties:
+                          valueFrom:
+                            properties:
+                              secretKeyRef:
+                                properties:
+                                  key:
+                                    type: string
+                                  name:
+                                    type: string
+                                required:
+                                - key
+                                - name
+                                type: object
+                            required:
+                            - secretKeyRef
+                            type: object
+                        required:
+                        - valueFrom
+                        type: object
+                      accessToken:
+                        properties:
+                          valueFrom:
+                            properties:
+                              secretKeyRef:
+                                properties:
+                                  key:
+                                    type: string
+                                  name:
+                                    type: string
+                                required:
+                                - key
+                                - name
+                                type: object
+                            required:
+                            - secretKeyRef
+                            type: object
+                        required:
+                        - valueFrom
+                        type: object
+                    required:
+                    - accessKey
+                    - accessSecretKey
+                    type: object
+                  podIdentity:
+                    description: |-
+                      AuthPodIdentity allows users to select the platform native identity
+                      mechanism
+                    properties:
+                      identityAuthorityHost:
+                        description: Set identityAuthorityHost to override the default
+                          Azure authority host. If this is set, then the IdentityTenantID
+                          must also be set
+                        type: string
+                      identityId:
+                        type: string
+                      identityOwner:
+                        description: IdentityOwner configures which identity has to
+                          be used during auto discovery, keda or the scaled workload.
+                          Mutually exclusive with roleArn
+                        enum:
+                        - keda
+                        - workload
+                        type: string
+                      identityTenantId:
+                        description: Set identityTenantId to override the default
+                          Azure tenant id. If this is set, then the IdentityID must
+                          also be set
+                        type: string
+                      provider:
+                        description: PodIdentityProvider contains the list of providers
+                        enum:
+                        - azure-workload
+                        - gcp
+                        - aws
+                        - aws-eks
+                        - none
+                        type: string
+                      roleArn:
+                        description: RoleArn sets the AWS RoleArn to be used. Mutually
+                          exclusive with IdentityOwner
+                        type: string
+                    required:
+                    - provider
+                    type: object
+                  region:
+                    type: string
+                  secrets:
+                    items:
+                      properties:
+                        name:
+                          type: string
+                        parameter:
+                          type: string
+                        secretKey:
+                          type: string
+                        versionId:
+                          type: string
+                        versionStage:
+                          type: string
+                      required:
+                      - name
+                      - parameter
+                      type: object
+                    type: array
+                required:
+                - secrets
+                type: object
+              azureKeyVault:
+                description: AzureKeyVault is used to authenticate using Azure Key
+                  Vault
+                properties:
+                  cloud:
+                    properties:
+                      activeDirectoryEndpoint:
+                        type: string
+                      keyVaultResourceURL:
+                        type: string
+                      type:
+                        type: string
+                    required:
+                    - type
+                    type: object
+                  credentials:
+                    properties:
+                      clientId:
+                        type: string
+                      clientSecret:
+                        properties:
+                          valueFrom:
+                            properties:
+                              secretKeyRef:
+                                properties:
+                                  key:
+                                    type: string
+                                  name:
+                                    type: string
+                                required:
+                                - key
+                                - name
+                                type: object
+                            required:
+                            - secretKeyRef
+                            type: object
+                        required:
+                        - valueFrom
+                        type: object
+                      tenantId:
+                        type: string
+                    required:
+                    - clientId
+                    - clientSecret
+                    - tenantId
+                    type: object
+                  podIdentity:
+                    description: |-
+                      AuthPodIdentity allows users to select the platform native identity
+                      mechanism
+                    properties:
+                      identityAuthorityHost:
+                        description: Set identityAuthorityHost to override the default
+                          Azure authority host. If this is set, then the IdentityTenantID
+                          must also be set
+                        type: string
+                      identityId:
+                        type: string
+                      identityOwner:
+                        description: IdentityOwner configures which identity has to
+                          be used during auto discovery, keda or the scaled workload.
+                          Mutually exclusive with roleArn
+                        enum:
+                        - keda
+                        - workload
+                        type: string
+                      identityTenantId:
+                        description: Set identityTenantId to override the default
+                          Azure tenant id. If this is set, then the IdentityID must
+                          also be set
+                        type: string
+                      provider:
+                        description: PodIdentityProvider contains the list of providers
+                        enum:
+                        - azure-workload
+                        - gcp
+                        - aws
+                        - aws-eks
+                        - none
+                        type: string
+                      roleArn:
+                        description: RoleArn sets the AWS RoleArn to be used. Mutually
+                          exclusive with IdentityOwner
+                        type: string
+                    required:
+                    - provider
+                    type: object
+                  secrets:
+                    items:
+                      properties:
+                        name:
+                          type: string
+                        parameter:
+                          type: string
+                        version:
+                          type: string
+                      required:
+                      - name
+                      - parameter
+                      type: object
+                    type: array
+                  vaultUri:
+                    type: string
+                required:
+                - secrets
+                - vaultUri
+                type: object
+              boundServiceAccountToken:
+                items:
+                  properties:
+                    parameter:
+                      type: string
+                    serviceAccountName:
+                      type: string
+                  required:
+                  - parameter
+                  - serviceAccountName
+                  type: object
+                type: array
+              configMapTargetRef:
+                items:
+                  description: AuthConfigMapTargetRef is used to authenticate using
+                    a reference to a config map
+                  properties:
+                    key:
+                      type: string
+                    name:
+                      type: string
+                    parameter:
+                      type: string
+                  required:
+                  - key
+                  - name
+                  - parameter
+                  type: object
+                type: array
+              env:
+                items:
+                  description: |-
+                    AuthEnvironment is used to authenticate using environment variables
+                    in the destination ScaleTarget spec
+                  properties:
+                    containerName:
+                      type: string
+                    name:
+                      type: string
+                    parameter:
+                      type: string
+                  required:
+                  - name
+                  - parameter
+                  type: object
+                type: array
+              filePath:
+                description: |-
+                  FilePath specifies a file containing auth parameters as JSON map[string]string.
+                  When set, auth params are read directly from this file instead.
+                type: string
+              gcpSecretManager:
+                properties:
+                  credentials:
+                    properties:
+                      clientSecret:
+                        properties:
+                          valueFrom:
+                            properties:
+                              secretKeyRef:
+                                properties:
+                                  key:
+                                    type: string
+                                  name:
+                                    type: string
+                                required:
+                                - key
+                                - name
+                                type: object
+                            required:
+                            - secretKeyRef
+                            type: object
+                        required:
+                        - valueFrom
+                        type: object
+                    required:
+                    - clientSecret
+                    type: object
+                  podIdentity:
+                    description: |-
+                      AuthPodIdentity allows users to select the platform native identity
+                      mechanism
+                    properties:
+                      identityAuthorityHost:
+                        description: Set identityAuthorityHost to override the default
+                          Azure authority host. If this is set, then the IdentityTenantID
+                          must also be set
+                        type: string
+                      identityId:
+                        type: string
+                      identityOwner:
+                        description: IdentityOwner configures which identity has to
+                          be used during auto discovery, keda or the scaled workload.
+                          Mutually exclusive with roleArn
+                        enum:
+                        - keda
+                        - workload
+                        type: string
+                      identityTenantId:
+                        description: Set identityTenantId to override the default
+                          Azure tenant id. If this is set, then the IdentityID must
+                          also be set
+                        type: string
+                      provider:
+                        description: PodIdentityProvider contains the list of providers
+                        enum:
+                        - azure-workload
+                        - gcp
+                        - aws
+                        - aws-eks
+                        - none
+                        type: string
+                      roleArn:
+                        description: RoleArn sets the AWS RoleArn to be used. Mutually
+                          exclusive with IdentityOwner
+                        type: string
+                    required:
+                    - provider
+                    type: object
+                  secrets:
+                    items:
+                      properties:
+                        id:
+                          type: string
+                        parameter:
+                          type: string
+                        version:
+                          type: string
+                      required:
+                      - id
+                      - parameter
+                      type: object
+                    type: array
+                required:
+                - secrets
+                type: object
+              hashiCorpVault:
+                description: HashiCorpVault is used to authenticate using Hashicorp
+                  Vault
+                properties:
+                  address:
+                    type: string
+                  authentication:
+                    description: VaultAuthentication contains the list of Hashicorp
+                      Vault authentication methods
+                    type: string
+                  credential:
+                    description: Credential defines the Hashicorp Vault credentials
+                      depending on the authentication method
+                    properties:
+                      serviceAccount:
+                        type: string
+                      serviceAccountName:
+                        type: string
+                      token:
+                        type: string
+                    type: object
+                  mount:
+                    type: string
+                  namespace:
+                    type: string
+                  role:
+                    type: string
+                  secrets:
+                    items:
+                      description: VaultSecret defines the mapping between the path
+                        of the secret in Vault to the parameter
+                      properties:
+                        key:
+                          type: string
+                        parameter:
+                          type: string
+                        path:
+                          type: string
+                        pkiData:
+                          properties:
+                            altNames:
+                              type: string
+                            commonName:
+                              type: string
+                            format:
+                              type: string
+                            ipSans:
+                              type: string
+                            otherSans:
+                              type: string
+                            ttl:
+                              type: string
+                            uriSans:
+                              type: string
+                          type: object
+                        type:
+                          description: VaultSecretType defines the type of vault secret
+                          type: string
+                      required:
+                      - key
+                      - parameter
+                      - path
+                      type: object
+                    type: array
+                required:
+                - address
+                - authentication
+                - secrets
+                type: object
+              podIdentity:
+                description: |-
+                  AuthPodIdentity allows users to select the platform native identity
+                  mechanism
+                properties:
+                  identityAuthorityHost:
+                    description: Set identityAuthorityHost to override the default
+                      Azure authority host. If this is set, then the IdentityTenantID
+                      must also be set
+                    type: string
+                  identityId:
+                    type: string
+                  identityOwner:
+                    description: IdentityOwner configures which identity has to be
+                      used during auto discovery, keda or the scaled workload. Mutually
+                      exclusive with roleArn
+                    enum:
+                    - keda
+                    - workload
+                    type: string
+                  identityTenantId:
+                    description: Set identityTenantId to override the default Azure
+                      tenant id. If this is set, then the IdentityID must also be
+                      set
+                    type: string
+                  provider:
+                    description: PodIdentityProvider contains the list of providers
+                    enum:
+                    - azure-workload
+                    - gcp
+                    - aws
+                    - aws-eks
+                    - none
+                    type: string
+                  roleArn:
+                    description: RoleArn sets the AWS RoleArn to be used. Mutually
+                      exclusive with IdentityOwner
+                    type: string
+                required:
+                - provider
+                type: object
+              secretTargetRef:
+                items:
+                  description: AuthSecretTargetRef is used to authenticate using a
+                    reference to a secret
+                  properties:
+                    key:
+                      type: string
+                    name:
+                      type: string
+                    parameter:
+                      type: string
+                  required:
+                  - key
+                  - name
+                  - parameter
+                  type: object
+                type: array
+            type: object
+          status:
+            description: TriggerAuthenticationStatus defines the observed state of
+              TriggerAuthentication
+            properties:
+              scaledjobs:
+                type: string
+              scaledobjects:
+                type: string
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+# Source: keda/templates/crds/crd-scaledjobs.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.20.0
+  labels:
+    app.kubernetes.io/name: keda-operator    
+    helm.sh/chart: keda-2.19.0
+    app.kubernetes.io/component: operator
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: keda-operator
+    app.kubernetes.io/version: 2.19.0
+  name: scaledjobs.keda.sh
+spec:
+  group: keda.sh
+  names:
+    kind: ScaledJob
+    listKind: ScaledJobList
+    plural: scaledjobs
+    shortNames:
+    - sj
+    singular: scaledjob
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.minReplicaCount
+      name: Min
+      type: integer
+    - jsonPath: .spec.maxReplicaCount
+      name: Max
+      type: integer
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Active")].status
+      name: Active
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Paused")].status
+      name: Paused
+      type: string
+    - jsonPath: .status.triggersTypes
+      name: Triggers
+      type: string
+    - jsonPath: .status.authenticationsTypes
+      name: Authentications
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: ScaledJob is the Schema for the scaledjobs API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ScaledJobSpec defines the desired state of ScaledJob
+            properties:
+              envSourceContainerName:
+                type: string
+              failedJobsHistoryLimit:
+                format: int32
+                type: integer
+              jobTargetRef:
+                description: JobSpec describes how the job execution will look like.
+                properties:
+                  activeDeadlineSeconds:
+                    description: |-
+                      Specifies the duration in seconds relative to the startTime that the job
+                      may be continuously active before the system tries to terminate it; value
+                      must be positive integer. If a Job is suspended (at creation or through an
+                      update), this timer will effectively be stopped and reset when the Job is
+                      resumed again.
+                    format: int64
+                    type: integer
+                  backoffLimit:
+                    description: |-
+                      Specifies the number of retries before marking this job failed.
+                      Defaults to 6, unless backoffLimitPerIndex (only Indexed Job) is specified.
+                      When backoffLimitPerIndex is specified, backoffLimit defaults to 2147483647.
+                    format: int32
+                    type: integer
+                  backoffLimitPerIndex:
+                    description: |-
+                      Specifies the limit for the number of retries within an
+                      index before marking this index as failed. When enabled the number of
+                      failures per index is kept in the pod's
+                      batch.kubernetes.io/job-index-failure-count annotation. It can only
+                      be set when Job's completionMode=Indexed, and the Pod's restart
+                      policy is Never. The field is immutable.
+                    format: int32
+                    type: integer
+                  completionMode:
+                    description: |-
+                      completionMode specifies how Pod completions are tracked. It can be
+                      `NonIndexed` (default) or `Indexed`.
+
+                      `NonIndexed` means that the Job is considered complete when there have
+                      been .spec.completions successfully completed Pods. Each Pod completion is
+                      homologous to each other.
+
+                      `Indexed` means that the Pods of a
+                      Job get an associated completion index from 0 to (.spec.completions - 1),
+                      available in the annotation batch.kubernetes.io/job-completion-index.
+                      The Job is considered complete when there is one successfully completed Pod
+                      for each index.
+                      When value is `Indexed`, .spec.completions must be specified and
+                      `.spec.parallelism` must be less than or equal to 10^5.
+                      In addition, The Pod name takes the form
+                      `$(job-name)-$(index)-$(random-string)`,
+                      the Pod hostname takes the form `$(job-name)-$(index)`.
+
+                      More completion modes can be added in the future.
+                      If the Job controller observes a mode that it doesn't recognize, which
+                      is possible during upgrades due to version skew, the controller
+                      skips updates for the Job.
+                    type: string
+                  completions:
+                    description: |-
+                      Specifies the desired number of successfully finished pods the
+                      job should be run with.  Setting to null means that the success of any
+                      pod signals the success of all pods, and allows parallelism to have any positive
+                      value.  Setting to 1 means that parallelism is limited to 1 and the success of that
+                      pod signals the success of the job.
+                      More info: https://kubernetes.io/docs/concepts/workloads/controllers/jobs-run-to-completion/
+                    format: int32
+                    type: integer
+                  managedBy:
+                    description: |-
+                      ManagedBy field indicates the controller that manages a Job. The k8s Job
+                      controller reconciles jobs which don't have this field at all or the field
+                      value is the reserved string `kubernetes.io/job-controller`, but skips
+                      reconciling Jobs with a custom value for this field.
+                      The value must be a valid domain-prefixed path (e.g. acme.io/foo) -
+                      all characters before the first "/" must be a valid subdomain as defined
+                      by RFC 1123. All characters trailing the first "/" must be valid HTTP Path
+                      characters as defined by RFC 3986. The value cannot exceed 63 characters.
+                      This field is immutable.
+
+                      This field is beta-level. The job controller accepts setting the field
+                      when the feature gate JobManagedBy is enabled (enabled by default).
+                    type: string
+                  manualSelector:
+                    description: |-
+                      manualSelector controls generation of pod labels and pod selectors.
+                      Leave `manualSelector` unset unless you are certain what you are doing.
+                      When false or unset, the system pick labels unique to this job
+                      and appends those labels to the pod template.  When true,
+                      the user is responsible for picking unique labels and specifying
+                      the selector.  Failure to pick a unique label may cause this
+                      and other jobs to not function correctly.  However, You may see
+                      `manualSelector=true` in jobs that were created with the old `extensions/v1beta1`
+                      API.
+                      More info: https://kubernetes.io/docs/concepts/workloads/controllers/jobs-run-to-completion/#specifying-your-own-pod-selector
+                    type: boolean
+                  maxFailedIndexes:
+                    description: |-
+                      Specifies the maximal number of failed indexes before marking the Job as
+                      failed, when backoffLimitPerIndex is set. Once the number of failed
+                      indexes exceeds this number the entire Job is marked as Failed and its
+                      execution is terminated. When left as null the job continues execution of
+                      all of its indexes and is marked with the `Complete` Job condition.
+                      It can only be specified when backoffLimitPerIndex is set.
+                      It can be null or up to completions. It is required and must be
+                      less than or equal to 10^4 when is completions greater than 10^5.
+                    format: int32
+                    type: integer
+                  parallelism:
+                    description: |-
+                      Specifies the maximum desired number of pods the job should
+                      run at any given time. The actual number of pods running in steady state will
+                      be less than this number when ((.spec.completions - .status.successful) < .spec.parallelism),
+                      i.e. when the work left to do is less than max parallelism.
+                      More info: https://kubernetes.io/docs/concepts/workloads/controllers/jobs-run-to-completion/
+                    format: int32
+                    type: integer
+                  podFailurePolicy:
+                    description: |-
+                      Specifies the policy of handling failed pods. In particular, it allows to
+                      specify the set of actions and conditions which need to be
+                      satisfied to take the associated action.
+                      If empty, the default behaviour applies - the counter of failed pods,
+                      represented by the jobs's .status.failed field, is incremented and it is
+                      checked against the backoffLimit. This field cannot be used in combination
+                      with restartPolicy=OnFailure.
+                    properties:
+                      rules:
+                        description: |-
+                          A list of pod failure policy rules. The rules are evaluated in order.
+                          Once a rule matches a Pod failure, the remaining of the rules are ignored.
+                          When no rule matches the Pod failure, the default handling applies - the
+                          counter of pod failures is incremented and it is checked against
+                          the backoffLimit. At most 20 elements are allowed.
+                        items:
+                          description: |-
+                            PodFailurePolicyRule describes how a pod failure is handled when the requirements are met.
+                            One of onExitCodes and onPodConditions, but not both, can be used in each rule.
+                          properties:
+                            action:
+                              description: |-
+                                Specifies the action taken on a pod failure when the requirements are satisfied.
+                                Possible values are:
+
+                                - FailJob: indicates that the pod's job is marked as Failed and all
+                                  running pods are terminated.
+                                - FailIndex: indicates that the pod's index is marked as Failed and will
+                                  not be restarted.
+                                - Ignore: indicates that the counter towards the .backoffLimit is not
+                                  incremented and a replacement pod is created.
+                                - Count: indicates that the pod is handled in the default way - the
+                                  counter towards the .backoffLimit is incremented.
+                                Additional values are considered to be added in the future. Clients should
+                                react to an unknown action by skipping the rule.
+                              type: string
+                            onExitCodes:
+                              description: Represents the requirement on the container
+                                exit codes.
+                              properties:
+                                containerName:
+                                  description: |-
+                                    Restricts the check for exit codes to the container with the
+                                    specified name. When null, the rule applies to all containers.
+                                    When specified, it should match one the container or initContainer
+                                    names in the pod template.
+                                  type: string
+                                operator:
+                                  description: |-
+                                    Represents the relationship between the container exit code(s) and the
+                                    specified values. Containers completed with success (exit code 0) are
+                                    excluded from the requirement check. Possible values are:
+
+                                    - In: the requirement is satisfied if at least one container exit code
+                                      (might be multiple if there are multiple containers not restricted
+                                      by the 'containerName' field) is in the set of specified values.
+                                    - NotIn: the requirement is satisfied if at least one container exit code
+                                      (might be multiple if there are multiple containers not restricted
+                                      by the 'containerName' field) is not in the set of specified values.
+                                    Additional values are considered to be added in the future. Clients should
+                                    react to an unknown operator by assuming the requirement is not satisfied.
+                                  type: string
+                                values:
+                                  description: |-
+                                    Specifies the set of values. Each returned container exit code (might be
+                                    multiple in case of multiple containers) is checked against this set of
+                                    values with respect to the operator. The list of values must be ordered
+                                    and must not contain duplicates. Value '0' cannot be used for the In operator.
+                                    At least one element is required. At most 255 elements are allowed.
+                                  items:
+                                    format: int32
+                                    type: integer
+                                  type: array
+                                  x-kubernetes-list-type: set
+                              required:
+                              - operator
+                              - values
+                              type: object
+                            onPodConditions:
+                              description: |-
+                                Represents the requirement on the pod conditions. The requirement is represented
+                                as a list of pod condition patterns. The requirement is satisfied if at
+                                least one pattern matches an actual pod condition. At most 20 elements are allowed.
+                              items:
+                                description: |-
+                                  PodFailurePolicyOnPodConditionsPattern describes a pattern for matching
+                                  an actual pod condition type.
+                                properties:
+                                  status:
+                                    description: |-
+                                      Specifies the required Pod condition status. To match a pod condition
+                                      it is required that the specified status equals the pod condition status.
+                                      Defaults to True.
+                                    type: string
+                                  type:
+                                    description: |-
+                                      Specifies the required Pod condition type. To match a pod condition
+                                      it is required that specified type equals the pod condition type.
+                                    type: string
+                                required:
+                                - status
+                                - type
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                          required:
+                          - action
+                          type: object
+                        type: array
+                        x-kubernetes-list-type: atomic
+                    required:
+                    - rules
+                    type: object
+                  podReplacementPolicy:
+                    description: |-
+                      podReplacementPolicy specifies when to create replacement Pods.
+                      Possible values are:
+                      - TerminatingOrFailed means that we recreate pods
+                        when they are terminating (has a metadata.deletionTimestamp) or failed.
+                      - Failed means to wait until a previously created Pod is fully terminated (has phase
+                        Failed or Succeeded) before creating a replacement Pod.
+
+                      When using podFailurePolicy, Failed is the the only allowed value.
+                      TerminatingOrFailed and Failed are allowed values when podFailurePolicy is not in use.
+                    type: string
+                  selector:
+                    description: |-
+                      A label query over pods that should match the pod count.
+                      Normally, the system sets this field for you.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors
+                    properties:
+                      matchExpressions:
+                        description: matchExpressions is a list of label selector
+                          requirements. The requirements are ANDed.
+                        items:
+                          description: |-
+                            A label selector requirement is a selector that contains values, a key, and an operator that
+                            relates the key and values.
+                          properties:
+                            key:
+                              description: key is the label key that the selector
+                                applies to.
+                              type: string
+                            operator:
+                              description: |-
+                                operator represents a key's relationship to a set of values.
+                                Valid operators are In, NotIn, Exists and DoesNotExist.
+                              type: string
+                            values:
+                              description: |-
+                                values is an array of string values. If the operator is In or NotIn,
+                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                the values array must be empty. This array is replaced during a strategic
+                                merge patch.
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                          required:
+                          - key
+                          - operator
+                          type: object
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      matchLabels:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                          map is equivalent to an element of matchExpressions, whose key field is "key", the
+                          operator is "In", and the values array contains only "value". The requirements are ANDed.
+                        type: object
+                    type: object
+                    x-kubernetes-map-type: atomic
+                  successPolicy:
+                    description: |-
+                      successPolicy specifies the policy when the Job can be declared as succeeded.
+                      If empty, the default behavior applies - the Job is declared as succeeded
+                      only when the number of succeeded pods equals to the completions.
+                      When the field is specified, it must be immutable and works only for the Indexed Jobs.
+                      Once the Job meets the SuccessPolicy, the lingering pods are terminated.
+                    properties:
+                      rules:
+                        description: |-
+                          rules represents the list of alternative rules for the declaring the Jobs
+                          as successful before `.status.succeeded >= .spec.completions`. Once any of the rules are met,
+                          the "SuccessCriteriaMet" condition is added, and the lingering pods are removed.
+                          The terminal state for such a Job has the "Complete" condition.
+                          Additionally, these rules are evaluated in order; Once the Job meets one of the rules,
+                          other rules are ignored. At most 20 elements are allowed.
+                        items:
+                          description: |-
+                            SuccessPolicyRule describes rule for declaring a Job as succeeded.
+                            Each rule must have at least one of the "succeededIndexes" or "succeededCount" specified.
+                          properties:
+                            succeededCount:
+                              description: |-
+                                succeededCount specifies the minimal required size of the actual set of the succeeded indexes
+                                for the Job. When succeededCount is used along with succeededIndexes, the check is
+                                constrained only to the set of indexes specified by succeededIndexes.
+                                For example, given that succeededIndexes is "1-4", succeededCount is "3",
+                                and completed indexes are "1", "3", and "5", the Job isn't declared as succeeded
+                                because only "1" and "3" indexes are considered in that rules.
+                                When this field is null, this doesn't default to any value and
+                                is never evaluated at any time.
+                                When specified it needs to be a positive integer.
+                              format: int32
+                              type: integer
+                            succeededIndexes:
+                              description: |-
+                                succeededIndexes specifies the set of indexes
+                                which need to be contained in the actual set of the succeeded indexes for the Job.
+                                The list of indexes must be within 0 to ".spec.completions-1" and
+                                must not contain duplicates. At least one element is required.
+                                The indexes are represented as intervals separated by commas.
+                                The intervals can be a decimal integer or a pair of decimal integers separated by a hyphen.
+                                The number are listed in represented by the first and last element of the series,
+                                separated by a hyphen.
+                                For example, if the completed indexes are 1, 3, 4, 5 and 7, they are
+                                represented as "1,3-5,7".
+                                When this field is null, this field doesn't default to any value
+                                and is never evaluated at any time.
+                              type: string
+                          type: object
+                        type: array
+                        x-kubernetes-list-type: atomic
+                    required:
+                    - rules
+                    type: object
+                  suspend:
+                    description: |-
+                      suspend specifies whether the Job controller should create Pods or not. If
+                      a Job is created with suspend set to true, no Pods are created by the Job
+                      controller. If a Job is suspended after creation (i.e. the flag goes from
+                      false to true), the Job controller will delete all active Pods associated
+                      with this Job. Users must design their workload to gracefully handle this.
+                      Suspending a Job will reset the StartTime field of the Job, effectively
+                      resetting the ActiveDeadlineSeconds timer too. Defaults to false.
+                    type: boolean
+                  template:
+                    description: |-
+                      Describes the pod that will be created when executing a job.
+                      The only allowed template.spec.restartPolicy values are "Never" or "OnFailure".
+                      More info: https://kubernetes.io/docs/concepts/workloads/controllers/jobs-run-to-completion/
+                    properties:
+                      metadata:
+                        description: |-
+                          Standard object's metadata.
+                          More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+                        properties:
+                          annotations:
+                            additionalProperties:
+                              type: string
+                            type: object
+                          finalizers:
+                            items:
+                              type: string
+                            type: array
+                          labels:
+                            additionalProperties:
+                              type: string
+                            type: object
+                          name:
+                            type: string
+                          namespace:
+                            type: string
+                        type: object
+                        x-kubernetes-preserve-unknown-fields: true
+                      spec:
+                        description: |-
+                          Specification of the desired behavior of the pod.
+                          More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+                        properties:
+                          activeDeadlineSeconds:
+                            description: |-
+                              Optional duration in seconds the pod may be active on the node relative to
+                              StartTime before the system will actively try to mark it failed and kill associated containers.
+                              Value must be a positive integer.
+                            format: int64
+                            type: integer
+                          affinity:
+                            description: If specified, the pod's scheduling constraints
+                            properties:
+                              nodeAffinity:
+                                description: Describes node affinity scheduling rules
+                                  for the pod.
+                                properties:
+                                  preferredDuringSchedulingIgnoredDuringExecution:
+                                    description: |-
+                                      The scheduler will prefer to schedule pods to nodes that satisfy
+                                      the affinity expressions specified by this field, but it may choose
+                                      a node that violates one or more of the expressions. The node that is
+                                      most preferred is the one with the greatest sum of weights, i.e.
+                                      for each node that meets all of the scheduling requirements (resource
+                                      request, requiredDuringScheduling affinity expressions, etc.),
+                                      compute a sum by iterating through the elements of this field and adding
+                                      "weight" to the sum if the node matches the corresponding matchExpressions; the
+                                      node(s) with the highest sum are the most preferred.
+                                    items:
+                                      description: |-
+                                        An empty preferred scheduling term matches all objects with implicit weight 0
+                                        (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
+                                      properties:
+                                        preference:
+                                          description: A node selector term, associated
+                                            with the corresponding weight.
+                                          properties:
+                                            matchExpressions:
+                                              description: A list of node selector
+                                                requirements by node's labels.
+                                              items:
+                                                description: |-
+                                                  A node selector requirement is a selector that contains values, a key, and an operator
+                                                  that relates the key and values.
+                                                properties:
+                                                  key:
+                                                    description: The label key that
+                                                      the selector applies to.
+                                                    type: string
+                                                  operator:
+                                                    description: |-
+                                                      Represents a key's relationship to a set of values.
+                                                      Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                    type: string
+                                                  values:
+                                                    description: |-
+                                                      An array of string values. If the operator is In or NotIn,
+                                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                      the values array must be empty. If the operator is Gt or Lt, the values
+                                                      array must have a single element, which will be interpreted as an integer.
+                                                      This array is replaced during a strategic merge patch.
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                required:
+                                                - key
+                                                - operator
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            matchFields:
+                                              description: A list of node selector
+                                                requirements by node's fields.
+                                              items:
+                                                description: |-
+                                                  A node selector requirement is a selector that contains values, a key, and an operator
+                                                  that relates the key and values.
+                                                properties:
+                                                  key:
+                                                    description: The label key that
+                                                      the selector applies to.
+                                                    type: string
+                                                  operator:
+                                                    description: |-
+                                                      Represents a key's relationship to a set of values.
+                                                      Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                    type: string
+                                                  values:
+                                                    description: |-
+                                                      An array of string values. If the operator is In or NotIn,
+                                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                      the values array must be empty. If the operator is Gt or Lt, the values
+                                                      array must have a single element, which will be interpreted as an integer.
+                                                      This array is replaced during a strategic merge patch.
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                required:
+                                                - key
+                                                - operator
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        weight:
+                                          description: Weight associated with matching
+                                            the corresponding nodeSelectorTerm, in
+                                            the range 1-100.
+                                          format: int32
+                                          type: integer
+                                      required:
+                                      - preference
+                                      - weight
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                  requiredDuringSchedulingIgnoredDuringExecution:
+                                    description: |-
+                                      If the affinity requirements specified by this field are not met at
+                                      scheduling time, the pod will not be scheduled onto the node.
+                                      If the affinity requirements specified by this field cease to be met
+                                      at some point during pod execution (e.g. due to an update), the system
+                                      may or may not try to eventually evict the pod from its node.
+                                    properties:
+                                      nodeSelectorTerms:
+                                        description: Required. A list of node selector
+                                          terms. The terms are ORed.
+                                        items:
+                                          description: |-
+                                            A null or empty node selector term matches no objects. The requirements of
+                                            them are ANDed.
+                                            The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
+                                          properties:
+                                            matchExpressions:
+                                              description: A list of node selector
+                                                requirements by node's labels.
+                                              items:
+                                                description: |-
+                                                  A node selector requirement is a selector that contains values, a key, and an operator
+                                                  that relates the key and values.
+                                                properties:
+                                                  key:
+                                                    description: The label key that
+                                                      the selector applies to.
+                                                    type: string
+                                                  operator:
+                                                    description: |-
+                                                      Represents a key's relationship to a set of values.
+                                                      Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                    type: string
+                                                  values:
+                                                    description: |-
+                                                      An array of string values. If the operator is In or NotIn,
+                                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                      the values array must be empty. If the operator is Gt or Lt, the values
+                                                      array must have a single element, which will be interpreted as an integer.
+                                                      This array is replaced during a strategic merge patch.
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                required:
+                                                - key
+                                                - operator
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            matchFields:
+                                              description: A list of node selector
+                                                requirements by node's fields.
+                                              items:
+                                                description: |-
+                                                  A node selector requirement is a selector that contains values, a key, and an operator
+                                                  that relates the key and values.
+                                                properties:
+                                                  key:
+                                                    description: The label key that
+                                                      the selector applies to.
+                                                    type: string
+                                                  operator:
+                                                    description: |-
+                                                      Represents a key's relationship to a set of values.
+                                                      Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                    type: string
+                                                  values:
+                                                    description: |-
+                                                      An array of string values. If the operator is In or NotIn,
+                                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                      the values array must be empty. If the operator is Gt or Lt, the values
+                                                      array must have a single element, which will be interpreted as an integer.
+                                                      This array is replaced during a strategic merge patch.
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                required:
+                                                - key
+                                                - operator
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                    required:
+                                    - nodeSelectorTerms
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                type: object
+                              podAffinity:
+                                description: Describes pod affinity scheduling rules
+                                  (e.g. co-locate this pod in the same node, zone,
+                                  etc. as some other pod(s)).
+                                properties:
+                                  preferredDuringSchedulingIgnoredDuringExecution:
+                                    description: |-
+                                      The scheduler will prefer to schedule pods to nodes that satisfy
+                                      the affinity expressions specified by this field, but it may choose
+                                      a node that violates one or more of the expressions. The node that is
+                                      most preferred is the one with the greatest sum of weights, i.e.
+                                      for each node that meets all of the scheduling requirements (resource
+                                      request, requiredDuringScheduling affinity expressions, etc.),
+                                      compute a sum by iterating through the elements of this field and adding
+                                      "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the
+                                      node(s) with the highest sum are the most preferred.
+                                    items:
+                                      description: The weights of all of the matched
+                                        WeightedPodAffinityTerm fields are added per-node
+                                        to find the most preferred node(s)
+                                      properties:
+                                        podAffinityTerm:
+                                          description: Required. A pod affinity term,
+                                            associated with the corresponding weight.
+                                          properties:
+                                            labelSelector:
+                                              description: |-
+                                                A label query over a set of resources, in this case pods.
+                                                If it's null, this PodAffinityTerm matches with no Pods.
+                                              properties:
+                                                matchExpressions:
+                                                  description: matchExpressions is
+                                                    a list of label selector requirements.
+                                                    The requirements are ANDed.
+                                                  items:
+                                                    description: |-
+                                                      A label selector requirement is a selector that contains values, a key, and an operator that
+                                                      relates the key and values.
+                                                    properties:
+                                                      key:
+                                                        description: key is the label
+                                                          key that the selector applies
+                                                          to.
+                                                        type: string
+                                                      operator:
+                                                        description: |-
+                                                          operator represents a key's relationship to a set of values.
+                                                          Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                        type: string
+                                                      values:
+                                                        description: |-
+                                                          values is an array of string values. If the operator is In or NotIn,
+                                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                          the values array must be empty. This array is replaced during a strategic
+                                                          merge patch.
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                    required:
+                                                    - key
+                                                    - operator
+                                                    type: object
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                                matchLabels:
+                                                  additionalProperties:
+                                                    type: string
+                                                  description: |-
+                                                    matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                    map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                    operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                  type: object
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            matchLabelKeys:
+                                              description: |-
+                                                MatchLabelKeys is a set of pod label keys to select which pods will
+                                                be taken into consideration. The keys are used to lookup values from the
+                                                incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                                to select the group of existing pods which pods will be taken into consideration
+                                                for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                                pod labels will be ignored. The default value is empty.
+                                                The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                                Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            mismatchLabelKeys:
+                                              description: |-
+                                                MismatchLabelKeys is a set of pod label keys to select which pods will
+                                                be taken into consideration. The keys are used to lookup values from the
+                                                incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                                to select the group of existing pods which pods will be taken into consideration
+                                                for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                                pod labels will be ignored. The default value is empty.
+                                                The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                                Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            namespaceSelector:
+                                              description: |-
+                                                A label query over the set of namespaces that the term applies to.
+                                                The term is applied to the union of the namespaces selected by this field
+                                                and the ones listed in the namespaces field.
+                                                null selector and null or empty namespaces list means "this pod's namespace".
+                                                An empty selector ({}) matches all namespaces.
+                                              properties:
+                                                matchExpressions:
+                                                  description: matchExpressions is
+                                                    a list of label selector requirements.
+                                                    The requirements are ANDed.
+                                                  items:
+                                                    description: |-
+                                                      A label selector requirement is a selector that contains values, a key, and an operator that
+                                                      relates the key and values.
+                                                    properties:
+                                                      key:
+                                                        description: key is the label
+                                                          key that the selector applies
+                                                          to.
+                                                        type: string
+                                                      operator:
+                                                        description: |-
+                                                          operator represents a key's relationship to a set of values.
+                                                          Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                        type: string
+                                                      values:
+                                                        description: |-
+                                                          values is an array of string values. If the operator is In or NotIn,
+                                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                          the values array must be empty. This array is replaced during a strategic
+                                                          merge patch.
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                    required:
+                                                    - key
+                                                    - operator
+                                                    type: object
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                                matchLabels:
+                                                  additionalProperties:
+                                                    type: string
+                                                  description: |-
+                                                    matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                    map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                    operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                  type: object
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            namespaces:
+                                              description: |-
+                                                namespaces specifies a static list of namespace names that the term applies to.
+                                                The term is applied to the union of the namespaces listed in this field
+                                                and the ones selected by namespaceSelector.
+                                                null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            topologyKey:
+                                              description: |-
+                                                This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                                the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                                whose value of the label with key topologyKey matches that of any node on which any of the
+                                                selected pods is running.
+                                                Empty topologyKey is not allowed.
+                                              type: string
+                                          required:
+                                          - topologyKey
+                                          type: object
+                                        weight:
+                                          description: |-
+                                            weight associated with matching the corresponding podAffinityTerm,
+                                            in the range 1-100.
+                                          format: int32
+                                          type: integer
+                                      required:
+                                      - podAffinityTerm
+                                      - weight
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                  requiredDuringSchedulingIgnoredDuringExecution:
+                                    description: |-
+                                      If the affinity requirements specified by this field are not met at
+                                      scheduling time, the pod will not be scheduled onto the node.
+                                      If the affinity requirements specified by this field cease to be met
+                                      at some point during pod execution (e.g. due to a pod label update), the
+                                      system may or may not try to eventually evict the pod from its node.
+                                      When there are multiple elements, the lists of nodes corresponding to each
+                                      podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                                    items:
+                                      description: |-
+                                        Defines a set of pods (namely those matching the labelSelector
+                                        relative to the given namespace(s)) that this pod should be
+                                        co-located (affinity) or not co-located (anti-affinity) with,
+                                        where co-located is defined as running on a node whose value of
+                                        the label with key <topologyKey> matches that of any node on which
+                                        a pod of the set of pods is running
+                                      properties:
+                                        labelSelector:
+                                          description: |-
+                                            A label query over a set of resources, in this case pods.
+                                            If it's null, this PodAffinityTerm matches with no Pods.
+                                          properties:
+                                            matchExpressions:
+                                              description: matchExpressions is a list
+                                                of label selector requirements. The
+                                                requirements are ANDed.
+                                              items:
+                                                description: |-
+                                                  A label selector requirement is a selector that contains values, a key, and an operator that
+                                                  relates the key and values.
+                                                properties:
+                                                  key:
+                                                    description: key is the label
+                                                      key that the selector applies
+                                                      to.
+                                                    type: string
+                                                  operator:
+                                                    description: |-
+                                                      operator represents a key's relationship to a set of values.
+                                                      Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                    type: string
+                                                  values:
+                                                    description: |-
+                                                      values is an array of string values. If the operator is In or NotIn,
+                                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                      the values array must be empty. This array is replaced during a strategic
+                                                      merge patch.
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                required:
+                                                - key
+                                                - operator
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              description: |-
+                                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                              type: object
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        matchLabelKeys:
+                                          description: |-
+                                            MatchLabelKeys is a set of pod label keys to select which pods will
+                                            be taken into consideration. The keys are used to lookup values from the
+                                            incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                            to select the group of existing pods which pods will be taken into consideration
+                                            for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                            pod labels will be ignored. The default value is empty.
+                                            The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                            Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        mismatchLabelKeys:
+                                          description: |-
+                                            MismatchLabelKeys is a set of pod label keys to select which pods will
+                                            be taken into consideration. The keys are used to lookup values from the
+                                            incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                            to select the group of existing pods which pods will be taken into consideration
+                                            for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                            pod labels will be ignored. The default value is empty.
+                                            The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                            Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        namespaceSelector:
+                                          description: |-
+                                            A label query over the set of namespaces that the term applies to.
+                                            The term is applied to the union of the namespaces selected by this field
+                                            and the ones listed in the namespaces field.
+                                            null selector and null or empty namespaces list means "this pod's namespace".
+                                            An empty selector ({}) matches all namespaces.
+                                          properties:
+                                            matchExpressions:
+                                              description: matchExpressions is a list
+                                                of label selector requirements. The
+                                                requirements are ANDed.
+                                              items:
+                                                description: |-
+                                                  A label selector requirement is a selector that contains values, a key, and an operator that
+                                                  relates the key and values.
+                                                properties:
+                                                  key:
+                                                    description: key is the label
+                                                      key that the selector applies
+                                                      to.
+                                                    type: string
+                                                  operator:
+                                                    description: |-
+                                                      operator represents a key's relationship to a set of values.
+                                                      Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                    type: string
+                                                  values:
+                                                    description: |-
+                                                      values is an array of string values. If the operator is In or NotIn,
+                                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                      the values array must be empty. This array is replaced during a strategic
+                                                      merge patch.
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                required:
+                                                - key
+                                                - operator
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              description: |-
+                                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                              type: object
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        namespaces:
+                                          description: |-
+                                            namespaces specifies a static list of namespace names that the term applies to.
+                                            The term is applied to the union of the namespaces listed in this field
+                                            and the ones selected by namespaceSelector.
+                                            null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        topologyKey:
+                                          description: |-
+                                            This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                            the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                            whose value of the label with key topologyKey matches that of any node on which any of the
+                                            selected pods is running.
+                                            Empty topologyKey is not allowed.
+                                          type: string
+                                      required:
+                                      - topologyKey
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                type: object
+                              podAntiAffinity:
+                                description: Describes pod anti-affinity scheduling
+                                  rules (e.g. avoid putting this pod in the same node,
+                                  zone, etc. as some other pod(s)).
+                                properties:
+                                  preferredDuringSchedulingIgnoredDuringExecution:
+                                    description: |-
+                                      The scheduler will prefer to schedule pods to nodes that satisfy
+                                      the anti-affinity expressions specified by this field, but it may choose
+                                      a node that violates one or more of the expressions. The node that is
+                                      most preferred is the one with the greatest sum of weights, i.e.
+                                      for each node that meets all of the scheduling requirements (resource
+                                      request, requiredDuringScheduling anti-affinity expressions, etc.),
+                                      compute a sum by iterating through the elements of this field and subtracting
+                                      "weight" from the sum if the node has pods which matches the corresponding podAffinityTerm; the
+                                      node(s) with the highest sum are the most preferred.
+                                    items:
+                                      description: The weights of all of the matched
+                                        WeightedPodAffinityTerm fields are added per-node
+                                        to find the most preferred node(s)
+                                      properties:
+                                        podAffinityTerm:
+                                          description: Required. A pod affinity term,
+                                            associated with the corresponding weight.
+                                          properties:
+                                            labelSelector:
+                                              description: |-
+                                                A label query over a set of resources, in this case pods.
+                                                If it's null, this PodAffinityTerm matches with no Pods.
+                                              properties:
+                                                matchExpressions:
+                                                  description: matchExpressions is
+                                                    a list of label selector requirements.
+                                                    The requirements are ANDed.
+                                                  items:
+                                                    description: |-
+                                                      A label selector requirement is a selector that contains values, a key, and an operator that
+                                                      relates the key and values.
+                                                    properties:
+                                                      key:
+                                                        description: key is the label
+                                                          key that the selector applies
+                                                          to.
+                                                        type: string
+                                                      operator:
+                                                        description: |-
+                                                          operator represents a key's relationship to a set of values.
+                                                          Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                        type: string
+                                                      values:
+                                                        description: |-
+                                                          values is an array of string values. If the operator is In or NotIn,
+                                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                          the values array must be empty. This array is replaced during a strategic
+                                                          merge patch.
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                    required:
+                                                    - key
+                                                    - operator
+                                                    type: object
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                                matchLabels:
+                                                  additionalProperties:
+                                                    type: string
+                                                  description: |-
+                                                    matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                    map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                    operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                  type: object
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            matchLabelKeys:
+                                              description: |-
+                                                MatchLabelKeys is a set of pod label keys to select which pods will
+                                                be taken into consideration. The keys are used to lookup values from the
+                                                incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                                to select the group of existing pods which pods will be taken into consideration
+                                                for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                                pod labels will be ignored. The default value is empty.
+                                                The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                                Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            mismatchLabelKeys:
+                                              description: |-
+                                                MismatchLabelKeys is a set of pod label keys to select which pods will
+                                                be taken into consideration. The keys are used to lookup values from the
+                                                incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                                to select the group of existing pods which pods will be taken into consideration
+                                                for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                                pod labels will be ignored. The default value is empty.
+                                                The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                                Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            namespaceSelector:
+                                              description: |-
+                                                A label query over the set of namespaces that the term applies to.
+                                                The term is applied to the union of the namespaces selected by this field
+                                                and the ones listed in the namespaces field.
+                                                null selector and null or empty namespaces list means "this pod's namespace".
+                                                An empty selector ({}) matches all namespaces.
+                                              properties:
+                                                matchExpressions:
+                                                  description: matchExpressions is
+                                                    a list of label selector requirements.
+                                                    The requirements are ANDed.
+                                                  items:
+                                                    description: |-
+                                                      A label selector requirement is a selector that contains values, a key, and an operator that
+                                                      relates the key and values.
+                                                    properties:
+                                                      key:
+                                                        description: key is the label
+                                                          key that the selector applies
+                                                          to.
+                                                        type: string
+                                                      operator:
+                                                        description: |-
+                                                          operator represents a key's relationship to a set of values.
+                                                          Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                        type: string
+                                                      values:
+                                                        description: |-
+                                                          values is an array of string values. If the operator is In or NotIn,
+                                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                          the values array must be empty. This array is replaced during a strategic
+                                                          merge patch.
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                    required:
+                                                    - key
+                                                    - operator
+                                                    type: object
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                                matchLabels:
+                                                  additionalProperties:
+                                                    type: string
+                                                  description: |-
+                                                    matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                    map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                    operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                  type: object
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            namespaces:
+                                              description: |-
+                                                namespaces specifies a static list of namespace names that the term applies to.
+                                                The term is applied to the union of the namespaces listed in this field
+                                                and the ones selected by namespaceSelector.
+                                                null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            topologyKey:
+                                              description: |-
+                                                This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                                the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                                whose value of the label with key topologyKey matches that of any node on which any of the
+                                                selected pods is running.
+                                                Empty topologyKey is not allowed.
+                                              type: string
+                                          required:
+                                          - topologyKey
+                                          type: object
+                                        weight:
+                                          description: |-
+                                            weight associated with matching the corresponding podAffinityTerm,
+                                            in the range 1-100.
+                                          format: int32
+                                          type: integer
+                                      required:
+                                      - podAffinityTerm
+                                      - weight
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                  requiredDuringSchedulingIgnoredDuringExecution:
+                                    description: |-
+                                      If the anti-affinity requirements specified by this field are not met at
+                                      scheduling time, the pod will not be scheduled onto the node.
+                                      If the anti-affinity requirements specified by this field cease to be met
+                                      at some point during pod execution (e.g. due to a pod label update), the
+                                      system may or may not try to eventually evict the pod from its node.
+                                      When there are multiple elements, the lists of nodes corresponding to each
+                                      podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                                    items:
+                                      description: |-
+                                        Defines a set of pods (namely those matching the labelSelector
+                                        relative to the given namespace(s)) that this pod should be
+                                        co-located (affinity) or not co-located (anti-affinity) with,
+                                        where co-located is defined as running on a node whose value of
+                                        the label with key <topologyKey> matches that of any node on which
+                                        a pod of the set of pods is running
+                                      properties:
+                                        labelSelector:
+                                          description: |-
+                                            A label query over a set of resources, in this case pods.
+                                            If it's null, this PodAffinityTerm matches with no Pods.
+                                          properties:
+                                            matchExpressions:
+                                              description: matchExpressions is a list
+                                                of label selector requirements. The
+                                                requirements are ANDed.
+                                              items:
+                                                description: |-
+                                                  A label selector requirement is a selector that contains values, a key, and an operator that
+                                                  relates the key and values.
+                                                properties:
+                                                  key:
+                                                    description: key is the label
+                                                      key that the selector applies
+                                                      to.
+                                                    type: string
+                                                  operator:
+                                                    description: |-
+                                                      operator represents a key's relationship to a set of values.
+                                                      Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                    type: string
+                                                  values:
+                                                    description: |-
+                                                      values is an array of string values. If the operator is In or NotIn,
+                                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                      the values array must be empty. This array is replaced during a strategic
+                                                      merge patch.
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                required:
+                                                - key
+                                                - operator
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              description: |-
+                                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                              type: object
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        matchLabelKeys:
+                                          description: |-
+                                            MatchLabelKeys is a set of pod label keys to select which pods will
+                                            be taken into consideration. The keys are used to lookup values from the
+                                            incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                            to select the group of existing pods which pods will be taken into consideration
+                                            for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                            pod labels will be ignored. The default value is empty.
+                                            The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                            Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        mismatchLabelKeys:
+                                          description: |-
+                                            MismatchLabelKeys is a set of pod label keys to select which pods will
+                                            be taken into consideration. The keys are used to lookup values from the
+                                            incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                            to select the group of existing pods which pods will be taken into consideration
+                                            for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                            pod labels will be ignored. The default value is empty.
+                                            The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                            Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        namespaceSelector:
+                                          description: |-
+                                            A label query over the set of namespaces that the term applies to.
+                                            The term is applied to the union of the namespaces selected by this field
+                                            and the ones listed in the namespaces field.
+                                            null selector and null or empty namespaces list means "this pod's namespace".
+                                            An empty selector ({}) matches all namespaces.
+                                          properties:
+                                            matchExpressions:
+                                              description: matchExpressions is a list
+                                                of label selector requirements. The
+                                                requirements are ANDed.
+                                              items:
+                                                description: |-
+                                                  A label selector requirement is a selector that contains values, a key, and an operator that
+                                                  relates the key and values.
+                                                properties:
+                                                  key:
+                                                    description: key is the label
+                                                      key that the selector applies
+                                                      to.
+                                                    type: string
+                                                  operator:
+                                                    description: |-
+                                                      operator represents a key's relationship to a set of values.
+                                                      Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                    type: string
+                                                  values:
+                                                    description: |-
+                                                      values is an array of string values. If the operator is In or NotIn,
+                                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                      the values array must be empty. This array is replaced during a strategic
+                                                      merge patch.
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                required:
+                                                - key
+                                                - operator
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              description: |-
+                                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                              type: object
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        namespaces:
+                                          description: |-
+                                            namespaces specifies a static list of namespace names that the term applies to.
+                                            The term is applied to the union of the namespaces listed in this field
+                                            and the ones selected by namespaceSelector.
+                                            null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        topologyKey:
+                                          description: |-
+                                            This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                            the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                            whose value of the label with key topologyKey matches that of any node on which any of the
+                                            selected pods is running.
+                                            Empty topologyKey is not allowed.
+                                          type: string
+                                      required:
+                                      - topologyKey
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                type: object
+                            type: object
+                          automountServiceAccountToken:
+                            description: AutomountServiceAccountToken indicates whether
+                              a service account token should be automatically mounted.
+                            type: boolean
+                          containers:
+                            description: |-
+                              List of containers belonging to the pod.
+                              Containers cannot currently be added or removed.
+                              There must be at least one container in a Pod.
+                              Cannot be updated.
+                            items:
+                              description: A single application container that you
+                                want to run within a pod.
+                              properties:
+                                args:
+                                  description: |-
+                                    Arguments to the entrypoint.
+                                    The container image's CMD is used if this is not provided.
+                                    Variable references $(VAR_NAME) are expanded using the container's environment. If a variable
+                                    cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced
+                                    to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will
+                                    produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless
+                                    of whether the variable exists or not. Cannot be updated.
+                                    More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                command:
+                                  description: |-
+                                    Entrypoint array. Not executed within a shell.
+                                    The container image's ENTRYPOINT is used if this is not provided.
+                                    Variable references $(VAR_NAME) are expanded using the container's environment. If a variable
+                                    cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced
+                                    to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will
+                                    produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless
+                                    of whether the variable exists or not. Cannot be updated.
+                                    More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                env:
+                                  description: |-
+                                    List of environment variables to set in the container.
+                                    Cannot be updated.
+                                  items:
+                                    description: EnvVar represents an environment
+                                      variable present in a Container.
+                                    properties:
+                                      name:
+                                        description: |-
+                                          Name of the environment variable.
+                                          May consist of any printable ASCII characters except '='.
+                                        type: string
+                                      value:
+                                        description: |-
+                                          Variable references $(VAR_NAME) are expanded
+                                          using the previously defined environment variables in the container and
+                                          any service environment variables. If a variable cannot be resolved,
+                                          the reference in the input string will be unchanged. Double $$ are reduced
+                                          to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                                          "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                                          Escaped references will never be expanded, regardless of whether the variable
+                                          exists or not.
+                                          Defaults to "".
+                                        type: string
+                                      valueFrom:
+                                        description: Source for the environment variable's
+                                          value. Cannot be used if value is not empty.
+                                        properties:
+                                          configMapKeyRef:
+                                            description: Selects a key of a ConfigMap.
+                                            properties:
+                                              key:
+                                                description: The key to select.
+                                                type: string
+                                              name:
+                                                default: ""
+                                                description: |-
+                                                  Name of the referent.
+                                                  This field is effectively required, but due to backwards compatibility is
+                                                  allowed to be empty. Instances of this type with an empty value here are
+                                                  almost certainly wrong.
+                                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                type: string
+                                              optional:
+                                                description: Specify whether the ConfigMap
+                                                  or its key must be defined
+                                                type: boolean
+                                            required:
+                                            - key
+                                            type: object
+                                            x-kubernetes-map-type: atomic
+                                          fieldRef:
+                                            description: |-
+                                              Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                                              spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+                                            properties:
+                                              apiVersion:
+                                                description: Version of the schema
+                                                  the FieldPath is written in terms
+                                                  of, defaults to "v1".
+                                                type: string
+                                              fieldPath:
+                                                description: Path of the field to
+                                                  select in the specified API version.
+                                                type: string
+                                            required:
+                                            - fieldPath
+                                            type: object
+                                            x-kubernetes-map-type: atomic
+                                          fileKeyRef:
+                                            description: |-
+                                              FileKeyRef selects a key of the env file.
+                                              Requires the EnvFiles feature gate to be enabled.
+                                            properties:
+                                              key:
+                                                description: |-
+                                                  The key within the env file. An invalid key will prevent the pod from starting.
+                                                  The keys defined within a source may consist of any printable ASCII characters except '='.
+                                                  During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
+                                                type: string
+                                              optional:
+                                                default: false
+                                                description: |-
+                                                  Specify whether the file or its key must be defined. If the file or key
+                                                  does not exist, then the env var is not published.
+                                                  If optional is set to true and the specified key does not exist,
+                                                  the environment variable will not be set in the Pod's containers.
+
+                                                  If optional is set to false and the specified key does not exist,
+                                                  an error will be returned during Pod creation.
+                                                type: boolean
+                                              path:
+                                                description: |-
+                                                  The path within the volume from which to select the file.
+                                                  Must be relative and may not contain the '..' path or start with '..'.
+                                                type: string
+                                              volumeName:
+                                                description: The name of the volume
+                                                  mount containing the env file.
+                                                type: string
+                                            required:
+                                            - key
+                                            - path
+                                            - volumeName
+                                            type: object
+                                            x-kubernetes-map-type: atomic
+                                          resourceFieldRef:
+                                            description: |-
+                                              Selects a resource of the container: only resources limits and requests
+                                              (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+                                            properties:
+                                              containerName:
+                                                description: 'Container name: required
+                                                  for volumes, optional for env vars'
+                                                type: string
+                                              divisor:
+                                                anyOf:
+                                                - type: integer
+                                                - type: string
+                                                description: Specifies the output
+                                                  format of the exposed resources,
+                                                  defaults to "1"
+                                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                x-kubernetes-int-or-string: true
+                                              resource:
+                                                description: 'Required: resource to
+                                                  select'
+                                                type: string
+                                            required:
+                                            - resource
+                                            type: object
+                                            x-kubernetes-map-type: atomic
+                                          secretKeyRef:
+                                            description: Selects a key of a secret
+                                              in the pod's namespace
+                                            properties:
+                                              key:
+                                                description: The key of the secret
+                                                  to select from.  Must be a valid
+                                                  secret key.
+                                                type: string
+                                              name:
+                                                default: ""
+                                                description: |-
+                                                  Name of the referent.
+                                                  This field is effectively required, but due to backwards compatibility is
+                                                  allowed to be empty. Instances of this type with an empty value here are
+                                                  almost certainly wrong.
+                                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                type: string
+                                              optional:
+                                                description: Specify whether the Secret
+                                                  or its key must be defined
+                                                type: boolean
+                                            required:
+                                            - key
+                                            type: object
+                                            x-kubernetes-map-type: atomic
+                                        type: object
+                                    required:
+                                    - name
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                  - name
+                                  x-kubernetes-list-type: map
+                                envFrom:
+                                  description: |-
+                                    List of sources to populate environment variables in the container.
+                                    The keys defined within a source may consist of any printable ASCII characters except '='.
+                                    When a key exists in multiple
+                                    sources, the value associated with the last source will take precedence.
+                                    Values defined by an Env with a duplicate key will take precedence.
+                                    Cannot be updated.
+                                  items:
+                                    description: EnvFromSource represents the source
+                                      of a set of ConfigMaps or Secrets
+                                    properties:
+                                      configMapRef:
+                                        description: The ConfigMap to select from
+                                        properties:
+                                          name:
+                                            default: ""
+                                            description: |-
+                                              Name of the referent.
+                                              This field is effectively required, but due to backwards compatibility is
+                                              allowed to be empty. Instances of this type with an empty value here are
+                                              almost certainly wrong.
+                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                            type: string
+                                          optional:
+                                            description: Specify whether the ConfigMap
+                                              must be defined
+                                            type: boolean
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      prefix:
+                                        description: |-
+                                          Optional text to prepend to the name of each environment variable.
+                                          May consist of any printable ASCII characters except '='.
+                                        type: string
+                                      secretRef:
+                                        description: The Secret to select from
+                                        properties:
+                                          name:
+                                            default: ""
+                                            description: |-
+                                              Name of the referent.
+                                              This field is effectively required, but due to backwards compatibility is
+                                              allowed to be empty. Instances of this type with an empty value here are
+                                              almost certainly wrong.
+                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                            type: string
+                                          optional:
+                                            description: Specify whether the Secret
+                                              must be defined
+                                            type: boolean
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                image:
+                                  description: |-
+                                    Container image name.
+                                    More info: https://kubernetes.io/docs/concepts/containers/images
+                                    This field is optional to allow higher level config management to default or override
+                                    container images in workload controllers like Deployments and StatefulSets.
+                                  type: string
+                                imagePullPolicy:
+                                  description: |-
+                                    Image pull policy.
+                                    One of Always, Never, IfNotPresent.
+                                    Defaults to Always if :latest tag is specified, or IfNotPresent otherwise.
+                                    Cannot be updated.
+                                    More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
+                                  type: string
+                                lifecycle:
+                                  description: |-
+                                    Actions that the management system should take in response to container lifecycle events.
+                                    Cannot be updated.
+                                  properties:
+                                    postStart:
+                                      description: |-
+                                        PostStart is called immediately after a container is created. If the handler fails,
+                                        the container is terminated and restarted according to its restart policy.
+                                        Other management of the container blocks until the hook completes.
+                                        More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
+                                      properties:
+                                        exec:
+                                          description: Exec specifies a command to
+                                            execute in the container.
+                                          properties:
+                                            command:
+                                              description: |-
+                                                Command is the command line to execute inside the container, the working directory for the
+                                                command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                                not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                                a shell, you need to explicitly call out to that shell.
+                                                Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          type: object
+                                        httpGet:
+                                          description: HTTPGet specifies an HTTP GET
+                                            request to perform.
+                                          properties:
+                                            host:
+                                              description: |-
+                                                Host name to connect to, defaults to the pod IP. You probably want to set
+                                                "Host" in httpHeaders instead.
+                                              type: string
+                                            httpHeaders:
+                                              description: Custom headers to set in
+                                                the request. HTTP allows repeated
+                                                headers.
+                                              items:
+                                                description: HTTPHeader describes
+                                                  a custom header to be used in HTTP
+                                                  probes
+                                                properties:
+                                                  name:
+                                                    description: |-
+                                                      The header field name.
+                                                      This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                                    type: string
+                                                  value:
+                                                    description: The header field
+                                                      value
+                                                    type: string
+                                                required:
+                                                - name
+                                                - value
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            path:
+                                              description: Path to access on the HTTP
+                                                server.
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              description: |-
+                                                Name or number of the port to access on the container.
+                                                Number must be in the range 1 to 65535.
+                                                Name must be an IANA_SVC_NAME.
+                                              x-kubernetes-int-or-string: true
+                                            scheme:
+                                              description: |-
+                                                Scheme to use for connecting to the host.
+                                                Defaults to HTTP.
+                                              type: string
+                                          required:
+                                          - port
+                                          type: object
+                                        sleep:
+                                          description: Sleep represents a duration
+                                            that the container should sleep.
+                                          properties:
+                                            seconds:
+                                              description: Seconds is the number of
+                                                seconds to sleep.
+                                              format: int64
+                                              type: integer
+                                          required:
+                                          - seconds
+                                          type: object
+                                        tcpSocket:
+                                          description: |-
+                                            Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
+                                            for backward compatibility. There is no validation of this field and
+                                            lifecycle hooks will fail at runtime when it is specified.
+                                          properties:
+                                            host:
+                                              description: 'Optional: Host name to
+                                                connect to, defaults to the pod IP.'
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              description: |-
+                                                Number or name of the port to access on the container.
+                                                Number must be in the range 1 to 65535.
+                                                Name must be an IANA_SVC_NAME.
+                                              x-kubernetes-int-or-string: true
+                                          required:
+                                          - port
+                                          type: object
+                                      type: object
+                                    preStop:
+                                      description: |-
+                                        PreStop is called immediately before a container is terminated due to an
+                                        API request or management event such as liveness/startup probe failure,
+                                        preemption, resource contention, etc. The handler is not called if the
+                                        container crashes or exits. The Pod's termination grace period countdown begins before the
+                                        PreStop hook is executed. Regardless of the outcome of the handler, the
+                                        container will eventually terminate within the Pod's termination grace
+                                        period (unless delayed by finalizers). Other management of the container blocks until the hook completes
+                                        or until the termination grace period is reached.
+                                        More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
+                                      properties:
+                                        exec:
+                                          description: Exec specifies a command to
+                                            execute in the container.
+                                          properties:
+                                            command:
+                                              description: |-
+                                                Command is the command line to execute inside the container, the working directory for the
+                                                command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                                not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                                a shell, you need to explicitly call out to that shell.
+                                                Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          type: object
+                                        httpGet:
+                                          description: HTTPGet specifies an HTTP GET
+                                            request to perform.
+                                          properties:
+                                            host:
+                                              description: |-
+                                                Host name to connect to, defaults to the pod IP. You probably want to set
+                                                "Host" in httpHeaders instead.
+                                              type: string
+                                            httpHeaders:
+                                              description: Custom headers to set in
+                                                the request. HTTP allows repeated
+                                                headers.
+                                              items:
+                                                description: HTTPHeader describes
+                                                  a custom header to be used in HTTP
+                                                  probes
+                                                properties:
+                                                  name:
+                                                    description: |-
+                                                      The header field name.
+                                                      This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                                    type: string
+                                                  value:
+                                                    description: The header field
+                                                      value
+                                                    type: string
+                                                required:
+                                                - name
+                                                - value
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            path:
+                                              description: Path to access on the HTTP
+                                                server.
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              description: |-
+                                                Name or number of the port to access on the container.
+                                                Number must be in the range 1 to 65535.
+                                                Name must be an IANA_SVC_NAME.
+                                              x-kubernetes-int-or-string: true
+                                            scheme:
+                                              description: |-
+                                                Scheme to use for connecting to the host.
+                                                Defaults to HTTP.
+                                              type: string
+                                          required:
+                                          - port
+                                          type: object
+                                        sleep:
+                                          description: Sleep represents a duration
+                                            that the container should sleep.
+                                          properties:
+                                            seconds:
+                                              description: Seconds is the number of
+                                                seconds to sleep.
+                                              format: int64
+                                              type: integer
+                                          required:
+                                          - seconds
+                                          type: object
+                                        tcpSocket:
+                                          description: |-
+                                            Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
+                                            for backward compatibility. There is no validation of this field and
+                                            lifecycle hooks will fail at runtime when it is specified.
+                                          properties:
+                                            host:
+                                              description: 'Optional: Host name to
+                                                connect to, defaults to the pod IP.'
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              description: |-
+                                                Number or name of the port to access on the container.
+                                                Number must be in the range 1 to 65535.
+                                                Name must be an IANA_SVC_NAME.
+                                              x-kubernetes-int-or-string: true
+                                          required:
+                                          - port
+                                          type: object
+                                      type: object
+                                    stopSignal:
+                                      description: |-
+                                        StopSignal defines which signal will be sent to a container when it is being stopped.
+                                        If not specified, the default is defined by the container runtime in use.
+                                        StopSignal can only be set for Pods with a non-empty .spec.os.name
+                                      type: string
+                                  type: object
+                                livenessProbe:
+                                  description: |-
+                                    Periodic probe of container liveness.
+                                    Container will be restarted if the probe fails.
+                                    Cannot be updated.
+                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                  properties:
+                                    exec:
+                                      description: Exec specifies a command to execute
+                                        in the container.
+                                      properties:
+                                        command:
+                                          description: |-
+                                            Command is the command line to execute inside the container, the working directory for the
+                                            command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                            not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                            a shell, you need to explicitly call out to that shell.
+                                            Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                      type: object
+                                    failureThreshold:
+                                      description: |-
+                                        Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                                        Defaults to 3. Minimum value is 1.
+                                      format: int32
+                                      type: integer
+                                    grpc:
+                                      description: GRPC specifies a GRPC HealthCheckRequest.
+                                      properties:
+                                        port:
+                                          description: Port number of the gRPC service.
+                                            Number must be in the range 1 to 65535.
+                                          format: int32
+                                          type: integer
+                                        service:
+                                          default: ""
+                                          description: |-
+                                            Service is the name of the service to place in the gRPC HealthCheckRequest
+                                            (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                            If this is not specified, the default behavior is defined by gRPC.
+                                          type: string
+                                      required:
+                                      - port
+                                      type: object
+                                    httpGet:
+                                      description: HTTPGet specifies an HTTP GET request
+                                        to perform.
+                                      properties:
+                                        host:
+                                          description: |-
+                                            Host name to connect to, defaults to the pod IP. You probably want to set
+                                            "Host" in httpHeaders instead.
+                                          type: string
+                                        httpHeaders:
+                                          description: Custom headers to set in the
+                                            request. HTTP allows repeated headers.
+                                          items:
+                                            description: HTTPHeader describes a custom
+                                              header to be used in HTTP probes
+                                            properties:
+                                              name:
+                                                description: |-
+                                                  The header field name.
+                                                  This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                                type: string
+                                              value:
+                                                description: The header field value
+                                                type: string
+                                            required:
+                                            - name
+                                            - value
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        path:
+                                          description: Path to access on the HTTP
+                                            server.
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          description: |-
+                                            Name or number of the port to access on the container.
+                                            Number must be in the range 1 to 65535.
+                                            Name must be an IANA_SVC_NAME.
+                                          x-kubernetes-int-or-string: true
+                                        scheme:
+                                          description: |-
+                                            Scheme to use for connecting to the host.
+                                            Defaults to HTTP.
+                                          type: string
+                                      required:
+                                      - port
+                                      type: object
+                                    initialDelaySeconds:
+                                      description: |-
+                                        Number of seconds after the container has started before liveness probes are initiated.
+                                        More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                      format: int32
+                                      type: integer
+                                    periodSeconds:
+                                      description: |-
+                                        How often (in seconds) to perform the probe.
+                                        Default to 10 seconds. Minimum value is 1.
+                                      format: int32
+                                      type: integer
+                                    successThreshold:
+                                      description: |-
+                                        Minimum consecutive successes for the probe to be considered successful after having failed.
+                                        Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
+                                      format: int32
+                                      type: integer
+                                    tcpSocket:
+                                      description: TCPSocket specifies a connection
+                                        to a TCP port.
+                                      properties:
+                                        host:
+                                          description: 'Optional: Host name to connect
+                                            to, defaults to the pod IP.'
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          description: |-
+                                            Number or name of the port to access on the container.
+                                            Number must be in the range 1 to 65535.
+                                            Name must be an IANA_SVC_NAME.
+                                          x-kubernetes-int-or-string: true
+                                      required:
+                                      - port
+                                      type: object
+                                    terminationGracePeriodSeconds:
+                                      description: |-
+                                        Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                                        The grace period is the duration in seconds after the processes running in the pod are sent
+                                        a termination signal and the time when the processes are forcibly halted with a kill signal.
+                                        Set this value longer than the expected cleanup time for your process.
+                                        If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
+                                        value overrides the value provided by the pod spec.
+                                        Value must be non-negative integer. The value zero indicates stop immediately via
+                                        the kill signal (no opportunity to shut down).
+                                        This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
+                                        Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
+                                      format: int64
+                                      type: integer
+                                    timeoutSeconds:
+                                      description: |-
+                                        Number of seconds after which the probe times out.
+                                        Defaults to 1 second. Minimum value is 1.
+                                        More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                      format: int32
+                                      type: integer
+                                  type: object
+                                name:
+                                  description: |-
+                                    Name of the container specified as a DNS_LABEL.
+                                    Each container in a pod must have a unique name (DNS_LABEL).
+                                    Cannot be updated.
+                                  type: string
+                                ports:
+                                  description: |-
+                                    List of ports to expose from the container. Not specifying a port here
+                                    DOES NOT prevent that port from being exposed. Any port which is
+                                    listening on the default "0.0.0.0" address inside a container will be
+                                    accessible from the network.
+                                    Modifying this array with strategic merge patch may corrupt the data.
+                                    For more information See https://github.com/kubernetes/kubernetes/issues/108255.
+                                    Cannot be updated.
+                                  items:
+                                    description: ContainerPort represents a network
+                                      port in a single container.
+                                    properties:
+                                      containerPort:
+                                        description: |-
+                                          Number of port to expose on the pod's IP address.
+                                          This must be a valid port number, 0 < x < 65536.
+                                        format: int32
+                                        type: integer
+                                      hostIP:
+                                        description: What host IP to bind the external
+                                          port to.
+                                        type: string
+                                      hostPort:
+                                        description: |-
+                                          Number of port to expose on the host.
+                                          If specified, this must be a valid port number, 0 < x < 65536.
+                                          If HostNetwork is specified, this must match ContainerPort.
+                                          Most containers do not need this.
+                                        format: int32
+                                        type: integer
+                                      name:
+                                        description: |-
+                                          If specified, this must be an IANA_SVC_NAME and unique within the pod. Each
+                                          named port in a pod must have a unique name. Name for the port that can be
+                                          referred to by services.
+                                        type: string
+                                      protocol:
+                                        default: TCP
+                                        description: |-
+                                          Protocol for port. Must be UDP, TCP, or SCTP.
+                                          Defaults to "TCP".
+                                        type: string
+                                    required:
+                                    - containerPort
+                                    - protocol
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                  - containerPort
+                                  - protocol
+                                  x-kubernetes-list-type: map
+                                readinessProbe:
+                                  description: |-
+                                    Periodic probe of container service readiness.
+                                    Container will be removed from service endpoints if the probe fails.
+                                    Cannot be updated.
+                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                  properties:
+                                    exec:
+                                      description: Exec specifies a command to execute
+                                        in the container.
+                                      properties:
+                                        command:
+                                          description: |-
+                                            Command is the command line to execute inside the container, the working directory for the
+                                            command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                            not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                            a shell, you need to explicitly call out to that shell.
+                                            Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                      type: object
+                                    failureThreshold:
+                                      description: |-
+                                        Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                                        Defaults to 3. Minimum value is 1.
+                                      format: int32
+                                      type: integer
+                                    grpc:
+                                      description: GRPC specifies a GRPC HealthCheckRequest.
+                                      properties:
+                                        port:
+                                          description: Port number of the gRPC service.
+                                            Number must be in the range 1 to 65535.
+                                          format: int32
+                                          type: integer
+                                        service:
+                                          default: ""
+                                          description: |-
+                                            Service is the name of the service to place in the gRPC HealthCheckRequest
+                                            (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                            If this is not specified, the default behavior is defined by gRPC.
+                                          type: string
+                                      required:
+                                      - port
+                                      type: object
+                                    httpGet:
+                                      description: HTTPGet specifies an HTTP GET request
+                                        to perform.
+                                      properties:
+                                        host:
+                                          description: |-
+                                            Host name to connect to, defaults to the pod IP. You probably want to set
+                                            "Host" in httpHeaders instead.
+                                          type: string
+                                        httpHeaders:
+                                          description: Custom headers to set in the
+                                            request. HTTP allows repeated headers.
+                                          items:
+                                            description: HTTPHeader describes a custom
+                                              header to be used in HTTP probes
+                                            properties:
+                                              name:
+                                                description: |-
+                                                  The header field name.
+                                                  This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                                type: string
+                                              value:
+                                                description: The header field value
+                                                type: string
+                                            required:
+                                            - name
+                                            - value
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        path:
+                                          description: Path to access on the HTTP
+                                            server.
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          description: |-
+                                            Name or number of the port to access on the container.
+                                            Number must be in the range 1 to 65535.
+                                            Name must be an IANA_SVC_NAME.
+                                          x-kubernetes-int-or-string: true
+                                        scheme:
+                                          description: |-
+                                            Scheme to use for connecting to the host.
+                                            Defaults to HTTP.
+                                          type: string
+                                      required:
+                                      - port
+                                      type: object
+                                    initialDelaySeconds:
+                                      description: |-
+                                        Number of seconds after the container has started before liveness probes are initiated.
+                                        More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                      format: int32
+                                      type: integer
+                                    periodSeconds:
+                                      description: |-
+                                        How often (in seconds) to perform the probe.
+                                        Default to 10 seconds. Minimum value is 1.
+                                      format: int32
+                                      type: integer
+                                    successThreshold:
+                                      description: |-
+                                        Minimum consecutive successes for the probe to be considered successful after having failed.
+                                        Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
+                                      format: int32
+                                      type: integer
+                                    tcpSocket:
+                                      description: TCPSocket specifies a connection
+                                        to a TCP port.
+                                      properties:
+                                        host:
+                                          description: 'Optional: Host name to connect
+                                            to, defaults to the pod IP.'
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          description: |-
+                                            Number or name of the port to access on the container.
+                                            Number must be in the range 1 to 65535.
+                                            Name must be an IANA_SVC_NAME.
+                                          x-kubernetes-int-or-string: true
+                                      required:
+                                      - port
+                                      type: object
+                                    terminationGracePeriodSeconds:
+                                      description: |-
+                                        Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                                        The grace period is the duration in seconds after the processes running in the pod are sent
+                                        a termination signal and the time when the processes are forcibly halted with a kill signal.
+                                        Set this value longer than the expected cleanup time for your process.
+                                        If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
+                                        value overrides the value provided by the pod spec.
+                                        Value must be non-negative integer. The value zero indicates stop immediately via
+                                        the kill signal (no opportunity to shut down).
+                                        This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
+                                        Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
+                                      format: int64
+                                      type: integer
+                                    timeoutSeconds:
+                                      description: |-
+                                        Number of seconds after which the probe times out.
+                                        Defaults to 1 second. Minimum value is 1.
+                                        More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                      format: int32
+                                      type: integer
+                                  type: object
+                                resizePolicy:
+                                  description: Resources resize policy for the container.
+                                  items:
+                                    description: ContainerResizePolicy represents
+                                      resource resize policy for the container.
+                                    properties:
+                                      resourceName:
+                                        description: |-
+                                          Name of the resource to which this resource resize policy applies.
+                                          Supported values: cpu, memory.
+                                        type: string
+                                      restartPolicy:
+                                        description: |-
+                                          Restart policy to apply when specified resource is resized.
+                                          If not specified, it defaults to NotRequired.
+                                        type: string
+                                    required:
+                                    - resourceName
+                                    - restartPolicy
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                resources:
+                                  description: |-
+                                    Compute Resources required by this container.
+                                    Cannot be updated.
+                                    More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                  properties:
+                                    claims:
+                                      description: |-
+                                        Claims lists the names of resources, defined in spec.resourceClaims,
+                                        that are used by this container.
+
+                                        This field depends on the
+                                        DynamicResourceAllocation feature gate.
+
+                                        This field is immutable. It can only be set for containers.
+                                      items:
+                                        description: ResourceClaim references one
+                                          entry in PodSpec.ResourceClaims.
+                                        properties:
+                                          name:
+                                            description: |-
+                                              Name must match the name of one entry in pod.spec.resourceClaims of
+                                              the Pod where this field is used. It makes that resource available
+                                              inside a container.
+                                            type: string
+                                          request:
+                                            description: |-
+                                              Request is the name chosen for a request in the referenced claim.
+                                              If empty, everything from the claim is made available, otherwise
+                                              only the result of this request.
+                                            type: string
+                                        required:
+                                        - name
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                      - name
+                                      x-kubernetes-list-type: map
+                                    limits:
+                                      additionalProperties:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
+                                      description: |-
+                                        Limits describes the maximum amount of compute resources allowed.
+                                        More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                      type: object
+                                    requests:
+                                      additionalProperties:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
+                                      description: |-
+                                        Requests describes the minimum amount of compute resources required.
+                                        If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                                        otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                                        More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                      type: object
+                                  type: object
+                                restartPolicy:
+                                  description: |-
+                                    RestartPolicy defines the restart behavior of individual containers in a pod.
+                                    This overrides the pod-level restart policy. When this field is not specified,
+                                    the restart behavior is defined by the Pod's restart policy and the container type.
+                                    Additionally, setting the RestartPolicy as "Always" for the init container will
+                                    have the following effect:
+                                    this init container will be continually restarted on
+                                    exit until all regular containers have terminated. Once all regular
+                                    containers have completed, all init containers with restartPolicy "Always"
+                                    will be shut down. This lifecycle differs from normal init containers and
+                                    is often referred to as a "sidecar" container. Although this init
+                                    container still starts in the init container sequence, it does not wait
+                                    for the container to complete before proceeding to the next init
+                                    container. Instead, the next init container starts immediately after this
+                                    init container is started, or after any startupProbe has successfully
+                                    completed.
+                                  type: string
+                                restartPolicyRules:
+                                  description: |-
+                                    Represents a list of rules to be checked to determine if the
+                                    container should be restarted on exit. The rules are evaluated in
+                                    order. Once a rule matches a container exit condition, the remaining
+                                    rules are ignored. If no rule matches the container exit condition,
+                                    the Container-level restart policy determines the whether the container
+                                    is restarted or not. Constraints on the rules:
+                                    - At most 20 rules are allowed.
+                                    - Rules can have the same action.
+                                    - Identical rules are not forbidden in validations.
+                                    When rules are specified, container MUST set RestartPolicy explicitly
+                                    even it if matches the Pod's RestartPolicy.
+                                  items:
+                                    description: ContainerRestartRule describes how
+                                      a container exit is handled.
+                                    properties:
+                                      action:
+                                        description: |-
+                                          Specifies the action taken on a container exit if the requirements
+                                          are satisfied. The only possible value is "Restart" to restart the
+                                          container.
+                                        type: string
+                                      exitCodes:
+                                        description: Represents the exit codes to
+                                          check on container exits.
+                                        properties:
+                                          operator:
+                                            description: |-
+                                              Represents the relationship between the container exit code(s) and the
+                                              specified values. Possible values are:
+                                              - In: the requirement is satisfied if the container exit code is in the
+                                                set of specified values.
+                                              - NotIn: the requirement is satisfied if the container exit code is
+                                                not in the set of specified values.
+                                            type: string
+                                          values:
+                                            description: |-
+                                              Specifies the set of values to check for container exit codes.
+                                              At most 255 elements are allowed.
+                                            items:
+                                              format: int32
+                                              type: integer
+                                            type: array
+                                            x-kubernetes-list-type: set
+                                        required:
+                                        - operator
+                                        type: object
+                                    required:
+                                    - action
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                securityContext:
+                                  description: |-
+                                    SecurityContext defines the security options the container should be run with.
+                                    If set, the fields of SecurityContext override the equivalent fields of PodSecurityContext.
+                                    More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
+                                  properties:
+                                    allowPrivilegeEscalation:
+                                      description: |-
+                                        AllowPrivilegeEscalation controls whether a process can gain more
+                                        privileges than its parent process. This bool directly controls if
+                                        the no_new_privs flag will be set on the container process.
+                                        AllowPrivilegeEscalation is true always when the container is:
+                                        1) run as Privileged
+                                        2) has CAP_SYS_ADMIN
+                                        Note that this field cannot be set when spec.os.name is windows.
+                                      type: boolean
+                                    appArmorProfile:
+                                      description: |-
+                                        appArmorProfile is the AppArmor options to use by this container. If set, this profile
+                                        overrides the pod's appArmorProfile.
+                                        Note that this field cannot be set when spec.os.name is windows.
+                                      properties:
+                                        localhostProfile:
+                                          description: |-
+                                            localhostProfile indicates a profile loaded on the node that should be used.
+                                            The profile must be preconfigured on the node to work.
+                                            Must match the loaded name of the profile.
+                                            Must be set if and only if type is "Localhost".
+                                          type: string
+                                        type:
+                                          description: |-
+                                            type indicates which kind of AppArmor profile will be applied.
+                                            Valid options are:
+                                              Localhost - a profile pre-loaded on the node.
+                                              RuntimeDefault - the container runtime's default profile.
+                                              Unconfined - no AppArmor enforcement.
+                                          type: string
+                                      required:
+                                      - type
+                                      type: object
+                                    capabilities:
+                                      description: |-
+                                        The capabilities to add/drop when running containers.
+                                        Defaults to the default set of capabilities granted by the container runtime.
+                                        Note that this field cannot be set when spec.os.name is windows.
+                                      properties:
+                                        add:
+                                          description: Added capabilities
+                                          items:
+                                            description: Capability represent POSIX
+                                              capabilities type
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        drop:
+                                          description: Removed capabilities
+                                          items:
+                                            description: Capability represent POSIX
+                                              capabilities type
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                      type: object
+                                    privileged:
+                                      description: |-
+                                        Run container in privileged mode.
+                                        Processes in privileged containers are essentially equivalent to root on the host.
+                                        Defaults to false.
+                                        Note that this field cannot be set when spec.os.name is windows.
+                                      type: boolean
+                                    procMount:
+                                      description: |-
+                                        procMount denotes the type of proc mount to use for the containers.
+                                        The default value is Default which uses the container runtime defaults for
+                                        readonly paths and masked paths.
+                                        This requires the ProcMountType feature flag to be enabled.
+                                        Note that this field cannot be set when spec.os.name is windows.
+                                      type: string
+                                    readOnlyRootFilesystem:
+                                      description: |-
+                                        Whether this container has a read-only root filesystem.
+                                        Default is false.
+                                        Note that this field cannot be set when spec.os.name is windows.
+                                      type: boolean
+                                    runAsGroup:
+                                      description: |-
+                                        The GID to run the entrypoint of the container process.
+                                        Uses runtime default if unset.
+                                        May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                        PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                        Note that this field cannot be set when spec.os.name is windows.
+                                      format: int64
+                                      type: integer
+                                    runAsNonRoot:
+                                      description: |-
+                                        Indicates that the container must run as a non-root user.
+                                        If true, the Kubelet will validate the image at runtime to ensure that it
+                                        does not run as UID 0 (root) and fail to start the container if it does.
+                                        If unset or false, no such validation will be performed.
+                                        May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                        PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                      type: boolean
+                                    runAsUser:
+                                      description: |-
+                                        The UID to run the entrypoint of the container process.
+                                        Defaults to user specified in image metadata if unspecified.
+                                        May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                        PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                        Note that this field cannot be set when spec.os.name is windows.
+                                      format: int64
+                                      type: integer
+                                    seLinuxOptions:
+                                      description: |-
+                                        The SELinux context to be applied to the container.
+                                        If unspecified, the container runtime will allocate a random SELinux context for each
+                                        container.  May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                        PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                        Note that this field cannot be set when spec.os.name is windows.
+                                      properties:
+                                        level:
+                                          description: Level is SELinux level label
+                                            that applies to the container.
+                                          type: string
+                                        role:
+                                          description: Role is a SELinux role label
+                                            that applies to the container.
+                                          type: string
+                                        type:
+                                          description: Type is a SELinux type label
+                                            that applies to the container.
+                                          type: string
+                                        user:
+                                          description: User is a SELinux user label
+                                            that applies to the container.
+                                          type: string
+                                      type: object
+                                    seccompProfile:
+                                      description: |-
+                                        The seccomp options to use by this container. If seccomp options are
+                                        provided at both the pod & container level, the container options
+                                        override the pod options.
+                                        Note that this field cannot be set when spec.os.name is windows.
+                                      properties:
+                                        localhostProfile:
+                                          description: |-
+                                            localhostProfile indicates a profile defined in a file on the node should be used.
+                                            The profile must be preconfigured on the node to work.
+                                            Must be a descending path, relative to the kubelet's configured seccomp profile location.
+                                            Must be set if type is "Localhost". Must NOT be set for any other type.
+                                          type: string
+                                        type:
+                                          description: |-
+                                            type indicates which kind of seccomp profile will be applied.
+                                            Valid options are:
+
+                                            Localhost - a profile defined in a file on the node should be used.
+                                            RuntimeDefault - the container runtime default profile should be used.
+                                            Unconfined - no profile should be applied.
+                                          type: string
+                                      required:
+                                      - type
+                                      type: object
+                                    windowsOptions:
+                                      description: |-
+                                        The Windows specific settings applied to all containers.
+                                        If unspecified, the options from the PodSecurityContext will be used.
+                                        If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                        Note that this field cannot be set when spec.os.name is linux.
+                                      properties:
+                                        gmsaCredentialSpec:
+                                          description: |-
+                                            GMSACredentialSpec is where the GMSA admission webhook
+                                            (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the
+                                            GMSA credential spec named by the GMSACredentialSpecName field.
+                                          type: string
+                                        gmsaCredentialSpecName:
+                                          description: GMSACredentialSpecName is the
+                                            name of the GMSA credential spec to use.
+                                          type: string
+                                        hostProcess:
+                                          description: |-
+                                            HostProcess determines if a container should be run as a 'Host Process' container.
+                                            All of a Pod's containers must have the same effective HostProcess value
+                                            (it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).
+                                            In addition, if HostProcess is true then HostNetwork must also be set to true.
+                                          type: boolean
+                                        runAsUserName:
+                                          description: |-
+                                            The UserName in Windows to run the entrypoint of the container process.
+                                            Defaults to the user specified in image metadata if unspecified.
+                                            May also be set in PodSecurityContext. If set in both SecurityContext and
+                                            PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                          type: string
+                                      type: object
+                                  type: object
+                                startupProbe:
+                                  description: |-
+                                    StartupProbe indicates that the Pod has successfully initialized.
+                                    If specified, no other probes are executed until this completes successfully.
+                                    If this probe fails, the Pod will be restarted, just as if the livenessProbe failed.
+                                    This can be used to provide different probe parameters at the beginning of a Pod's lifecycle,
+                                    when it might take a long time to load data or warm a cache, than during steady-state operation.
+                                    This cannot be updated.
+                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                  properties:
+                                    exec:
+                                      description: Exec specifies a command to execute
+                                        in the container.
+                                      properties:
+                                        command:
+                                          description: |-
+                                            Command is the command line to execute inside the container, the working directory for the
+                                            command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                            not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                            a shell, you need to explicitly call out to that shell.
+                                            Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                      type: object
+                                    failureThreshold:
+                                      description: |-
+                                        Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                                        Defaults to 3. Minimum value is 1.
+                                      format: int32
+                                      type: integer
+                                    grpc:
+                                      description: GRPC specifies a GRPC HealthCheckRequest.
+                                      properties:
+                                        port:
+                                          description: Port number of the gRPC service.
+                                            Number must be in the range 1 to 65535.
+                                          format: int32
+                                          type: integer
+                                        service:
+                                          default: ""
+                                          description: |-
+                                            Service is the name of the service to place in the gRPC HealthCheckRequest
+                                            (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                            If this is not specified, the default behavior is defined by gRPC.
+                                          type: string
+                                      required:
+                                      - port
+                                      type: object
+                                    httpGet:
+                                      description: HTTPGet specifies an HTTP GET request
+                                        to perform.
+                                      properties:
+                                        host:
+                                          description: |-
+                                            Host name to connect to, defaults to the pod IP. You probably want to set
+                                            "Host" in httpHeaders instead.
+                                          type: string
+                                        httpHeaders:
+                                          description: Custom headers to set in the
+                                            request. HTTP allows repeated headers.
+                                          items:
+                                            description: HTTPHeader describes a custom
+                                              header to be used in HTTP probes
+                                            properties:
+                                              name:
+                                                description: |-
+                                                  The header field name.
+                                                  This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                                type: string
+                                              value:
+                                                description: The header field value
+                                                type: string
+                                            required:
+                                            - name
+                                            - value
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        path:
+                                          description: Path to access on the HTTP
+                                            server.
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          description: |-
+                                            Name or number of the port to access on the container.
+                                            Number must be in the range 1 to 65535.
+                                            Name must be an IANA_SVC_NAME.
+                                          x-kubernetes-int-or-string: true
+                                        scheme:
+                                          description: |-
+                                            Scheme to use for connecting to the host.
+                                            Defaults to HTTP.
+                                          type: string
+                                      required:
+                                      - port
+                                      type: object
+                                    initialDelaySeconds:
+                                      description: |-
+                                        Number of seconds after the container has started before liveness probes are initiated.
+                                        More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                      format: int32
+                                      type: integer
+                                    periodSeconds:
+                                      description: |-
+                                        How often (in seconds) to perform the probe.
+                                        Default to 10 seconds. Minimum value is 1.
+                                      format: int32
+                                      type: integer
+                                    successThreshold:
+                                      description: |-
+                                        Minimum consecutive successes for the probe to be considered successful after having failed.
+                                        Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
+                                      format: int32
+                                      type: integer
+                                    tcpSocket:
+                                      description: TCPSocket specifies a connection
+                                        to a TCP port.
+                                      properties:
+                                        host:
+                                          description: 'Optional: Host name to connect
+                                            to, defaults to the pod IP.'
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          description: |-
+                                            Number or name of the port to access on the container.
+                                            Number must be in the range 1 to 65535.
+                                            Name must be an IANA_SVC_NAME.
+                                          x-kubernetes-int-or-string: true
+                                      required:
+                                      - port
+                                      type: object
+                                    terminationGracePeriodSeconds:
+                                      description: |-
+                                        Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                                        The grace period is the duration in seconds after the processes running in the pod are sent
+                                        a termination signal and the time when the processes are forcibly halted with a kill signal.
+                                        Set this value longer than the expected cleanup time for your process.
+                                        If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
+                                        value overrides the value provided by the pod spec.
+                                        Value must be non-negative integer. The value zero indicates stop immediately via
+                                        the kill signal (no opportunity to shut down).
+                                        This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
+                                        Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
+                                      format: int64
+                                      type: integer
+                                    timeoutSeconds:
+                                      description: |-
+                                        Number of seconds after which the probe times out.
+                                        Defaults to 1 second. Minimum value is 1.
+                                        More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                      format: int32
+                                      type: integer
+                                  type: object
+                                stdin:
+                                  description: |-
+                                    Whether this container should allocate a buffer for stdin in the container runtime. If this
+                                    is not set, reads from stdin in the container will always result in EOF.
+                                    Default is false.
+                                  type: boolean
+                                stdinOnce:
+                                  description: |-
+                                    Whether the container runtime should close the stdin channel after it has been opened by
+                                    a single attach. When stdin is true the stdin stream will remain open across multiple attach
+                                    sessions. If stdinOnce is set to true, stdin is opened on container start, is empty until the
+                                    first client attaches to stdin, and then remains open and accepts data until the client disconnects,
+                                    at which time stdin is closed and remains closed until the container is restarted. If this
+                                    flag is false, a container processes that reads from stdin will never receive an EOF.
+                                    Default is false
+                                  type: boolean
+                                terminationMessagePath:
+                                  description: |-
+                                    Optional: Path at which the file to which the container's termination message
+                                    will be written is mounted into the container's filesystem.
+                                    Message written is intended to be brief final status, such as an assertion failure message.
+                                    Will be truncated by the node if greater than 4096 bytes. The total message length across
+                                    all containers will be limited to 12kb.
+                                    Defaults to /dev/termination-log.
+                                    Cannot be updated.
+                                  type: string
+                                terminationMessagePolicy:
+                                  description: |-
+                                    Indicate how the termination message should be populated. File will use the contents of
+                                    terminationMessagePath to populate the container status message on both success and failure.
+                                    FallbackToLogsOnError will use the last chunk of container log output if the termination
+                                    message file is empty and the container exited with an error.
+                                    The log output is limited to 2048 bytes or 80 lines, whichever is smaller.
+                                    Defaults to File.
+                                    Cannot be updated.
+                                  type: string
+                                tty:
+                                  description: |-
+                                    Whether this container should allocate a TTY for itself, also requires 'stdin' to be true.
+                                    Default is false.
+                                  type: boolean
+                                volumeDevices:
+                                  description: volumeDevices is the list of block
+                                    devices to be used by the container.
+                                  items:
+                                    description: volumeDevice describes a mapping
+                                      of a raw block device within a container.
+                                    properties:
+                                      devicePath:
+                                        description: devicePath is the path inside
+                                          of the container that the device will be
+                                          mapped to.
+                                        type: string
+                                      name:
+                                        description: name must match the name of a
+                                          persistentVolumeClaim in the pod
+                                        type: string
+                                    required:
+                                    - devicePath
+                                    - name
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                  - devicePath
+                                  x-kubernetes-list-type: map
+                                volumeMounts:
+                                  description: |-
+                                    Pod volumes to mount into the container's filesystem.
+                                    Cannot be updated.
+                                  items:
+                                    description: VolumeMount describes a mounting
+                                      of a Volume within a container.
+                                    properties:
+                                      mountPath:
+                                        description: |-
+                                          Path within the container at which the volume should be mounted.  Must
+                                          not contain ':'.
+                                        type: string
+                                      mountPropagation:
+                                        description: |-
+                                          mountPropagation determines how mounts are propagated from the host
+                                          to container and the other way around.
+                                          When not set, MountPropagationNone is used.
+                                          This field is beta in 1.10.
+                                          When RecursiveReadOnly is set to IfPossible or to Enabled, MountPropagation must be None or unspecified
+                                          (which defaults to None).
+                                        type: string
+                                      name:
+                                        description: This must match the Name of a
+                                          Volume.
+                                        type: string
+                                      readOnly:
+                                        description: |-
+                                          Mounted read-only if true, read-write otherwise (false or unspecified).
+                                          Defaults to false.
+                                        type: boolean
+                                      recursiveReadOnly:
+                                        description: |-
+                                          RecursiveReadOnly specifies whether read-only mounts should be handled
+                                          recursively.
+
+                                          If ReadOnly is false, this field has no meaning and must be unspecified.
+
+                                          If ReadOnly is true, and this field is set to Disabled, the mount is not made
+                                          recursively read-only.  If this field is set to IfPossible, the mount is made
+                                          recursively read-only, if it is supported by the container runtime.  If this
+                                          field is set to Enabled, the mount is made recursively read-only if it is
+                                          supported by the container runtime, otherwise the pod will not be started and
+                                          an error will be generated to indicate the reason.
+
+                                          If this field is set to IfPossible or Enabled, MountPropagation must be set to
+                                          None (or be unspecified, which defaults to None).
+
+                                          If this field is not specified, it is treated as an equivalent of Disabled.
+                                        type: string
+                                      subPath:
+                                        description: |-
+                                          Path within the volume from which the container's volume should be mounted.
+                                          Defaults to "" (volume's root).
+                                        type: string
+                                      subPathExpr:
+                                        description: |-
+                                          Expanded path within the volume from which the container's volume should be mounted.
+                                          Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment.
+                                          Defaults to "" (volume's root).
+                                          SubPathExpr and SubPath are mutually exclusive.
+                                        type: string
+                                    required:
+                                    - mountPath
+                                    - name
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                  - mountPath
+                                  x-kubernetes-list-type: map
+                                workingDir:
+                                  description: |-
+                                    Container's working directory.
+                                    If not specified, the container runtime's default will be used, which
+                                    might be configured in the container image.
+                                    Cannot be updated.
+                                  type: string
+                              required:
+                              - name
+                              type: object
+                            type: array
+                            x-kubernetes-list-map-keys:
+                            - name
+                            x-kubernetes-list-type: map
+                          dnsConfig:
+                            description: |-
+                              Specifies the DNS parameters of a pod.
+                              Parameters specified here will be merged to the generated DNS
+                              configuration based on DNSPolicy.
+                            properties:
+                              nameservers:
+                                description: |-
+                                  A list of DNS name server IP addresses.
+                                  This will be appended to the base nameservers generated from DNSPolicy.
+                                  Duplicated nameservers will be removed.
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              options:
+                                description: |-
+                                  A list of DNS resolver options.
+                                  This will be merged with the base options generated from DNSPolicy.
+                                  Duplicated entries will be removed. Resolution options given in Options
+                                  will override those that appear in the base DNSPolicy.
+                                items:
+                                  description: PodDNSConfigOption defines DNS resolver
+                                    options of a pod.
+                                  properties:
+                                    name:
+                                      description: |-
+                                        Name is this DNS resolver option's name.
+                                        Required.
+                                      type: string
+                                    value:
+                                      description: Value is this DNS resolver option's
+                                        value.
+                                      type: string
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              searches:
+                                description: |-
+                                  A list of DNS search domains for host-name lookup.
+                                  This will be appended to the base search paths generated from DNSPolicy.
+                                  Duplicated search paths will be removed.
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: atomic
+                            type: object
+                          dnsPolicy:
+                            description: |-
+                              Set DNS policy for the pod.
+                              Defaults to "ClusterFirst".
+                              Valid values are 'ClusterFirstWithHostNet', 'ClusterFirst', 'Default' or 'None'.
+                              DNS parameters given in DNSConfig will be merged with the policy selected with DNSPolicy.
+                              To have DNS options set along with hostNetwork, you have to specify DNS policy
+                              explicitly to 'ClusterFirstWithHostNet'.
+                            type: string
+                          enableServiceLinks:
+                            description: |-
+                              EnableServiceLinks indicates whether information about services should be injected into pod's
+                              environment variables, matching the syntax of Docker links.
+                              Optional: Defaults to true.
+                            type: boolean
+                          ephemeralContainers:
+                            description: |-
+                              List of ephemeral containers run in this pod. Ephemeral containers may be run in an existing
+                              pod to perform user-initiated actions such as debugging. This list cannot be specified when
+                              creating a pod, and it cannot be modified by updating the pod spec. In order to add an
+                              ephemeral container to an existing pod, use the pod's ephemeralcontainers subresource.
+                            items:
+                              description: |-
+                                An EphemeralContainer is a temporary container that you may add to an existing Pod for
+                                user-initiated activities such as debugging. Ephemeral containers have no resource or
+                                scheduling guarantees, and they will not be restarted when they exit or when a Pod is
+                                removed or restarted. The kubelet may evict a Pod if an ephemeral container causes the
+                                Pod to exceed its resource allocation.
+
+                                To add an ephemeral container, use the ephemeralcontainers subresource of an existing
+                                Pod. Ephemeral containers may not be removed or restarted.
+                              properties:
+                                args:
+                                  description: |-
+                                    Arguments to the entrypoint.
+                                    The image's CMD is used if this is not provided.
+                                    Variable references $(VAR_NAME) are expanded using the container's environment. If a variable
+                                    cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced
+                                    to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will
+                                    produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless
+                                    of whether the variable exists or not. Cannot be updated.
+                                    More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                command:
+                                  description: |-
+                                    Entrypoint array. Not executed within a shell.
+                                    The image's ENTRYPOINT is used if this is not provided.
+                                    Variable references $(VAR_NAME) are expanded using the container's environment. If a variable
+                                    cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced
+                                    to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will
+                                    produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless
+                                    of whether the variable exists or not. Cannot be updated.
+                                    More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                env:
+                                  description: |-
+                                    List of environment variables to set in the container.
+                                    Cannot be updated.
+                                  items:
+                                    description: EnvVar represents an environment
+                                      variable present in a Container.
+                                    properties:
+                                      name:
+                                        description: |-
+                                          Name of the environment variable.
+                                          May consist of any printable ASCII characters except '='.
+                                        type: string
+                                      value:
+                                        description: |-
+                                          Variable references $(VAR_NAME) are expanded
+                                          using the previously defined environment variables in the container and
+                                          any service environment variables. If a variable cannot be resolved,
+                                          the reference in the input string will be unchanged. Double $$ are reduced
+                                          to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                                          "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                                          Escaped references will never be expanded, regardless of whether the variable
+                                          exists or not.
+                                          Defaults to "".
+                                        type: string
+                                      valueFrom:
+                                        description: Source for the environment variable's
+                                          value. Cannot be used if value is not empty.
+                                        properties:
+                                          configMapKeyRef:
+                                            description: Selects a key of a ConfigMap.
+                                            properties:
+                                              key:
+                                                description: The key to select.
+                                                type: string
+                                              name:
+                                                default: ""
+                                                description: |-
+                                                  Name of the referent.
+                                                  This field is effectively required, but due to backwards compatibility is
+                                                  allowed to be empty. Instances of this type with an empty value here are
+                                                  almost certainly wrong.
+                                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                type: string
+                                              optional:
+                                                description: Specify whether the ConfigMap
+                                                  or its key must be defined
+                                                type: boolean
+                                            required:
+                                            - key
+                                            type: object
+                                            x-kubernetes-map-type: atomic
+                                          fieldRef:
+                                            description: |-
+                                              Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                                              spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+                                            properties:
+                                              apiVersion:
+                                                description: Version of the schema
+                                                  the FieldPath is written in terms
+                                                  of, defaults to "v1".
+                                                type: string
+                                              fieldPath:
+                                                description: Path of the field to
+                                                  select in the specified API version.
+                                                type: string
+                                            required:
+                                            - fieldPath
+                                            type: object
+                                            x-kubernetes-map-type: atomic
+                                          fileKeyRef:
+                                            description: |-
+                                              FileKeyRef selects a key of the env file.
+                                              Requires the EnvFiles feature gate to be enabled.
+                                            properties:
+                                              key:
+                                                description: |-
+                                                  The key within the env file. An invalid key will prevent the pod from starting.
+                                                  The keys defined within a source may consist of any printable ASCII characters except '='.
+                                                  During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
+                                                type: string
+                                              optional:
+                                                default: false
+                                                description: |-
+                                                  Specify whether the file or its key must be defined. If the file or key
+                                                  does not exist, then the env var is not published.
+                                                  If optional is set to true and the specified key does not exist,
+                                                  the environment variable will not be set in the Pod's containers.
+
+                                                  If optional is set to false and the specified key does not exist,
+                                                  an error will be returned during Pod creation.
+                                                type: boolean
+                                              path:
+                                                description: |-
+                                                  The path within the volume from which to select the file.
+                                                  Must be relative and may not contain the '..' path or start with '..'.
+                                                type: string
+                                              volumeName:
+                                                description: The name of the volume
+                                                  mount containing the env file.
+                                                type: string
+                                            required:
+                                            - key
+                                            - path
+                                            - volumeName
+                                            type: object
+                                            x-kubernetes-map-type: atomic
+                                          resourceFieldRef:
+                                            description: |-
+                                              Selects a resource of the container: only resources limits and requests
+                                              (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+                                            properties:
+                                              containerName:
+                                                description: 'Container name: required
+                                                  for volumes, optional for env vars'
+                                                type: string
+                                              divisor:
+                                                anyOf:
+                                                - type: integer
+                                                - type: string
+                                                description: Specifies the output
+                                                  format of the exposed resources,
+                                                  defaults to "1"
+                                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                x-kubernetes-int-or-string: true
+                                              resource:
+                                                description: 'Required: resource to
+                                                  select'
+                                                type: string
+                                            required:
+                                            - resource
+                                            type: object
+                                            x-kubernetes-map-type: atomic
+                                          secretKeyRef:
+                                            description: Selects a key of a secret
+                                              in the pod's namespace
+                                            properties:
+                                              key:
+                                                description: The key of the secret
+                                                  to select from.  Must be a valid
+                                                  secret key.
+                                                type: string
+                                              name:
+                                                default: ""
+                                                description: |-
+                                                  Name of the referent.
+                                                  This field is effectively required, but due to backwards compatibility is
+                                                  allowed to be empty. Instances of this type with an empty value here are
+                                                  almost certainly wrong.
+                                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                type: string
+                                              optional:
+                                                description: Specify whether the Secret
+                                                  or its key must be defined
+                                                type: boolean
+                                            required:
+                                            - key
+                                            type: object
+                                            x-kubernetes-map-type: atomic
+                                        type: object
+                                    required:
+                                    - name
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                  - name
+                                  x-kubernetes-list-type: map
+                                envFrom:
+                                  description: |-
+                                    List of sources to populate environment variables in the container.
+                                    The keys defined within a source may consist of any printable ASCII characters except '='.
+                                    When a key exists in multiple
+                                    sources, the value associated with the last source will take precedence.
+                                    Values defined by an Env with a duplicate key will take precedence.
+                                    Cannot be updated.
+                                  items:
+                                    description: EnvFromSource represents the source
+                                      of a set of ConfigMaps or Secrets
+                                    properties:
+                                      configMapRef:
+                                        description: The ConfigMap to select from
+                                        properties:
+                                          name:
+                                            default: ""
+                                            description: |-
+                                              Name of the referent.
+                                              This field is effectively required, but due to backwards compatibility is
+                                              allowed to be empty. Instances of this type with an empty value here are
+                                              almost certainly wrong.
+                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                            type: string
+                                          optional:
+                                            description: Specify whether the ConfigMap
+                                              must be defined
+                                            type: boolean
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      prefix:
+                                        description: |-
+                                          Optional text to prepend to the name of each environment variable.
+                                          May consist of any printable ASCII characters except '='.
+                                        type: string
+                                      secretRef:
+                                        description: The Secret to select from
+                                        properties:
+                                          name:
+                                            default: ""
+                                            description: |-
+                                              Name of the referent.
+                                              This field is effectively required, but due to backwards compatibility is
+                                              allowed to be empty. Instances of this type with an empty value here are
+                                              almost certainly wrong.
+                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                            type: string
+                                          optional:
+                                            description: Specify whether the Secret
+                                              must be defined
+                                            type: boolean
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                image:
+                                  description: |-
+                                    Container image name.
+                                    More info: https://kubernetes.io/docs/concepts/containers/images
+                                  type: string
+                                imagePullPolicy:
+                                  description: |-
+                                    Image pull policy.
+                                    One of Always, Never, IfNotPresent.
+                                    Defaults to Always if :latest tag is specified, or IfNotPresent otherwise.
+                                    Cannot be updated.
+                                    More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
+                                  type: string
+                                lifecycle:
+                                  description: Lifecycle is not allowed for ephemeral
+                                    containers.
+                                  properties:
+                                    postStart:
+                                      description: |-
+                                        PostStart is called immediately after a container is created. If the handler fails,
+                                        the container is terminated and restarted according to its restart policy.
+                                        Other management of the container blocks until the hook completes.
+                                        More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
+                                      properties:
+                                        exec:
+                                          description: Exec specifies a command to
+                                            execute in the container.
+                                          properties:
+                                            command:
+                                              description: |-
+                                                Command is the command line to execute inside the container, the working directory for the
+                                                command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                                not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                                a shell, you need to explicitly call out to that shell.
+                                                Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          type: object
+                                        httpGet:
+                                          description: HTTPGet specifies an HTTP GET
+                                            request to perform.
+                                          properties:
+                                            host:
+                                              description: |-
+                                                Host name to connect to, defaults to the pod IP. You probably want to set
+                                                "Host" in httpHeaders instead.
+                                              type: string
+                                            httpHeaders:
+                                              description: Custom headers to set in
+                                                the request. HTTP allows repeated
+                                                headers.
+                                              items:
+                                                description: HTTPHeader describes
+                                                  a custom header to be used in HTTP
+                                                  probes
+                                                properties:
+                                                  name:
+                                                    description: |-
+                                                      The header field name.
+                                                      This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                                    type: string
+                                                  value:
+                                                    description: The header field
+                                                      value
+                                                    type: string
+                                                required:
+                                                - name
+                                                - value
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            path:
+                                              description: Path to access on the HTTP
+                                                server.
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              description: |-
+                                                Name or number of the port to access on the container.
+                                                Number must be in the range 1 to 65535.
+                                                Name must be an IANA_SVC_NAME.
+                                              x-kubernetes-int-or-string: true
+                                            scheme:
+                                              description: |-
+                                                Scheme to use for connecting to the host.
+                                                Defaults to HTTP.
+                                              type: string
+                                          required:
+                                          - port
+                                          type: object
+                                        sleep:
+                                          description: Sleep represents a duration
+                                            that the container should sleep.
+                                          properties:
+                                            seconds:
+                                              description: Seconds is the number of
+                                                seconds to sleep.
+                                              format: int64
+                                              type: integer
+                                          required:
+                                          - seconds
+                                          type: object
+                                        tcpSocket:
+                                          description: |-
+                                            Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
+                                            for backward compatibility. There is no validation of this field and
+                                            lifecycle hooks will fail at runtime when it is specified.
+                                          properties:
+                                            host:
+                                              description: 'Optional: Host name to
+                                                connect to, defaults to the pod IP.'
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              description: |-
+                                                Number or name of the port to access on the container.
+                                                Number must be in the range 1 to 65535.
+                                                Name must be an IANA_SVC_NAME.
+                                              x-kubernetes-int-or-string: true
+                                          required:
+                                          - port
+                                          type: object
+                                      type: object
+                                    preStop:
+                                      description: |-
+                                        PreStop is called immediately before a container is terminated due to an
+                                        API request or management event such as liveness/startup probe failure,
+                                        preemption, resource contention, etc. The handler is not called if the
+                                        container crashes or exits. The Pod's termination grace period countdown begins before the
+                                        PreStop hook is executed. Regardless of the outcome of the handler, the
+                                        container will eventually terminate within the Pod's termination grace
+                                        period (unless delayed by finalizers). Other management of the container blocks until the hook completes
+                                        or until the termination grace period is reached.
+                                        More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
+                                      properties:
+                                        exec:
+                                          description: Exec specifies a command to
+                                            execute in the container.
+                                          properties:
+                                            command:
+                                              description: |-
+                                                Command is the command line to execute inside the container, the working directory for the
+                                                command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                                not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                                a shell, you need to explicitly call out to that shell.
+                                                Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          type: object
+                                        httpGet:
+                                          description: HTTPGet specifies an HTTP GET
+                                            request to perform.
+                                          properties:
+                                            host:
+                                              description: |-
+                                                Host name to connect to, defaults to the pod IP. You probably want to set
+                                                "Host" in httpHeaders instead.
+                                              type: string
+                                            httpHeaders:
+                                              description: Custom headers to set in
+                                                the request. HTTP allows repeated
+                                                headers.
+                                              items:
+                                                description: HTTPHeader describes
+                                                  a custom header to be used in HTTP
+                                                  probes
+                                                properties:
+                                                  name:
+                                                    description: |-
+                                                      The header field name.
+                                                      This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                                    type: string
+                                                  value:
+                                                    description: The header field
+                                                      value
+                                                    type: string
+                                                required:
+                                                - name
+                                                - value
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            path:
+                                              description: Path to access on the HTTP
+                                                server.
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              description: |-
+                                                Name or number of the port to access on the container.
+                                                Number must be in the range 1 to 65535.
+                                                Name must be an IANA_SVC_NAME.
+                                              x-kubernetes-int-or-string: true
+                                            scheme:
+                                              description: |-
+                                                Scheme to use for connecting to the host.
+                                                Defaults to HTTP.
+                                              type: string
+                                          required:
+                                          - port
+                                          type: object
+                                        sleep:
+                                          description: Sleep represents a duration
+                                            that the container should sleep.
+                                          properties:
+                                            seconds:
+                                              description: Seconds is the number of
+                                                seconds to sleep.
+                                              format: int64
+                                              type: integer
+                                          required:
+                                          - seconds
+                                          type: object
+                                        tcpSocket:
+                                          description: |-
+                                            Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
+                                            for backward compatibility. There is no validation of this field and
+                                            lifecycle hooks will fail at runtime when it is specified.
+                                          properties:
+                                            host:
+                                              description: 'Optional: Host name to
+                                                connect to, defaults to the pod IP.'
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              description: |-
+                                                Number or name of the port to access on the container.
+                                                Number must be in the range 1 to 65535.
+                                                Name must be an IANA_SVC_NAME.
+                                              x-kubernetes-int-or-string: true
+                                          required:
+                                          - port
+                                          type: object
+                                      type: object
+                                    stopSignal:
+                                      description: |-
+                                        StopSignal defines which signal will be sent to a container when it is being stopped.
+                                        If not specified, the default is defined by the container runtime in use.
+                                        StopSignal can only be set for Pods with a non-empty .spec.os.name
+                                      type: string
+                                  type: object
+                                livenessProbe:
+                                  description: Probes are not allowed for ephemeral
+                                    containers.
+                                  properties:
+                                    exec:
+                                      description: Exec specifies a command to execute
+                                        in the container.
+                                      properties:
+                                        command:
+                                          description: |-
+                                            Command is the command line to execute inside the container, the working directory for the
+                                            command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                            not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                            a shell, you need to explicitly call out to that shell.
+                                            Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                      type: object
+                                    failureThreshold:
+                                      description: |-
+                                        Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                                        Defaults to 3. Minimum value is 1.
+                                      format: int32
+                                      type: integer
+                                    grpc:
+                                      description: GRPC specifies a GRPC HealthCheckRequest.
+                                      properties:
+                                        port:
+                                          description: Port number of the gRPC service.
+                                            Number must be in the range 1 to 65535.
+                                          format: int32
+                                          type: integer
+                                        service:
+                                          default: ""
+                                          description: |-
+                                            Service is the name of the service to place in the gRPC HealthCheckRequest
+                                            (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                            If this is not specified, the default behavior is defined by gRPC.
+                                          type: string
+                                      required:
+                                      - port
+                                      type: object
+                                    httpGet:
+                                      description: HTTPGet specifies an HTTP GET request
+                                        to perform.
+                                      properties:
+                                        host:
+                                          description: |-
+                                            Host name to connect to, defaults to the pod IP. You probably want to set
+                                            "Host" in httpHeaders instead.
+                                          type: string
+                                        httpHeaders:
+                                          description: Custom headers to set in the
+                                            request. HTTP allows repeated headers.
+                                          items:
+                                            description: HTTPHeader describes a custom
+                                              header to be used in HTTP probes
+                                            properties:
+                                              name:
+                                                description: |-
+                                                  The header field name.
+                                                  This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                                type: string
+                                              value:
+                                                description: The header field value
+                                                type: string
+                                            required:
+                                            - name
+                                            - value
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        path:
+                                          description: Path to access on the HTTP
+                                            server.
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          description: |-
+                                            Name or number of the port to access on the container.
+                                            Number must be in the range 1 to 65535.
+                                            Name must be an IANA_SVC_NAME.
+                                          x-kubernetes-int-or-string: true
+                                        scheme:
+                                          description: |-
+                                            Scheme to use for connecting to the host.
+                                            Defaults to HTTP.
+                                          type: string
+                                      required:
+                                      - port
+                                      type: object
+                                    initialDelaySeconds:
+                                      description: |-
+                                        Number of seconds after the container has started before liveness probes are initiated.
+                                        More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                      format: int32
+                                      type: integer
+                                    periodSeconds:
+                                      description: |-
+                                        How often (in seconds) to perform the probe.
+                                        Default to 10 seconds. Minimum value is 1.
+                                      format: int32
+                                      type: integer
+                                    successThreshold:
+                                      description: |-
+                                        Minimum consecutive successes for the probe to be considered successful after having failed.
+                                        Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
+                                      format: int32
+                                      type: integer
+                                    tcpSocket:
+                                      description: TCPSocket specifies a connection
+                                        to a TCP port.
+                                      properties:
+                                        host:
+                                          description: 'Optional: Host name to connect
+                                            to, defaults to the pod IP.'
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          description: |-
+                                            Number or name of the port to access on the container.
+                                            Number must be in the range 1 to 65535.
+                                            Name must be an IANA_SVC_NAME.
+                                          x-kubernetes-int-or-string: true
+                                      required:
+                                      - port
+                                      type: object
+                                    terminationGracePeriodSeconds:
+                                      description: |-
+                                        Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                                        The grace period is the duration in seconds after the processes running in the pod are sent
+                                        a termination signal and the time when the processes are forcibly halted with a kill signal.
+                                        Set this value longer than the expected cleanup time for your process.
+                                        If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
+                                        value overrides the value provided by the pod spec.
+                                        Value must be non-negative integer. The value zero indicates stop immediately via
+                                        the kill signal (no opportunity to shut down).
+                                        This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
+                                        Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
+                                      format: int64
+                                      type: integer
+                                    timeoutSeconds:
+                                      description: |-
+                                        Number of seconds after which the probe times out.
+                                        Defaults to 1 second. Minimum value is 1.
+                                        More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                      format: int32
+                                      type: integer
+                                  type: object
+                                name:
+                                  description: |-
+                                    Name of the ephemeral container specified as a DNS_LABEL.
+                                    This name must be unique among all containers, init containers and ephemeral containers.
+                                  type: string
+                                ports:
+                                  description: Ports are not allowed for ephemeral
+                                    containers.
+                                  items:
+                                    description: ContainerPort represents a network
+                                      port in a single container.
+                                    properties:
+                                      containerPort:
+                                        description: |-
+                                          Number of port to expose on the pod's IP address.
+                                          This must be a valid port number, 0 < x < 65536.
+                                        format: int32
+                                        type: integer
+                                      hostIP:
+                                        description: What host IP to bind the external
+                                          port to.
+                                        type: string
+                                      hostPort:
+                                        description: |-
+                                          Number of port to expose on the host.
+                                          If specified, this must be a valid port number, 0 < x < 65536.
+                                          If HostNetwork is specified, this must match ContainerPort.
+                                          Most containers do not need this.
+                                        format: int32
+                                        type: integer
+                                      name:
+                                        description: |-
+                                          If specified, this must be an IANA_SVC_NAME and unique within the pod. Each
+                                          named port in a pod must have a unique name. Name for the port that can be
+                                          referred to by services.
+                                        type: string
+                                      protocol:
+                                        default: TCP
+                                        description: |-
+                                          Protocol for port. Must be UDP, TCP, or SCTP.
+                                          Defaults to "TCP".
+                                        type: string
+                                    required:
+                                    - containerPort
+                                    - protocol
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                  - containerPort
+                                  - protocol
+                                  x-kubernetes-list-type: map
+                                readinessProbe:
+                                  description: Probes are not allowed for ephemeral
+                                    containers.
+                                  properties:
+                                    exec:
+                                      description: Exec specifies a command to execute
+                                        in the container.
+                                      properties:
+                                        command:
+                                          description: |-
+                                            Command is the command line to execute inside the container, the working directory for the
+                                            command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                            not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                            a shell, you need to explicitly call out to that shell.
+                                            Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                      type: object
+                                    failureThreshold:
+                                      description: |-
+                                        Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                                        Defaults to 3. Minimum value is 1.
+                                      format: int32
+                                      type: integer
+                                    grpc:
+                                      description: GRPC specifies a GRPC HealthCheckRequest.
+                                      properties:
+                                        port:
+                                          description: Port number of the gRPC service.
+                                            Number must be in the range 1 to 65535.
+                                          format: int32
+                                          type: integer
+                                        service:
+                                          default: ""
+                                          description: |-
+                                            Service is the name of the service to place in the gRPC HealthCheckRequest
+                                            (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                            If this is not specified, the default behavior is defined by gRPC.
+                                          type: string
+                                      required:
+                                      - port
+                                      type: object
+                                    httpGet:
+                                      description: HTTPGet specifies an HTTP GET request
+                                        to perform.
+                                      properties:
+                                        host:
+                                          description: |-
+                                            Host name to connect to, defaults to the pod IP. You probably want to set
+                                            "Host" in httpHeaders instead.
+                                          type: string
+                                        httpHeaders:
+                                          description: Custom headers to set in the
+                                            request. HTTP allows repeated headers.
+                                          items:
+                                            description: HTTPHeader describes a custom
+                                              header to be used in HTTP probes
+                                            properties:
+                                              name:
+                                                description: |-
+                                                  The header field name.
+                                                  This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                                type: string
+                                              value:
+                                                description: The header field value
+                                                type: string
+                                            required:
+                                            - name
+                                            - value
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        path:
+                                          description: Path to access on the HTTP
+                                            server.
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          description: |-
+                                            Name or number of the port to access on the container.
+                                            Number must be in the range 1 to 65535.
+                                            Name must be an IANA_SVC_NAME.
+                                          x-kubernetes-int-or-string: true
+                                        scheme:
+                                          description: |-
+                                            Scheme to use for connecting to the host.
+                                            Defaults to HTTP.
+                                          type: string
+                                      required:
+                                      - port
+                                      type: object
+                                    initialDelaySeconds:
+                                      description: |-
+                                        Number of seconds after the container has started before liveness probes are initiated.
+                                        More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                      format: int32
+                                      type: integer
+                                    periodSeconds:
+                                      description: |-
+                                        How often (in seconds) to perform the probe.
+                                        Default to 10 seconds. Minimum value is 1.
+                                      format: int32
+                                      type: integer
+                                    successThreshold:
+                                      description: |-
+                                        Minimum consecutive successes for the probe to be considered successful after having failed.
+                                        Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
+                                      format: int32
+                                      type: integer
+                                    tcpSocket:
+                                      description: TCPSocket specifies a connection
+                                        to a TCP port.
+                                      properties:
+                                        host:
+                                          description: 'Optional: Host name to connect
+                                            to, defaults to the pod IP.'
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          description: |-
+                                            Number or name of the port to access on the container.
+                                            Number must be in the range 1 to 65535.
+                                            Name must be an IANA_SVC_NAME.
+                                          x-kubernetes-int-or-string: true
+                                      required:
+                                      - port
+                                      type: object
+                                    terminationGracePeriodSeconds:
+                                      description: |-
+                                        Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                                        The grace period is the duration in seconds after the processes running in the pod are sent
+                                        a termination signal and the time when the processes are forcibly halted with a kill signal.
+                                        Set this value longer than the expected cleanup time for your process.
+                                        If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
+                                        value overrides the value provided by the pod spec.
+                                        Value must be non-negative integer. The value zero indicates stop immediately via
+                                        the kill signal (no opportunity to shut down).
+                                        This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
+                                        Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
+                                      format: int64
+                                      type: integer
+                                    timeoutSeconds:
+                                      description: |-
+                                        Number of seconds after which the probe times out.
+                                        Defaults to 1 second. Minimum value is 1.
+                                        More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                      format: int32
+                                      type: integer
+                                  type: object
+                                resizePolicy:
+                                  description: Resources resize policy for the container.
+                                  items:
+                                    description: ContainerResizePolicy represents
+                                      resource resize policy for the container.
+                                    properties:
+                                      resourceName:
+                                        description: |-
+                                          Name of the resource to which this resource resize policy applies.
+                                          Supported values: cpu, memory.
+                                        type: string
+                                      restartPolicy:
+                                        description: |-
+                                          Restart policy to apply when specified resource is resized.
+                                          If not specified, it defaults to NotRequired.
+                                        type: string
+                                    required:
+                                    - resourceName
+                                    - restartPolicy
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                resources:
+                                  description: |-
+                                    Resources are not allowed for ephemeral containers. Ephemeral containers use spare resources
+                                    already allocated to the pod.
+                                  properties:
+                                    claims:
+                                      description: |-
+                                        Claims lists the names of resources, defined in spec.resourceClaims,
+                                        that are used by this container.
+
+                                        This field depends on the
+                                        DynamicResourceAllocation feature gate.
+
+                                        This field is immutable. It can only be set for containers.
+                                      items:
+                                        description: ResourceClaim references one
+                                          entry in PodSpec.ResourceClaims.
+                                        properties:
+                                          name:
+                                            description: |-
+                                              Name must match the name of one entry in pod.spec.resourceClaims of
+                                              the Pod where this field is used. It makes that resource available
+                                              inside a container.
+                                            type: string
+                                          request:
+                                            description: |-
+                                              Request is the name chosen for a request in the referenced claim.
+                                              If empty, everything from the claim is made available, otherwise
+                                              only the result of this request.
+                                            type: string
+                                        required:
+                                        - name
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                      - name
+                                      x-kubernetes-list-type: map
+                                    limits:
+                                      additionalProperties:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
+                                      description: |-
+                                        Limits describes the maximum amount of compute resources allowed.
+                                        More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                      type: object
+                                    requests:
+                                      additionalProperties:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
+                                      description: |-
+                                        Requests describes the minimum amount of compute resources required.
+                                        If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                                        otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                                        More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                      type: object
+                                  type: object
+                                restartPolicy:
+                                  description: |-
+                                    Restart policy for the container to manage the restart behavior of each
+                                    container within a pod.
+                                    You cannot set this field on ephemeral containers.
+                                  type: string
+                                restartPolicyRules:
+                                  description: |-
+                                    Represents a list of rules to be checked to determine if the
+                                    container should be restarted on exit. You cannot set this field on
+                                    ephemeral containers.
+                                  items:
+                                    description: ContainerRestartRule describes how
+                                      a container exit is handled.
+                                    properties:
+                                      action:
+                                        description: |-
+                                          Specifies the action taken on a container exit if the requirements
+                                          are satisfied. The only possible value is "Restart" to restart the
+                                          container.
+                                        type: string
+                                      exitCodes:
+                                        description: Represents the exit codes to
+                                          check on container exits.
+                                        properties:
+                                          operator:
+                                            description: |-
+                                              Represents the relationship between the container exit code(s) and the
+                                              specified values. Possible values are:
+                                              - In: the requirement is satisfied if the container exit code is in the
+                                                set of specified values.
+                                              - NotIn: the requirement is satisfied if the container exit code is
+                                                not in the set of specified values.
+                                            type: string
+                                          values:
+                                            description: |-
+                                              Specifies the set of values to check for container exit codes.
+                                              At most 255 elements are allowed.
+                                            items:
+                                              format: int32
+                                              type: integer
+                                            type: array
+                                            x-kubernetes-list-type: set
+                                        required:
+                                        - operator
+                                        type: object
+                                    required:
+                                    - action
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                securityContext:
+                                  description: |-
+                                    Optional: SecurityContext defines the security options the ephemeral container should be run with.
+                                    If set, the fields of SecurityContext override the equivalent fields of PodSecurityContext.
+                                  properties:
+                                    allowPrivilegeEscalation:
+                                      description: |-
+                                        AllowPrivilegeEscalation controls whether a process can gain more
+                                        privileges than its parent process. This bool directly controls if
+                                        the no_new_privs flag will be set on the container process.
+                                        AllowPrivilegeEscalation is true always when the container is:
+                                        1) run as Privileged
+                                        2) has CAP_SYS_ADMIN
+                                        Note that this field cannot be set when spec.os.name is windows.
+                                      type: boolean
+                                    appArmorProfile:
+                                      description: |-
+                                        appArmorProfile is the AppArmor options to use by this container. If set, this profile
+                                        overrides the pod's appArmorProfile.
+                                        Note that this field cannot be set when spec.os.name is windows.
+                                      properties:
+                                        localhostProfile:
+                                          description: |-
+                                            localhostProfile indicates a profile loaded on the node that should be used.
+                                            The profile must be preconfigured on the node to work.
+                                            Must match the loaded name of the profile.
+                                            Must be set if and only if type is "Localhost".
+                                          type: string
+                                        type:
+                                          description: |-
+                                            type indicates which kind of AppArmor profile will be applied.
+                                            Valid options are:
+                                              Localhost - a profile pre-loaded on the node.
+                                              RuntimeDefault - the container runtime's default profile.
+                                              Unconfined - no AppArmor enforcement.
+                                          type: string
+                                      required:
+                                      - type
+                                      type: object
+                                    capabilities:
+                                      description: |-
+                                        The capabilities to add/drop when running containers.
+                                        Defaults to the default set of capabilities granted by the container runtime.
+                                        Note that this field cannot be set when spec.os.name is windows.
+                                      properties:
+                                        add:
+                                          description: Added capabilities
+                                          items:
+                                            description: Capability represent POSIX
+                                              capabilities type
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        drop:
+                                          description: Removed capabilities
+                                          items:
+                                            description: Capability represent POSIX
+                                              capabilities type
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                      type: object
+                                    privileged:
+                                      description: |-
+                                        Run container in privileged mode.
+                                        Processes in privileged containers are essentially equivalent to root on the host.
+                                        Defaults to false.
+                                        Note that this field cannot be set when spec.os.name is windows.
+                                      type: boolean
+                                    procMount:
+                                      description: |-
+                                        procMount denotes the type of proc mount to use for the containers.
+                                        The default value is Default which uses the container runtime defaults for
+                                        readonly paths and masked paths.
+                                        This requires the ProcMountType feature flag to be enabled.
+                                        Note that this field cannot be set when spec.os.name is windows.
+                                      type: string
+                                    readOnlyRootFilesystem:
+                                      description: |-
+                                        Whether this container has a read-only root filesystem.
+                                        Default is false.
+                                        Note that this field cannot be set when spec.os.name is windows.
+                                      type: boolean
+                                    runAsGroup:
+                                      description: |-
+                                        The GID to run the entrypoint of the container process.
+                                        Uses runtime default if unset.
+                                        May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                        PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                        Note that this field cannot be set when spec.os.name is windows.
+                                      format: int64
+                                      type: integer
+                                    runAsNonRoot:
+                                      description: |-
+                                        Indicates that the container must run as a non-root user.
+                                        If true, the Kubelet will validate the image at runtime to ensure that it
+                                        does not run as UID 0 (root) and fail to start the container if it does.
+                                        If unset or false, no such validation will be performed.
+                                        May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                        PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                      type: boolean
+                                    runAsUser:
+                                      description: |-
+                                        The UID to run the entrypoint of the container process.
+                                        Defaults to user specified in image metadata if unspecified.
+                                        May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                        PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                        Note that this field cannot be set when spec.os.name is windows.
+                                      format: int64
+                                      type: integer
+                                    seLinuxOptions:
+                                      description: |-
+                                        The SELinux context to be applied to the container.
+                                        If unspecified, the container runtime will allocate a random SELinux context for each
+                                        container.  May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                        PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                        Note that this field cannot be set when spec.os.name is windows.
+                                      properties:
+                                        level:
+                                          description: Level is SELinux level label
+                                            that applies to the container.
+                                          type: string
+                                        role:
+                                          description: Role is a SELinux role label
+                                            that applies to the container.
+                                          type: string
+                                        type:
+                                          description: Type is a SELinux type label
+                                            that applies to the container.
+                                          type: string
+                                        user:
+                                          description: User is a SELinux user label
+                                            that applies to the container.
+                                          type: string
+                                      type: object
+                                    seccompProfile:
+                                      description: |-
+                                        The seccomp options to use by this container. If seccomp options are
+                                        provided at both the pod & container level, the container options
+                                        override the pod options.
+                                        Note that this field cannot be set when spec.os.name is windows.
+                                      properties:
+                                        localhostProfile:
+                                          description: |-
+                                            localhostProfile indicates a profile defined in a file on the node should be used.
+                                            The profile must be preconfigured on the node to work.
+                                            Must be a descending path, relative to the kubelet's configured seccomp profile location.
+                                            Must be set if type is "Localhost". Must NOT be set for any other type.
+                                          type: string
+                                        type:
+                                          description: |-
+                                            type indicates which kind of seccomp profile will be applied.
+                                            Valid options are:
+
+                                            Localhost - a profile defined in a file on the node should be used.
+                                            RuntimeDefault - the container runtime default profile should be used.
+                                            Unconfined - no profile should be applied.
+                                          type: string
+                                      required:
+                                      - type
+                                      type: object
+                                    windowsOptions:
+                                      description: |-
+                                        The Windows specific settings applied to all containers.
+                                        If unspecified, the options from the PodSecurityContext will be used.
+                                        If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                        Note that this field cannot be set when spec.os.name is linux.
+                                      properties:
+                                        gmsaCredentialSpec:
+                                          description: |-
+                                            GMSACredentialSpec is where the GMSA admission webhook
+                                            (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the
+                                            GMSA credential spec named by the GMSACredentialSpecName field.
+                                          type: string
+                                        gmsaCredentialSpecName:
+                                          description: GMSACredentialSpecName is the
+                                            name of the GMSA credential spec to use.
+                                          type: string
+                                        hostProcess:
+                                          description: |-
+                                            HostProcess determines if a container should be run as a 'Host Process' container.
+                                            All of a Pod's containers must have the same effective HostProcess value
+                                            (it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).
+                                            In addition, if HostProcess is true then HostNetwork must also be set to true.
+                                          type: boolean
+                                        runAsUserName:
+                                          description: |-
+                                            The UserName in Windows to run the entrypoint of the container process.
+                                            Defaults to the user specified in image metadata if unspecified.
+                                            May also be set in PodSecurityContext. If set in both SecurityContext and
+                                            PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                          type: string
+                                      type: object
+                                  type: object
+                                startupProbe:
+                                  description: Probes are not allowed for ephemeral
+                                    containers.
+                                  properties:
+                                    exec:
+                                      description: Exec specifies a command to execute
+                                        in the container.
+                                      properties:
+                                        command:
+                                          description: |-
+                                            Command is the command line to execute inside the container, the working directory for the
+                                            command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                            not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                            a shell, you need to explicitly call out to that shell.
+                                            Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                      type: object
+                                    failureThreshold:
+                                      description: |-
+                                        Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                                        Defaults to 3. Minimum value is 1.
+                                      format: int32
+                                      type: integer
+                                    grpc:
+                                      description: GRPC specifies a GRPC HealthCheckRequest.
+                                      properties:
+                                        port:
+                                          description: Port number of the gRPC service.
+                                            Number must be in the range 1 to 65535.
+                                          format: int32
+                                          type: integer
+                                        service:
+                                          default: ""
+                                          description: |-
+                                            Service is the name of the service to place in the gRPC HealthCheckRequest
+                                            (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                            If this is not specified, the default behavior is defined by gRPC.
+                                          type: string
+                                      required:
+                                      - port
+                                      type: object
+                                    httpGet:
+                                      description: HTTPGet specifies an HTTP GET request
+                                        to perform.
+                                      properties:
+                                        host:
+                                          description: |-
+                                            Host name to connect to, defaults to the pod IP. You probably want to set
+                                            "Host" in httpHeaders instead.
+                                          type: string
+                                        httpHeaders:
+                                          description: Custom headers to set in the
+                                            request. HTTP allows repeated headers.
+                                          items:
+                                            description: HTTPHeader describes a custom
+                                              header to be used in HTTP probes
+                                            properties:
+                                              name:
+                                                description: |-
+                                                  The header field name.
+                                                  This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                                type: string
+                                              value:
+                                                description: The header field value
+                                                type: string
+                                            required:
+                                            - name
+                                            - value
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        path:
+                                          description: Path to access on the HTTP
+                                            server.
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          description: |-
+                                            Name or number of the port to access on the container.
+                                            Number must be in the range 1 to 65535.
+                                            Name must be an IANA_SVC_NAME.
+                                          x-kubernetes-int-or-string: true
+                                        scheme:
+                                          description: |-
+                                            Scheme to use for connecting to the host.
+                                            Defaults to HTTP.
+                                          type: string
+                                      required:
+                                      - port
+                                      type: object
+                                    initialDelaySeconds:
+                                      description: |-
+                                        Number of seconds after the container has started before liveness probes are initiated.
+                                        More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                      format: int32
+                                      type: integer
+                                    periodSeconds:
+                                      description: |-
+                                        How often (in seconds) to perform the probe.
+                                        Default to 10 seconds. Minimum value is 1.
+                                      format: int32
+                                      type: integer
+                                    successThreshold:
+                                      description: |-
+                                        Minimum consecutive successes for the probe to be considered successful after having failed.
+                                        Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
+                                      format: int32
+                                      type: integer
+                                    tcpSocket:
+                                      description: TCPSocket specifies a connection
+                                        to a TCP port.
+                                      properties:
+                                        host:
+                                          description: 'Optional: Host name to connect
+                                            to, defaults to the pod IP.'
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          description: |-
+                                            Number or name of the port to access on the container.
+                                            Number must be in the range 1 to 65535.
+                                            Name must be an IANA_SVC_NAME.
+                                          x-kubernetes-int-or-string: true
+                                      required:
+                                      - port
+                                      type: object
+                                    terminationGracePeriodSeconds:
+                                      description: |-
+                                        Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                                        The grace period is the duration in seconds after the processes running in the pod are sent
+                                        a termination signal and the time when the processes are forcibly halted with a kill signal.
+                                        Set this value longer than the expected cleanup time for your process.
+                                        If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
+                                        value overrides the value provided by the pod spec.
+                                        Value must be non-negative integer. The value zero indicates stop immediately via
+                                        the kill signal (no opportunity to shut down).
+                                        This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
+                                        Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
+                                      format: int64
+                                      type: integer
+                                    timeoutSeconds:
+                                      description: |-
+                                        Number of seconds after which the probe times out.
+                                        Defaults to 1 second. Minimum value is 1.
+                                        More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                      format: int32
+                                      type: integer
+                                  type: object
+                                stdin:
+                                  description: |-
+                                    Whether this container should allocate a buffer for stdin in the container runtime. If this
+                                    is not set, reads from stdin in the container will always result in EOF.
+                                    Default is false.
+                                  type: boolean
+                                stdinOnce:
+                                  description: |-
+                                    Whether the container runtime should close the stdin channel after it has been opened by
+                                    a single attach. When stdin is true the stdin stream will remain open across multiple attach
+                                    sessions. If stdinOnce is set to true, stdin is opened on container start, is empty until the
+                                    first client attaches to stdin, and then remains open and accepts data until the client disconnects,
+                                    at which time stdin is closed and remains closed until the container is restarted. If this
+                                    flag is false, a container processes that reads from stdin will never receive an EOF.
+                                    Default is false
+                                  type: boolean
+                                targetContainerName:
+                                  description: |-
+                                    If set, the name of the container from PodSpec that this ephemeral container targets.
+                                    The ephemeral container will be run in the namespaces (IPC, PID, etc) of this container.
+                                    If not set then the ephemeral container uses the namespaces configured in the Pod spec.
+
+                                    The container runtime must implement support for this feature. If the runtime does not
+                                    support namespace targeting then the result of setting this field is undefined.
+                                  type: string
+                                terminationMessagePath:
+                                  description: |-
+                                    Optional: Path at which the file to which the container's termination message
+                                    will be written is mounted into the container's filesystem.
+                                    Message written is intended to be brief final status, such as an assertion failure message.
+                                    Will be truncated by the node if greater than 4096 bytes. The total message length across
+                                    all containers will be limited to 12kb.
+                                    Defaults to /dev/termination-log.
+                                    Cannot be updated.
+                                  type: string
+                                terminationMessagePolicy:
+                                  description: |-
+                                    Indicate how the termination message should be populated. File will use the contents of
+                                    terminationMessagePath to populate the container status message on both success and failure.
+                                    FallbackToLogsOnError will use the last chunk of container log output if the termination
+                                    message file is empty and the container exited with an error.
+                                    The log output is limited to 2048 bytes or 80 lines, whichever is smaller.
+                                    Defaults to File.
+                                    Cannot be updated.
+                                  type: string
+                                tty:
+                                  description: |-
+                                    Whether this container should allocate a TTY for itself, also requires 'stdin' to be true.
+                                    Default is false.
+                                  type: boolean
+                                volumeDevices:
+                                  description: volumeDevices is the list of block
+                                    devices to be used by the container.
+                                  items:
+                                    description: volumeDevice describes a mapping
+                                      of a raw block device within a container.
+                                    properties:
+                                      devicePath:
+                                        description: devicePath is the path inside
+                                          of the container that the device will be
+                                          mapped to.
+                                        type: string
+                                      name:
+                                        description: name must match the name of a
+                                          persistentVolumeClaim in the pod
+                                        type: string
+                                    required:
+                                    - devicePath
+                                    - name
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                  - devicePath
+                                  x-kubernetes-list-type: map
+                                volumeMounts:
+                                  description: |-
+                                    Pod volumes to mount into the container's filesystem. Subpath mounts are not allowed for ephemeral containers.
+                                    Cannot be updated.
+                                  items:
+                                    description: VolumeMount describes a mounting
+                                      of a Volume within a container.
+                                    properties:
+                                      mountPath:
+                                        description: |-
+                                          Path within the container at which the volume should be mounted.  Must
+                                          not contain ':'.
+                                        type: string
+                                      mountPropagation:
+                                        description: |-
+                                          mountPropagation determines how mounts are propagated from the host
+                                          to container and the other way around.
+                                          When not set, MountPropagationNone is used.
+                                          This field is beta in 1.10.
+                                          When RecursiveReadOnly is set to IfPossible or to Enabled, MountPropagation must be None or unspecified
+                                          (which defaults to None).
+                                        type: string
+                                      name:
+                                        description: This must match the Name of a
+                                          Volume.
+                                        type: string
+                                      readOnly:
+                                        description: |-
+                                          Mounted read-only if true, read-write otherwise (false or unspecified).
+                                          Defaults to false.
+                                        type: boolean
+                                      recursiveReadOnly:
+                                        description: |-
+                                          RecursiveReadOnly specifies whether read-only mounts should be handled
+                                          recursively.
+
+                                          If ReadOnly is false, this field has no meaning and must be unspecified.
+
+                                          If ReadOnly is true, and this field is set to Disabled, the mount is not made
+                                          recursively read-only.  If this field is set to IfPossible, the mount is made
+                                          recursively read-only, if it is supported by the container runtime.  If this
+                                          field is set to Enabled, the mount is made recursively read-only if it is
+                                          supported by the container runtime, otherwise the pod will not be started and
+                                          an error will be generated to indicate the reason.
+
+                                          If this field is set to IfPossible or Enabled, MountPropagation must be set to
+                                          None (or be unspecified, which defaults to None).
+
+                                          If this field is not specified, it is treated as an equivalent of Disabled.
+                                        type: string
+                                      subPath:
+                                        description: |-
+                                          Path within the volume from which the container's volume should be mounted.
+                                          Defaults to "" (volume's root).
+                                        type: string
+                                      subPathExpr:
+                                        description: |-
+                                          Expanded path within the volume from which the container's volume should be mounted.
+                                          Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment.
+                                          Defaults to "" (volume's root).
+                                          SubPathExpr and SubPath are mutually exclusive.
+                                        type: string
+                                    required:
+                                    - mountPath
+                                    - name
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                  - mountPath
+                                  x-kubernetes-list-type: map
+                                workingDir:
+                                  description: |-
+                                    Container's working directory.
+                                    If not specified, the container runtime's default will be used, which
+                                    might be configured in the container image.
+                                    Cannot be updated.
+                                  type: string
+                              required:
+                              - name
+                              type: object
+                            type: array
+                            x-kubernetes-list-map-keys:
+                            - name
+                            x-kubernetes-list-type: map
+                          hostAliases:
+                            description: |-
+                              HostAliases is an optional list of hosts and IPs that will be injected into the pod's hosts
+                              file if specified.
+                            items:
+                              description: |-
+                                HostAlias holds the mapping between IP and hostnames that will be injected as an entry in the
+                                pod's hosts file.
+                              properties:
+                                hostnames:
+                                  description: Hostnames for the above IP address.
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                ip:
+                                  description: IP address of the host file entry.
+                                  type: string
+                              required:
+                              - ip
+                              type: object
+                            type: array
+                            x-kubernetes-list-map-keys:
+                            - ip
+                            x-kubernetes-list-type: map
+                          hostIPC:
+                            description: |-
+                              Use the host's ipc namespace.
+                              Optional: Default to false.
+                            type: boolean
+                          hostNetwork:
+                            description: |-
+                              Host networking requested for this pod. Use the host's network namespace.
+                              When using HostNetwork you should specify ports so the scheduler is aware.
+                              When `hostNetwork` is true, specified `hostPort` fields in port definitions must match `containerPort`,
+                              and unspecified `hostPort` fields in port definitions are defaulted to match `containerPort`.
+                              Default to false.
+                            type: boolean
+                          hostPID:
+                            description: |-
+                              Use the host's pid namespace.
+                              Optional: Default to false.
+                            type: boolean
+                          hostUsers:
+                            description: |-
+                              Use the host's user namespace.
+                              Optional: Default to true.
+                              If set to true or not present, the pod will be run in the host user namespace, useful
+                              for when the pod needs a feature only available to the host user namespace, such as
+                              loading a kernel module with CAP_SYS_MODULE.
+                              When set to false, a new userns is created for the pod. Setting false is useful for
+                              mitigating container breakout vulnerabilities even allowing users to run their
+                              containers as root without actually having root privileges on the host.
+                              This field is alpha-level and is only honored by servers that enable the UserNamespacesSupport feature.
+                            type: boolean
+                          hostname:
+                            description: |-
+                              Specifies the hostname of the Pod
+                              If not specified, the pod's hostname will be set to a system-defined value.
+                            type: string
+                          hostnameOverride:
+                            description: |-
+                              HostnameOverride specifies an explicit override for the pod's hostname as perceived by the pod.
+                              This field only specifies the pod's hostname and does not affect its DNS records.
+                              When this field is set to a non-empty string:
+                              - It takes precedence over the values set in `hostname` and `subdomain`.
+                              - The Pod's hostname will be set to this value.
+                              - `setHostnameAsFQDN` must be nil or set to false.
+                              - `hostNetwork` must be set to false.
+
+                              This field must be a valid DNS subdomain as defined in RFC 1123 and contain at most 64 characters.
+                              Requires the HostnameOverride feature gate to be enabled.
+                            type: string
+                          imagePullSecrets:
+                            description: |-
+                              ImagePullSecrets is an optional list of references to secrets in the same namespace to use for pulling any of the images used by this PodSpec.
+                              If specified, these secrets will be passed to individual puller implementations for them to use.
+                              More info: https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod
+                            items:
+                              description: |-
+                                LocalObjectReference contains enough information to let you locate the
+                                referenced object inside the same namespace.
+                              properties:
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            type: array
+                            x-kubernetes-list-map-keys:
+                            - name
+                            x-kubernetes-list-type: map
+                          initContainers:
+                            description: |-
+                              List of initialization containers belonging to the pod.
+                              Init containers are executed in order prior to containers being started. If any
+                              init container fails, the pod is considered to have failed and is handled according
+                              to its restartPolicy. The name for an init container or normal container must be
+                              unique among all containers.
+                              Init containers may not have Lifecycle actions, Readiness probes, Liveness probes, or Startup probes.
+                              The resourceRequirements of an init container are taken into account during scheduling
+                              by finding the highest request/limit for each resource type, and then using the max of
+                              that value or the sum of the normal containers. Limits are applied to init containers
+                              in a similar fashion.
+                              Init containers cannot currently be added or removed.
+                              Cannot be updated.
+                              More info: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/
+                            items:
+                              description: A single application container that you
+                                want to run within a pod.
+                              properties:
+                                args:
+                                  description: |-
+                                    Arguments to the entrypoint.
+                                    The container image's CMD is used if this is not provided.
+                                    Variable references $(VAR_NAME) are expanded using the container's environment. If a variable
+                                    cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced
+                                    to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will
+                                    produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless
+                                    of whether the variable exists or not. Cannot be updated.
+                                    More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                command:
+                                  description: |-
+                                    Entrypoint array. Not executed within a shell.
+                                    The container image's ENTRYPOINT is used if this is not provided.
+                                    Variable references $(VAR_NAME) are expanded using the container's environment. If a variable
+                                    cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced
+                                    to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will
+                                    produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless
+                                    of whether the variable exists or not. Cannot be updated.
+                                    More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                env:
+                                  description: |-
+                                    List of environment variables to set in the container.
+                                    Cannot be updated.
+                                  items:
+                                    description: EnvVar represents an environment
+                                      variable present in a Container.
+                                    properties:
+                                      name:
+                                        description: |-
+                                          Name of the environment variable.
+                                          May consist of any printable ASCII characters except '='.
+                                        type: string
+                                      value:
+                                        description: |-
+                                          Variable references $(VAR_NAME) are expanded
+                                          using the previously defined environment variables in the container and
+                                          any service environment variables. If a variable cannot be resolved,
+                                          the reference in the input string will be unchanged. Double $$ are reduced
+                                          to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                                          "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                                          Escaped references will never be expanded, regardless of whether the variable
+                                          exists or not.
+                                          Defaults to "".
+                                        type: string
+                                      valueFrom:
+                                        description: Source for the environment variable's
+                                          value. Cannot be used if value is not empty.
+                                        properties:
+                                          configMapKeyRef:
+                                            description: Selects a key of a ConfigMap.
+                                            properties:
+                                              key:
+                                                description: The key to select.
+                                                type: string
+                                              name:
+                                                default: ""
+                                                description: |-
+                                                  Name of the referent.
+                                                  This field is effectively required, but due to backwards compatibility is
+                                                  allowed to be empty. Instances of this type with an empty value here are
+                                                  almost certainly wrong.
+                                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                type: string
+                                              optional:
+                                                description: Specify whether the ConfigMap
+                                                  or its key must be defined
+                                                type: boolean
+                                            required:
+                                            - key
+                                            type: object
+                                            x-kubernetes-map-type: atomic
+                                          fieldRef:
+                                            description: |-
+                                              Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                                              spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+                                            properties:
+                                              apiVersion:
+                                                description: Version of the schema
+                                                  the FieldPath is written in terms
+                                                  of, defaults to "v1".
+                                                type: string
+                                              fieldPath:
+                                                description: Path of the field to
+                                                  select in the specified API version.
+                                                type: string
+                                            required:
+                                            - fieldPath
+                                            type: object
+                                            x-kubernetes-map-type: atomic
+                                          fileKeyRef:
+                                            description: |-
+                                              FileKeyRef selects a key of the env file.
+                                              Requires the EnvFiles feature gate to be enabled.
+                                            properties:
+                                              key:
+                                                description: |-
+                                                  The key within the env file. An invalid key will prevent the pod from starting.
+                                                  The keys defined within a source may consist of any printable ASCII characters except '='.
+                                                  During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
+                                                type: string
+                                              optional:
+                                                default: false
+                                                description: |-
+                                                  Specify whether the file or its key must be defined. If the file or key
+                                                  does not exist, then the env var is not published.
+                                                  If optional is set to true and the specified key does not exist,
+                                                  the environment variable will not be set in the Pod's containers.
+
+                                                  If optional is set to false and the specified key does not exist,
+                                                  an error will be returned during Pod creation.
+                                                type: boolean
+                                              path:
+                                                description: |-
+                                                  The path within the volume from which to select the file.
+                                                  Must be relative and may not contain the '..' path or start with '..'.
+                                                type: string
+                                              volumeName:
+                                                description: The name of the volume
+                                                  mount containing the env file.
+                                                type: string
+                                            required:
+                                            - key
+                                            - path
+                                            - volumeName
+                                            type: object
+                                            x-kubernetes-map-type: atomic
+                                          resourceFieldRef:
+                                            description: |-
+                                              Selects a resource of the container: only resources limits and requests
+                                              (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+                                            properties:
+                                              containerName:
+                                                description: 'Container name: required
+                                                  for volumes, optional for env vars'
+                                                type: string
+                                              divisor:
+                                                anyOf:
+                                                - type: integer
+                                                - type: string
+                                                description: Specifies the output
+                                                  format of the exposed resources,
+                                                  defaults to "1"
+                                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                x-kubernetes-int-or-string: true
+                                              resource:
+                                                description: 'Required: resource to
+                                                  select'
+                                                type: string
+                                            required:
+                                            - resource
+                                            type: object
+                                            x-kubernetes-map-type: atomic
+                                          secretKeyRef:
+                                            description: Selects a key of a secret
+                                              in the pod's namespace
+                                            properties:
+                                              key:
+                                                description: The key of the secret
+                                                  to select from.  Must be a valid
+                                                  secret key.
+                                                type: string
+                                              name:
+                                                default: ""
+                                                description: |-
+                                                  Name of the referent.
+                                                  This field is effectively required, but due to backwards compatibility is
+                                                  allowed to be empty. Instances of this type with an empty value here are
+                                                  almost certainly wrong.
+                                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                type: string
+                                              optional:
+                                                description: Specify whether the Secret
+                                                  or its key must be defined
+                                                type: boolean
+                                            required:
+                                            - key
+                                            type: object
+                                            x-kubernetes-map-type: atomic
+                                        type: object
+                                    required:
+                                    - name
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                  - name
+                                  x-kubernetes-list-type: map
+                                envFrom:
+                                  description: |-
+                                    List of sources to populate environment variables in the container.
+                                    The keys defined within a source may consist of any printable ASCII characters except '='.
+                                    When a key exists in multiple
+                                    sources, the value associated with the last source will take precedence.
+                                    Values defined by an Env with a duplicate key will take precedence.
+                                    Cannot be updated.
+                                  items:
+                                    description: EnvFromSource represents the source
+                                      of a set of ConfigMaps or Secrets
+                                    properties:
+                                      configMapRef:
+                                        description: The ConfigMap to select from
+                                        properties:
+                                          name:
+                                            default: ""
+                                            description: |-
+                                              Name of the referent.
+                                              This field is effectively required, but due to backwards compatibility is
+                                              allowed to be empty. Instances of this type with an empty value here are
+                                              almost certainly wrong.
+                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                            type: string
+                                          optional:
+                                            description: Specify whether the ConfigMap
+                                              must be defined
+                                            type: boolean
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      prefix:
+                                        description: |-
+                                          Optional text to prepend to the name of each environment variable.
+                                          May consist of any printable ASCII characters except '='.
+                                        type: string
+                                      secretRef:
+                                        description: The Secret to select from
+                                        properties:
+                                          name:
+                                            default: ""
+                                            description: |-
+                                              Name of the referent.
+                                              This field is effectively required, but due to backwards compatibility is
+                                              allowed to be empty. Instances of this type with an empty value here are
+                                              almost certainly wrong.
+                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                            type: string
+                                          optional:
+                                            description: Specify whether the Secret
+                                              must be defined
+                                            type: boolean
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                image:
+                                  description: |-
+                                    Container image name.
+                                    More info: https://kubernetes.io/docs/concepts/containers/images
+                                    This field is optional to allow higher level config management to default or override
+                                    container images in workload controllers like Deployments and StatefulSets.
+                                  type: string
+                                imagePullPolicy:
+                                  description: |-
+                                    Image pull policy.
+                                    One of Always, Never, IfNotPresent.
+                                    Defaults to Always if :latest tag is specified, or IfNotPresent otherwise.
+                                    Cannot be updated.
+                                    More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
+                                  type: string
+                                lifecycle:
+                                  description: |-
+                                    Actions that the management system should take in response to container lifecycle events.
+                                    Cannot be updated.
+                                  properties:
+                                    postStart:
+                                      description: |-
+                                        PostStart is called immediately after a container is created. If the handler fails,
+                                        the container is terminated and restarted according to its restart policy.
+                                        Other management of the container blocks until the hook completes.
+                                        More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
+                                      properties:
+                                        exec:
+                                          description: Exec specifies a command to
+                                            execute in the container.
+                                          properties:
+                                            command:
+                                              description: |-
+                                                Command is the command line to execute inside the container, the working directory for the
+                                                command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                                not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                                a shell, you need to explicitly call out to that shell.
+                                                Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          type: object
+                                        httpGet:
+                                          description: HTTPGet specifies an HTTP GET
+                                            request to perform.
+                                          properties:
+                                            host:
+                                              description: |-
+                                                Host name to connect to, defaults to the pod IP. You probably want to set
+                                                "Host" in httpHeaders instead.
+                                              type: string
+                                            httpHeaders:
+                                              description: Custom headers to set in
+                                                the request. HTTP allows repeated
+                                                headers.
+                                              items:
+                                                description: HTTPHeader describes
+                                                  a custom header to be used in HTTP
+                                                  probes
+                                                properties:
+                                                  name:
+                                                    description: |-
+                                                      The header field name.
+                                                      This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                                    type: string
+                                                  value:
+                                                    description: The header field
+                                                      value
+                                                    type: string
+                                                required:
+                                                - name
+                                                - value
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            path:
+                                              description: Path to access on the HTTP
+                                                server.
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              description: |-
+                                                Name or number of the port to access on the container.
+                                                Number must be in the range 1 to 65535.
+                                                Name must be an IANA_SVC_NAME.
+                                              x-kubernetes-int-or-string: true
+                                            scheme:
+                                              description: |-
+                                                Scheme to use for connecting to the host.
+                                                Defaults to HTTP.
+                                              type: string
+                                          required:
+                                          - port
+                                          type: object
+                                        sleep:
+                                          description: Sleep represents a duration
+                                            that the container should sleep.
+                                          properties:
+                                            seconds:
+                                              description: Seconds is the number of
+                                                seconds to sleep.
+                                              format: int64
+                                              type: integer
+                                          required:
+                                          - seconds
+                                          type: object
+                                        tcpSocket:
+                                          description: |-
+                                            Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
+                                            for backward compatibility. There is no validation of this field and
+                                            lifecycle hooks will fail at runtime when it is specified.
+                                          properties:
+                                            host:
+                                              description: 'Optional: Host name to
+                                                connect to, defaults to the pod IP.'
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              description: |-
+                                                Number or name of the port to access on the container.
+                                                Number must be in the range 1 to 65535.
+                                                Name must be an IANA_SVC_NAME.
+                                              x-kubernetes-int-or-string: true
+                                          required:
+                                          - port
+                                          type: object
+                                      type: object
+                                    preStop:
+                                      description: |-
+                                        PreStop is called immediately before a container is terminated due to an
+                                        API request or management event such as liveness/startup probe failure,
+                                        preemption, resource contention, etc. The handler is not called if the
+                                        container crashes or exits. The Pod's termination grace period countdown begins before the
+                                        PreStop hook is executed. Regardless of the outcome of the handler, the
+                                        container will eventually terminate within the Pod's termination grace
+                                        period (unless delayed by finalizers). Other management of the container blocks until the hook completes
+                                        or until the termination grace period is reached.
+                                        More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
+                                      properties:
+                                        exec:
+                                          description: Exec specifies a command to
+                                            execute in the container.
+                                          properties:
+                                            command:
+                                              description: |-
+                                                Command is the command line to execute inside the container, the working directory for the
+                                                command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                                not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                                a shell, you need to explicitly call out to that shell.
+                                                Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          type: object
+                                        httpGet:
+                                          description: HTTPGet specifies an HTTP GET
+                                            request to perform.
+                                          properties:
+                                            host:
+                                              description: |-
+                                                Host name to connect to, defaults to the pod IP. You probably want to set
+                                                "Host" in httpHeaders instead.
+                                              type: string
+                                            httpHeaders:
+                                              description: Custom headers to set in
+                                                the request. HTTP allows repeated
+                                                headers.
+                                              items:
+                                                description: HTTPHeader describes
+                                                  a custom header to be used in HTTP
+                                                  probes
+                                                properties:
+                                                  name:
+                                                    description: |-
+                                                      The header field name.
+                                                      This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                                    type: string
+                                                  value:
+                                                    description: The header field
+                                                      value
+                                                    type: string
+                                                required:
+                                                - name
+                                                - value
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            path:
+                                              description: Path to access on the HTTP
+                                                server.
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              description: |-
+                                                Name or number of the port to access on the container.
+                                                Number must be in the range 1 to 65535.
+                                                Name must be an IANA_SVC_NAME.
+                                              x-kubernetes-int-or-string: true
+                                            scheme:
+                                              description: |-
+                                                Scheme to use for connecting to the host.
+                                                Defaults to HTTP.
+                                              type: string
+                                          required:
+                                          - port
+                                          type: object
+                                        sleep:
+                                          description: Sleep represents a duration
+                                            that the container should sleep.
+                                          properties:
+                                            seconds:
+                                              description: Seconds is the number of
+                                                seconds to sleep.
+                                              format: int64
+                                              type: integer
+                                          required:
+                                          - seconds
+                                          type: object
+                                        tcpSocket:
+                                          description: |-
+                                            Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
+                                            for backward compatibility. There is no validation of this field and
+                                            lifecycle hooks will fail at runtime when it is specified.
+                                          properties:
+                                            host:
+                                              description: 'Optional: Host name to
+                                                connect to, defaults to the pod IP.'
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              description: |-
+                                                Number or name of the port to access on the container.
+                                                Number must be in the range 1 to 65535.
+                                                Name must be an IANA_SVC_NAME.
+                                              x-kubernetes-int-or-string: true
+                                          required:
+                                          - port
+                                          type: object
+                                      type: object
+                                    stopSignal:
+                                      description: |-
+                                        StopSignal defines which signal will be sent to a container when it is being stopped.
+                                        If not specified, the default is defined by the container runtime in use.
+                                        StopSignal can only be set for Pods with a non-empty .spec.os.name
+                                      type: string
+                                  type: object
+                                livenessProbe:
+                                  description: |-
+                                    Periodic probe of container liveness.
+                                    Container will be restarted if the probe fails.
+                                    Cannot be updated.
+                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                  properties:
+                                    exec:
+                                      description: Exec specifies a command to execute
+                                        in the container.
+                                      properties:
+                                        command:
+                                          description: |-
+                                            Command is the command line to execute inside the container, the working directory for the
+                                            command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                            not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                            a shell, you need to explicitly call out to that shell.
+                                            Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                      type: object
+                                    failureThreshold:
+                                      description: |-
+                                        Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                                        Defaults to 3. Minimum value is 1.
+                                      format: int32
+                                      type: integer
+                                    grpc:
+                                      description: GRPC specifies a GRPC HealthCheckRequest.
+                                      properties:
+                                        port:
+                                          description: Port number of the gRPC service.
+                                            Number must be in the range 1 to 65535.
+                                          format: int32
+                                          type: integer
+                                        service:
+                                          default: ""
+                                          description: |-
+                                            Service is the name of the service to place in the gRPC HealthCheckRequest
+                                            (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                            If this is not specified, the default behavior is defined by gRPC.
+                                          type: string
+                                      required:
+                                      - port
+                                      type: object
+                                    httpGet:
+                                      description: HTTPGet specifies an HTTP GET request
+                                        to perform.
+                                      properties:
+                                        host:
+                                          description: |-
+                                            Host name to connect to, defaults to the pod IP. You probably want to set
+                                            "Host" in httpHeaders instead.
+                                          type: string
+                                        httpHeaders:
+                                          description: Custom headers to set in the
+                                            request. HTTP allows repeated headers.
+                                          items:
+                                            description: HTTPHeader describes a custom
+                                              header to be used in HTTP probes
+                                            properties:
+                                              name:
+                                                description: |-
+                                                  The header field name.
+                                                  This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                                type: string
+                                              value:
+                                                description: The header field value
+                                                type: string
+                                            required:
+                                            - name
+                                            - value
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        path:
+                                          description: Path to access on the HTTP
+                                            server.
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          description: |-
+                                            Name or number of the port to access on the container.
+                                            Number must be in the range 1 to 65535.
+                                            Name must be an IANA_SVC_NAME.
+                                          x-kubernetes-int-or-string: true
+                                        scheme:
+                                          description: |-
+                                            Scheme to use for connecting to the host.
+                                            Defaults to HTTP.
+                                          type: string
+                                      required:
+                                      - port
+                                      type: object
+                                    initialDelaySeconds:
+                                      description: |-
+                                        Number of seconds after the container has started before liveness probes are initiated.
+                                        More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                      format: int32
+                                      type: integer
+                                    periodSeconds:
+                                      description: |-
+                                        How often (in seconds) to perform the probe.
+                                        Default to 10 seconds. Minimum value is 1.
+                                      format: int32
+                                      type: integer
+                                    successThreshold:
+                                      description: |-
+                                        Minimum consecutive successes for the probe to be considered successful after having failed.
+                                        Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
+                                      format: int32
+                                      type: integer
+                                    tcpSocket:
+                                      description: TCPSocket specifies a connection
+                                        to a TCP port.
+                                      properties:
+                                        host:
+                                          description: 'Optional: Host name to connect
+                                            to, defaults to the pod IP.'
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          description: |-
+                                            Number or name of the port to access on the container.
+                                            Number must be in the range 1 to 65535.
+                                            Name must be an IANA_SVC_NAME.
+                                          x-kubernetes-int-or-string: true
+                                      required:
+                                      - port
+                                      type: object
+                                    terminationGracePeriodSeconds:
+                                      description: |-
+                                        Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                                        The grace period is the duration in seconds after the processes running in the pod are sent
+                                        a termination signal and the time when the processes are forcibly halted with a kill signal.
+                                        Set this value longer than the expected cleanup time for your process.
+                                        If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
+                                        value overrides the value provided by the pod spec.
+                                        Value must be non-negative integer. The value zero indicates stop immediately via
+                                        the kill signal (no opportunity to shut down).
+                                        This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
+                                        Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
+                                      format: int64
+                                      type: integer
+                                    timeoutSeconds:
+                                      description: |-
+                                        Number of seconds after which the probe times out.
+                                        Defaults to 1 second. Minimum value is 1.
+                                        More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                      format: int32
+                                      type: integer
+                                  type: object
+                                name:
+                                  description: |-
+                                    Name of the container specified as a DNS_LABEL.
+                                    Each container in a pod must have a unique name (DNS_LABEL).
+                                    Cannot be updated.
+                                  type: string
+                                ports:
+                                  description: |-
+                                    List of ports to expose from the container. Not specifying a port here
+                                    DOES NOT prevent that port from being exposed. Any port which is
+                                    listening on the default "0.0.0.0" address inside a container will be
+                                    accessible from the network.
+                                    Modifying this array with strategic merge patch may corrupt the data.
+                                    For more information See https://github.com/kubernetes/kubernetes/issues/108255.
+                                    Cannot be updated.
+                                  items:
+                                    description: ContainerPort represents a network
+                                      port in a single container.
+                                    properties:
+                                      containerPort:
+                                        description: |-
+                                          Number of port to expose on the pod's IP address.
+                                          This must be a valid port number, 0 < x < 65536.
+                                        format: int32
+                                        type: integer
+                                      hostIP:
+                                        description: What host IP to bind the external
+                                          port to.
+                                        type: string
+                                      hostPort:
+                                        description: |-
+                                          Number of port to expose on the host.
+                                          If specified, this must be a valid port number, 0 < x < 65536.
+                                          If HostNetwork is specified, this must match ContainerPort.
+                                          Most containers do not need this.
+                                        format: int32
+                                        type: integer
+                                      name:
+                                        description: |-
+                                          If specified, this must be an IANA_SVC_NAME and unique within the pod. Each
+                                          named port in a pod must have a unique name. Name for the port that can be
+                                          referred to by services.
+                                        type: string
+                                      protocol:
+                                        default: TCP
+                                        description: |-
+                                          Protocol for port. Must be UDP, TCP, or SCTP.
+                                          Defaults to "TCP".
+                                        type: string
+                                    required:
+                                    - containerPort
+                                    - protocol
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                  - containerPort
+                                  - protocol
+                                  x-kubernetes-list-type: map
+                                readinessProbe:
+                                  description: |-
+                                    Periodic probe of container service readiness.
+                                    Container will be removed from service endpoints if the probe fails.
+                                    Cannot be updated.
+                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                  properties:
+                                    exec:
+                                      description: Exec specifies a command to execute
+                                        in the container.
+                                      properties:
+                                        command:
+                                          description: |-
+                                            Command is the command line to execute inside the container, the working directory for the
+                                            command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                            not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                            a shell, you need to explicitly call out to that shell.
+                                            Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                      type: object
+                                    failureThreshold:
+                                      description: |-
+                                        Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                                        Defaults to 3. Minimum value is 1.
+                                      format: int32
+                                      type: integer
+                                    grpc:
+                                      description: GRPC specifies a GRPC HealthCheckRequest.
+                                      properties:
+                                        port:
+                                          description: Port number of the gRPC service.
+                                            Number must be in the range 1 to 65535.
+                                          format: int32
+                                          type: integer
+                                        service:
+                                          default: ""
+                                          description: |-
+                                            Service is the name of the service to place in the gRPC HealthCheckRequest
+                                            (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                            If this is not specified, the default behavior is defined by gRPC.
+                                          type: string
+                                      required:
+                                      - port
+                                      type: object
+                                    httpGet:
+                                      description: HTTPGet specifies an HTTP GET request
+                                        to perform.
+                                      properties:
+                                        host:
+                                          description: |-
+                                            Host name to connect to, defaults to the pod IP. You probably want to set
+                                            "Host" in httpHeaders instead.
+                                          type: string
+                                        httpHeaders:
+                                          description: Custom headers to set in the
+                                            request. HTTP allows repeated headers.
+                                          items:
+                                            description: HTTPHeader describes a custom
+                                              header to be used in HTTP probes
+                                            properties:
+                                              name:
+                                                description: |-
+                                                  The header field name.
+                                                  This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                                type: string
+                                              value:
+                                                description: The header field value
+                                                type: string
+                                            required:
+                                            - name
+                                            - value
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        path:
+                                          description: Path to access on the HTTP
+                                            server.
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          description: |-
+                                            Name or number of the port to access on the container.
+                                            Number must be in the range 1 to 65535.
+                                            Name must be an IANA_SVC_NAME.
+                                          x-kubernetes-int-or-string: true
+                                        scheme:
+                                          description: |-
+                                            Scheme to use for connecting to the host.
+                                            Defaults to HTTP.
+                                          type: string
+                                      required:
+                                      - port
+                                      type: object
+                                    initialDelaySeconds:
+                                      description: |-
+                                        Number of seconds after the container has started before liveness probes are initiated.
+                                        More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                      format: int32
+                                      type: integer
+                                    periodSeconds:
+                                      description: |-
+                                        How often (in seconds) to perform the probe.
+                                        Default to 10 seconds. Minimum value is 1.
+                                      format: int32
+                                      type: integer
+                                    successThreshold:
+                                      description: |-
+                                        Minimum consecutive successes for the probe to be considered successful after having failed.
+                                        Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
+                                      format: int32
+                                      type: integer
+                                    tcpSocket:
+                                      description: TCPSocket specifies a connection
+                                        to a TCP port.
+                                      properties:
+                                        host:
+                                          description: 'Optional: Host name to connect
+                                            to, defaults to the pod IP.'
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          description: |-
+                                            Number or name of the port to access on the container.
+                                            Number must be in the range 1 to 65535.
+                                            Name must be an IANA_SVC_NAME.
+                                          x-kubernetes-int-or-string: true
+                                      required:
+                                      - port
+                                      type: object
+                                    terminationGracePeriodSeconds:
+                                      description: |-
+                                        Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                                        The grace period is the duration in seconds after the processes running in the pod are sent
+                                        a termination signal and the time when the processes are forcibly halted with a kill signal.
+                                        Set this value longer than the expected cleanup time for your process.
+                                        If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
+                                        value overrides the value provided by the pod spec.
+                                        Value must be non-negative integer. The value zero indicates stop immediately via
+                                        the kill signal (no opportunity to shut down).
+                                        This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
+                                        Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
+                                      format: int64
+                                      type: integer
+                                    timeoutSeconds:
+                                      description: |-
+                                        Number of seconds after which the probe times out.
+                                        Defaults to 1 second. Minimum value is 1.
+                                        More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                      format: int32
+                                      type: integer
+                                  type: object
+                                resizePolicy:
+                                  description: Resources resize policy for the container.
+                                  items:
+                                    description: ContainerResizePolicy represents
+                                      resource resize policy for the container.
+                                    properties:
+                                      resourceName:
+                                        description: |-
+                                          Name of the resource to which this resource resize policy applies.
+                                          Supported values: cpu, memory.
+                                        type: string
+                                      restartPolicy:
+                                        description: |-
+                                          Restart policy to apply when specified resource is resized.
+                                          If not specified, it defaults to NotRequired.
+                                        type: string
+                                    required:
+                                    - resourceName
+                                    - restartPolicy
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                resources:
+                                  description: |-
+                                    Compute Resources required by this container.
+                                    Cannot be updated.
+                                    More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                  properties:
+                                    claims:
+                                      description: |-
+                                        Claims lists the names of resources, defined in spec.resourceClaims,
+                                        that are used by this container.
+
+                                        This field depends on the
+                                        DynamicResourceAllocation feature gate.
+
+                                        This field is immutable. It can only be set for containers.
+                                      items:
+                                        description: ResourceClaim references one
+                                          entry in PodSpec.ResourceClaims.
+                                        properties:
+                                          name:
+                                            description: |-
+                                              Name must match the name of one entry in pod.spec.resourceClaims of
+                                              the Pod where this field is used. It makes that resource available
+                                              inside a container.
+                                            type: string
+                                          request:
+                                            description: |-
+                                              Request is the name chosen for a request in the referenced claim.
+                                              If empty, everything from the claim is made available, otherwise
+                                              only the result of this request.
+                                            type: string
+                                        required:
+                                        - name
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                      - name
+                                      x-kubernetes-list-type: map
+                                    limits:
+                                      additionalProperties:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
+                                      description: |-
+                                        Limits describes the maximum amount of compute resources allowed.
+                                        More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                      type: object
+                                    requests:
+                                      additionalProperties:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
+                                      description: |-
+                                        Requests describes the minimum amount of compute resources required.
+                                        If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                                        otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                                        More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                      type: object
+                                  type: object
+                                restartPolicy:
+                                  description: |-
+                                    RestartPolicy defines the restart behavior of individual containers in a pod.
+                                    This overrides the pod-level restart policy. When this field is not specified,
+                                    the restart behavior is defined by the Pod's restart policy and the container type.
+                                    Additionally, setting the RestartPolicy as "Always" for the init container will
+                                    have the following effect:
+                                    this init container will be continually restarted on
+                                    exit until all regular containers have terminated. Once all regular
+                                    containers have completed, all init containers with restartPolicy "Always"
+                                    will be shut down. This lifecycle differs from normal init containers and
+                                    is often referred to as a "sidecar" container. Although this init
+                                    container still starts in the init container sequence, it does not wait
+                                    for the container to complete before proceeding to the next init
+                                    container. Instead, the next init container starts immediately after this
+                                    init container is started, or after any startupProbe has successfully
+                                    completed.
+                                  type: string
+                                restartPolicyRules:
+                                  description: |-
+                                    Represents a list of rules to be checked to determine if the
+                                    container should be restarted on exit. The rules are evaluated in
+                                    order. Once a rule matches a container exit condition, the remaining
+                                    rules are ignored. If no rule matches the container exit condition,
+                                    the Container-level restart policy determines the whether the container
+                                    is restarted or not. Constraints on the rules:
+                                    - At most 20 rules are allowed.
+                                    - Rules can have the same action.
+                                    - Identical rules are not forbidden in validations.
+                                    When rules are specified, container MUST set RestartPolicy explicitly
+                                    even it if matches the Pod's RestartPolicy.
+                                  items:
+                                    description: ContainerRestartRule describes how
+                                      a container exit is handled.
+                                    properties:
+                                      action:
+                                        description: |-
+                                          Specifies the action taken on a container exit if the requirements
+                                          are satisfied. The only possible value is "Restart" to restart the
+                                          container.
+                                        type: string
+                                      exitCodes:
+                                        description: Represents the exit codes to
+                                          check on container exits.
+                                        properties:
+                                          operator:
+                                            description: |-
+                                              Represents the relationship between the container exit code(s) and the
+                                              specified values. Possible values are:
+                                              - In: the requirement is satisfied if the container exit code is in the
+                                                set of specified values.
+                                              - NotIn: the requirement is satisfied if the container exit code is
+                                                not in the set of specified values.
+                                            type: string
+                                          values:
+                                            description: |-
+                                              Specifies the set of values to check for container exit codes.
+                                              At most 255 elements are allowed.
+                                            items:
+                                              format: int32
+                                              type: integer
+                                            type: array
+                                            x-kubernetes-list-type: set
+                                        required:
+                                        - operator
+                                        type: object
+                                    required:
+                                    - action
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                securityContext:
+                                  description: |-
+                                    SecurityContext defines the security options the container should be run with.
+                                    If set, the fields of SecurityContext override the equivalent fields of PodSecurityContext.
+                                    More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
+                                  properties:
+                                    allowPrivilegeEscalation:
+                                      description: |-
+                                        AllowPrivilegeEscalation controls whether a process can gain more
+                                        privileges than its parent process. This bool directly controls if
+                                        the no_new_privs flag will be set on the container process.
+                                        AllowPrivilegeEscalation is true always when the container is:
+                                        1) run as Privileged
+                                        2) has CAP_SYS_ADMIN
+                                        Note that this field cannot be set when spec.os.name is windows.
+                                      type: boolean
+                                    appArmorProfile:
+                                      description: |-
+                                        appArmorProfile is the AppArmor options to use by this container. If set, this profile
+                                        overrides the pod's appArmorProfile.
+                                        Note that this field cannot be set when spec.os.name is windows.
+                                      properties:
+                                        localhostProfile:
+                                          description: |-
+                                            localhostProfile indicates a profile loaded on the node that should be used.
+                                            The profile must be preconfigured on the node to work.
+                                            Must match the loaded name of the profile.
+                                            Must be set if and only if type is "Localhost".
+                                          type: string
+                                        type:
+                                          description: |-
+                                            type indicates which kind of AppArmor profile will be applied.
+                                            Valid options are:
+                                              Localhost - a profile pre-loaded on the node.
+                                              RuntimeDefault - the container runtime's default profile.
+                                              Unconfined - no AppArmor enforcement.
+                                          type: string
+                                      required:
+                                      - type
+                                      type: object
+                                    capabilities:
+                                      description: |-
+                                        The capabilities to add/drop when running containers.
+                                        Defaults to the default set of capabilities granted by the container runtime.
+                                        Note that this field cannot be set when spec.os.name is windows.
+                                      properties:
+                                        add:
+                                          description: Added capabilities
+                                          items:
+                                            description: Capability represent POSIX
+                                              capabilities type
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        drop:
+                                          description: Removed capabilities
+                                          items:
+                                            description: Capability represent POSIX
+                                              capabilities type
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                      type: object
+                                    privileged:
+                                      description: |-
+                                        Run container in privileged mode.
+                                        Processes in privileged containers are essentially equivalent to root on the host.
+                                        Defaults to false.
+                                        Note that this field cannot be set when spec.os.name is windows.
+                                      type: boolean
+                                    procMount:
+                                      description: |-
+                                        procMount denotes the type of proc mount to use for the containers.
+                                        The default value is Default which uses the container runtime defaults for
+                                        readonly paths and masked paths.
+                                        This requires the ProcMountType feature flag to be enabled.
+                                        Note that this field cannot be set when spec.os.name is windows.
+                                      type: string
+                                    readOnlyRootFilesystem:
+                                      description: |-
+                                        Whether this container has a read-only root filesystem.
+                                        Default is false.
+                                        Note that this field cannot be set when spec.os.name is windows.
+                                      type: boolean
+                                    runAsGroup:
+                                      description: |-
+                                        The GID to run the entrypoint of the container process.
+                                        Uses runtime default if unset.
+                                        May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                        PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                        Note that this field cannot be set when spec.os.name is windows.
+                                      format: int64
+                                      type: integer
+                                    runAsNonRoot:
+                                      description: |-
+                                        Indicates that the container must run as a non-root user.
+                                        If true, the Kubelet will validate the image at runtime to ensure that it
+                                        does not run as UID 0 (root) and fail to start the container if it does.
+                                        If unset or false, no such validation will be performed.
+                                        May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                        PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                      type: boolean
+                                    runAsUser:
+                                      description: |-
+                                        The UID to run the entrypoint of the container process.
+                                        Defaults to user specified in image metadata if unspecified.
+                                        May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                        PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                        Note that this field cannot be set when spec.os.name is windows.
+                                      format: int64
+                                      type: integer
+                                    seLinuxOptions:
+                                      description: |-
+                                        The SELinux context to be applied to the container.
+                                        If unspecified, the container runtime will allocate a random SELinux context for each
+                                        container.  May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                        PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                        Note that this field cannot be set when spec.os.name is windows.
+                                      properties:
+                                        level:
+                                          description: Level is SELinux level label
+                                            that applies to the container.
+                                          type: string
+                                        role:
+                                          description: Role is a SELinux role label
+                                            that applies to the container.
+                                          type: string
+                                        type:
+                                          description: Type is a SELinux type label
+                                            that applies to the container.
+                                          type: string
+                                        user:
+                                          description: User is a SELinux user label
+                                            that applies to the container.
+                                          type: string
+                                      type: object
+                                    seccompProfile:
+                                      description: |-
+                                        The seccomp options to use by this container. If seccomp options are
+                                        provided at both the pod & container level, the container options
+                                        override the pod options.
+                                        Note that this field cannot be set when spec.os.name is windows.
+                                      properties:
+                                        localhostProfile:
+                                          description: |-
+                                            localhostProfile indicates a profile defined in a file on the node should be used.
+                                            The profile must be preconfigured on the node to work.
+                                            Must be a descending path, relative to the kubelet's configured seccomp profile location.
+                                            Must be set if type is "Localhost". Must NOT be set for any other type.
+                                          type: string
+                                        type:
+                                          description: |-
+                                            type indicates which kind of seccomp profile will be applied.
+                                            Valid options are:
+
+                                            Localhost - a profile defined in a file on the node should be used.
+                                            RuntimeDefault - the container runtime default profile should be used.
+                                            Unconfined - no profile should be applied.
+                                          type: string
+                                      required:
+                                      - type
+                                      type: object
+                                    windowsOptions:
+                                      description: |-
+                                        The Windows specific settings applied to all containers.
+                                        If unspecified, the options from the PodSecurityContext will be used.
+                                        If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                        Note that this field cannot be set when spec.os.name is linux.
+                                      properties:
+                                        gmsaCredentialSpec:
+                                          description: |-
+                                            GMSACredentialSpec is where the GMSA admission webhook
+                                            (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the
+                                            GMSA credential spec named by the GMSACredentialSpecName field.
+                                          type: string
+                                        gmsaCredentialSpecName:
+                                          description: GMSACredentialSpecName is the
+                                            name of the GMSA credential spec to use.
+                                          type: string
+                                        hostProcess:
+                                          description: |-
+                                            HostProcess determines if a container should be run as a 'Host Process' container.
+                                            All of a Pod's containers must have the same effective HostProcess value
+                                            (it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).
+                                            In addition, if HostProcess is true then HostNetwork must also be set to true.
+                                          type: boolean
+                                        runAsUserName:
+                                          description: |-
+                                            The UserName in Windows to run the entrypoint of the container process.
+                                            Defaults to the user specified in image metadata if unspecified.
+                                            May also be set in PodSecurityContext. If set in both SecurityContext and
+                                            PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                          type: string
+                                      type: object
+                                  type: object
+                                startupProbe:
+                                  description: |-
+                                    StartupProbe indicates that the Pod has successfully initialized.
+                                    If specified, no other probes are executed until this completes successfully.
+                                    If this probe fails, the Pod will be restarted, just as if the livenessProbe failed.
+                                    This can be used to provide different probe parameters at the beginning of a Pod's lifecycle,
+                                    when it might take a long time to load data or warm a cache, than during steady-state operation.
+                                    This cannot be updated.
+                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                  properties:
+                                    exec:
+                                      description: Exec specifies a command to execute
+                                        in the container.
+                                      properties:
+                                        command:
+                                          description: |-
+                                            Command is the command line to execute inside the container, the working directory for the
+                                            command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                            not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                            a shell, you need to explicitly call out to that shell.
+                                            Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                      type: object
+                                    failureThreshold:
+                                      description: |-
+                                        Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                                        Defaults to 3. Minimum value is 1.
+                                      format: int32
+                                      type: integer
+                                    grpc:
+                                      description: GRPC specifies a GRPC HealthCheckRequest.
+                                      properties:
+                                        port:
+                                          description: Port number of the gRPC service.
+                                            Number must be in the range 1 to 65535.
+                                          format: int32
+                                          type: integer
+                                        service:
+                                          default: ""
+                                          description: |-
+                                            Service is the name of the service to place in the gRPC HealthCheckRequest
+                                            (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                            If this is not specified, the default behavior is defined by gRPC.
+                                          type: string
+                                      required:
+                                      - port
+                                      type: object
+                                    httpGet:
+                                      description: HTTPGet specifies an HTTP GET request
+                                        to perform.
+                                      properties:
+                                        host:
+                                          description: |-
+                                            Host name to connect to, defaults to the pod IP. You probably want to set
+                                            "Host" in httpHeaders instead.
+                                          type: string
+                                        httpHeaders:
+                                          description: Custom headers to set in the
+                                            request. HTTP allows repeated headers.
+                                          items:
+                                            description: HTTPHeader describes a custom
+                                              header to be used in HTTP probes
+                                            properties:
+                                              name:
+                                                description: |-
+                                                  The header field name.
+                                                  This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                                type: string
+                                              value:
+                                                description: The header field value
+                                                type: string
+                                            required:
+                                            - name
+                                            - value
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        path:
+                                          description: Path to access on the HTTP
+                                            server.
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          description: |-
+                                            Name or number of the port to access on the container.
+                                            Number must be in the range 1 to 65535.
+                                            Name must be an IANA_SVC_NAME.
+                                          x-kubernetes-int-or-string: true
+                                        scheme:
+                                          description: |-
+                                            Scheme to use for connecting to the host.
+                                            Defaults to HTTP.
+                                          type: string
+                                      required:
+                                      - port
+                                      type: object
+                                    initialDelaySeconds:
+                                      description: |-
+                                        Number of seconds after the container has started before liveness probes are initiated.
+                                        More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                      format: int32
+                                      type: integer
+                                    periodSeconds:
+                                      description: |-
+                                        How often (in seconds) to perform the probe.
+                                        Default to 10 seconds. Minimum value is 1.
+                                      format: int32
+                                      type: integer
+                                    successThreshold:
+                                      description: |-
+                                        Minimum consecutive successes for the probe to be considered successful after having failed.
+                                        Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
+                                      format: int32
+                                      type: integer
+                                    tcpSocket:
+                                      description: TCPSocket specifies a connection
+                                        to a TCP port.
+                                      properties:
+                                        host:
+                                          description: 'Optional: Host name to connect
+                                            to, defaults to the pod IP.'
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          description: |-
+                                            Number or name of the port to access on the container.
+                                            Number must be in the range 1 to 65535.
+                                            Name must be an IANA_SVC_NAME.
+                                          x-kubernetes-int-or-string: true
+                                      required:
+                                      - port
+                                      type: object
+                                    terminationGracePeriodSeconds:
+                                      description: |-
+                                        Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                                        The grace period is the duration in seconds after the processes running in the pod are sent
+                                        a termination signal and the time when the processes are forcibly halted with a kill signal.
+                                        Set this value longer than the expected cleanup time for your process.
+                                        If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
+                                        value overrides the value provided by the pod spec.
+                                        Value must be non-negative integer. The value zero indicates stop immediately via
+                                        the kill signal (no opportunity to shut down).
+                                        This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
+                                        Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
+                                      format: int64
+                                      type: integer
+                                    timeoutSeconds:
+                                      description: |-
+                                        Number of seconds after which the probe times out.
+                                        Defaults to 1 second. Minimum value is 1.
+                                        More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                      format: int32
+                                      type: integer
+                                  type: object
+                                stdin:
+                                  description: |-
+                                    Whether this container should allocate a buffer for stdin in the container runtime. If this
+                                    is not set, reads from stdin in the container will always result in EOF.
+                                    Default is false.
+                                  type: boolean
+                                stdinOnce:
+                                  description: |-
+                                    Whether the container runtime should close the stdin channel after it has been opened by
+                                    a single attach. When stdin is true the stdin stream will remain open across multiple attach
+                                    sessions. If stdinOnce is set to true, stdin is opened on container start, is empty until the
+                                    first client attaches to stdin, and then remains open and accepts data until the client disconnects,
+                                    at which time stdin is closed and remains closed until the container is restarted. If this
+                                    flag is false, a container processes that reads from stdin will never receive an EOF.
+                                    Default is false
+                                  type: boolean
+                                terminationMessagePath:
+                                  description: |-
+                                    Optional: Path at which the file to which the container's termination message
+                                    will be written is mounted into the container's filesystem.
+                                    Message written is intended to be brief final status, such as an assertion failure message.
+                                    Will be truncated by the node if greater than 4096 bytes. The total message length across
+                                    all containers will be limited to 12kb.
+                                    Defaults to /dev/termination-log.
+                                    Cannot be updated.
+                                  type: string
+                                terminationMessagePolicy:
+                                  description: |-
+                                    Indicate how the termination message should be populated. File will use the contents of
+                                    terminationMessagePath to populate the container status message on both success and failure.
+                                    FallbackToLogsOnError will use the last chunk of container log output if the termination
+                                    message file is empty and the container exited with an error.
+                                    The log output is limited to 2048 bytes or 80 lines, whichever is smaller.
+                                    Defaults to File.
+                                    Cannot be updated.
+                                  type: string
+                                tty:
+                                  description: |-
+                                    Whether this container should allocate a TTY for itself, also requires 'stdin' to be true.
+                                    Default is false.
+                                  type: boolean
+                                volumeDevices:
+                                  description: volumeDevices is the list of block
+                                    devices to be used by the container.
+                                  items:
+                                    description: volumeDevice describes a mapping
+                                      of a raw block device within a container.
+                                    properties:
+                                      devicePath:
+                                        description: devicePath is the path inside
+                                          of the container that the device will be
+                                          mapped to.
+                                        type: string
+                                      name:
+                                        description: name must match the name of a
+                                          persistentVolumeClaim in the pod
+                                        type: string
+                                    required:
+                                    - devicePath
+                                    - name
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                  - devicePath
+                                  x-kubernetes-list-type: map
+                                volumeMounts:
+                                  description: |-
+                                    Pod volumes to mount into the container's filesystem.
+                                    Cannot be updated.
+                                  items:
+                                    description: VolumeMount describes a mounting
+                                      of a Volume within a container.
+                                    properties:
+                                      mountPath:
+                                        description: |-
+                                          Path within the container at which the volume should be mounted.  Must
+                                          not contain ':'.
+                                        type: string
+                                      mountPropagation:
+                                        description: |-
+                                          mountPropagation determines how mounts are propagated from the host
+                                          to container and the other way around.
+                                          When not set, MountPropagationNone is used.
+                                          This field is beta in 1.10.
+                                          When RecursiveReadOnly is set to IfPossible or to Enabled, MountPropagation must be None or unspecified
+                                          (which defaults to None).
+                                        type: string
+                                      name:
+                                        description: This must match the Name of a
+                                          Volume.
+                                        type: string
+                                      readOnly:
+                                        description: |-
+                                          Mounted read-only if true, read-write otherwise (false or unspecified).
+                                          Defaults to false.
+                                        type: boolean
+                                      recursiveReadOnly:
+                                        description: |-
+                                          RecursiveReadOnly specifies whether read-only mounts should be handled
+                                          recursively.
+
+                                          If ReadOnly is false, this field has no meaning and must be unspecified.
+
+                                          If ReadOnly is true, and this field is set to Disabled, the mount is not made
+                                          recursively read-only.  If this field is set to IfPossible, the mount is made
+                                          recursively read-only, if it is supported by the container runtime.  If this
+                                          field is set to Enabled, the mount is made recursively read-only if it is
+                                          supported by the container runtime, otherwise the pod will not be started and
+                                          an error will be generated to indicate the reason.
+
+                                          If this field is set to IfPossible or Enabled, MountPropagation must be set to
+                                          None (or be unspecified, which defaults to None).
+
+                                          If this field is not specified, it is treated as an equivalent of Disabled.
+                                        type: string
+                                      subPath:
+                                        description: |-
+                                          Path within the volume from which the container's volume should be mounted.
+                                          Defaults to "" (volume's root).
+                                        type: string
+                                      subPathExpr:
+                                        description: |-
+                                          Expanded path within the volume from which the container's volume should be mounted.
+                                          Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment.
+                                          Defaults to "" (volume's root).
+                                          SubPathExpr and SubPath are mutually exclusive.
+                                        type: string
+                                    required:
+                                    - mountPath
+                                    - name
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                  - mountPath
+                                  x-kubernetes-list-type: map
+                                workingDir:
+                                  description: |-
+                                    Container's working directory.
+                                    If not specified, the container runtime's default will be used, which
+                                    might be configured in the container image.
+                                    Cannot be updated.
+                                  type: string
+                              required:
+                              - name
+                              type: object
+                            type: array
+                            x-kubernetes-list-map-keys:
+                            - name
+                            x-kubernetes-list-type: map
+                          nodeName:
+                            description: |-
+                              NodeName indicates in which node this pod is scheduled.
+                              If empty, this pod is a candidate for scheduling by the scheduler defined in schedulerName.
+                              Once this field is set, the kubelet for this node becomes responsible for the lifecycle of this pod.
+                              This field should not be used to express a desire for the pod to be scheduled on a specific node.
+                              https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodename
+                            type: string
+                          nodeSelector:
+                            additionalProperties:
+                              type: string
+                            description: |-
+                              NodeSelector is a selector which must be true for the pod to fit on a node.
+                              Selector which must match a node's labels for the pod to be scheduled on that node.
+                              More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          os:
+                            description: |-
+                              Specifies the OS of the containers in the pod.
+                              Some pod and container fields are restricted if this is set.
+
+                              If the OS field is set to linux, the following fields must be unset:
+                              -securityContext.windowsOptions
+
+                              If the OS field is set to windows, following fields must be unset:
+                              - spec.hostPID
+                              - spec.hostIPC
+                              - spec.hostUsers
+                              - spec.resources
+                              - spec.securityContext.appArmorProfile
+                              - spec.securityContext.seLinuxOptions
+                              - spec.securityContext.seccompProfile
+                              - spec.securityContext.fsGroup
+                              - spec.securityContext.fsGroupChangePolicy
+                              - spec.securityContext.sysctls
+                              - spec.shareProcessNamespace
+                              - spec.securityContext.runAsUser
+                              - spec.securityContext.runAsGroup
+                              - spec.securityContext.supplementalGroups
+                              - spec.securityContext.supplementalGroupsPolicy
+                              - spec.containers[*].securityContext.appArmorProfile
+                              - spec.containers[*].securityContext.seLinuxOptions
+                              - spec.containers[*].securityContext.seccompProfile
+                              - spec.containers[*].securityContext.capabilities
+                              - spec.containers[*].securityContext.readOnlyRootFilesystem
+                              - spec.containers[*].securityContext.privileged
+                              - spec.containers[*].securityContext.allowPrivilegeEscalation
+                              - spec.containers[*].securityContext.procMount
+                              - spec.containers[*].securityContext.runAsUser
+                              - spec.containers[*].securityContext.runAsGroup
+                            properties:
+                              name:
+                                description: |-
+                                  Name is the name of the operating system. The currently supported values are linux and windows.
+                                  Additional value may be defined in future and can be one of:
+                                  https://github.com/opencontainers/runtime-spec/blob/master/config.md#platform-specific-configuration
+                                  Clients should expect to handle additional values and treat unrecognized values in this field as os: null
+                                type: string
+                            required:
+                            - name
+                            type: object
+                          overhead:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            description: |-
+                              Overhead represents the resource overhead associated with running a pod for a given RuntimeClass.
+                              This field will be autopopulated at admission time by the RuntimeClass admission controller. If
+                              the RuntimeClass admission controller is enabled, overhead must not be set in Pod create requests.
+                              The RuntimeClass admission controller will reject Pod create requests which have the overhead already
+                              set. If RuntimeClass is configured and selected in the PodSpec, Overhead will be set to the value
+                              defined in the corresponding RuntimeClass, otherwise it will remain unset and treated as zero.
+                              More info: https://git.k8s.io/enhancements/keps/sig-node/688-pod-overhead/README.md
+                            type: object
+                          preemptionPolicy:
+                            description: |-
+                              PreemptionPolicy is the Policy for preempting pods with lower priority.
+                              One of Never, PreemptLowerPriority.
+                              Defaults to PreemptLowerPriority if unset.
+                            type: string
+                          priority:
+                            description: |-
+                              The priority value. Various system components use this field to find the
+                              priority of the pod. When Priority Admission Controller is enabled, it
+                              prevents users from setting this field. The admission controller populates
+                              this field from PriorityClassName.
+                              The higher the value, the higher the priority.
+                            format: int32
+                            type: integer
+                          priorityClassName:
+                            description: |-
+                              If specified, indicates the pod's priority. "system-node-critical" and
+                              "system-cluster-critical" are two special keywords which indicate the
+                              highest priorities with the former being the highest priority. Any other
+                              name must be defined by creating a PriorityClass object with that name.
+                              If not specified, the pod priority will be default or zero if there is no
+                              default.
+                            type: string
+                          readinessGates:
+                            description: |-
+                              If specified, all readiness gates will be evaluated for pod readiness.
+                              A pod is ready when all its containers are ready AND
+                              all conditions specified in the readiness gates have status equal to "True"
+                              More info: https://git.k8s.io/enhancements/keps/sig-network/580-pod-readiness-gates
+                            items:
+                              description: PodReadinessGate contains the reference
+                                to a pod condition
+                              properties:
+                                conditionType:
+                                  description: ConditionType refers to a condition
+                                    in the pod's condition list with matching type.
+                                  type: string
+                              required:
+                              - conditionType
+                              type: object
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          resourceClaims:
+                            description: |-
+                              ResourceClaims defines which ResourceClaims must be allocated
+                              and reserved before the Pod is allowed to start. The resources
+                              will be made available to those containers which consume them
+                              by name.
+
+                              This is an alpha field and requires enabling the
+                              DynamicResourceAllocation feature gate.
+
+                              This field is immutable.
+                            items:
+                              description: |-
+                                PodResourceClaim references exactly one ResourceClaim, either directly
+                                or by naming a ResourceClaimTemplate which is then turned into a ResourceClaim
+                                for the pod.
+
+                                It adds a name to it that uniquely identifies the ResourceClaim inside the Pod.
+                                Containers that need access to the ResourceClaim reference it with this name.
+                              properties:
+                                name:
+                                  description: |-
+                                    Name uniquely identifies this resource claim inside the pod.
+                                    This must be a DNS_LABEL.
+                                  type: string
+                                resourceClaimName:
+                                  description: |-
+                                    ResourceClaimName is the name of a ResourceClaim object in the same
+                                    namespace as this pod.
+
+                                    Exactly one of ResourceClaimName and ResourceClaimTemplateName must
+                                    be set.
+                                  type: string
+                                resourceClaimTemplateName:
+                                  description: |-
+                                    ResourceClaimTemplateName is the name of a ResourceClaimTemplate
+                                    object in the same namespace as this pod.
+
+                                    The template will be used to create a new ResourceClaim, which will
+                                    be bound to this pod. When this pod is deleted, the ResourceClaim
+                                    will also be deleted. The pod name and resource name, along with a
+                                    generated component, will be used to form a unique name for the
+                                    ResourceClaim, which will be recorded in pod.status.resourceClaimStatuses.
+
+                                    This field is immutable and no changes will be made to the
+                                    corresponding ResourceClaim by the control plane after creating the
+                                    ResourceClaim.
+
+                                    Exactly one of ResourceClaimName and ResourceClaimTemplateName must
+                                    be set.
+                                  type: string
+                              required:
+                              - name
+                              type: object
+                            type: array
+                            x-kubernetes-list-map-keys:
+                            - name
+                            x-kubernetes-list-type: map
+                          resources:
+                            description: |-
+                              Resources is the total amount of CPU and Memory resources required by all
+                              containers in the pod. It supports specifying Requests and Limits for
+                              "cpu", "memory" and "hugepages-" resource names only. ResourceClaims are not supported.
+
+                              This field enables fine-grained control over resource allocation for the
+                              entire pod, allowing resource sharing among containers in a pod.
+
+                              This is an alpha field and requires enabling the PodLevelResources feature
+                              gate.
+                            properties:
+                              claims:
+                                description: |-
+                                  Claims lists the names of resources, defined in spec.resourceClaims,
+                                  that are used by this container.
+
+                                  This field depends on the
+                                  DynamicResourceAllocation feature gate.
+
+                                  This field is immutable. It can only be set for containers.
+                                items:
+                                  description: ResourceClaim references one entry
+                                    in PodSpec.ResourceClaims.
+                                  properties:
+                                    name:
+                                      description: |-
+                                        Name must match the name of one entry in pod.spec.resourceClaims of
+                                        the Pod where this field is used. It makes that resource available
+                                        inside a container.
+                                      type: string
+                                    request:
+                                      description: |-
+                                        Request is the name chosen for a request in the referenced claim.
+                                        If empty, everything from the claim is made available, otherwise
+                                        only the result of this request.
+                                      type: string
+                                  required:
+                                  - name
+                                  type: object
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                - name
+                                x-kubernetes-list-type: map
+                              limits:
+                                additionalProperties:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                description: |-
+                                  Limits describes the maximum amount of compute resources allowed.
+                                  More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                type: object
+                              requests:
+                                additionalProperties:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                description: |-
+                                  Requests describes the minimum amount of compute resources required.
+                                  If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                                  otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                                  More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                type: object
+                            type: object
+                          restartPolicy:
+                            description: |-
+                              Restart policy for all containers within the pod.
+                              One of Always, OnFailure, Never. In some contexts, only a subset of those values may be permitted.
+                              Default to Always.
+                              More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#restart-policy
+                            type: string
+                          runtimeClassName:
+                            description: |-
+                              RuntimeClassName refers to a RuntimeClass object in the node.k8s.io group, which should be used
+                              to run this pod.  If no RuntimeClass resource matches the named class, the pod will not be run.
+                              If unset or empty, the "legacy" RuntimeClass will be used, which is an implicit class with an
+                              empty definition that uses the default runtime handler.
+                              More info: https://git.k8s.io/enhancements/keps/sig-node/585-runtime-class
+                            type: string
+                          schedulerName:
+                            description: |-
+                              If specified, the pod will be dispatched by specified scheduler.
+                              If not specified, the pod will be dispatched by default scheduler.
+                            type: string
+                          schedulingGates:
+                            description: |-
+                              SchedulingGates is an opaque list of values that if specified will block scheduling the pod.
+                              If schedulingGates is not empty, the pod will stay in the SchedulingGated state and the
+                              scheduler will not attempt to schedule the pod.
+
+                              SchedulingGates can only be set at pod creation time, and be removed only afterwards.
+                            items:
+                              description: PodSchedulingGate is associated to a Pod
+                                to guard its scheduling.
+                              properties:
+                                name:
+                                  description: |-
+                                    Name of the scheduling gate.
+                                    Each scheduling gate must have a unique name field.
+                                  type: string
+                              required:
+                              - name
+                              type: object
+                            type: array
+                            x-kubernetes-list-map-keys:
+                            - name
+                            x-kubernetes-list-type: map
+                          securityContext:
+                            description: |-
+                              SecurityContext holds pod-level security attributes and common container settings.
+                              Optional: Defaults to empty.  See type description for default values of each field.
+                            properties:
+                              appArmorProfile:
+                                description: |-
+                                  appArmorProfile is the AppArmor options to use by the containers in this pod.
+                                  Note that this field cannot be set when spec.os.name is windows.
+                                properties:
+                                  localhostProfile:
+                                    description: |-
+                                      localhostProfile indicates a profile loaded on the node that should be used.
+                                      The profile must be preconfigured on the node to work.
+                                      Must match the loaded name of the profile.
+                                      Must be set if and only if type is "Localhost".
+                                    type: string
+                                  type:
+                                    description: |-
+                                      type indicates which kind of AppArmor profile will be applied.
+                                      Valid options are:
+                                        Localhost - a profile pre-loaded on the node.
+                                        RuntimeDefault - the container runtime's default profile.
+                                        Unconfined - no AppArmor enforcement.
+                                    type: string
+                                required:
+                                - type
+                                type: object
+                              fsGroup:
+                                description: |-
+                                  A special supplemental group that applies to all containers in a pod.
+                                  Some volume types allow the Kubelet to change the ownership of that volume
+                                  to be owned by the pod:
+
+                                  1. The owning GID will be the FSGroup
+                                  2. The setgid bit is set (new files created in the volume will be owned by FSGroup)
+                                  3. The permission bits are OR'd with rw-rw----
+
+                                  If unset, the Kubelet will not modify the ownership and permissions of any volume.
+                                  Note that this field cannot be set when spec.os.name is windows.
+                                format: int64
+                                type: integer
+                              fsGroupChangePolicy:
+                                description: |-
+                                  fsGroupChangePolicy defines behavior of changing ownership and permission of the volume
+                                  before being exposed inside Pod. This field will only apply to
+                                  volume types which support fsGroup based ownership(and permissions).
+                                  It will have no effect on ephemeral volume types such as: secret, configmaps
+                                  and emptydir.
+                                  Valid values are "OnRootMismatch" and "Always". If not specified, "Always" is used.
+                                  Note that this field cannot be set when spec.os.name is windows.
+                                type: string
+                              runAsGroup:
+                                description: |-
+                                  The GID to run the entrypoint of the container process.
+                                  Uses runtime default if unset.
+                                  May also be set in SecurityContext.  If set in both SecurityContext and
+                                  PodSecurityContext, the value specified in SecurityContext takes precedence
+                                  for that container.
+                                  Note that this field cannot be set when spec.os.name is windows.
+                                format: int64
+                                type: integer
+                              runAsNonRoot:
+                                description: |-
+                                  Indicates that the container must run as a non-root user.
+                                  If true, the Kubelet will validate the image at runtime to ensure that it
+                                  does not run as UID 0 (root) and fail to start the container if it does.
+                                  If unset or false, no such validation will be performed.
+                                  May also be set in SecurityContext.  If set in both SecurityContext and
+                                  PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                type: boolean
+                              runAsUser:
+                                description: |-
+                                  The UID to run the entrypoint of the container process.
+                                  Defaults to user specified in image metadata if unspecified.
+                                  May also be set in SecurityContext.  If set in both SecurityContext and
+                                  PodSecurityContext, the value specified in SecurityContext takes precedence
+                                  for that container.
+                                  Note that this field cannot be set when spec.os.name is windows.
+                                format: int64
+                                type: integer
+                              seLinuxChangePolicy:
+                                description: |-
+                                  seLinuxChangePolicy defines how the container's SELinux label is applied to all volumes used by the Pod.
+                                  It has no effect on nodes that do not support SELinux or to volumes does not support SELinux.
+                                  Valid values are "MountOption" and "Recursive".
+
+                                  "Recursive" means relabeling of all files on all Pod volumes by the container runtime.
+                                  This may be slow for large volumes, but allows mixing privileged and unprivileged Pods sharing the same volume on the same node.
+
+                                  "MountOption" mounts all eligible Pod volumes with `-o context` mount option.
+                                  This requires all Pods that share the same volume to use the same SELinux label.
+                                  It is not possible to share the same volume among privileged and unprivileged Pods.
+                                  Eligible volumes are in-tree FibreChannel and iSCSI volumes, and all CSI volumes
+                                  whose CSI driver announces SELinux support by setting spec.seLinuxMount: true in their
+                                  CSIDriver instance. Other volumes are always re-labelled recursively.
+                                  "MountOption" value is allowed only when SELinuxMount feature gate is enabled.
+
+                                  If not specified and SELinuxMount feature gate is enabled, "MountOption" is used.
+                                  If not specified and SELinuxMount feature gate is disabled, "MountOption" is used for ReadWriteOncePod volumes
+                                  and "Recursive" for all other volumes.
+
+                                  This field affects only Pods that have SELinux label set, either in PodSecurityContext or in SecurityContext of all containers.
+
+                                  All Pods that use the same volume should use the same seLinuxChangePolicy, otherwise some pods can get stuck in ContainerCreating state.
+                                  Note that this field cannot be set when spec.os.name is windows.
+                                type: string
+                              seLinuxOptions:
+                                description: |-
+                                  The SELinux context to be applied to all containers.
+                                  If unspecified, the container runtime will allocate a random SELinux context for each
+                                  container.  May also be set in SecurityContext.  If set in
+                                  both SecurityContext and PodSecurityContext, the value specified in SecurityContext
+                                  takes precedence for that container.
+                                  Note that this field cannot be set when spec.os.name is windows.
+                                properties:
+                                  level:
+                                    description: Level is SELinux level label that
+                                      applies to the container.
+                                    type: string
+                                  role:
+                                    description: Role is a SELinux role label that
+                                      applies to the container.
+                                    type: string
+                                  type:
+                                    description: Type is a SELinux type label that
+                                      applies to the container.
+                                    type: string
+                                  user:
+                                    description: User is a SELinux user label that
+                                      applies to the container.
+                                    type: string
+                                type: object
+                              seccompProfile:
+                                description: |-
+                                  The seccomp options to use by the containers in this pod.
+                                  Note that this field cannot be set when spec.os.name is windows.
+                                properties:
+                                  localhostProfile:
+                                    description: |-
+                                      localhostProfile indicates a profile defined in a file on the node should be used.
+                                      The profile must be preconfigured on the node to work.
+                                      Must be a descending path, relative to the kubelet's configured seccomp profile location.
+                                      Must be set if type is "Localhost". Must NOT be set for any other type.
+                                    type: string
+                                  type:
+                                    description: |-
+                                      type indicates which kind of seccomp profile will be applied.
+                                      Valid options are:
+
+                                      Localhost - a profile defined in a file on the node should be used.
+                                      RuntimeDefault - the container runtime default profile should be used.
+                                      Unconfined - no profile should be applied.
+                                    type: string
+                                required:
+                                - type
+                                type: object
+                              supplementalGroups:
+                                description: |-
+                                  A list of groups applied to the first process run in each container, in
+                                  addition to the container's primary GID and fsGroup (if specified).  If
+                                  the SupplementalGroupsPolicy feature is enabled, the
+                                  supplementalGroupsPolicy field determines whether these are in addition
+                                  to or instead of any group memberships defined in the container image.
+                                  If unspecified, no additional groups are added, though group memberships
+                                  defined in the container image may still be used, depending on the
+                                  supplementalGroupsPolicy field.
+                                  Note that this field cannot be set when spec.os.name is windows.
+                                items:
+                                  format: int64
+                                  type: integer
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              supplementalGroupsPolicy:
+                                description: |-
+                                  Defines how supplemental groups of the first container processes are calculated.
+                                  Valid values are "Merge" and "Strict". If not specified, "Merge" is used.
+                                  (Alpha) Using the field requires the SupplementalGroupsPolicy feature gate to be enabled
+                                  and the container runtime must implement support for this feature.
+                                  Note that this field cannot be set when spec.os.name is windows.
+                                type: string
+                              sysctls:
+                                description: |-
+                                  Sysctls hold a list of namespaced sysctls used for the pod. Pods with unsupported
+                                  sysctls (by the container runtime) might fail to launch.
+                                  Note that this field cannot be set when spec.os.name is windows.
+                                items:
+                                  description: Sysctl defines a kernel parameter to
+                                    be set
+                                  properties:
+                                    name:
+                                      description: Name of a property to set
+                                      type: string
+                                    value:
+                                      description: Value of a property to set
+                                      type: string
+                                  required:
+                                  - name
+                                  - value
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              windowsOptions:
+                                description: |-
+                                  The Windows specific settings applied to all containers.
+                                  If unspecified, the options within a container's SecurityContext will be used.
+                                  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                  Note that this field cannot be set when spec.os.name is linux.
+                                properties:
+                                  gmsaCredentialSpec:
+                                    description: |-
+                                      GMSACredentialSpec is where the GMSA admission webhook
+                                      (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the
+                                      GMSA credential spec named by the GMSACredentialSpecName field.
+                                    type: string
+                                  gmsaCredentialSpecName:
+                                    description: GMSACredentialSpecName is the name
+                                      of the GMSA credential spec to use.
+                                    type: string
+                                  hostProcess:
+                                    description: |-
+                                      HostProcess determines if a container should be run as a 'Host Process' container.
+                                      All of a Pod's containers must have the same effective HostProcess value
+                                      (it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).
+                                      In addition, if HostProcess is true then HostNetwork must also be set to true.
+                                    type: boolean
+                                  runAsUserName:
+                                    description: |-
+                                      The UserName in Windows to run the entrypoint of the container process.
+                                      Defaults to the user specified in image metadata if unspecified.
+                                      May also be set in PodSecurityContext. If set in both SecurityContext and
+                                      PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                    type: string
+                                type: object
+                            type: object
+                          serviceAccount:
+                            description: |-
+                              DeprecatedServiceAccount is a deprecated alias for ServiceAccountName.
+                              Deprecated: Use serviceAccountName instead.
+                            type: string
+                          serviceAccountName:
+                            description: |-
+                              ServiceAccountName is the name of the ServiceAccount to use to run this pod.
+                              More info: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
+                            type: string
+                          setHostnameAsFQDN:
+                            description: |-
+                              If true the pod's hostname will be configured as the pod's FQDN, rather than the leaf name (the default).
+                              In Linux containers, this means setting the FQDN in the hostname field of the kernel (the nodename field of struct utsname).
+                              In Windows containers, this means setting the registry value of hostname for the registry key HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\Tcpip\\Parameters to FQDN.
+                              If a pod does not have FQDN, this has no effect.
+                              Default to false.
+                            type: boolean
+                          shareProcessNamespace:
+                            description: |-
+                              Share a single process namespace between all of the containers in a pod.
+                              When this is set containers will be able to view and signal processes from other containers
+                              in the same pod, and the first process in each container will not be assigned PID 1.
+                              HostPID and ShareProcessNamespace cannot both be set.
+                              Optional: Default to false.
+                            type: boolean
+                          subdomain:
+                            description: |-
+                              If specified, the fully qualified Pod hostname will be "<hostname>.<subdomain>.<pod namespace>.svc.<cluster domain>".
+                              If not specified, the pod will not have a domainname at all.
+                            type: string
+                          terminationGracePeriodSeconds:
+                            description: |-
+                              Optional duration in seconds the pod needs to terminate gracefully. May be decreased in delete request.
+                              Value must be non-negative integer. The value zero indicates stop immediately via
+                              the kill signal (no opportunity to shut down).
+                              If this value is nil, the default grace period will be used instead.
+                              The grace period is the duration in seconds after the processes running in the pod are sent
+                              a termination signal and the time when the processes are forcibly halted with a kill signal.
+                              Set this value longer than the expected cleanup time for your process.
+                              Defaults to 30 seconds.
+                            format: int64
+                            type: integer
+                          tolerations:
+                            description: If specified, the pod's tolerations.
+                            items:
+                              description: |-
+                                The pod this Toleration is attached to tolerates any taint that matches
+                                the triple <key,value,effect> using the matching operator <operator>.
+                              properties:
+                                effect:
+                                  description: |-
+                                    Effect indicates the taint effect to match. Empty means match all taint effects.
+                                    When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                                  type: string
+                                key:
+                                  description: |-
+                                    Key is the taint key that the toleration applies to. Empty means match all taint keys.
+                                    If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                                  type: string
+                                operator:
+                                  description: |-
+                                    Operator represents a key's relationship to the value.
+                                    Valid operators are Exists and Equal. Defaults to Equal.
+                                    Exists is equivalent to wildcard for value, so that a pod can
+                                    tolerate all taints of a particular category.
+                                  type: string
+                                tolerationSeconds:
+                                  description: |-
+                                    TolerationSeconds represents the period of time the toleration (which must be
+                                    of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
+                                    it is not set, which means tolerate the taint forever (do not evict). Zero and
+                                    negative values will be treated as 0 (evict immediately) by the system.
+                                  format: int64
+                                  type: integer
+                                value:
+                                  description: |-
+                                    Value is the taint value the toleration matches to.
+                                    If the operator is Exists, the value should be empty, otherwise just a regular string.
+                                  type: string
+                              type: object
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          topologySpreadConstraints:
+                            description: |-
+                              TopologySpreadConstraints describes how a group of pods ought to spread across topology
+                              domains. Scheduler will schedule pods in a way which abides by the constraints.
+                              All topologySpreadConstraints are ANDed.
+                            items:
+                              description: TopologySpreadConstraint specifies how
+                                to spread matching pods among the given topology.
+                              properties:
+                                labelSelector:
+                                  description: |-
+                                    LabelSelector is used to find matching pods.
+                                    Pods that match this label selector are counted to determine the number of pods
+                                    in their corresponding topology domain.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: |-
+                                          A label selector requirement is a selector that contains values, a key, and an operator that
+                                          relates the key and values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: |-
+                                              operator represents a key's relationship to a set of values.
+                                              Valid operators are In, NotIn, Exists and DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: |-
+                                              values is an array of string values. If the operator is In or NotIn,
+                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: |-
+                                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                        operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                matchLabelKeys:
+                                  description: |-
+                                    MatchLabelKeys is a set of pod label keys to select the pods over which
+                                    spreading will be calculated. The keys are used to lookup values from the
+                                    incoming pod labels, those key-value labels are ANDed with labelSelector
+                                    to select the group of existing pods over which spreading will be calculated
+                                    for the incoming pod. The same key is forbidden to exist in both MatchLabelKeys and LabelSelector.
+                                    MatchLabelKeys cannot be set when LabelSelector isn't set.
+                                    Keys that don't exist in the incoming pod labels will
+                                    be ignored. A null or empty list means only match against labelSelector.
+
+                                    This is a beta field and requires the MatchLabelKeysInPodTopologySpread feature gate to be enabled (enabled by default).
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                maxSkew:
+                                  description: |-
+                                    MaxSkew describes the degree to which pods may be unevenly distributed.
+                                    When `whenUnsatisfiable=DoNotSchedule`, it is the maximum permitted difference
+                                    between the number of matching pods in the target topology and the global minimum.
+                                    The global minimum is the minimum number of matching pods in an eligible domain
+                                    or zero if the number of eligible domains is less than MinDomains.
+                                    For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same
+                                    labelSelector spread as 2/2/1:
+                                    In this case, the global minimum is 1.
+                                    | zone1 | zone2 | zone3 |
+                                    |  P P  |  P P  |   P   |
+                                    - if MaxSkew is 1, incoming pod can only be scheduled to zone3 to become 2/2/2;
+                                    scheduling it onto zone1(zone2) would make the ActualSkew(3-1) on zone1(zone2)
+                                    violate MaxSkew(1).
+                                    - if MaxSkew is 2, incoming pod can be scheduled onto any zone.
+                                    When `whenUnsatisfiable=ScheduleAnyway`, it is used to give higher precedence
+                                    to topologies that satisfy it.
+                                    It's a required field. Default value is 1 and 0 is not allowed.
+                                  format: int32
+                                  type: integer
+                                minDomains:
+                                  description: |-
+                                    MinDomains indicates a minimum number of eligible domains.
+                                    When the number of eligible domains with matching topology keys is less than minDomains,
+                                    Pod Topology Spread treats "global minimum" as 0, and then the calculation of Skew is performed.
+                                    And when the number of eligible domains with matching topology keys equals or greater than minDomains,
+                                    this value has no effect on scheduling.
+                                    As a result, when the number of eligible domains is less than minDomains,
+                                    scheduler won't schedule more than maxSkew Pods to those domains.
+                                    If value is nil, the constraint behaves as if MinDomains is equal to 1.
+                                    Valid values are integers greater than 0.
+                                    When value is not nil, WhenUnsatisfiable must be DoNotSchedule.
+
+                                    For example, in a 3-zone cluster, MaxSkew is set to 2, MinDomains is set to 5 and pods with the same
+                                    labelSelector spread as 2/2/2:
+                                    | zone1 | zone2 | zone3 |
+                                    |  P P  |  P P  |  P P  |
+                                    The number of domains is less than 5(MinDomains), so "global minimum" is treated as 0.
+                                    In this situation, new pod with the same labelSelector cannot be scheduled,
+                                    because computed skew will be 3(3 - 0) if new Pod is scheduled to any of the three zones,
+                                    it will violate MaxSkew.
+                                  format: int32
+                                  type: integer
+                                nodeAffinityPolicy:
+                                  description: |-
+                                    NodeAffinityPolicy indicates how we will treat Pod's nodeAffinity/nodeSelector
+                                    when calculating pod topology spread skew. Options are:
+                                    - Honor: only nodes matching nodeAffinity/nodeSelector are included in the calculations.
+                                    - Ignore: nodeAffinity/nodeSelector are ignored. All nodes are included in the calculations.
+
+                                    If this value is nil, the behavior is equivalent to the Honor policy.
+                                  type: string
+                                nodeTaintsPolicy:
+                                  description: |-
+                                    NodeTaintsPolicy indicates how we will treat node taints when calculating
+                                    pod topology spread skew. Options are:
+                                    - Honor: nodes without taints, along with tainted nodes for which the incoming pod
+                                    has a toleration, are included.
+                                    - Ignore: node taints are ignored. All nodes are included.
+
+                                    If this value is nil, the behavior is equivalent to the Ignore policy.
+                                  type: string
+                                topologyKey:
+                                  description: |-
+                                    TopologyKey is the key of node labels. Nodes that have a label with this key
+                                    and identical values are considered to be in the same topology.
+                                    We consider each <key, value> as a "bucket", and try to put balanced number
+                                    of pods into each bucket.
+                                    We define a domain as a particular instance of a topology.
+                                    Also, we define an eligible domain as a domain whose nodes meet the requirements of
+                                    nodeAffinityPolicy and nodeTaintsPolicy.
+                                    e.g. If TopologyKey is "kubernetes.io/hostname", each Node is a domain of that topology.
+                                    And, if TopologyKey is "topology.kubernetes.io/zone", each zone is a domain of that topology.
+                                    It's a required field.
+                                  type: string
+                                whenUnsatisfiable:
+                                  description: |-
+                                    WhenUnsatisfiable indicates how to deal with a pod if it doesn't satisfy
+                                    the spread constraint.
+                                    - DoNotSchedule (default) tells the scheduler not to schedule it.
+                                    - ScheduleAnyway tells the scheduler to schedule the pod in any location,
+                                      but giving higher precedence to topologies that would help reduce the
+                                      skew.
+                                    A constraint is considered "Unsatisfiable" for an incoming pod
+                                    if and only if every possible node assignment for that pod would violate
+                                    "MaxSkew" on some topology.
+                                    For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same
+                                    labelSelector spread as 3/1/1:
+                                    | zone1 | zone2 | zone3 |
+                                    | P P P |   P   |   P   |
+                                    If WhenUnsatisfiable is set to DoNotSchedule, incoming pod can only be scheduled
+                                    to zone2(zone3) to become 3/2/1(3/1/2) as ActualSkew(2-1) on zone2(zone3) satisfies
+                                    MaxSkew(1). In other words, the cluster can still be imbalanced, but scheduler
+                                    won't make it *more* imbalanced.
+                                    It's a required field.
+                                  type: string
+                              required:
+                              - maxSkew
+                              - topologyKey
+                              - whenUnsatisfiable
+                              type: object
+                            type: array
+                            x-kubernetes-list-map-keys:
+                            - topologyKey
+                            - whenUnsatisfiable
+                            x-kubernetes-list-type: map
+                          volumes:
+                            description: |-
+                              List of volumes that can be mounted by containers belonging to the pod.
+                              More info: https://kubernetes.io/docs/concepts/storage/volumes
+                            items:
+                              description: Volume represents a named volume in a pod
+                                that may be accessed by any container in the pod.
+                              properties:
+                                awsElasticBlockStore:
+                                  description: |-
+                                    awsElasticBlockStore represents an AWS Disk resource that is attached to a
+                                    kubelet's host machine and then exposed to the pod.
+                                    Deprecated: AWSElasticBlockStore is deprecated. All operations for the in-tree
+                                    awsElasticBlockStore type are redirected to the ebs.csi.aws.com CSI driver.
+                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
+                                  properties:
+                                    fsType:
+                                      description: |-
+                                        fsType is the filesystem type of the volume that you want to mount.
+                                        Tip: Ensure that the filesystem type is supported by the host operating system.
+                                        Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                        More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
+                                      type: string
+                                    partition:
+                                      description: |-
+                                        partition is the partition in the volume that you want to mount.
+                                        If omitted, the default is to mount by volume name.
+                                        Examples: For volume /dev/sda1, you specify the partition as "1".
+                                        Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty).
+                                      format: int32
+                                      type: integer
+                                    readOnly:
+                                      description: |-
+                                        readOnly value true will force the readOnly setting in VolumeMounts.
+                                        More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
+                                      type: boolean
+                                    volumeID:
+                                      description: |-
+                                        volumeID is unique ID of the persistent disk resource in AWS (Amazon EBS volume).
+                                        More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
+                                      type: string
+                                  required:
+                                  - volumeID
+                                  type: object
+                                azureDisk:
+                                  description: |-
+                                    azureDisk represents an Azure Data Disk mount on the host and bind mount to the pod.
+                                    Deprecated: AzureDisk is deprecated. All operations for the in-tree azureDisk type
+                                    are redirected to the disk.csi.azure.com CSI driver.
+                                  properties:
+                                    cachingMode:
+                                      description: 'cachingMode is the Host Caching
+                                        mode: None, Read Only, Read Write.'
+                                      type: string
+                                    diskName:
+                                      description: diskName is the Name of the data
+                                        disk in the blob storage
+                                      type: string
+                                    diskURI:
+                                      description: diskURI is the URI of data disk
+                                        in the blob storage
+                                      type: string
+                                    fsType:
+                                      default: ext4
+                                      description: |-
+                                        fsType is Filesystem type to mount.
+                                        Must be a filesystem type supported by the host operating system.
+                                        Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                      type: string
+                                    kind:
+                                      description: 'kind expected values are Shared:
+                                        multiple blob disks per storage account  Dedicated:
+                                        single blob disk per storage account  Managed:
+                                        azure managed data disk (only in managed availability
+                                        set). defaults to shared'
+                                      type: string
+                                    readOnly:
+                                      default: false
+                                      description: |-
+                                        readOnly Defaults to false (read/write). ReadOnly here will force
+                                        the ReadOnly setting in VolumeMounts.
+                                      type: boolean
+                                  required:
+                                  - diskName
+                                  - diskURI
+                                  type: object
+                                azureFile:
+                                  description: |-
+                                    azureFile represents an Azure File Service mount on the host and bind mount to the pod.
+                                    Deprecated: AzureFile is deprecated. All operations for the in-tree azureFile type
+                                    are redirected to the file.csi.azure.com CSI driver.
+                                  properties:
+                                    readOnly:
+                                      description: |-
+                                        readOnly defaults to false (read/write). ReadOnly here will force
+                                        the ReadOnly setting in VolumeMounts.
+                                      type: boolean
+                                    secretName:
+                                      description: secretName is the  name of secret
+                                        that contains Azure Storage Account Name and
+                                        Key
+                                      type: string
+                                    shareName:
+                                      description: shareName is the azure share Name
+                                      type: string
+                                  required:
+                                  - secretName
+                                  - shareName
+                                  type: object
+                                cephfs:
+                                  description: |-
+                                    cephFS represents a Ceph FS mount on the host that shares a pod's lifetime.
+                                    Deprecated: CephFS is deprecated and the in-tree cephfs type is no longer supported.
+                                  properties:
+                                    monitors:
+                                      description: |-
+                                        monitors is Required: Monitors is a collection of Ceph monitors
+                                        More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    path:
+                                      description: 'path is Optional: Used as the
+                                        mounted root, rather than the full Ceph tree,
+                                        default is /'
+                                      type: string
+                                    readOnly:
+                                      description: |-
+                                        readOnly is Optional: Defaults to false (read/write). ReadOnly here will force
+                                        the ReadOnly setting in VolumeMounts.
+                                        More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+                                      type: boolean
+                                    secretFile:
+                                      description: |-
+                                        secretFile is Optional: SecretFile is the path to key ring for User, default is /etc/ceph/user.secret
+                                        More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+                                      type: string
+                                    secretRef:
+                                      description: |-
+                                        secretRef is Optional: SecretRef is reference to the authentication secret for User, default is empty.
+                                        More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+                                      properties:
+                                        name:
+                                          default: ""
+                                          description: |-
+                                            Name of the referent.
+                                            This field is effectively required, but due to backwards compatibility is
+                                            allowed to be empty. Instances of this type with an empty value here are
+                                            almost certainly wrong.
+                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          type: string
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    user:
+                                      description: |-
+                                        user is optional: User is the rados user name, default is admin
+                                        More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+                                      type: string
+                                  required:
+                                  - monitors
+                                  type: object
+                                cinder:
+                                  description: |-
+                                    cinder represents a cinder volume attached and mounted on kubelets host machine.
+                                    Deprecated: Cinder is deprecated. All operations for the in-tree cinder type
+                                    are redirected to the cinder.csi.openstack.org CSI driver.
+                                    More info: https://examples.k8s.io/mysql-cinder-pd/README.md
+                                  properties:
+                                    fsType:
+                                      description: |-
+                                        fsType is the filesystem type to mount.
+                                        Must be a filesystem type supported by the host operating system.
+                                        Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                        More info: https://examples.k8s.io/mysql-cinder-pd/README.md
+                                      type: string
+                                    readOnly:
+                                      description: |-
+                                        readOnly defaults to false (read/write). ReadOnly here will force
+                                        the ReadOnly setting in VolumeMounts.
+                                        More info: https://examples.k8s.io/mysql-cinder-pd/README.md
+                                      type: boolean
+                                    secretRef:
+                                      description: |-
+                                        secretRef is optional: points to a secret object containing parameters used to connect
+                                        to OpenStack.
+                                      properties:
+                                        name:
+                                          default: ""
+                                          description: |-
+                                            Name of the referent.
+                                            This field is effectively required, but due to backwards compatibility is
+                                            allowed to be empty. Instances of this type with an empty value here are
+                                            almost certainly wrong.
+                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          type: string
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    volumeID:
+                                      description: |-
+                                        volumeID used to identify the volume in cinder.
+                                        More info: https://examples.k8s.io/mysql-cinder-pd/README.md
+                                      type: string
+                                  required:
+                                  - volumeID
+                                  type: object
+                                configMap:
+                                  description: configMap represents a configMap that
+                                    should populate this volume
+                                  properties:
+                                    defaultMode:
+                                      description: |-
+                                        defaultMode is optional: mode bits used to set permissions on created files by default.
+                                        Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                        YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                        Defaults to 0644.
+                                        Directories within the path are not affected by this setting.
+                                        This might be in conflict with other options that affect the file
+                                        mode, like fsGroup, and the result can be other mode bits set.
+                                      format: int32
+                                      type: integer
+                                    items:
+                                      description: |-
+                                        items if unspecified, each key-value pair in the Data field of the referenced
+                                        ConfigMap will be projected into the volume as a file whose name is the
+                                        key and content is the value. If specified, the listed keys will be
+                                        projected into the specified paths, and unlisted keys will not be
+                                        present. If a key is specified which is not present in the ConfigMap,
+                                        the volume setup will error unless it is marked optional. Paths must be
+                                        relative and may not contain the '..' path or start with '..'.
+                                      items:
+                                        description: Maps a string key to a path within
+                                          a volume.
+                                        properties:
+                                          key:
+                                            description: key is the key to project.
+                                            type: string
+                                          mode:
+                                            description: |-
+                                              mode is Optional: mode bits used to set permissions on this file.
+                                              Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                              YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                              If not specified, the volume defaultMode will be used.
+                                              This might be in conflict with other options that affect the file
+                                              mode, like fsGroup, and the result can be other mode bits set.
+                                            format: int32
+                                            type: integer
+                                          path:
+                                            description: |-
+                                              path is the relative path of the file to map the key to.
+                                              May not be an absolute path.
+                                              May not contain the path element '..'.
+                                              May not start with the string '..'.
+                                            type: string
+                                        required:
+                                        - key
+                                        - path
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    name:
+                                      default: ""
+                                      description: |-
+                                        Name of the referent.
+                                        This field is effectively required, but due to backwards compatibility is
+                                        allowed to be empty. Instances of this type with an empty value here are
+                                        almost certainly wrong.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      type: string
+                                    optional:
+                                      description: optional specify whether the ConfigMap
+                                        or its keys must be defined
+                                      type: boolean
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                csi:
+                                  description: csi (Container Storage Interface) represents
+                                    ephemeral storage that is handled by certain external
+                                    CSI drivers.
+                                  properties:
+                                    driver:
+                                      description: |-
+                                        driver is the name of the CSI driver that handles this volume.
+                                        Consult with your admin for the correct name as registered in the cluster.
+                                      type: string
+                                    fsType:
+                                      description: |-
+                                        fsType to mount. Ex. "ext4", "xfs", "ntfs".
+                                        If not provided, the empty value is passed to the associated CSI driver
+                                        which will determine the default filesystem to apply.
+                                      type: string
+                                    nodePublishSecretRef:
+                                      description: |-
+                                        nodePublishSecretRef is a reference to the secret object containing
+                                        sensitive information to pass to the CSI driver to complete the CSI
+                                        NodePublishVolume and NodeUnpublishVolume calls.
+                                        This field is optional, and  may be empty if no secret is required. If the
+                                        secret object contains more than one secret, all secret references are passed.
+                                      properties:
+                                        name:
+                                          default: ""
+                                          description: |-
+                                            Name of the referent.
+                                            This field is effectively required, but due to backwards compatibility is
+                                            allowed to be empty. Instances of this type with an empty value here are
+                                            almost certainly wrong.
+                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          type: string
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    readOnly:
+                                      description: |-
+                                        readOnly specifies a read-only configuration for the volume.
+                                        Defaults to false (read/write).
+                                      type: boolean
+                                    volumeAttributes:
+                                      additionalProperties:
+                                        type: string
+                                      description: |-
+                                        volumeAttributes stores driver-specific properties that are passed to the CSI
+                                        driver. Consult your driver's documentation for supported values.
+                                      type: object
+                                  required:
+                                  - driver
+                                  type: object
+                                downwardAPI:
+                                  description: downwardAPI represents downward API
+                                    about the pod that should populate this volume
+                                  properties:
+                                    defaultMode:
+                                      description: |-
+                                        Optional: mode bits to use on created files by default. Must be a
+                                        Optional: mode bits used to set permissions on created files by default.
+                                        Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                        YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                        Defaults to 0644.
+                                        Directories within the path are not affected by this setting.
+                                        This might be in conflict with other options that affect the file
+                                        mode, like fsGroup, and the result can be other mode bits set.
+                                      format: int32
+                                      type: integer
+                                    items:
+                                      description: Items is a list of downward API
+                                        volume file
+                                      items:
+                                        description: DownwardAPIVolumeFile represents
+                                          information to create the file containing
+                                          the pod field
+                                        properties:
+                                          fieldRef:
+                                            description: 'Required: Selects a field
+                                              of the pod: only annotations, labels,
+                                              name, namespace and uid are supported.'
+                                            properties:
+                                              apiVersion:
+                                                description: Version of the schema
+                                                  the FieldPath is written in terms
+                                                  of, defaults to "v1".
+                                                type: string
+                                              fieldPath:
+                                                description: Path of the field to
+                                                  select in the specified API version.
+                                                type: string
+                                            required:
+                                            - fieldPath
+                                            type: object
+                                            x-kubernetes-map-type: atomic
+                                          mode:
+                                            description: |-
+                                              Optional: mode bits used to set permissions on this file, must be an octal value
+                                              between 0000 and 0777 or a decimal value between 0 and 511.
+                                              YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                              If not specified, the volume defaultMode will be used.
+                                              This might be in conflict with other options that affect the file
+                                              mode, like fsGroup, and the result can be other mode bits set.
+                                            format: int32
+                                            type: integer
+                                          path:
+                                            description: 'Required: Path is  the relative
+                                              path name of the file to be created.
+                                              Must not be absolute or contain the
+                                              ''..'' path. Must be utf-8 encoded.
+                                              The first item of the relative path
+                                              must not start with ''..'''
+                                            type: string
+                                          resourceFieldRef:
+                                            description: |-
+                                              Selects a resource of the container: only resources limits and requests
+                                              (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.
+                                            properties:
+                                              containerName:
+                                                description: 'Container name: required
+                                                  for volumes, optional for env vars'
+                                                type: string
+                                              divisor:
+                                                anyOf:
+                                                - type: integer
+                                                - type: string
+                                                description: Specifies the output
+                                                  format of the exposed resources,
+                                                  defaults to "1"
+                                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                x-kubernetes-int-or-string: true
+                                              resource:
+                                                description: 'Required: resource to
+                                                  select'
+                                                type: string
+                                            required:
+                                            - resource
+                                            type: object
+                                            x-kubernetes-map-type: atomic
+                                        required:
+                                        - path
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                  type: object
+                                emptyDir:
+                                  description: |-
+                                    emptyDir represents a temporary directory that shares a pod's lifetime.
+                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
+                                  properties:
+                                    medium:
+                                      description: |-
+                                        medium represents what type of storage medium should back this directory.
+                                        The default is "" which means to use the node's default medium.
+                                        Must be an empty string (default) or Memory.
+                                        More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
+                                      type: string
+                                    sizeLimit:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: |-
+                                        sizeLimit is the total amount of local storage required for this EmptyDir volume.
+                                        The size limit is also applicable for memory medium.
+                                        The maximum usage on memory medium EmptyDir would be the minimum value between
+                                        the SizeLimit specified here and the sum of memory limits of all containers in a pod.
+                                        The default is nil which means that the limit is undefined.
+                                        More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                  type: object
+                                ephemeral:
+                                  description: |-
+                                    ephemeral represents a volume that is handled by a cluster storage driver.
+                                    The volume's lifecycle is tied to the pod that defines it - it will be created before the pod starts,
+                                    and deleted when the pod is removed.
+
+                                    Use this if:
+                                    a) the volume is only needed while the pod runs,
+                                    b) features of normal volumes like restoring from snapshot or capacity
+                                       tracking are needed,
+                                    c) the storage driver is specified through a storage class, and
+                                    d) the storage driver supports dynamic volume provisioning through
+                                       a PersistentVolumeClaim (see EphemeralVolumeSource for more
+                                       information on the connection between this volume type
+                                       and PersistentVolumeClaim).
+
+                                    Use PersistentVolumeClaim or one of the vendor-specific
+                                    APIs for volumes that persist for longer than the lifecycle
+                                    of an individual pod.
+
+                                    Use CSI for light-weight local ephemeral volumes if the CSI driver is meant to
+                                    be used that way - see the documentation of the driver for
+                                    more information.
+
+                                    A pod can use both types of ephemeral volumes and
+                                    persistent volumes at the same time.
+                                  properties:
+                                    volumeClaimTemplate:
+                                      description: |-
+                                        Will be used to create a stand-alone PVC to provision the volume.
+                                        The pod in which this EphemeralVolumeSource is embedded will be the
+                                        owner of the PVC, i.e. the PVC will be deleted together with the
+                                        pod.  The name of the PVC will be `<pod name>-<volume name>` where
+                                        `<volume name>` is the name from the `PodSpec.Volumes` array
+                                        entry. Pod validation will reject the pod if the concatenated name
+                                        is not valid for a PVC (for example, too long).
+
+                                        An existing PVC with that name that is not owned by the pod
+                                        will *not* be used for the pod to avoid using an unrelated
+                                        volume by mistake. Starting the pod is then blocked until
+                                        the unrelated PVC is removed. If such a pre-created PVC is
+                                        meant to be used by the pod, the PVC has to updated with an
+                                        owner reference to the pod once the pod exists. Normally
+                                        this should not be necessary, but it may be useful when
+                                        manually reconstructing a broken cluster.
+
+                                        This field is read-only and no changes will be made by Kubernetes
+                                        to the PVC after it has been created.
+
+                                        Required, must not be nil.
+                                      properties:
+                                        metadata:
+                                          description: |-
+                                            May contain labels and annotations that will be copied into the PVC
+                                            when creating it. No other fields are allowed and will be rejected during
+                                            validation.
+                                          properties:
+                                            annotations:
+                                              additionalProperties:
+                                                type: string
+                                              type: object
+                                            finalizers:
+                                              items:
+                                                type: string
+                                              type: array
+                                            labels:
+                                              additionalProperties:
+                                                type: string
+                                              type: object
+                                            name:
+                                              type: string
+                                            namespace:
+                                              type: string
+                                          type: object
+                                        spec:
+                                          description: |-
+                                            The specification for the PersistentVolumeClaim. The entire content is
+                                            copied unchanged into the PVC that gets created from this
+                                            template. The same fields as in a PersistentVolumeClaim
+                                            are also valid here.
+                                          properties:
+                                            accessModes:
+                                              description: |-
+                                                accessModes contains the desired access modes the volume should have.
+                                                More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            dataSource:
+                                              description: |-
+                                                dataSource field can be used to specify either:
+                                                * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)
+                                                * An existing PVC (PersistentVolumeClaim)
+                                                If the provisioner or an external controller can support the specified data source,
+                                                it will create a new volume based on the contents of the specified data source.
+                                                When the AnyVolumeDataSource feature gate is enabled, dataSource contents will be copied to dataSourceRef,
+                                                and dataSourceRef contents will be copied to dataSource when dataSourceRef.namespace is not specified.
+                                                If the namespace is specified, then dataSourceRef will not be copied to dataSource.
+                                              properties:
+                                                apiGroup:
+                                                  description: |-
+                                                    APIGroup is the group for the resource being referenced.
+                                                    If APIGroup is not specified, the specified Kind must be in the core API group.
+                                                    For any other third-party types, APIGroup is required.
+                                                  type: string
+                                                kind:
+                                                  description: Kind is the type of
+                                                    resource being referenced
+                                                  type: string
+                                                name:
+                                                  description: Name is the name of
+                                                    resource being referenced
+                                                  type: string
+                                              required:
+                                              - kind
+                                              - name
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            dataSourceRef:
+                                              description: |-
+                                                dataSourceRef specifies the object from which to populate the volume with data, if a non-empty
+                                                volume is desired. This may be any object from a non-empty API group (non
+                                                core object) or a PersistentVolumeClaim object.
+                                                When this field is specified, volume binding will only succeed if the type of
+                                                the specified object matches some installed volume populator or dynamic
+                                                provisioner.
+                                                This field will replace the functionality of the dataSource field and as such
+                                                if both fields are non-empty, they must have the same value. For backwards
+                                                compatibility, when namespace isn't specified in dataSourceRef,
+                                                both fields (dataSource and dataSourceRef) will be set to the same
+                                                value automatically if one of them is empty and the other is non-empty.
+                                                When namespace is specified in dataSourceRef,
+                                                dataSource isn't set to the same value and must be empty.
+                                                There are three important differences between dataSource and dataSourceRef:
+                                                * While dataSource only allows two specific types of objects, dataSourceRef
+                                                  allows any non-core object, as well as PersistentVolumeClaim objects.
+                                                * While dataSource ignores disallowed values (dropping them), dataSourceRef
+                                                  preserves all values, and generates an error if a disallowed value is
+                                                  specified.
+                                                * While dataSource only allows local objects, dataSourceRef allows objects
+                                                  in any namespaces.
+                                                (Beta) Using this field requires the AnyVolumeDataSource feature gate to be enabled.
+                                                (Alpha) Using the namespace field of dataSourceRef requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
+                                              properties:
+                                                apiGroup:
+                                                  description: |-
+                                                    APIGroup is the group for the resource being referenced.
+                                                    If APIGroup is not specified, the specified Kind must be in the core API group.
+                                                    For any other third-party types, APIGroup is required.
+                                                  type: string
+                                                kind:
+                                                  description: Kind is the type of
+                                                    resource being referenced
+                                                  type: string
+                                                name:
+                                                  description: Name is the name of
+                                                    resource being referenced
+                                                  type: string
+                                                namespace:
+                                                  description: |-
+                                                    Namespace is the namespace of resource being referenced
+                                                    Note that when a namespace is specified, a gateway.networking.k8s.io/ReferenceGrant object is required in the referent namespace to allow that namespace's owner to accept the reference. See the ReferenceGrant documentation for details.
+                                                    (Alpha) This field requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
+                                                  type: string
+                                              required:
+                                              - kind
+                                              - name
+                                              type: object
+                                            resources:
+                                              description: |-
+                                                resources represents the minimum resources the volume should have.
+                                                If RecoverVolumeExpansionFailure feature is enabled users are allowed to specify resource requirements
+                                                that are lower than previous value but must still be higher than capacity recorded in the
+                                                status field of the claim.
+                                                More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources
+                                              properties:
+                                                limits:
+                                                  additionalProperties:
+                                                    anyOf:
+                                                    - type: integer
+                                                    - type: string
+                                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                    x-kubernetes-int-or-string: true
+                                                  description: |-
+                                                    Limits describes the maximum amount of compute resources allowed.
+                                                    More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                                  type: object
+                                                requests:
+                                                  additionalProperties:
+                                                    anyOf:
+                                                    - type: integer
+                                                    - type: string
+                                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                    x-kubernetes-int-or-string: true
+                                                  description: |-
+                                                    Requests describes the minimum amount of compute resources required.
+                                                    If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                                                    otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                                                    More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                                  type: object
+                                              type: object
+                                            selector:
+                                              description: selector is a label query
+                                                over volumes to consider for binding.
+                                              properties:
+                                                matchExpressions:
+                                                  description: matchExpressions is
+                                                    a list of label selector requirements.
+                                                    The requirements are ANDed.
+                                                  items:
+                                                    description: |-
+                                                      A label selector requirement is a selector that contains values, a key, and an operator that
+                                                      relates the key and values.
+                                                    properties:
+                                                      key:
+                                                        description: key is the label
+                                                          key that the selector applies
+                                                          to.
+                                                        type: string
+                                                      operator:
+                                                        description: |-
+                                                          operator represents a key's relationship to a set of values.
+                                                          Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                        type: string
+                                                      values:
+                                                        description: |-
+                                                          values is an array of string values. If the operator is In or NotIn,
+                                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                          the values array must be empty. This array is replaced during a strategic
+                                                          merge patch.
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                    required:
+                                                    - key
+                                                    - operator
+                                                    type: object
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                                matchLabels:
+                                                  additionalProperties:
+                                                    type: string
+                                                  description: |-
+                                                    matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                    map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                    operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                  type: object
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            storageClassName:
+                                              description: |-
+                                                storageClassName is the name of the StorageClass required by the claim.
+                                                More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1
+                                              type: string
+                                            volumeAttributesClassName:
+                                              description: |-
+                                                volumeAttributesClassName may be used to set the VolumeAttributesClass used by this claim.
+                                                If specified, the CSI driver will create or update the volume with the attributes defined
+                                                in the corresponding VolumeAttributesClass. This has a different purpose than storageClassName,
+                                                it can be changed after the claim is created. An empty string or nil value indicates that no
+                                                VolumeAttributesClass will be applied to the claim. If the claim enters an Infeasible error state,
+                                                this field can be reset to its previous value (including nil) to cancel the modification.
+                                                If the resource referred to by volumeAttributesClass does not exist, this PersistentVolumeClaim will be
+                                                set to a Pending state, as reflected by the modifyVolumeStatus field, until such as a resource
+                                                exists.
+                                                More info: https://kubernetes.io/docs/concepts/storage/volume-attributes-classes/
+                                              type: string
+                                            volumeMode:
+                                              description: |-
+                                                volumeMode defines what type of volume is required by the claim.
+                                                Value of Filesystem is implied when not included in claim spec.
+                                              type: string
+                                            volumeName:
+                                              description: volumeName is the binding
+                                                reference to the PersistentVolume
+                                                backing this claim.
+                                              type: string
+                                          type: object
+                                      required:
+                                      - spec
+                                      type: object
+                                  type: object
+                                fc:
+                                  description: fc represents a Fibre Channel resource
+                                    that is attached to a kubelet's host machine and
+                                    then exposed to the pod.
+                                  properties:
+                                    fsType:
+                                      description: |-
+                                        fsType is the filesystem type to mount.
+                                        Must be a filesystem type supported by the host operating system.
+                                        Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                      type: string
+                                    lun:
+                                      description: 'lun is Optional: FC target lun
+                                        number'
+                                      format: int32
+                                      type: integer
+                                    readOnly:
+                                      description: |-
+                                        readOnly is Optional: Defaults to false (read/write). ReadOnly here will force
+                                        the ReadOnly setting in VolumeMounts.
+                                      type: boolean
+                                    targetWWNs:
+                                      description: 'targetWWNs is Optional: FC target
+                                        worldwide names (WWNs)'
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    wwids:
+                                      description: |-
+                                        wwids Optional: FC volume world wide identifiers (wwids)
+                                        Either wwids or combination of targetWWNs and lun must be set, but not both simultaneously.
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                  type: object
+                                flexVolume:
+                                  description: |-
+                                    flexVolume represents a generic volume resource that is
+                                    provisioned/attached using an exec based plugin.
+                                    Deprecated: FlexVolume is deprecated. Consider using a CSIDriver instead.
+                                  properties:
+                                    driver:
+                                      description: driver is the name of the driver
+                                        to use for this volume.
+                                      type: string
+                                    fsType:
+                                      description: |-
+                                        fsType is the filesystem type to mount.
+                                        Must be a filesystem type supported by the host operating system.
+                                        Ex. "ext4", "xfs", "ntfs". The default filesystem depends on FlexVolume script.
+                                      type: string
+                                    options:
+                                      additionalProperties:
+                                        type: string
+                                      description: 'options is Optional: this field
+                                        holds extra command options if any.'
+                                      type: object
+                                    readOnly:
+                                      description: |-
+                                        readOnly is Optional: defaults to false (read/write). ReadOnly here will force
+                                        the ReadOnly setting in VolumeMounts.
+                                      type: boolean
+                                    secretRef:
+                                      description: |-
+                                        secretRef is Optional: secretRef is reference to the secret object containing
+                                        sensitive information to pass to the plugin scripts. This may be
+                                        empty if no secret object is specified. If the secret object
+                                        contains more than one secret, all secrets are passed to the plugin
+                                        scripts.
+                                      properties:
+                                        name:
+                                          default: ""
+                                          description: |-
+                                            Name of the referent.
+                                            This field is effectively required, but due to backwards compatibility is
+                                            allowed to be empty. Instances of this type with an empty value here are
+                                            almost certainly wrong.
+                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          type: string
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                  required:
+                                  - driver
+                                  type: object
+                                flocker:
+                                  description: |-
+                                    flocker represents a Flocker volume attached to a kubelet's host machine. This depends on the Flocker control service being running.
+                                    Deprecated: Flocker is deprecated and the in-tree flocker type is no longer supported.
+                                  properties:
+                                    datasetName:
+                                      description: |-
+                                        datasetName is Name of the dataset stored as metadata -> name on the dataset for Flocker
+                                        should be considered as deprecated
+                                      type: string
+                                    datasetUUID:
+                                      description: datasetUUID is the UUID of the
+                                        dataset. This is unique identifier of a Flocker
+                                        dataset
+                                      type: string
+                                  type: object
+                                gcePersistentDisk:
+                                  description: |-
+                                    gcePersistentDisk represents a GCE Disk resource that is attached to a
+                                    kubelet's host machine and then exposed to the pod.
+                                    Deprecated: GCEPersistentDisk is deprecated. All operations for the in-tree
+                                    gcePersistentDisk type are redirected to the pd.csi.storage.gke.io CSI driver.
+                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
+                                  properties:
+                                    fsType:
+                                      description: |-
+                                        fsType is filesystem type of the volume that you want to mount.
+                                        Tip: Ensure that the filesystem type is supported by the host operating system.
+                                        Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                        More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
+                                      type: string
+                                    partition:
+                                      description: |-
+                                        partition is the partition in the volume that you want to mount.
+                                        If omitted, the default is to mount by volume name.
+                                        Examples: For volume /dev/sda1, you specify the partition as "1".
+                                        Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty).
+                                        More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
+                                      format: int32
+                                      type: integer
+                                    pdName:
+                                      description: |-
+                                        pdName is unique name of the PD resource in GCE. Used to identify the disk in GCE.
+                                        More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
+                                      type: string
+                                    readOnly:
+                                      description: |-
+                                        readOnly here will force the ReadOnly setting in VolumeMounts.
+                                        Defaults to false.
+                                        More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
+                                      type: boolean
+                                  required:
+                                  - pdName
+                                  type: object
+                                gitRepo:
+                                  description: |-
+                                    gitRepo represents a git repository at a particular revision.
+                                    Deprecated: GitRepo is deprecated. To provision a container with a git repo, mount an
+                                    EmptyDir into an InitContainer that clones the repo using git, then mount the EmptyDir
+                                    into the Pod's container.
+                                  properties:
+                                    directory:
+                                      description: |-
+                                        directory is the target directory name.
+                                        Must not contain or start with '..'.  If '.' is supplied, the volume directory will be the
+                                        git repository.  Otherwise, if specified, the volume will contain the git repository in
+                                        the subdirectory with the given name.
+                                      type: string
+                                    repository:
+                                      description: repository is the URL
+                                      type: string
+                                    revision:
+                                      description: revision is the commit hash for
+                                        the specified revision.
+                                      type: string
+                                  required:
+                                  - repository
+                                  type: object
+                                glusterfs:
+                                  description: |-
+                                    glusterfs represents a Glusterfs mount on the host that shares a pod's lifetime.
+                                    Deprecated: Glusterfs is deprecated and the in-tree glusterfs type is no longer supported.
+                                  properties:
+                                    endpoints:
+                                      description: endpoints is the endpoint name
+                                        that details Glusterfs topology.
+                                      type: string
+                                    path:
+                                      description: |-
+                                        path is the Glusterfs volume path.
+                                        More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
+                                      type: string
+                                    readOnly:
+                                      description: |-
+                                        readOnly here will force the Glusterfs volume to be mounted with read-only permissions.
+                                        Defaults to false.
+                                        More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
+                                      type: boolean
+                                  required:
+                                  - endpoints
+                                  - path
+                                  type: object
+                                hostPath:
+                                  description: |-
+                                    hostPath represents a pre-existing file or directory on the host
+                                    machine that is directly exposed to the container. This is generally
+                                    used for system agents or other privileged things that are allowed
+                                    to see the host machine. Most containers will NOT need this.
+                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
+                                  properties:
+                                    path:
+                                      description: |-
+                                        path of the directory on the host.
+                                        If the path is a symlink, it will follow the link to the real path.
+                                        More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
+                                      type: string
+                                    type:
+                                      description: |-
+                                        type for HostPath Volume
+                                        Defaults to ""
+                                        More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
+                                      type: string
+                                  required:
+                                  - path
+                                  type: object
+                                image:
+                                  description: |-
+                                    image represents an OCI object (a container image or artifact) pulled and mounted on the kubelet's host machine.
+                                    The volume is resolved at pod startup depending on which PullPolicy value is provided:
+
+                                    - Always: the kubelet always attempts to pull the reference. Container creation will fail If the pull fails.
+                                    - Never: the kubelet never pulls the reference and only uses a local image or artifact. Container creation will fail if the reference isn't present.
+                                    - IfNotPresent: the kubelet pulls if the reference isn't already present on disk. Container creation will fail if the reference isn't present and the pull fails.
+
+                                    The volume gets re-resolved if the pod gets deleted and recreated, which means that new remote content will become available on pod recreation.
+                                    A failure to resolve or pull the image during pod startup will block containers from starting and may add significant latency. Failures will be retried using normal volume backoff and will be reported on the pod reason and message.
+                                    The types of objects that may be mounted by this volume are defined by the container runtime implementation on a host machine and at minimum must include all valid types supported by the container image field.
+                                    The OCI object gets mounted in a single directory (spec.containers[*].volumeMounts.mountPath) by merging the manifest layers in the same way as for container images.
+                                    The volume will be mounted read-only (ro) and non-executable files (noexec).
+                                    Sub path mounts for containers are not supported (spec.containers[*].volumeMounts.subpath) before 1.33.
+                                    The field spec.securityContext.fsGroupChangePolicy has no effect on this volume type.
+                                  properties:
+                                    pullPolicy:
+                                      description: |-
+                                        Policy for pulling OCI objects. Possible values are:
+                                        Always: the kubelet always attempts to pull the reference. Container creation will fail If the pull fails.
+                                        Never: the kubelet never pulls the reference and only uses a local image or artifact. Container creation will fail if the reference isn't present.
+                                        IfNotPresent: the kubelet pulls if the reference isn't already present on disk. Container creation will fail if the reference isn't present and the pull fails.
+                                        Defaults to Always if :latest tag is specified, or IfNotPresent otherwise.
+                                      type: string
+                                    reference:
+                                      description: |-
+                                        Required: Image or artifact reference to be used.
+                                        Behaves in the same way as pod.spec.containers[*].image.
+                                        Pull secrets will be assembled in the same way as for the container image by looking up node credentials, SA image pull secrets, and pod spec image pull secrets.
+                                        More info: https://kubernetes.io/docs/concepts/containers/images
+                                        This field is optional to allow higher level config management to default or override
+                                        container images in workload controllers like Deployments and StatefulSets.
+                                      type: string
+                                  type: object
+                                iscsi:
+                                  description: |-
+                                    iscsi represents an ISCSI Disk resource that is attached to a
+                                    kubelet's host machine and then exposed to the pod.
+                                    More info: https://kubernetes.io/docs/concepts/storage/volumes/#iscsi
+                                  properties:
+                                    chapAuthDiscovery:
+                                      description: chapAuthDiscovery defines whether
+                                        support iSCSI Discovery CHAP authentication
+                                      type: boolean
+                                    chapAuthSession:
+                                      description: chapAuthSession defines whether
+                                        support iSCSI Session CHAP authentication
+                                      type: boolean
+                                    fsType:
+                                      description: |-
+                                        fsType is the filesystem type of the volume that you want to mount.
+                                        Tip: Ensure that the filesystem type is supported by the host operating system.
+                                        Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                        More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi
+                                      type: string
+                                    initiatorName:
+                                      description: |-
+                                        initiatorName is the custom iSCSI Initiator Name.
+                                        If initiatorName is specified with iscsiInterface simultaneously, new iSCSI interface
+                                        <target portal>:<volume name> will be created for the connection.
+                                      type: string
+                                    iqn:
+                                      description: iqn is the target iSCSI Qualified
+                                        Name.
+                                      type: string
+                                    iscsiInterface:
+                                      default: default
+                                      description: |-
+                                        iscsiInterface is the interface Name that uses an iSCSI transport.
+                                        Defaults to 'default' (tcp).
+                                      type: string
+                                    lun:
+                                      description: lun represents iSCSI Target Lun
+                                        number.
+                                      format: int32
+                                      type: integer
+                                    portals:
+                                      description: |-
+                                        portals is the iSCSI Target Portal List. The portal is either an IP or ip_addr:port if the port
+                                        is other than default (typically TCP ports 860 and 3260).
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    readOnly:
+                                      description: |-
+                                        readOnly here will force the ReadOnly setting in VolumeMounts.
+                                        Defaults to false.
+                                      type: boolean
+                                    secretRef:
+                                      description: secretRef is the CHAP Secret for
+                                        iSCSI target and initiator authentication
+                                      properties:
+                                        name:
+                                          default: ""
+                                          description: |-
+                                            Name of the referent.
+                                            This field is effectively required, but due to backwards compatibility is
+                                            allowed to be empty. Instances of this type with an empty value here are
+                                            almost certainly wrong.
+                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          type: string
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    targetPortal:
+                                      description: |-
+                                        targetPortal is iSCSI Target Portal. The Portal is either an IP or ip_addr:port if the port
+                                        is other than default (typically TCP ports 860 and 3260).
+                                      type: string
+                                  required:
+                                  - iqn
+                                  - lun
+                                  - targetPortal
+                                  type: object
+                                name:
+                                  description: |-
+                                    name of the volume.
+                                    Must be a DNS_LABEL and unique within the pod.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                                nfs:
+                                  description: |-
+                                    nfs represents an NFS mount on the host that shares a pod's lifetime
+                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
+                                  properties:
+                                    path:
+                                      description: |-
+                                        path that is exported by the NFS server.
+                                        More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
+                                      type: string
+                                    readOnly:
+                                      description: |-
+                                        readOnly here will force the NFS export to be mounted with read-only permissions.
+                                        Defaults to false.
+                                        More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
+                                      type: boolean
+                                    server:
+                                      description: |-
+                                        server is the hostname or IP address of the NFS server.
+                                        More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
+                                      type: string
+                                  required:
+                                  - path
+                                  - server
+                                  type: object
+                                persistentVolumeClaim:
+                                  description: |-
+                                    persistentVolumeClaimVolumeSource represents a reference to a
+                                    PersistentVolumeClaim in the same namespace.
+                                    More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims
+                                  properties:
+                                    claimName:
+                                      description: |-
+                                        claimName is the name of a PersistentVolumeClaim in the same namespace as the pod using this volume.
+                                        More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims
+                                      type: string
+                                    readOnly:
+                                      description: |-
+                                        readOnly Will force the ReadOnly setting in VolumeMounts.
+                                        Default false.
+                                      type: boolean
+                                  required:
+                                  - claimName
+                                  type: object
+                                photonPersistentDisk:
+                                  description: |-
+                                    photonPersistentDisk represents a PhotonController persistent disk attached and mounted on kubelets host machine.
+                                    Deprecated: PhotonPersistentDisk is deprecated and the in-tree photonPersistentDisk type is no longer supported.
+                                  properties:
+                                    fsType:
+                                      description: |-
+                                        fsType is the filesystem type to mount.
+                                        Must be a filesystem type supported by the host operating system.
+                                        Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                      type: string
+                                    pdID:
+                                      description: pdID is the ID that identifies
+                                        Photon Controller persistent disk
+                                      type: string
+                                  required:
+                                  - pdID
+                                  type: object
+                                portworxVolume:
+                                  description: |-
+                                    portworxVolume represents a portworx volume attached and mounted on kubelets host machine.
+                                    Deprecated: PortworxVolume is deprecated. All operations for the in-tree portworxVolume type
+                                    are redirected to the pxd.portworx.com CSI driver when the CSIMigrationPortworx feature-gate
+                                    is on.
+                                  properties:
+                                    fsType:
+                                      description: |-
+                                        fSType represents the filesystem type to mount
+                                        Must be a filesystem type supported by the host operating system.
+                                        Ex. "ext4", "xfs". Implicitly inferred to be "ext4" if unspecified.
+                                      type: string
+                                    readOnly:
+                                      description: |-
+                                        readOnly defaults to false (read/write). ReadOnly here will force
+                                        the ReadOnly setting in VolumeMounts.
+                                      type: boolean
+                                    volumeID:
+                                      description: volumeID uniquely identifies a
+                                        Portworx volume
+                                      type: string
+                                  required:
+                                  - volumeID
+                                  type: object
+                                projected:
+                                  description: projected items for all in one resources
+                                    secrets, configmaps, and downward API
+                                  properties:
+                                    defaultMode:
+                                      description: |-
+                                        defaultMode are the mode bits used to set permissions on created files by default.
+                                        Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                        YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                        Directories within the path are not affected by this setting.
+                                        This might be in conflict with other options that affect the file
+                                        mode, like fsGroup, and the result can be other mode bits set.
+                                      format: int32
+                                      type: integer
+                                    sources:
+                                      description: |-
+                                        sources is the list of volume projections. Each entry in this list
+                                        handles one source.
+                                      items:
+                                        description: |-
+                                          Projection that may be projected along with other supported volume types.
+                                          Exactly one of these fields must be set.
+                                        properties:
+                                          clusterTrustBundle:
+                                            description: |-
+                                              ClusterTrustBundle allows a pod to access the `.spec.trustBundle` field
+                                              of ClusterTrustBundle objects in an auto-updating file.
+
+                                              Alpha, gated by the ClusterTrustBundleProjection feature gate.
+
+                                              ClusterTrustBundle objects can either be selected by name, or by the
+                                              combination of signer name and a label selector.
+
+                                              Kubelet performs aggressive normalization of the PEM contents written
+                                              into the pod filesystem.  Esoteric PEM features such as inter-block
+                                              comments and block headers are stripped.  Certificates are deduplicated.
+                                              The ordering of certificates within the file is arbitrary, and Kubelet
+                                              may change the order over time.
+                                            properties:
+                                              labelSelector:
+                                                description: |-
+                                                  Select all ClusterTrustBundles that match this label selector.  Only has
+                                                  effect if signerName is set.  Mutually-exclusive with name.  If unset,
+                                                  interpreted as "match nothing".  If set but empty, interpreted as "match
+                                                  everything".
+                                                properties:
+                                                  matchExpressions:
+                                                    description: matchExpressions
+                                                      is a list of label selector
+                                                      requirements. The requirements
+                                                      are ANDed.
+                                                    items:
+                                                      description: |-
+                                                        A label selector requirement is a selector that contains values, a key, and an operator that
+                                                        relates the key and values.
+                                                      properties:
+                                                        key:
+                                                          description: key is the
+                                                            label key that the selector
+                                                            applies to.
+                                                          type: string
+                                                        operator:
+                                                          description: |-
+                                                            operator represents a key's relationship to a set of values.
+                                                            Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                          type: string
+                                                        values:
+                                                          description: |-
+                                                            values is an array of string values. If the operator is In or NotIn,
+                                                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                            the values array must be empty. This array is replaced during a strategic
+                                                            merge patch.
+                                                          items:
+                                                            type: string
+                                                          type: array
+                                                          x-kubernetes-list-type: atomic
+                                                      required:
+                                                      - key
+                                                      - operator
+                                                      type: object
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                  matchLabels:
+                                                    additionalProperties:
+                                                      type: string
+                                                    description: |-
+                                                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                      map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                      operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                    type: object
+                                                type: object
+                                                x-kubernetes-map-type: atomic
+                                              name:
+                                                description: |-
+                                                  Select a single ClusterTrustBundle by object name.  Mutually-exclusive
+                                                  with signerName and labelSelector.
+                                                type: string
+                                              optional:
+                                                description: |-
+                                                  If true, don't block pod startup if the referenced ClusterTrustBundle(s)
+                                                  aren't available.  If using name, then the named ClusterTrustBundle is
+                                                  allowed not to exist.  If using signerName, then the combination of
+                                                  signerName and labelSelector is allowed to match zero
+                                                  ClusterTrustBundles.
+                                                type: boolean
+                                              path:
+                                                description: Relative path from the
+                                                  volume root to write the bundle.
+                                                type: string
+                                              signerName:
+                                                description: |-
+                                                  Select all ClusterTrustBundles that match this signer name.
+                                                  Mutually-exclusive with name.  The contents of all selected
+                                                  ClusterTrustBundles will be unified and deduplicated.
+                                                type: string
+                                            required:
+                                            - path
+                                            type: object
+                                          configMap:
+                                            description: configMap information about
+                                              the configMap data to project
+                                            properties:
+                                              items:
+                                                description: |-
+                                                  items if unspecified, each key-value pair in the Data field of the referenced
+                                                  ConfigMap will be projected into the volume as a file whose name is the
+                                                  key and content is the value. If specified, the listed keys will be
+                                                  projected into the specified paths, and unlisted keys will not be
+                                                  present. If a key is specified which is not present in the ConfigMap,
+                                                  the volume setup will error unless it is marked optional. Paths must be
+                                                  relative and may not contain the '..' path or start with '..'.
+                                                items:
+                                                  description: Maps a string key to
+                                                    a path within a volume.
+                                                  properties:
+                                                    key:
+                                                      description: key is the key
+                                                        to project.
+                                                      type: string
+                                                    mode:
+                                                      description: |-
+                                                        mode is Optional: mode bits used to set permissions on this file.
+                                                        Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                                        YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                                        If not specified, the volume defaultMode will be used.
+                                                        This might be in conflict with other options that affect the file
+                                                        mode, like fsGroup, and the result can be other mode bits set.
+                                                      format: int32
+                                                      type: integer
+                                                    path:
+                                                      description: |-
+                                                        path is the relative path of the file to map the key to.
+                                                        May not be an absolute path.
+                                                        May not contain the path element '..'.
+                                                        May not start with the string '..'.
+                                                      type: string
+                                                  required:
+                                                  - key
+                                                  - path
+                                                  type: object
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                              name:
+                                                default: ""
+                                                description: |-
+                                                  Name of the referent.
+                                                  This field is effectively required, but due to backwards compatibility is
+                                                  allowed to be empty. Instances of this type with an empty value here are
+                                                  almost certainly wrong.
+                                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                type: string
+                                              optional:
+                                                description: optional specify whether
+                                                  the ConfigMap or its keys must be
+                                                  defined
+                                                type: boolean
+                                            type: object
+                                            x-kubernetes-map-type: atomic
+                                          downwardAPI:
+                                            description: downwardAPI information about
+                                              the downwardAPI data to project
+                                            properties:
+                                              items:
+                                                description: Items is a list of DownwardAPIVolume
+                                                  file
+                                                items:
+                                                  description: DownwardAPIVolumeFile
+                                                    represents information to create
+                                                    the file containing the pod field
+                                                  properties:
+                                                    fieldRef:
+                                                      description: 'Required: Selects
+                                                        a field of the pod: only annotations,
+                                                        labels, name, namespace and
+                                                        uid are supported.'
+                                                      properties:
+                                                        apiVersion:
+                                                          description: Version of
+                                                            the schema the FieldPath
+                                                            is written in terms of,
+                                                            defaults to "v1".
+                                                          type: string
+                                                        fieldPath:
+                                                          description: Path of the
+                                                            field to select in the
+                                                            specified API version.
+                                                          type: string
+                                                      required:
+                                                      - fieldPath
+                                                      type: object
+                                                      x-kubernetes-map-type: atomic
+                                                    mode:
+                                                      description: |-
+                                                        Optional: mode bits used to set permissions on this file, must be an octal value
+                                                        between 0000 and 0777 or a decimal value between 0 and 511.
+                                                        YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                                        If not specified, the volume defaultMode will be used.
+                                                        This might be in conflict with other options that affect the file
+                                                        mode, like fsGroup, and the result can be other mode bits set.
+                                                      format: int32
+                                                      type: integer
+                                                    path:
+                                                      description: 'Required: Path
+                                                        is  the relative path name
+                                                        of the file to be created.
+                                                        Must not be absolute or contain
+                                                        the ''..'' path. Must be utf-8
+                                                        encoded. The first item of
+                                                        the relative path must not
+                                                        start with ''..'''
+                                                      type: string
+                                                    resourceFieldRef:
+                                                      description: |-
+                                                        Selects a resource of the container: only resources limits and requests
+                                                        (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.
+                                                      properties:
+                                                        containerName:
+                                                          description: 'Container
+                                                            name: required for volumes,
+                                                            optional for env vars'
+                                                          type: string
+                                                        divisor:
+                                                          anyOf:
+                                                          - type: integer
+                                                          - type: string
+                                                          description: Specifies the
+                                                            output format of the exposed
+                                                            resources, defaults to
+                                                            "1"
+                                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                          x-kubernetes-int-or-string: true
+                                                        resource:
+                                                          description: 'Required:
+                                                            resource to select'
+                                                          type: string
+                                                      required:
+                                                      - resource
+                                                      type: object
+                                                      x-kubernetes-map-type: atomic
+                                                  required:
+                                                  - path
+                                                  type: object
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            type: object
+                                          podCertificate:
+                                            description: |-
+                                              Projects an auto-rotating credential bundle (private key and certificate
+                                              chain) that the pod can use either as a TLS client or server.
+
+                                              Kubelet generates a private key and uses it to send a
+                                              PodCertificateRequest to the named signer.  Once the signer approves the
+                                              request and issues a certificate chain, Kubelet writes the key and
+                                              certificate chain to the pod filesystem.  The pod does not start until
+                                              certificates have been issued for each podCertificate projected volume
+                                              source in its spec.
+
+                                              Kubelet will begin trying to rotate the certificate at the time indicated
+                                              by the signer using the PodCertificateRequest.Status.BeginRefreshAt
+                                              timestamp.
+
+                                              Kubelet can write a single file, indicated by the credentialBundlePath
+                                              field, or separate files, indicated by the keyPath and
+                                              certificateChainPath fields.
+
+                                              The credential bundle is a single file in PEM format.  The first PEM
+                                              entry is the private key (in PKCS#8 format), and the remaining PEM
+                                              entries are the certificate chain issued by the signer (typically,
+                                              signers will return their certificate chain in leaf-to-root order).
+
+                                              Prefer using the credential bundle format, since your application code
+                                              can read it atomically.  If you use keyPath and certificateChainPath,
+                                              your application must make two separate file reads. If these coincide
+                                              with a certificate rotation, it is possible that the private key and leaf
+                                              certificate you read may not correspond to each other.  Your application
+                                              will need to check for this condition, and re-read until they are
+                                              consistent.
+
+                                              The named signer controls chooses the format of the certificate it
+                                              issues; consult the signer implementation's documentation to learn how to
+                                              use the certificates it issues.
+                                            properties:
+                                              certificateChainPath:
+                                                description: |-
+                                                  Write the certificate chain at this path in the projected volume.
+
+                                                  Most applications should use credentialBundlePath.  When using keyPath
+                                                  and certificateChainPath, your application needs to check that the key
+                                                  and leaf certificate are consistent, because it is possible to read the
+                                                  files mid-rotation.
+                                                type: string
+                                              credentialBundlePath:
+                                                description: |-
+                                                  Write the credential bundle at this path in the projected volume.
+
+                                                  The credential bundle is a single file that contains multiple PEM blocks.
+                                                  The first PEM block is a PRIVATE KEY block, containing a PKCS#8 private
+                                                  key.
+
+                                                  The remaining blocks are CERTIFICATE blocks, containing the issued
+                                                  certificate chain from the signer (leaf and any intermediates).
+
+                                                  Using credentialBundlePath lets your Pod's application code make a single
+                                                  atomic read that retrieves a consistent key and certificate chain.  If you
+                                                  project them to separate files, your application code will need to
+                                                  additionally check that the leaf certificate was issued to the key.
+                                                type: string
+                                              keyPath:
+                                                description: |-
+                                                  Write the key at this path in the projected volume.
+
+                                                  Most applications should use credentialBundlePath.  When using keyPath
+                                                  and certificateChainPath, your application needs to check that the key
+                                                  and leaf certificate are consistent, because it is possible to read the
+                                                  files mid-rotation.
+                                                type: string
+                                              keyType:
+                                                description: |-
+                                                  The type of keypair Kubelet will generate for the pod.
+
+                                                  Valid values are "RSA3072", "RSA4096", "ECDSAP256", "ECDSAP384",
+                                                  "ECDSAP521", and "ED25519".
+                                                type: string
+                                              maxExpirationSeconds:
+                                                description: |-
+                                                  maxExpirationSeconds is the maximum lifetime permitted for the
+                                                  certificate.
+
+                                                  Kubelet copies this value verbatim into the PodCertificateRequests it
+                                                  generates for this projection.
+
+                                                  If omitted, kube-apiserver will set it to 86400(24 hours). kube-apiserver
+                                                  will reject values shorter than 3600 (1 hour).  The maximum allowable
+                                                  value is 7862400 (91 days).
+
+                                                  The signer implementation is then free to issue a certificate with any
+                                                  lifetime *shorter* than MaxExpirationSeconds, but no shorter than 3600
+                                                  seconds (1 hour).  This constraint is enforced by kube-apiserver.
+                                                  `kubernetes.io` signers will never issue certificates with a lifetime
+                                                  longer than 24 hours.
+                                                format: int32
+                                                type: integer
+                                              signerName:
+                                                description: Kubelet's generated CSRs
+                                                  will be addressed to this signer.
+                                                type: string
+                                            required:
+                                            - keyType
+                                            - signerName
+                                            type: object
+                                          secret:
+                                            description: secret information about
+                                              the secret data to project
+                                            properties:
+                                              items:
+                                                description: |-
+                                                  items if unspecified, each key-value pair in the Data field of the referenced
+                                                  Secret will be projected into the volume as a file whose name is the
+                                                  key and content is the value. If specified, the listed keys will be
+                                                  projected into the specified paths, and unlisted keys will not be
+                                                  present. If a key is specified which is not present in the Secret,
+                                                  the volume setup will error unless it is marked optional. Paths must be
+                                                  relative and may not contain the '..' path or start with '..'.
+                                                items:
+                                                  description: Maps a string key to
+                                                    a path within a volume.
+                                                  properties:
+                                                    key:
+                                                      description: key is the key
+                                                        to project.
+                                                      type: string
+                                                    mode:
+                                                      description: |-
+                                                        mode is Optional: mode bits used to set permissions on this file.
+                                                        Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                                        YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                                        If not specified, the volume defaultMode will be used.
+                                                        This might be in conflict with other options that affect the file
+                                                        mode, like fsGroup, and the result can be other mode bits set.
+                                                      format: int32
+                                                      type: integer
+                                                    path:
+                                                      description: |-
+                                                        path is the relative path of the file to map the key to.
+                                                        May not be an absolute path.
+                                                        May not contain the path element '..'.
+                                                        May not start with the string '..'.
+                                                      type: string
+                                                  required:
+                                                  - key
+                                                  - path
+                                                  type: object
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                              name:
+                                                default: ""
+                                                description: |-
+                                                  Name of the referent.
+                                                  This field is effectively required, but due to backwards compatibility is
+                                                  allowed to be empty. Instances of this type with an empty value here are
+                                                  almost certainly wrong.
+                                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                type: string
+                                              optional:
+                                                description: optional field specify
+                                                  whether the Secret or its key must
+                                                  be defined
+                                                type: boolean
+                                            type: object
+                                            x-kubernetes-map-type: atomic
+                                          serviceAccountToken:
+                                            description: serviceAccountToken is information
+                                              about the serviceAccountToken data to
+                                              project
+                                            properties:
+                                              audience:
+                                                description: |-
+                                                  audience is the intended audience of the token. A recipient of a token
+                                                  must identify itself with an identifier specified in the audience of the
+                                                  token, and otherwise should reject the token. The audience defaults to the
+                                                  identifier of the apiserver.
+                                                type: string
+                                              expirationSeconds:
+                                                description: |-
+                                                  expirationSeconds is the requested duration of validity of the service
+                                                  account token. As the token approaches expiration, the kubelet volume
+                                                  plugin will proactively rotate the service account token. The kubelet will
+                                                  start trying to rotate the token if the token is older than 80 percent of
+                                                  its time to live or if the token is older than 24 hours.Defaults to 1 hour
+                                                  and must be at least 10 minutes.
+                                                format: int64
+                                                type: integer
+                                              path:
+                                                description: |-
+                                                  path is the path relative to the mount point of the file to project the
+                                                  token into.
+                                                type: string
+                                            required:
+                                            - path
+                                            type: object
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                  type: object
+                                quobyte:
+                                  description: |-
+                                    quobyte represents a Quobyte mount on the host that shares a pod's lifetime.
+                                    Deprecated: Quobyte is deprecated and the in-tree quobyte type is no longer supported.
+                                  properties:
+                                    group:
+                                      description: |-
+                                        group to map volume access to
+                                        Default is no group
+                                      type: string
+                                    readOnly:
+                                      description: |-
+                                        readOnly here will force the Quobyte volume to be mounted with read-only permissions.
+                                        Defaults to false.
+                                      type: boolean
+                                    registry:
+                                      description: |-
+                                        registry represents a single or multiple Quobyte Registry services
+                                        specified as a string as host:port pair (multiple entries are separated with commas)
+                                        which acts as the central registry for volumes
+                                      type: string
+                                    tenant:
+                                      description: |-
+                                        tenant owning the given Quobyte volume in the Backend
+                                        Used with dynamically provisioned Quobyte volumes, value is set by the plugin
+                                      type: string
+                                    user:
+                                      description: |-
+                                        user to map volume access to
+                                        Defaults to serivceaccount user
+                                      type: string
+                                    volume:
+                                      description: volume is a string that references
+                                        an already created Quobyte volume by name.
+                                      type: string
+                                  required:
+                                  - registry
+                                  - volume
+                                  type: object
+                                rbd:
+                                  description: |-
+                                    rbd represents a Rados Block Device mount on the host that shares a pod's lifetime.
+                                    Deprecated: RBD is deprecated and the in-tree rbd type is no longer supported.
+                                  properties:
+                                    fsType:
+                                      description: |-
+                                        fsType is the filesystem type of the volume that you want to mount.
+                                        Tip: Ensure that the filesystem type is supported by the host operating system.
+                                        Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                        More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd
+                                      type: string
+                                    image:
+                                      description: |-
+                                        image is the rados image name.
+                                        More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+                                      type: string
+                                    keyring:
+                                      default: /etc/ceph/keyring
+                                      description: |-
+                                        keyring is the path to key ring for RBDUser.
+                                        Default is /etc/ceph/keyring.
+                                        More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+                                      type: string
+                                    monitors:
+                                      description: |-
+                                        monitors is a collection of Ceph monitors.
+                                        More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    pool:
+                                      default: rbd
+                                      description: |-
+                                        pool is the rados pool name.
+                                        Default is rbd.
+                                        More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+                                      type: string
+                                    readOnly:
+                                      description: |-
+                                        readOnly here will force the ReadOnly setting in VolumeMounts.
+                                        Defaults to false.
+                                        More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+                                      type: boolean
+                                    secretRef:
+                                      description: |-
+                                        secretRef is name of the authentication secret for RBDUser. If provided
+                                        overrides keyring.
+                                        Default is nil.
+                                        More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+                                      properties:
+                                        name:
+                                          default: ""
+                                          description: |-
+                                            Name of the referent.
+                                            This field is effectively required, but due to backwards compatibility is
+                                            allowed to be empty. Instances of this type with an empty value here are
+                                            almost certainly wrong.
+                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          type: string
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    user:
+                                      default: admin
+                                      description: |-
+                                        user is the rados user name.
+                                        Default is admin.
+                                        More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+                                      type: string
+                                  required:
+                                  - image
+                                  - monitors
+                                  type: object
+                                scaleIO:
+                                  description: |-
+                                    scaleIO represents a ScaleIO persistent volume attached and mounted on Kubernetes nodes.
+                                    Deprecated: ScaleIO is deprecated and the in-tree scaleIO type is no longer supported.
+                                  properties:
+                                    fsType:
+                                      default: xfs
+                                      description: |-
+                                        fsType is the filesystem type to mount.
+                                        Must be a filesystem type supported by the host operating system.
+                                        Ex. "ext4", "xfs", "ntfs".
+                                        Default is "xfs".
+                                      type: string
+                                    gateway:
+                                      description: gateway is the host address of
+                                        the ScaleIO API Gateway.
+                                      type: string
+                                    protectionDomain:
+                                      description: protectionDomain is the name of
+                                        the ScaleIO Protection Domain for the configured
+                                        storage.
+                                      type: string
+                                    readOnly:
+                                      description: |-
+                                        readOnly Defaults to false (read/write). ReadOnly here will force
+                                        the ReadOnly setting in VolumeMounts.
+                                      type: boolean
+                                    secretRef:
+                                      description: |-
+                                        secretRef references to the secret for ScaleIO user and other
+                                        sensitive information. If this is not provided, Login operation will fail.
+                                      properties:
+                                        name:
+                                          default: ""
+                                          description: |-
+                                            Name of the referent.
+                                            This field is effectively required, but due to backwards compatibility is
+                                            allowed to be empty. Instances of this type with an empty value here are
+                                            almost certainly wrong.
+                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          type: string
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    sslEnabled:
+                                      description: sslEnabled Flag enable/disable
+                                        SSL communication with Gateway, default false
+                                      type: boolean
+                                    storageMode:
+                                      default: ThinProvisioned
+                                      description: |-
+                                        storageMode indicates whether the storage for a volume should be ThickProvisioned or ThinProvisioned.
+                                        Default is ThinProvisioned.
+                                      type: string
+                                    storagePool:
+                                      description: storagePool is the ScaleIO Storage
+                                        Pool associated with the protection domain.
+                                      type: string
+                                    system:
+                                      description: system is the name of the storage
+                                        system as configured in ScaleIO.
+                                      type: string
+                                    volumeName:
+                                      description: |-
+                                        volumeName is the name of a volume already created in the ScaleIO system
+                                        that is associated with this volume source.
+                                      type: string
+                                  required:
+                                  - gateway
+                                  - secretRef
+                                  - system
+                                  type: object
+                                secret:
+                                  description: |-
+                                    secret represents a secret that should populate this volume.
+                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#secret
+                                  properties:
+                                    defaultMode:
+                                      description: |-
+                                        defaultMode is Optional: mode bits used to set permissions on created files by default.
+                                        Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                        YAML accepts both octal and decimal values, JSON requires decimal values
+                                        for mode bits. Defaults to 0644.
+                                        Directories within the path are not affected by this setting.
+                                        This might be in conflict with other options that affect the file
+                                        mode, like fsGroup, and the result can be other mode bits set.
+                                      format: int32
+                                      type: integer
+                                    items:
+                                      description: |-
+                                        items If unspecified, each key-value pair in the Data field of the referenced
+                                        Secret will be projected into the volume as a file whose name is the
+                                        key and content is the value. If specified, the listed keys will be
+                                        projected into the specified paths, and unlisted keys will not be
+                                        present. If a key is specified which is not present in the Secret,
+                                        the volume setup will error unless it is marked optional. Paths must be
+                                        relative and may not contain the '..' path or start with '..'.
+                                      items:
+                                        description: Maps a string key to a path within
+                                          a volume.
+                                        properties:
+                                          key:
+                                            description: key is the key to project.
+                                            type: string
+                                          mode:
+                                            description: |-
+                                              mode is Optional: mode bits used to set permissions on this file.
+                                              Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                              YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                              If not specified, the volume defaultMode will be used.
+                                              This might be in conflict with other options that affect the file
+                                              mode, like fsGroup, and the result can be other mode bits set.
+                                            format: int32
+                                            type: integer
+                                          path:
+                                            description: |-
+                                              path is the relative path of the file to map the key to.
+                                              May not be an absolute path.
+                                              May not contain the path element '..'.
+                                              May not start with the string '..'.
+                                            type: string
+                                        required:
+                                        - key
+                                        - path
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    optional:
+                                      description: optional field specify whether
+                                        the Secret or its keys must be defined
+                                      type: boolean
+                                    secretName:
+                                      description: |-
+                                        secretName is the name of the secret in the pod's namespace to use.
+                                        More info: https://kubernetes.io/docs/concepts/storage/volumes#secret
+                                      type: string
+                                  type: object
+                                storageos:
+                                  description: |-
+                                    storageOS represents a StorageOS volume attached and mounted on Kubernetes nodes.
+                                    Deprecated: StorageOS is deprecated and the in-tree storageos type is no longer supported.
+                                  properties:
+                                    fsType:
+                                      description: |-
+                                        fsType is the filesystem type to mount.
+                                        Must be a filesystem type supported by the host operating system.
+                                        Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                      type: string
+                                    readOnly:
+                                      description: |-
+                                        readOnly defaults to false (read/write). ReadOnly here will force
+                                        the ReadOnly setting in VolumeMounts.
+                                      type: boolean
+                                    secretRef:
+                                      description: |-
+                                        secretRef specifies the secret to use for obtaining the StorageOS API
+                                        credentials.  If not specified, default values will be attempted.
+                                      properties:
+                                        name:
+                                          default: ""
+                                          description: |-
+                                            Name of the referent.
+                                            This field is effectively required, but due to backwards compatibility is
+                                            allowed to be empty. Instances of this type with an empty value here are
+                                            almost certainly wrong.
+                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          type: string
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    volumeName:
+                                      description: |-
+                                        volumeName is the human-readable name of the StorageOS volume.  Volume
+                                        names are only unique within a namespace.
+                                      type: string
+                                    volumeNamespace:
+                                      description: |-
+                                        volumeNamespace specifies the scope of the volume within StorageOS.  If no
+                                        namespace is specified then the Pod's namespace will be used.  This allows the
+                                        Kubernetes name scoping to be mirrored within StorageOS for tighter integration.
+                                        Set VolumeName to any name to override the default behaviour.
+                                        Set to "default" if you are not using namespaces within StorageOS.
+                                        Namespaces that do not pre-exist within StorageOS will be created.
+                                      type: string
+                                  type: object
+                                vsphereVolume:
+                                  description: |-
+                                    vsphereVolume represents a vSphere volume attached and mounted on kubelets host machine.
+                                    Deprecated: VsphereVolume is deprecated. All operations for the in-tree vsphereVolume type
+                                    are redirected to the csi.vsphere.vmware.com CSI driver.
+                                  properties:
+                                    fsType:
+                                      description: |-
+                                        fsType is filesystem type to mount.
+                                        Must be a filesystem type supported by the host operating system.
+                                        Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                      type: string
+                                    storagePolicyID:
+                                      description: storagePolicyID is the storage
+                                        Policy Based Management (SPBM) profile ID
+                                        associated with the StoragePolicyName.
+                                      type: string
+                                    storagePolicyName:
+                                      description: storagePolicyName is the storage
+                                        Policy Based Management (SPBM) profile name.
+                                      type: string
+                                    volumePath:
+                                      description: volumePath is the path that identifies
+                                        vSphere volume vmdk
+                                      type: string
+                                  required:
+                                  - volumePath
+                                  type: object
+                              required:
+                              - name
+                              type: object
+                            type: array
+                            x-kubernetes-list-map-keys:
+                            - name
+                            x-kubernetes-list-type: map
+                        required:
+                        - containers
+                        type: object
+                    type: object
+                  ttlSecondsAfterFinished:
+                    description: |-
+                      ttlSecondsAfterFinished limits the lifetime of a Job that has finished
+                      execution (either Complete or Failed). If this field is set,
+                      ttlSecondsAfterFinished after the Job finishes, it is eligible to be
+                      automatically deleted. When the Job is being deleted, its lifecycle
+                      guarantees (e.g. finalizers) will be honored. If this field is unset,
+                      the Job won't be automatically deleted. If this field is set to zero,
+                      the Job becomes eligible to be deleted immediately after it finishes.
+                    format: int32
+                    type: integer
+                required:
+                - template
+                type: object
+              maxReplicaCount:
+                format: int32
+                type: integer
+              minReplicaCount:
+                format: int32
+                type: integer
+              pollingInterval:
+                format: int32
+                type: integer
+              rollout:
+                description: Rollout defines the strategy for job rollouts
+                properties:
+                  propagationPolicy:
+                    type: string
+                  strategy:
+                    type: string
+                type: object
+              rolloutStrategy:
+                type: string
+              scalingStrategy:
+                description: ScalingStrategy defines the strategy of Scaling
+                properties:
+                  customScalingQueueLengthDeduction:
+                    format: int32
+                    type: integer
+                  customScalingRunningJobPercentage:
+                    type: string
+                  multipleScalersCalculation:
+                    type: string
+                  pendingPodConditions:
+                    items:
+                      type: string
+                    type: array
+                  strategy:
+                    type: string
+                type: object
+              successfulJobsHistoryLimit:
+                format: int32
+                type: integer
+              triggers:
+                items:
+                  description: ScaleTriggers reference the scaler that will be used
+                  properties:
+                    authenticationRef:
+                      description: |-
+                        AuthenticationRef points to the TriggerAuthentication or ClusterTriggerAuthentication object that
+                        is used to authenticate the scaler with the environment
+                      properties:
+                        kind:
+                          description: Kind of the resource being referred to. Defaults
+                            to TriggerAuthentication.
+                          type: string
+                        name:
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    metadata:
+                      additionalProperties:
+                        type: string
+                      type: object
+                    name:
+                      type: string
+                    type:
+                      type: string
+                    useCachedMetrics:
+                      type: boolean
+                  required:
+                  - metadata
+                  - type
+                  type: object
+                type: array
+            required:
+            - jobTargetRef
+            - triggers
+            type: object
+          status:
+            description: ScaledJobStatus defines the observed state of ScaledJob
+            properties:
+              Paused:
+                type: string
+              authenticationsTypes:
+                type: string
+              conditions:
+                description: Conditions an array representation to store multiple
+                  Conditions
+                items:
+                  description: Condition to store the condition state
+                  properties:
+                    message:
+                      description: A human readable message indicating details about
+                        the transition.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of condition
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              externalMetricNames:
+                items:
+                  type: string
+                type: array
+              lastActiveTime:
+                format: date-time
+                type: string
+              triggersActivity:
+                additionalProperties:
+                  description: TriggerActivityStatus represents the activity status
+                    of an external trigger
+                  properties:
+                    isActive:
+                      type: boolean
+                  type: object
+                type: object
+              triggersTypes:
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+# Source: keda/templates/crds/crd-scaledobjects.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.20.0
+  labels:
+    app.kubernetes.io/name: keda-operator    
+    helm.sh/chart: keda-2.19.0
+    app.kubernetes.io/component: operator
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: keda-operator
+    app.kubernetes.io/version: 2.19.0
+  name: scaledobjects.keda.sh
+spec:
+  group: keda.sh
+  names:
+    kind: ScaledObject
+    listKind: ScaledObjectList
+    plural: scaledobjects
+    shortNames:
+    - so
+    singular: scaledobject
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.scaleTargetKind
+      name: ScaleTargetKind
+      type: string
+    - jsonPath: .spec.scaleTargetRef.name
+      name: ScaleTargetName
+      type: string
+    - jsonPath: .spec.minReplicaCount
+      name: Min
+      type: integer
+    - jsonPath: .spec.maxReplicaCount
+      name: Max
+      type: integer
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Active")].status
+      name: Active
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Fallback")].status
+      name: Fallback
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Paused")].status
+      name: Paused
+      type: string
+    - jsonPath: .status.triggersTypes
+      name: Triggers
+      type: string
+    - jsonPath: .status.authenticationsTypes
+      name: Authentications
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: ScaledObject is a specification for a ScaledObject resource
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ScaledObjectSpec is the spec for a ScaledObject resource
+            properties:
+              advanced:
+                description: AdvancedConfig specifies advance scaling options
+                properties:
+                  horizontalPodAutoscalerConfig:
+                    description: HorizontalPodAutoscalerConfig specifies horizontal
+                      scale config
+                    properties:
+                      behavior:
+                        description: |-
+                          HorizontalPodAutoscalerBehavior configures the scaling behavior of the target
+                          in both Up and Down directions (scaleUp and scaleDown fields respectively).
+                        properties:
+                          scaleDown:
+                            description: |-
+                              scaleDown is scaling policy for scaling Down.
+                              If not set, the default value is to allow to scale down to minReplicas pods, with a
+                              300 second stabilization window (i.e., the highest recommendation for
+                              the last 300sec is used).
+                            properties:
+                              policies:
+                                description: |-
+                                  policies is a list of potential scaling polices which can be used during scaling.
+                                  If not set, use the default values:
+                                  - For scale up: allow doubling the number of pods, or an absolute change of 4 pods in a 15s window.
+                                  - For scale down: allow all pods to be removed in a 15s window.
+                                items:
+                                  description: HPAScalingPolicy is a single policy
+                                    which must hold true for a specified past interval.
+                                  properties:
+                                    periodSeconds:
+                                      description: |-
+                                        periodSeconds specifies the window of time for which the policy should hold true.
+                                        PeriodSeconds must be greater than zero and less than or equal to 1800 (30 min).
+                                      format: int32
+                                      type: integer
+                                    type:
+                                      description: type is used to specify the scaling
+                                        policy.
+                                      type: string
+                                    value:
+                                      description: |-
+                                        value contains the amount of change which is permitted by the policy.
+                                        It must be greater than zero
+                                      format: int32
+                                      type: integer
+                                  required:
+                                  - periodSeconds
+                                  - type
+                                  - value
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              selectPolicy:
+                                description: |-
+                                  selectPolicy is used to specify which policy should be used.
+                                  If not set, the default value Max is used.
+                                type: string
+                              stabilizationWindowSeconds:
+                                description: |-
+                                  stabilizationWindowSeconds is the number of seconds for which past recommendations should be
+                                  considered while scaling up or scaling down.
+                                  StabilizationWindowSeconds must be greater than or equal to zero and less than or equal to 3600 (one hour).
+                                  If not set, use the default values:
+                                  - For scale up: 0 (i.e. no stabilization is done).
+                                  - For scale down: 300 (i.e. the stabilization window is 300 seconds long).
+                                format: int32
+                                maximum: 3600
+                                minimum: 0
+                                type: integer
+                              tolerance:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                description: |-
+                                  tolerance is the tolerance on the ratio between the current and desired
+                                  metric value under which no updates are made to the desired number of
+                                  replicas (e.g. 0.01 for 1%). Must be greater than or equal to zero. If not
+                                  set, the default cluster-wide tolerance is applied (by default 10%).
+
+                                  For example, if autoscaling is configured with a memory consumption target of 100Mi,
+                                  and scale-down and scale-up tolerances of 5% and 1% respectively, scaling will be
+                                  triggered when the actual consumption falls below 95Mi or exceeds 101Mi.
+
+                                  This is an alpha field and requires enabling the HPAConfigurableTolerance
+                                  feature gate.
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                            type: object
+                          scaleUp:
+                            description: |-
+                              scaleUp is scaling policy for scaling Up.
+                              If not set, the default value is the higher of:
+                                * increase no more than 4 pods per 60 seconds
+                                * double the number of pods per 60 seconds
+                              No stabilization is used.
+                            properties:
+                              policies:
+                                description: |-
+                                  policies is a list of potential scaling polices which can be used during scaling.
+                                  If not set, use the default values:
+                                  - For scale up: allow doubling the number of pods, or an absolute change of 4 pods in a 15s window.
+                                  - For scale down: allow all pods to be removed in a 15s window.
+                                items:
+                                  description: HPAScalingPolicy is a single policy
+                                    which must hold true for a specified past interval.
+                                  properties:
+                                    periodSeconds:
+                                      description: |-
+                                        periodSeconds specifies the window of time for which the policy should hold true.
+                                        PeriodSeconds must be greater than zero and less than or equal to 1800 (30 min).
+                                      format: int32
+                                      type: integer
+                                    type:
+                                      description: type is used to specify the scaling
+                                        policy.
+                                      type: string
+                                    value:
+                                      description: |-
+                                        value contains the amount of change which is permitted by the policy.
+                                        It must be greater than zero
+                                      format: int32
+                                      type: integer
+                                  required:
+                                  - periodSeconds
+                                  - type
+                                  - value
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              selectPolicy:
+                                description: |-
+                                  selectPolicy is used to specify which policy should be used.
+                                  If not set, the default value Max is used.
+                                type: string
+                              stabilizationWindowSeconds:
+                                description: |-
+                                  stabilizationWindowSeconds is the number of seconds for which past recommendations should be
+                                  considered while scaling up or scaling down.
+                                  StabilizationWindowSeconds must be greater than or equal to zero and less than or equal to 3600 (one hour).
+                                  If not set, use the default values:
+                                  - For scale up: 0 (i.e. no stabilization is done).
+                                  - For scale down: 300 (i.e. the stabilization window is 300 seconds long).
+                                format: int32
+                                maximum: 3600
+                                minimum: 0
+                                type: integer
+                              tolerance:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                description: |-
+                                  tolerance is the tolerance on the ratio between the current and desired
+                                  metric value under which no updates are made to the desired number of
+                                  replicas (e.g. 0.01 for 1%). Must be greater than or equal to zero. If not
+                                  set, the default cluster-wide tolerance is applied (by default 10%).
+
+                                  For example, if autoscaling is configured with a memory consumption target of 100Mi,
+                                  and scale-down and scale-up tolerances of 5% and 1% respectively, scaling will be
+                                  triggered when the actual consumption falls below 95Mi or exceeds 101Mi.
+
+                                  This is an alpha field and requires enabling the HPAConfigurableTolerance
+                                  feature gate.
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                            type: object
+                        type: object
+                      name:
+                        type: string
+                    type: object
+                  restoreToOriginalReplicaCount:
+                    type: boolean
+                  scalingModifiers:
+                    description: ScalingModifiers describes advanced scaling logic
+                      options like formula
+                    properties:
+                      activationTarget:
+                        type: string
+                      formula:
+                        type: string
+                      metricType:
+                        description: |-
+                          MetricTargetType specifies the type of metric being targeted, and should be either
+                          "Value", "AverageValue", or "Utilization"
+                        enum:
+                        - AverageValue
+                        - Value
+                        type: string
+                      target:
+                        type: string
+                    type: object
+                type: object
+              cooldownPeriod:
+                format: int32
+                type: integer
+              fallback:
+                description: Fallback is the spec for fallback options
+                properties:
+                  behavior:
+                    default: static
+                    enum:
+                    - static
+                    - currentReplicas
+                    - currentReplicasIfHigher
+                    - currentReplicasIfLower
+                    type: string
+                  failureThreshold:
+                    format: int32
+                    type: integer
+                  replicas:
+                    format: int32
+                    type: integer
+                required:
+                - failureThreshold
+                - replicas
+                type: object
+              idleReplicaCount:
+                format: int32
+                type: integer
+              initialCooldownPeriod:
+                format: int32
+                type: integer
+              maxReplicaCount:
+                format: int32
+                type: integer
+              minReplicaCount:
+                format: int32
+                type: integer
+              pollingInterval:
+                format: int32
+                type: integer
+              scaleTargetRef:
+                description: ScaleTarget holds the reference to the scale target Object
+                properties:
+                  apiVersion:
+                    type: string
+                  envSourceContainerName:
+                    type: string
+                  kind:
+                    type: string
+                  name:
+                    type: string
+                required:
+                - name
+                type: object
+              triggers:
+                items:
+                  description: ScaleTriggers reference the scaler that will be used
+                  properties:
+                    authenticationRef:
+                      description: |-
+                        AuthenticationRef points to the TriggerAuthentication or ClusterTriggerAuthentication object that
+                        is used to authenticate the scaler with the environment
+                      properties:
+                        kind:
+                          description: Kind of the resource being referred to. Defaults
+                            to TriggerAuthentication.
+                          type: string
+                        name:
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    metadata:
+                      additionalProperties:
+                        type: string
+                      type: object
+                    metricType:
+                      description: |-
+                        MetricTargetType specifies the type of metric being targeted, and should be either
+                        "Value", "AverageValue", or "Utilization"
+                      type: string
+                    name:
+                      type: string
+                    type:
+                      type: string
+                    useCachedMetrics:
+                      type: boolean
+                  required:
+                  - metadata
+                  - type
+                  type: object
+                type: array
+            required:
+            - scaleTargetRef
+            - triggers
+            type: object
+          status:
+            description: ScaledObjectStatus is the status for a ScaledObject resource
+            properties:
+              authenticationsTypes:
+                type: string
+              compositeScalerName:
+                type: string
+              conditions:
+                description: Conditions an array representation to store multiple
+                  Conditions
+                items:
+                  description: Condition to store the condition state
+                  properties:
+                    message:
+                      description: A human readable message indicating details about
+                        the transition.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of condition
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              externalMetricNames:
+                items:
+                  type: string
+                type: array
+              health:
+                additionalProperties:
+                  description: HealthStatus is the status for a ScaledObject's health
+                  properties:
+                    numberOfFailures:
+                      format: int32
+                      type: integer
+                    status:
+                      description: HealthStatusType is an indication of whether the
+                        health status is happy or failing
+                      type: string
+                  type: object
+                type: object
+              hpaName:
+                type: string
+              lastActiveTime:
+                format: date-time
+                type: string
+              originalReplicaCount:
+                format: int32
+                type: integer
+              pausedReplicaCount:
+                format: int32
+                type: integer
+              resourceMetricNames:
+                items:
+                  type: string
+                type: array
+              scaleTargetGVKR:
+                description: GroupVersionKindResource provides unified structure for
+                  schema.GroupVersionKind and Resource
+                properties:
+                  group:
+                    type: string
+                  kind:
+                    type: string
+                  resource:
+                    type: string
+                  version:
+                    type: string
+                required:
+                - group
+                - kind
+                - resource
+                - version
+                type: object
+              scaleTargetKind:
+                type: string
+              triggersActivity:
+                additionalProperties:
+                  description: TriggerActivityStatus represents the activity status
+                    of an external trigger
+                  properties:
+                    isActive:
+                      type: boolean
+                  type: object
+                type: object
+              triggersTypes:
+                type: string
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+# Source: keda/templates/crds/crd-triggerauthentications.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.20.0
+  labels:
+    app.kubernetes.io/name: keda-operator    
+    helm.sh/chart: keda-2.19.0
+    app.kubernetes.io/component: operator
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: keda-operator
+    app.kubernetes.io/version: 2.19.0
+  name: triggerauthentications.keda.sh
+spec:
+  group: keda.sh
+  names:
+    kind: TriggerAuthentication
+    listKind: TriggerAuthenticationList
+    plural: triggerauthentications
+    shortNames:
+    - ta
+    - triggerauth
+    singular: triggerauthentication
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.podIdentity.provider
+      name: PodIdentity
+      type: string
+    - jsonPath: .spec.secretTargetRef[*].name
+      name: Secret
+      type: string
+    - jsonPath: .spec.env[*].name
+      name: Env
+      type: string
+    - jsonPath: .spec.hashiCorpVault.address
+      name: VaultAddress
+      type: string
+    - jsonPath: .status.scaledobjects
+      name: ScaledObjects
+      priority: 1
+      type: string
+    - jsonPath: .status.scaledjobs
+      name: ScaledJobs
+      priority: 1
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: TriggerAuthentication defines how a trigger can authenticate
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: TriggerAuthenticationSpec defines the various ways to authenticate
+            properties:
+              awsSecretManager:
+                description: AwsSecretManager is used to authenticate using AwsSecretManager
+                properties:
+                  credentials:
+                    properties:
+                      accessKey:
+                        properties:
+                          valueFrom:
+                            properties:
+                              secretKeyRef:
+                                properties:
+                                  key:
+                                    type: string
+                                  name:
+                                    type: string
+                                required:
+                                - key
+                                - name
+                                type: object
+                            required:
+                            - secretKeyRef
+                            type: object
+                        required:
+                        - valueFrom
+                        type: object
+                      accessSecretKey:
+                        properties:
+                          valueFrom:
+                            properties:
+                              secretKeyRef:
+                                properties:
+                                  key:
+                                    type: string
+                                  name:
+                                    type: string
+                                required:
+                                - key
+                                - name
+                                type: object
+                            required:
+                            - secretKeyRef
+                            type: object
+                        required:
+                        - valueFrom
+                        type: object
+                      accessToken:
+                        properties:
+                          valueFrom:
+                            properties:
+                              secretKeyRef:
+                                properties:
+                                  key:
+                                    type: string
+                                  name:
+                                    type: string
+                                required:
+                                - key
+                                - name
+                                type: object
+                            required:
+                            - secretKeyRef
+                            type: object
+                        required:
+                        - valueFrom
+                        type: object
+                    required:
+                    - accessKey
+                    - accessSecretKey
+                    type: object
+                  podIdentity:
+                    description: |-
+                      AuthPodIdentity allows users to select the platform native identity
+                      mechanism
+                    properties:
+                      identityAuthorityHost:
+                        description: Set identityAuthorityHost to override the default
+                          Azure authority host. If this is set, then the IdentityTenantID
+                          must also be set
+                        type: string
+                      identityId:
+                        type: string
+                      identityOwner:
+                        description: IdentityOwner configures which identity has to
+                          be used during auto discovery, keda or the scaled workload.
+                          Mutually exclusive with roleArn
+                        enum:
+                        - keda
+                        - workload
+                        type: string
+                      identityTenantId:
+                        description: Set identityTenantId to override the default
+                          Azure tenant id. If this is set, then the IdentityID must
+                          also be set
+                        type: string
+                      provider:
+                        description: PodIdentityProvider contains the list of providers
+                        enum:
+                        - azure-workload
+                        - gcp
+                        - aws
+                        - aws-eks
+                        - none
+                        type: string
+                      roleArn:
+                        description: RoleArn sets the AWS RoleArn to be used. Mutually
+                          exclusive with IdentityOwner
+                        type: string
+                    required:
+                    - provider
+                    type: object
+                  region:
+                    type: string
+                  secrets:
+                    items:
+                      properties:
+                        name:
+                          type: string
+                        parameter:
+                          type: string
+                        secretKey:
+                          type: string
+                        versionId:
+                          type: string
+                        versionStage:
+                          type: string
+                      required:
+                      - name
+                      - parameter
+                      type: object
+                    type: array
+                required:
+                - secrets
+                type: object
+              azureKeyVault:
+                description: AzureKeyVault is used to authenticate using Azure Key
+                  Vault
+                properties:
+                  cloud:
+                    properties:
+                      activeDirectoryEndpoint:
+                        type: string
+                      keyVaultResourceURL:
+                        type: string
+                      type:
+                        type: string
+                    required:
+                    - type
+                    type: object
+                  credentials:
+                    properties:
+                      clientId:
+                        type: string
+                      clientSecret:
+                        properties:
+                          valueFrom:
+                            properties:
+                              secretKeyRef:
+                                properties:
+                                  key:
+                                    type: string
+                                  name:
+                                    type: string
+                                required:
+                                - key
+                                - name
+                                type: object
+                            required:
+                            - secretKeyRef
+                            type: object
+                        required:
+                        - valueFrom
+                        type: object
+                      tenantId:
+                        type: string
+                    required:
+                    - clientId
+                    - clientSecret
+                    - tenantId
+                    type: object
+                  podIdentity:
+                    description: |-
+                      AuthPodIdentity allows users to select the platform native identity
+                      mechanism
+                    properties:
+                      identityAuthorityHost:
+                        description: Set identityAuthorityHost to override the default
+                          Azure authority host. If this is set, then the IdentityTenantID
+                          must also be set
+                        type: string
+                      identityId:
+                        type: string
+                      identityOwner:
+                        description: IdentityOwner configures which identity has to
+                          be used during auto discovery, keda or the scaled workload.
+                          Mutually exclusive with roleArn
+                        enum:
+                        - keda
+                        - workload
+                        type: string
+                      identityTenantId:
+                        description: Set identityTenantId to override the default
+                          Azure tenant id. If this is set, then the IdentityID must
+                          also be set
+                        type: string
+                      provider:
+                        description: PodIdentityProvider contains the list of providers
+                        enum:
+                        - azure-workload
+                        - gcp
+                        - aws
+                        - aws-eks
+                        - none
+                        type: string
+                      roleArn:
+                        description: RoleArn sets the AWS RoleArn to be used. Mutually
+                          exclusive with IdentityOwner
+                        type: string
+                    required:
+                    - provider
+                    type: object
+                  secrets:
+                    items:
+                      properties:
+                        name:
+                          type: string
+                        parameter:
+                          type: string
+                        version:
+                          type: string
+                      required:
+                      - name
+                      - parameter
+                      type: object
+                    type: array
+                  vaultUri:
+                    type: string
+                required:
+                - secrets
+                - vaultUri
+                type: object
+              boundServiceAccountToken:
+                items:
+                  properties:
+                    parameter:
+                      type: string
+                    serviceAccountName:
+                      type: string
+                  required:
+                  - parameter
+                  - serviceAccountName
+                  type: object
+                type: array
+              configMapTargetRef:
+                items:
+                  description: AuthConfigMapTargetRef is used to authenticate using
+                    a reference to a config map
+                  properties:
+                    key:
+                      type: string
+                    name:
+                      type: string
+                    parameter:
+                      type: string
+                  required:
+                  - key
+                  - name
+                  - parameter
+                  type: object
+                type: array
+              env:
+                items:
+                  description: |-
+                    AuthEnvironment is used to authenticate using environment variables
+                    in the destination ScaleTarget spec
+                  properties:
+                    containerName:
+                      type: string
+                    name:
+                      type: string
+                    parameter:
+                      type: string
+                  required:
+                  - name
+                  - parameter
+                  type: object
+                type: array
+              filePath:
+                description: |-
+                  FilePath specifies a file containing auth parameters as JSON map[string]string.
+                  When set, auth params are read directly from this file instead.
+                type: string
+              gcpSecretManager:
+                properties:
+                  credentials:
+                    properties:
+                      clientSecret:
+                        properties:
+                          valueFrom:
+                            properties:
+                              secretKeyRef:
+                                properties:
+                                  key:
+                                    type: string
+                                  name:
+                                    type: string
+                                required:
+                                - key
+                                - name
+                                type: object
+                            required:
+                            - secretKeyRef
+                            type: object
+                        required:
+                        - valueFrom
+                        type: object
+                    required:
+                    - clientSecret
+                    type: object
+                  podIdentity:
+                    description: |-
+                      AuthPodIdentity allows users to select the platform native identity
+                      mechanism
+                    properties:
+                      identityAuthorityHost:
+                        description: Set identityAuthorityHost to override the default
+                          Azure authority host. If this is set, then the IdentityTenantID
+                          must also be set
+                        type: string
+                      identityId:
+                        type: string
+                      identityOwner:
+                        description: IdentityOwner configures which identity has to
+                          be used during auto discovery, keda or the scaled workload.
+                          Mutually exclusive with roleArn
+                        enum:
+                        - keda
+                        - workload
+                        type: string
+                      identityTenantId:
+                        description: Set identityTenantId to override the default
+                          Azure tenant id. If this is set, then the IdentityID must
+                          also be set
+                        type: string
+                      provider:
+                        description: PodIdentityProvider contains the list of providers
+                        enum:
+                        - azure-workload
+                        - gcp
+                        - aws
+                        - aws-eks
+                        - none
+                        type: string
+                      roleArn:
+                        description: RoleArn sets the AWS RoleArn to be used. Mutually
+                          exclusive with IdentityOwner
+                        type: string
+                    required:
+                    - provider
+                    type: object
+                  secrets:
+                    items:
+                      properties:
+                        id:
+                          type: string
+                        parameter:
+                          type: string
+                        version:
+                          type: string
+                      required:
+                      - id
+                      - parameter
+                      type: object
+                    type: array
+                required:
+                - secrets
+                type: object
+              hashiCorpVault:
+                description: HashiCorpVault is used to authenticate using Hashicorp
+                  Vault
+                properties:
+                  address:
+                    type: string
+                  authentication:
+                    description: VaultAuthentication contains the list of Hashicorp
+                      Vault authentication methods
+                    type: string
+                  credential:
+                    description: Credential defines the Hashicorp Vault credentials
+                      depending on the authentication method
+                    properties:
+                      serviceAccount:
+                        type: string
+                      serviceAccountName:
+                        type: string
+                      token:
+                        type: string
+                    type: object
+                  mount:
+                    type: string
+                  namespace:
+                    type: string
+                  role:
+                    type: string
+                  secrets:
+                    items:
+                      description: VaultSecret defines the mapping between the path
+                        of the secret in Vault to the parameter
+                      properties:
+                        key:
+                          type: string
+                        parameter:
+                          type: string
+                        path:
+                          type: string
+                        pkiData:
+                          properties:
+                            altNames:
+                              type: string
+                            commonName:
+                              type: string
+                            format:
+                              type: string
+                            ipSans:
+                              type: string
+                            otherSans:
+                              type: string
+                            ttl:
+                              type: string
+                            uriSans:
+                              type: string
+                          type: object
+                        type:
+                          description: VaultSecretType defines the type of vault secret
+                          type: string
+                      required:
+                      - key
+                      - parameter
+                      - path
+                      type: object
+                    type: array
+                required:
+                - address
+                - authentication
+                - secrets
+                type: object
+              podIdentity:
+                description: |-
+                  AuthPodIdentity allows users to select the platform native identity
+                  mechanism
+                properties:
+                  identityAuthorityHost:
+                    description: Set identityAuthorityHost to override the default
+                      Azure authority host. If this is set, then the IdentityTenantID
+                      must also be set
+                    type: string
+                  identityId:
+                    type: string
+                  identityOwner:
+                    description: IdentityOwner configures which identity has to be
+                      used during auto discovery, keda or the scaled workload. Mutually
+                      exclusive with roleArn
+                    enum:
+                    - keda
+                    - workload
+                    type: string
+                  identityTenantId:
+                    description: Set identityTenantId to override the default Azure
+                      tenant id. If this is set, then the IdentityID must also be
+                      set
+                    type: string
+                  provider:
+                    description: PodIdentityProvider contains the list of providers
+                    enum:
+                    - azure-workload
+                    - gcp
+                    - aws
+                    - aws-eks
+                    - none
+                    type: string
+                  roleArn:
+                    description: RoleArn sets the AWS RoleArn to be used. Mutually
+                      exclusive with IdentityOwner
+                    type: string
+                required:
+                - provider
+                type: object
+              secretTargetRef:
+                items:
+                  description: AuthSecretTargetRef is used to authenticate using a
+                    reference to a secret
+                  properties:
+                    key:
+                      type: string
+                    name:
+                      type: string
+                    parameter:
+                      type: string
+                  required:
+                  - key
+                  - name
+                  - parameter
+                  type: object
+                type: array
+            type: object
+          status:
+            description: TriggerAuthenticationStatus defines the observed state of
+              TriggerAuthentication
+            properties:
+              scaledjobs:
+                type: string
+              scaledobjects:
+                type: string
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+# Source: keda/templates/manager/clusterrole.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/name: keda-operator    
+    helm.sh/chart: keda-2.19.0
+    app.kubernetes.io/component: operator
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: keda-operator
+    app.kubernetes.io/version: 2.19.0
+    app.kubernetes.io/instance: keda
+  name: keda-operator
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - configmaps/status
+  - limitranges
+  - pods
+  - services
+  - serviceaccounts
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
+    - discovery.k8s.io
+  resources:
+    - endpointslices
+  verbs:
+    - get
+    - list
+    - watch
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - "*"
+  resources:
+  - "*/scale"
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - "*"
+  resources:
+  - "*"
+  verbs:
+  - get
+- apiGroups:
+  - apps
+  resources:
+  - deployments/scale
+  - statefulsets/scale
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  - statefulsets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - autoscaling
+  resources:
+  - horizontalpodautoscalers
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - batch
+  resources:
+  - jobs
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - eventing.keda.sh
+  resources:
+  - cloudeventsources
+  - cloudeventsources/status
+  - clustercloudeventsources
+  - clustercloudeventsources/status
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - keda.sh
+  resources:
+  - scaledjobs
+  - scaledjobs/finalizers
+  - scaledjobs/status
+  - scaledobjects
+  - scaledobjects/finalizers
+  - scaledobjects/status
+  - triggerauthentications
+  - triggerauthentications/status
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+  - watch
+---
+# Source: keda/templates/manager/minimal-rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/name: keda-operator-minimal-cluster-role    
+    helm.sh/chart: keda-2.19.0
+    app.kubernetes.io/component: operator
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: keda-operator
+    app.kubernetes.io/version: 2.19.0
+    app.kubernetes.io/instance: keda
+  name: keda-operator-minimal-cluster-role
+rules:
+- apiGroups:
+  - keda.sh
+  resources:
+  - clustertriggerauthentications
+  - clustertriggerauthentications/status
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - admissionregistration.k8s.io
+  resources:
+  - validatingwebhookconfigurations
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - apiregistration.k8s.io
+  resources:
+  - apiservices
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - eventing.keda.sh
+  resources:
+  - cloudeventsources
+  - cloudeventsources/status
+  - clustercloudeventsources
+  - clustercloudeventsources/status
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+  - watch
+---
+# Source: keda/templates/metrics-server/clusterrole.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/name: keda-operator-external-metrics-reader    
+    helm.sh/chart: keda-2.19.0
+    app.kubernetes.io/component: operator
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: keda-operator
+    app.kubernetes.io/version: 2.19.0
+    app.kubernetes.io/instance: keda
+  name: keda-operator-external-metrics-reader
+rules:
+- apiGroups:
+  - external.metrics.k8s.io
+  resources:
+  - 'externalmetrics'
+  verbs:
+  - 'get'
+---
+# Source: keda/templates/webhooks/clusterrole.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/name: keda-operator-webhook    
+    helm.sh/chart: keda-2.19.0
+    app.kubernetes.io/component: operator
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: keda-operator
+    app.kubernetes.io/version: 2.19.0
+    app.kubernetes.io/instance: keda
+  name: keda-operator-webhook
+rules:
+- apiGroups:
+  - autoscaling
+  resources:
+  - horizontalpodautoscalers
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - keda.sh
+  resources:
+  - scaledobjects
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  - statefulsets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - limitranges
+  verbs:
+  - list
+---
+# Source: keda/templates/manager/clusterrolebindings.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/name: keda-operator    
+    helm.sh/chart: keda-2.19.0
+    app.kubernetes.io/component: operator
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: keda-operator
+    app.kubernetes.io/version: 2.19.0
+    app.kubernetes.io/instance: keda
+  name: keda-operator
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: keda-operator
+subjects:
+- kind: ServiceAccount
+  name: keda-operator
+  namespace: keda
+---
+# Source: keda/templates/manager/minimal-rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/name: keda-operator-minimal    
+    helm.sh/chart: keda-2.19.0
+    app.kubernetes.io/component: operator
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: keda-operator
+    app.kubernetes.io/version: 2.19.0
+    app.kubernetes.io/instance: keda
+  name: keda-operator-minimal
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: keda-operator-minimal-cluster-role
+subjects:
+- kind: ServiceAccount
+  name: keda-operator
+  namespace: keda
+---
+# Source: keda/templates/metrics-server/clusterrolebinding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/name: keda-operator-system-auth-delegator    
+    helm.sh/chart: keda-2.19.0
+    app.kubernetes.io/component: operator
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: keda-operator
+    app.kubernetes.io/version: 2.19.0
+    app.kubernetes.io/instance: keda
+  name: keda-operator-system-auth-delegator
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:auth-delegator
+subjects:
+- kind: ServiceAccount
+  name: keda-metrics-server
+  namespace: keda
+---
+# Source: keda/templates/metrics-server/clusterrolebinding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/name: keda-operator-hpa-controller-external-metrics    
+    helm.sh/chart: keda-2.19.0
+    app.kubernetes.io/component: operator
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: keda-operator
+    app.kubernetes.io/version: 2.19.0
+    app.kubernetes.io/instance: keda
+  name: keda-operator-hpa-controller-external-metrics
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: keda-operator-external-metrics-reader
+subjects:
+- kind: ServiceAccount
+  name: horizontal-pod-autoscaler
+  namespace: kube-system
+---
+# Source: keda/templates/webhooks/clusterrolebindings.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/name: keda-operator-webhook    
+    helm.sh/chart: keda-2.19.0
+    app.kubernetes.io/component: operator
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: keda-operator
+    app.kubernetes.io/version: 2.19.0
+    app.kubernetes.io/instance: keda
+  name: keda-operator-webhook
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: keda-operator-webhook
+subjects:
+- kind: ServiceAccount
+  name: keda-webhook
+  namespace: keda
+---
+# Source: keda/templates/manager/minimal-rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  labels:
+    app.kubernetes.io/name: keda-operator-certs    
+    helm.sh/chart: keda-2.19.0
+    app.kubernetes.io/component: operator
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: keda-operator
+    app.kubernetes.io/version: 2.19.0
+    app.kubernetes.io/instance: keda
+  name: keda-operator-certs
+  namespace: keda
+rules:
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  resourceNames:
+  - "kedaorg-certs"
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - create
+  - update
+---
+# Source: keda/templates/manager/minimal-rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/name: keda-operator-certs    
+    helm.sh/chart: keda-2.19.0
+    app.kubernetes.io/component: operator
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: keda-operator
+    app.kubernetes.io/version: 2.19.0
+    app.kubernetes.io/instance: keda
+  name: keda-operator-certs
+  namespace: keda
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: keda-operator-certs
+subjects:
+- kind: ServiceAccount
+  name: keda-operator
+  namespace: keda
+---
+# Source: keda/templates/metrics-server/clusterrolebinding.yaml
+# https://kubernetes.io/docs/tasks/extend-kubernetes/configure-aggregation-layer/#extension-apiserver-authenticates-the-request
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/name: keda-operator-auth-reader    
+    helm.sh/chart: keda-2.19.0
+    app.kubernetes.io/component: operator
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: keda-operator
+    app.kubernetes.io/version: 2.19.0
+    app.kubernetes.io/instance: keda
+  name: keda-operator-auth-reader
+  namespace: kube-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: extension-apiserver-authentication-reader
+subjects:
+- kind: ServiceAccount
+  name: keda-metrics-server
+  namespace: keda
+---
+# Source: keda/templates/manager/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/name: keda-operator    
+    helm.sh/chart: keda-2.19.0
+    app.kubernetes.io/component: operator
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: keda-operator
+    app.kubernetes.io/version: 2.19.0
+    app.kubernetes.io/instance: keda
+  name: keda-operator
+  namespace: keda
+spec:
+  ports:
+  - name: metricsservice
+    port: 9666
+    targetPort: 9666
+  selector:
+    app: keda-operator
+---
+# Source: keda/templates/metrics-server/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/name: keda-operator-metrics-apiserver
+    app: keda-operator-metrics-apiserver    
+    helm.sh/chart: keda-2.19.0
+    app.kubernetes.io/component: operator
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: keda-operator
+    app.kubernetes.io/version: 2.19.0
+    app.kubernetes.io/instance: keda
+  name: keda-operator-metrics-apiserver
+  namespace: keda
+spec:
+  type: ClusterIP
+  ports:
+  - name: https
+    port: 443
+    targetPort: 6443
+    protocol: TCP
+    appProtocol: https
+  - name: metrics
+    port: 8080
+    targetPort: 8080
+    protocol: TCP
+  selector:
+    app: keda-operator-metrics-apiserver
+---
+# Source: keda/templates/webhooks/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/name: keda-admission-webhooks    
+    helm.sh/chart: keda-2.19.0
+    app.kubernetes.io/component: operator
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: keda-operator
+    app.kubernetes.io/version: 2.19.0
+    app.kubernetes.io/instance: keda
+  name: keda-admission-webhooks
+  namespace: keda
+spec:
+  ports:
+  - name: https
+    port: 443
+    protocol: TCP
+    targetPort: 9443
+    appProtocol: https
+  selector:
+    app: keda-admission-webhooks
+---
+# Source: keda/templates/manager/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: keda-operator
+  namespace: keda
+  labels:
+    app: keda-operator
+    name: keda-operator
+    app.kubernetes.io/name: keda-operator    
+    helm.sh/chart: keda-2.19.0
+    app.kubernetes.io/component: operator
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: keda-operator
+    app.kubernetes.io/version: 2.19.0
+    app.kubernetes.io/instance: keda
+spec:
+  revisionHistoryLimit: 10
+  replicas: 1
+  selector:
+    matchLabels:
+      app: keda-operator
+  template:
+    metadata:
+      labels:
+        app: keda-operator
+        name: keda-operator
+        app.kubernetes.io/name: keda-operator        
+        helm.sh/chart: keda-2.19.0
+        app.kubernetes.io/component: operator
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/part-of: keda-operator
+        app.kubernetes.io/version: 2.19.0
+        app.kubernetes.io/instance: keda
+    spec:
+      enableServiceLinks: true
+      serviceAccountName: keda-operator
+      automountServiceAccountToken: true
+      securityContext:
+        runAsNonRoot: true
+      containers:
+        - name: keda-operator
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
+            seccompProfile:
+              type: RuntimeDefault
+          image: "ghcr.io/kedacore/keda:2.19.0"
+          command:
+          - "/keda"
+          args:
+          - "--leader-elect"
+          - "--disable-compression=true"
+          - "--zap-log-level=info"
+          - "--zap-encoder=console"
+          - "--zap-time-encoding=rfc3339"
+          - "--enable-webhook-patching=true"
+          - "--cert-dir=/certs"
+          - "--enable-cert-rotation=true"          
+          - "--cert-secret-name=kedaorg-certs"
+          - "--operator-service-name=keda-operator"
+          - "--metrics-server-service-name=keda-operator-metrics-apiserver"
+          - "--webhooks-service-name=keda-admission-webhooks"
+          - "--k8s-cluster-name=kubernetes-default"
+          - "--k8s-cluster-domain=cluster.local"
+          - "--enable-prometheus-metrics=false"
+          imagePullPolicy: Always
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 8081
+            initialDelaySeconds: 25
+            periodSeconds: 10
+            timeoutSeconds: 1
+            failureThreshold: 3
+            successThreshold: 1
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: 8081
+            initialDelaySeconds: 20
+            periodSeconds: 3
+            timeoutSeconds: 1
+            failureThreshold: 3
+            successThreshold: 1
+          ports:
+          - containerPort: 9666
+            name: metricsservice
+            protocol: TCP
+          env:
+            - name: WATCH_NAMESPACE
+              value: ""
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: OPERATOR_NAME
+              value: keda-operator
+            - name: KEDA_HTTP_DEFAULT_TIMEOUT
+              value: "3000"
+            - name: KEDA_HTTP_MIN_TLS_VERSION
+              value: TLS12
+          volumeMounts:         
+          - mountPath: /certs
+            name: certificates
+            readOnly: true
+          resources:
+            limits:
+              cpu: 1
+              memory: 1000Mi
+            requests:
+              cpu: 100m
+              memory: 100Mi
+      volumes:
+      - name: certificates
+        secret:
+          defaultMode: 420
+          secretName: kedaorg-certs
+          optional: true
+      nodeSelector:
+        kubernetes.io/os: linux
+      dnsPolicy: ClusterFirst
+      hostNetwork: false
+---
+# Source: keda/templates/metrics-server/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: keda-operator-metrics-apiserver
+  namespace: keda
+  labels:
+    app: keda-operator-metrics-apiserver
+    app.kubernetes.io/name: keda-operator-metrics-apiserver    
+    helm.sh/chart: keda-2.19.0
+    app.kubernetes.io/component: operator
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: keda-operator
+    app.kubernetes.io/version: 2.19.0
+    app.kubernetes.io/instance: keda
+spec:
+  revisionHistoryLimit: 10
+  replicas: 1
+  selector:
+    matchLabels:
+      app: keda-operator-metrics-apiserver
+  template:
+    metadata:
+      labels:
+        app: keda-operator-metrics-apiserver
+        app.kubernetes.io/name: keda-operator-metrics-apiserver        
+        helm.sh/chart: keda-2.19.0
+        app.kubernetes.io/component: operator
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/part-of: keda-operator
+        app.kubernetes.io/version: 2.19.0
+        app.kubernetes.io/instance: keda
+    spec:
+      enableServiceLinks: true
+      serviceAccountName: keda-metrics-server
+      automountServiceAccountToken: true
+      securityContext:
+        runAsNonRoot: true
+      containers:
+        - name: keda-operator-metrics-apiserver
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
+            seccompProfile:
+              type: RuntimeDefault
+          image: "ghcr.io/kedacore/keda-metrics-apiserver:2.19.0"
+          imagePullPolicy: Always
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 6443
+              scheme: HTTPS
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 1
+            failureThreshold: 3
+            successThreshold: 1
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: 6443
+              scheme: HTTPS
+            initialDelaySeconds: 5
+            periodSeconds: 3
+            timeoutSeconds: 1
+            failureThreshold: 3
+            successThreshold: 1
+          env:
+            - name: WATCH_NAMESPACE
+              value: ""
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: KEDA_HTTP_DEFAULT_TIMEOUT
+              value: "3000"
+            - name: KEDA_HTTP_MIN_TLS_VERSION
+              value: TLS12
+          command:
+           - /keda-adapter
+          args:
+          - --port=8080
+          - --secure-port=6443
+          - --logtostderr=true
+          - --stderrthreshold=ERROR
+          - --disable-compression=true
+          - --metrics-service-address=keda-operator.keda.svc.cluster.local:9666
+          - --client-ca-file=/certs/ca.crt
+          - --tls-cert-file=/certs/tls.crt
+          - --tls-private-key-file=/certs/tls.key
+          - --cert-dir=/certs
+          - --v=0
+          - --zap-log-level=info
+          - --zap-encoder=console
+          - --zap-time-encoding=rfc3339
+          ports:
+            - containerPort: 6443
+              name: https
+              protocol: TCP
+            - containerPort: 8080
+              name: metrics
+              protocol: TCP
+          volumeMounts:
+          - mountPath: /certs
+            name: certificates
+            readOnly: true
+          resources:
+            limits:
+              cpu: 1
+              memory: 1000Mi
+            requests:
+              cpu: 100m
+              memory: 100Mi
+      volumes:
+      - name: certificates
+        secret:
+          defaultMode: 420
+          secretName: kedaorg-certs
+      dnsPolicy: ClusterFirst
+      hostNetwork: false
+      nodeSelector:
+        kubernetes.io/os: linux
+---
+# Source: keda/templates/webhooks/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: keda-admission-webhooks
+  namespace: keda
+  labels:
+    app: keda-admission-webhooks
+    name: keda-admission-webhooks
+    app.kubernetes.io/name: keda-admission-webhooks    
+    helm.sh/chart: keda-2.19.0
+    app.kubernetes.io/component: operator
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: keda-operator
+    app.kubernetes.io/version: 2.19.0
+    app.kubernetes.io/instance: keda
+spec:
+  revisionHistoryLimit: 10
+  replicas: 1
+  selector:
+    matchLabels:
+      app: keda-admission-webhooks
+  template:
+    metadata:
+      labels:
+        app: keda-admission-webhooks
+        name: keda-admission-webhooks
+        app.kubernetes.io/name: keda-admission-webhooks        
+        helm.sh/chart: keda-2.19.0
+        app.kubernetes.io/component: operator
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/part-of: keda-operator
+        app.kubernetes.io/version: 2.19.0
+        app.kubernetes.io/instance: keda
+    spec:
+      enableServiceLinks: true
+      serviceAccountName: keda-webhook
+      automountServiceAccountToken: true
+      securityContext:
+        runAsNonRoot: true
+      containers:
+        - name: keda-admission-webhooks
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
+            seccompProfile:
+              type: RuntimeDefault
+          image: "ghcr.io/kedacore/keda-admission-webhooks:2.19.0"
+          command:
+          - /keda-admission-webhooks
+          args:
+          - "--zap-log-level=info"
+          - "--zap-encoder=console"
+          - "--zap-time-encoding=rfc3339"
+          - "--cert-dir=/certs"
+          - "--health-probe-bind-address=:8081"
+          - --metrics-bind-address=:8080
+          imagePullPolicy: Always
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 8081
+            initialDelaySeconds: 25
+            periodSeconds: 10
+            timeoutSeconds: 1
+            failureThreshold: 3
+            successThreshold: 1
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: 8081
+            initialDelaySeconds: 20
+            periodSeconds: 3
+            timeoutSeconds: 1
+            failureThreshold: 3
+            successThreshold: 1
+          ports:
+          - containerPort: 9443
+            name: http
+            protocol: TCP
+          env:
+            - name: WATCH_NAMESPACE
+              value: ""
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+          volumeMounts:
+          - mountPath: /certs
+            name: certificates
+            readOnly: true
+          resources:
+            limits:
+              cpu: 1
+              memory: 1000Mi
+            requests:
+              cpu: 100m
+              memory: 100Mi
+      volumes:
+      - name: certificates
+        secret:
+          defaultMode: 420
+          secretName: kedaorg-certs
+      hostNetwork: false
+      nodeSelector:
+        kubernetes.io/os: linux
+---
+# Source: keda/templates/metrics-server/apiservice.yaml
+apiVersion: apiregistration.k8s.io/v1
+kind: APIService
+metadata:
+  labels:
+    app.kubernetes.io/name: v1beta1.external.metrics.k8s.io    
+    helm.sh/chart: keda-2.19.0
+    app.kubernetes.io/component: operator
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: keda-operator
+    app.kubernetes.io/version: 2.19.0
+    app.kubernetes.io/instance: keda
+  name: v1beta1.external.metrics.k8s.io
+spec:
+  service:
+    name: keda-operator-metrics-apiserver
+    namespace: keda
+    port: 443
+  group: external.metrics.k8s.io
+  version: v1beta1
+  groupPriorityMinimum: 100
+  versionPriority: 100
+---
+# Source: keda/templates/webhooks/validatingconfiguration.yaml
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  labels:
+    app.kubernetes.io/name: keda-admission-webhooks    
+    helm.sh/chart: keda-2.19.0
+    app.kubernetes.io/component: operator
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: keda-operator
+    app.kubernetes.io/version: 2.19.0
+    app.kubernetes.io/instance: keda
+  name: keda-admission
+webhooks:
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: keda-admission-webhooks
+      namespace: keda
+      path: /validate-keda-sh-v1alpha1-scaledobject
+  failurePolicy: Ignore
+  matchPolicy: Equivalent
+  name: vscaledobject.kb.io
+  namespaceSelector: {}
+  objectSelector: {}
+  rules:
+  - apiGroups:
+    - keda.sh
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - scaledobjects
+  sideEffects: None
+  timeoutSeconds: 10
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: keda-admission-webhooks
+      namespace: keda
+      path: /validate-keda-sh-v1alpha1-scaledjob
+  failurePolicy: Ignore
+  matchPolicy: Equivalent
+  name: vscaledjob.kb.io
+  namespaceSelector: {}
+  objectSelector: {}
+  rules:
+  - apiGroups:
+    - keda.sh
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - scaledjobs
+  sideEffects: None
+  timeoutSeconds: 10
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: keda-admission-webhooks
+      namespace: keda
+      path: /validate-keda-sh-v1alpha1-triggerauthentication
+  failurePolicy: Ignore
+  matchPolicy: Equivalent
+  name: vstriggerauthentication.kb.io
+  namespaceSelector: {}
+  objectSelector: {}
+  rules:
+  - apiGroups:
+    - keda.sh
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - triggerauthentications
+  sideEffects: None
+  timeoutSeconds: 10
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: keda-admission-webhooks
+      namespace: keda
+      path: /validate-keda-sh-v1alpha1-clustertriggerauthentication
+  failurePolicy: Ignore
+  matchPolicy: Equivalent
+  name: vsclustertriggerauthentication.kb.io
+  namespaceSelector: {}
+  objectSelector: {}
+  rules:
+  - apiGroups:
+    - keda.sh
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - clustertriggerauthentications
+  sideEffects: None
+  timeoutSeconds: 10
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: keda-admission-webhooks
+      namespace: keda
+      path: /validate-eventing-keda-sh-v1alpha1-cloudeventsource
+  failurePolicy: Ignore
+  matchPolicy: Equivalent
+  name: vcloudeventsource.kb.io
+  namespaceSelector: {}
+  objectSelector: {}
+  rules:
+  - apiGroups:
+    - eventing.keda.sh
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - cloudeventsources
+  sideEffects: None
+  timeoutSeconds: 10
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: keda-admission-webhooks
+      namespace: keda
+      path: /validate-eventing-keda-sh-v1alpha1-clustercloudeventsource
+  failurePolicy: Ignore
+  matchPolicy: Equivalent
+  name: vclustercloudeventsource.kb.io
+  namespaceSelector: {}
+  objectSelector: {}
+  rules:
+  - apiGroups:
+    - eventing.keda.sh
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - clustercloudeventsources
+  sideEffects: None
+  timeoutSeconds: 10
+

--- a/kubernetes/manifests/production/kustomization.yaml
+++ b/kubernetes/manifests/production/kustomization.yaml
@@ -1,3 +1,6 @@
 resources:
   - ./00-namespaces
   - ./cilium
+  - ./gateway-api
+  - ./keda
+  - ./metrics-server

--- a/kubernetes/manifests/production/metrics-server/kustomization.yaml
+++ b/kubernetes/manifests/production/metrics-server/kustomization.yaml
@@ -1,0 +1,2 @@
+resources:
+  - manifest.yaml

--- a/kubernetes/manifests/production/metrics-server/manifest.yaml
+++ b/kubernetes/manifests/production/metrics-server/manifest.yaml
@@ -1,0 +1,257 @@
+---
+# Source: metrics-server/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: metrics-server
+  namespace: kube-system
+  labels:
+    helm.sh/chart: metrics-server-3.13.0
+    app.kubernetes.io/name: metrics-server
+    app.kubernetes.io/instance: metrics-server
+    app.kubernetes.io/version: "0.8.0"
+    app.kubernetes.io/managed-by: Helm
+---
+# Source: metrics-server/templates/clusterrole-aggregated-reader.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: system:metrics-server-aggregated-reader
+  labels:
+    helm.sh/chart: metrics-server-3.13.0
+    app.kubernetes.io/name: metrics-server
+    app.kubernetes.io/instance: metrics-server
+    app.kubernetes.io/version: "0.8.0"
+    app.kubernetes.io/managed-by: Helm
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
+rules:
+  - apiGroups:
+      - metrics.k8s.io
+    resources:
+      - pods
+      - nodes
+    verbs:
+      - get
+      - list
+      - watch
+---
+# Source: metrics-server/templates/clusterrole.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: system:metrics-server
+  labels:
+    helm.sh/chart: metrics-server-3.13.0
+    app.kubernetes.io/name: metrics-server
+    app.kubernetes.io/instance: metrics-server
+    app.kubernetes.io/version: "0.8.0"
+    app.kubernetes.io/managed-by: Helm
+rules:
+  - apiGroups:
+    - ""
+    resources:
+    - nodes/metrics
+    verbs:
+    - get
+  - apiGroups:
+    - ""
+    resources:
+      - pods
+      - nodes
+      - namespaces
+      - configmaps
+    verbs:
+      - get
+      - list
+      - watch
+---
+# Source: metrics-server/templates/clusterrolebinding-auth-delegator.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: metrics-server:system:auth-delegator
+  labels:
+    helm.sh/chart: metrics-server-3.13.0
+    app.kubernetes.io/name: metrics-server
+    app.kubernetes.io/instance: metrics-server
+    app.kubernetes.io/version: "0.8.0"
+    app.kubernetes.io/managed-by: Helm
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:auth-delegator
+subjects:
+  - kind: ServiceAccount
+    name: metrics-server
+    namespace: kube-system
+---
+# Source: metrics-server/templates/clusterrolebinding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: system:metrics-server
+  labels:
+    helm.sh/chart: metrics-server-3.13.0
+    app.kubernetes.io/name: metrics-server
+    app.kubernetes.io/instance: metrics-server
+    app.kubernetes.io/version: "0.8.0"
+    app.kubernetes.io/managed-by: Helm
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:metrics-server
+subjects:
+  - kind: ServiceAccount
+    name: metrics-server
+    namespace: kube-system
+---
+# Source: metrics-server/templates/rolebinding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: metrics-server-auth-reader
+  namespace: kube-system
+  labels:
+    helm.sh/chart: metrics-server-3.13.0
+    app.kubernetes.io/name: metrics-server
+    app.kubernetes.io/instance: metrics-server
+    app.kubernetes.io/version: "0.8.0"
+    app.kubernetes.io/managed-by: Helm
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: extension-apiserver-authentication-reader
+subjects:
+  - kind: ServiceAccount
+    name: metrics-server
+    namespace: kube-system
+---
+# Source: metrics-server/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: metrics-server
+  namespace: kube-system
+  labels:
+    helm.sh/chart: metrics-server-3.13.0
+    app.kubernetes.io/name: metrics-server
+    app.kubernetes.io/instance: metrics-server
+    app.kubernetes.io/version: "0.8.0"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  type: ClusterIP
+  ports:
+    - name: https
+      port: 443
+      protocol: TCP
+      targetPort: https
+      appProtocol: https
+  selector:
+    app.kubernetes.io/name: metrics-server
+    app.kubernetes.io/instance: metrics-server
+---
+# Source: metrics-server/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: metrics-server
+  namespace: kube-system
+  labels:
+    helm.sh/chart: metrics-server-3.13.0
+    app.kubernetes.io/name: metrics-server
+    app.kubernetes.io/instance: metrics-server
+    app.kubernetes.io/version: "0.8.0"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: metrics-server
+      app.kubernetes.io/instance: metrics-server
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: metrics-server
+        app.kubernetes.io/instance: metrics-server
+    spec:
+      serviceAccountName: metrics-server
+      priorityClassName: "system-cluster-critical"
+      containers:
+        - name: metrics-server
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 1000
+            seccompProfile:
+              type: RuntimeDefault
+          image: registry.k8s.io/metrics-server/metrics-server:v0.8.0
+          imagePullPolicy: IfNotPresent
+          args:
+            - --secure-port=10250
+            - --cert-dir=/tmp
+            - --kubelet-preferred-address-types=InternalIP
+            - --kubelet-use-node-status-port
+            - --metric-resolution=15s
+          ports:
+          - name: https
+            protocol: TCP
+            containerPort: 10250
+          livenessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /livez
+              port: https
+              scheme: HTTPS
+            initialDelaySeconds: 0
+            periodSeconds: 10
+          readinessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /readyz
+              port: https
+              scheme: HTTPS
+            initialDelaySeconds: 20
+            periodSeconds: 10
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+          resources:
+            limits:
+              cpu: 1000m
+              memory: 1Gi
+            requests:
+              cpu: 100m
+              memory: 200Mi
+      volumes:
+        - name: tmp
+          emptyDir: {}
+---
+# Source: metrics-server/templates/apiservice.yaml
+apiVersion: apiregistration.k8s.io/v1
+kind: APIService
+metadata:
+  name: v1beta1.metrics.k8s.io
+  labels:
+    helm.sh/chart: metrics-server-3.13.0
+    app.kubernetes.io/name: metrics-server
+    app.kubernetes.io/instance: metrics-server
+    app.kubernetes.io/version: "0.8.0"
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+spec:
+  group: metrics.k8s.io
+  groupPriorityMinimum: 100
+  insecureSkipTLSVerify: true
+  service:
+    name: metrics-server
+    namespace: kube-system
+    port: 443
+  version: v1beta1
+  versionPriority: 100
+


### PR DESCRIPTION
## Summary

Plan 1c-α: production EKS cluster `eks-production` に AWS 非依存の Foundation addons 3 件を Flux GitOps 経由で導入する。

### Code 変更（本 PR）

- `kubernetes/components/gateway-api/production/`: Gateway API v1.2.1 Standard channel CRDs を upstream URL から kustomize で取得
- `kubernetes/components/metrics-server/production/`: Helm chart 3.13.0、`defaultArgs` を override して `--kubelet-preferred-address-types=InternalIP` に narrow
- `kubernetes/components/keda/production/`: Helm chart 2.19.0、namespace `keda` 新設、values は chart default
- `kubernetes/manifests/production/`: hydrate output（4 component + 00-namespaces、計 ~85 K8s resources）
- `kubernetes/README.md`: Production Operations セクション更新（Cluster overview 拡張 / Foundation addon operations 新設 / Troubleshooting 3 行追加）

### Documents

- Plan: ``docs/superpowers/plans/2026-05-03-eks-production-foundation-addons-alpha.md``
- Spec: ``docs/superpowers/specs/2026-05-03-eks-production-foundation-addons-alpha-design.md``

これは Phase 1 (Foundation) の **Plan 1c-α**。次は Plan 1c-β で AWS 連携の foundation (ALB Controller / ExternalDNS / IRSA / ACM)。

## Migration sequence

Plan 1b と異なり既存 service routing への破壊的変更がないため、Flux suspend は不要。merge 後 Flux が自動で reconcile する。

1. Code 変更を main へ merge
2. CI: Hydrate Kubernetes (production) workflow が auto-run（既存）
3. Flux が main を pull → 差分（CRDs install + Helm release × 2 + namespace 追加）を apply
4. Verification battery を operator が手動実行（Plan の Task 8 参照）

## Test plan

### Code-level (PR 作成時点で完了済)

- [x] ``helmfile -e production list`` で cilium / metrics-server / keda の 3 release が表示される
- [x] ``helmfile -e production --selector name=metrics-server template`` が valid（`--kubelet-preferred-address-types=InternalIP` が 1 回のみ rendering、duplicate flag なし）
- [x] ``helmfile -e production --selector name=keda template`` が valid（29 kinds）
- [x] ``kustomize build kubernetes/components/gateway-api/production/kustomization`` で CRDs 5 個 rendering
- [x] ``kustomize build kubernetes/manifests/production`` が valid（85 resources）
- [x] ``kubernetes/manifests/production/00-namespaces/namespaces.yaml`` に keda namespace 追加
- [x] ``kubernetes/manifests/production/kustomization.yaml`` が `[./00-namespaces, ./cilium, ./gateway-api, ./keda, ./metrics-server]` を参照
- [x] kubernetes/README.md の Production Operations セクション更新

### Cluster-level (operator 実行、merge 後)

- [ ] ``flux get kustomizations -n flux-system flux-system`` で `Applied revision: main@<sha>` が新 commit を反映
- [ ] ``kubectl get crd | grep gateway.networking.k8s.io`` で 5 個程度の CRDs
- [ ] ``kubectl get gatewayclass cilium`` で `Programmed: True`（Cilium operator が CRDs を picking up）
- [ ] ``kubectl top nodes`` および ``kubectl top pods -A`` が値を返す（Metrics Server 動作）
- [ ] ``kubectl get deployment -n keda`` で ``keda-operator`` / ``keda-operator-metrics-apiserver`` が Ready
- [ ] minimal Gateway を apply → Programmed: True
- [ ] minimal ScaledObject を apply → KEDA-managed HPA が auto-create される

## Out of scope (spec を継承)

- AWS Load Balancer Controller / ExternalDNS / IRSA / ACM（Plan 1c-β）
- Gateway API Experimental channel
- KEDA AWS scaler の IRSA 設定（monorepo の async worker 投入時）
- Hubble UI / Grafana の Gateway 経由公開（Phase 4）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

* **Documentation**
  * Added implementation plan and design specification for EKS production foundation addons (alpha phase)
  * Updated cluster operations guide with foundation addon management procedures and troubleshooting guidance

* **New Features**
  * Added Gateway API CRDs (v1.2.1 Standard), Metrics Server (v3.13.0), and KEDA (v2.19.0) to EKS production cluster, deployable via Flux GitOps

<!-- end of auto-generated comment: release notes by coderabbit.ai -->