### PR TITLE
fix(aws/cost-management): drop member_account_discount_visibility for standalone account

### DIFF
--- a/aws/cost-management/modules/cost_optimization_hub.tf
+++ b/aws/cost-management/modules/cost_optimization_hub.tf
@@ -4,9 +4,12 @@ resource "aws_costoptimizationhub_enrollment_status" "this" {
   include_member_accounts = false
 }
 
+# member_account_discount_visibility is intentionally omitted: the AWS API
+# rejects this attribute for non-management accounts with
+# "Only management accounts can update member account discount visibility."
+# Add it back when this account becomes an Organization management account.
 resource "aws_costoptimizationhub_preferences" "this" {
-  savings_estimation_mode            = "BeforeDiscounts"
-  member_account_discount_visibility = "None"
+  savings_estimation_mode = "BeforeDiscounts"
 
   depends_on = [aws_costoptimizationhub_enrollment_status.this]
 }

--- a/docs/superpowers/specs/2026-05-03-aws-cost-management-design.md
+++ b/docs/superpowers/specs/2026-05-03-aws-cost-management-design.md
@@ -55,8 +55,7 @@ resource "aws_costoptimizationhub_enrollment_status" "this" {
 }
 
 resource "aws_costoptimizationhub_preferences" "this" {
-  savings_estimation_mode            = "BeforeDiscounts"
-  member_account_discount_visibility = "None"
+  savings_estimation_mode = "BeforeDiscounts"
 
   depends_on = [aws_costoptimizationhub_enrollment_status.this]
 }
@@ -64,7 +63,7 @@ resource "aws_costoptimizationhub_preferences" "this" {
 
 - `include_member_accounts = false`: standalone account のため。
 - `savings_estimation_mode = "BeforeDiscounts"`: EDP / RI 等の割引前で見積もる（standalone なら影響なし、デフォルト値）。
-- `member_account_discount_visibility = "None"`: standalone のため意味を持たない。明示する。
+- `member_account_discount_visibility` は **指定しない**: AWS API は non-management account に対しこの属性が含まれた呼び出しを拒否する (`ValidationException: Only management accounts can update member account discount visibility.`)。Organization の management account になった時点で追加する。
 
 #### Compute Optimizer (`compute_optimizer.tf`)
 


### PR DESCRIPTION
## Summary

#262 で merge した `aws_costoptimizationhub_preferences` の apply が失敗したため修正。AWS は management account 以外で `member_account_discount_visibility` 属性が含まれた API call を `ValidationException: Only management accounts can update member account discount visibility.` で拒否する。属性を削除し、Organization 化したタイミングで再追加する。

## Failure context

PR #262 マージ後の CI apply ([run 25279581755](https://github.com/panicboat/platform/actions/runs/25279581755/job/74114689324)) で:

- ✅ \`aws_costoptimizationhub_enrollment_status\` 作成成功 (state にあり)
- ✅ \`aws_computeoptimizer_enrollment_status\` 作成成功 (state にあり)
- ❌ \`aws_costoptimizationhub_preferences\` 作成失敗 (本 PR で修正)

## Changes

- \`aws/cost-management/modules/cost_optimization_hub.tf\`: \`member_account_discount_visibility = \"None\"\` を削除し、削除理由を コメントで明記
- \`docs/superpowers/specs/2026-05-03-aws-cost-management-design.md\`: 設計時の誤った仮説 (\"standalone のため意味を持たない。明示する。\") を AWS API 制約の説明に置き換え

## Test plan

- [ ] CI apply 後、`Plan: 1 to add, 0 to change, 0 to destroy.` で \`aws_costoptimizationhub_preferences.this\` のみ作成される
- [ ] AWS Console で Cost Optimization Hub の Preferences が \"Before discounts\" になっていることを確認

## Notes

ローカル apply は不要。CI apply で 既存 2 リソースは no-op、preferences のみ新規作成 で復旧する。