### PR TITLE
fix(aws/karpenter): use inline policy to avoid IAM 6144 char limit

### DIFF
--- a/aws/karpenter/modules/main.tf
+++ b/aws/karpenter/modules/main.tf
@@ -31,6 +31,12 @@ module "karpenter" {
   namespace       = "karpenter"
   service_account = "karpenter"
 
+  # Karpenter v1.x の controller IAM policy は accumulated permissions により
+  # standard IAM policy size limit (6,144 chars) を超過する。inline role
+  # policy にすると 10,240 chars 上限になりエラー回避できる (sub-module の
+  # variable description が直接このユースケースを推奨)。
+  enable_inline_policy = true
+
   # Node role: SSM Session Manager access (no SSH key, port 22 closed)
   node_iam_role_additional_policies = {
     AmazonSSMManagedInstanceCore = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"


### PR DESCRIPTION
## Summary

PR #271 (Plan 2 PR 1) merge 後の CI apply で発生した IAM policy size 制限超過エラーを修正する hotfix PR。

### Error

```
Error: creating IAM Policy (KarpenterController-2026050415434841450000000e):
operation error IAM: CreatePolicy, https response error StatusCode: 409,
LimitExceeded: Cannot exceed quota for PolicySize: 6144

with module.karpenter.aws_iam_policy.controller[0],
on .terraform/modules/karpenter/modules/karpenter/main.tf line 82, in resource "aws_iam_policy" "controller"
```

### 原因

Karpenter v1.x の controller IAM policy は v0.x 時代からの累積で permissions が膨らんでおり、AWS IAM **standard customer-managed policy** の size 上限 (6,144 chars) を超過する。

### 修正

`terraform-aws-modules/eks/aws//modules/karpenter v21.19.0` の `enable_inline_policy = true` を設定 (1 行追加)。Sub-module の variable description が **直接このユースケース** を推奨:

> This can be enabled when the error `LimitExceeded: Cannot exceed quota for PolicySize: 6144` is received since standard IAM policies have a limit of **6,144** characters versus an inline role policy's limit of **10,240**

これにより `aws_iam_policy.controller` (standalone managed policy) の代わりに `aws_iam_role_policy.controller` (inline role policy) が作成され、size 制限が 6,144 → 10,240 に拡大する。

### 影響範囲

- `aws/karpenter/modules/main.tf` の 1 行 (variable 1 つ追加 + コメント)

### terragrunt plan 結果

```
module.karpenter.aws_iam_role_policy.controller[0] will be created

Plan: 1 to add, 0 to change, 0 to destroy.
```

PR #271 の前回 apply で:
- 既に state に入っているリソース (SQS / EventBridge / Pod Identity / Node IAM / bootstrap MNG / EKS Access Entry) → 変更なし
- standalone policy `aws_iam_policy.controller` (作成失敗のため state に無い) → 削除なし、新たな inline policy を作成

## Test plan

### Code-level

- [x] `aws/karpenter/envs/production` で `terragrunt validate` 成功
- [x] `aws/karpenter/envs/production` で `terragrunt plan` が `Plan: 1 to add, 0 to change, 0 to destroy.` を表示
- [x] terraform-aws-modules/eks v21.19.0 の `enable_inline_policy` variable description 直接確認 (sub-module 公式の推奨 fix)

### Cluster-level (CI / merge 後)

- [ ] CI が `Deploy Terragrunt (karpenter:production)` apply 完了
- [ ] `aws iam list-role-policies --role-name <KarpenterController role>` で inline policy が attach されている
- [ ] `kubectl get nodes -L eks.amazonaws.com/nodegroup` で `karpenter_bootstrap × 2` が Ready (前回 apply で作成済の場合)

## Related

- Plan 2 PR 1: #271 (merged)
- Plan 2 完了後の learnings PR で「Karpenter v1.x の controller policy は IAM 6144 制限を超えるので `enable_inline_policy=true` 必須」を L? として記録予定