### PR TITLE
fix(kubernetes/components/karpenter): use Karpenter v1+ consolidationPolicy value

### DIFF
--- a/kubernetes/components/karpenter/production/kustomization/nodepool.yaml
+++ b/kubernetes/components/karpenter/production/kustomization/nodepool.yaml
@@ -42,7 +42,9 @@ spec:
           values: ["medium", "large", "xlarge", "2xlarge", "4xlarge"]
       expireAfter: 720h  # 30 days
   disruption:
-    consolidationPolicy: WhenUnderutilized
+    # Karpenter v1+ valid values: WhenEmpty | WhenEmptyOrUnderutilized
+    # (v0.x の WhenUnderutilized は廃止。spec/plan の値が古かった)
+    consolidationPolicy: WhenEmptyOrUnderutilized
     consolidateAfter: 30s
   limits:
     cpu: "200"

--- a/kubernetes/manifests/production/karpenter/manifest.yaml
+++ b/kubernetes/manifests/production/karpenter/manifest.yaml
@@ -2239,7 +2239,7 @@ metadata:
 spec:
   disruption:
     consolidateAfter: 30s
-    consolidationPolicy: WhenUnderutilized
+    consolidationPolicy: WhenEmptyOrUnderutilized
   limits:
     cpu: "200"
   template:


### PR DESCRIPTION
## Summary

PR #273 (Plan 2 PR 2) merge 後に Flux Kustomization が NodePool バリデーションで失敗していたため、`consolidationPolicy` の値を Karpenter v1+ で valid な値に修正する hotfix PR。

### Error

```
✗ flux-system  False  NodePool/system-components dry-run failed (Invalid):
  NodePool.karpenter.sh "system-components" is invalid:
  spec.disruption.consolidationPolicy: Unsupported value: "WhenUnderutilized":
  supported values: "WhenEmpty", "WhenEmptyOrUnderutilized"
```

### 原因

Karpenter v1+ で `consolidationPolicy` の有効値が変更された:
- ❌ `WhenUnderutilized` (v0.x、廃止)
- ✅ `WhenEmptyOrUnderutilized` (v1+ の同等機能)
- ✅ `WhenEmpty` (v0.x から継続)

Plan 2 spec / plan markdown は古い v0.x の値 `WhenUnderutilized` を記載していたため、PR #273 の NodePool YAML がバリデーション失敗。

### 修正

- `kubernetes/components/karpenter/production/kustomization/nodepool.yaml`: `WhenUnderutilized` → `WhenEmptyOrUnderutilized` (機能は同等)
- `kubernetes/manifests/production/karpenter/manifest.yaml`: re-hydrate

### 影響

PR #273 merge 後の Flux apply は失敗していたため、Karpenter Helm release / EC2NodeClass / NodePool / karpenter namespace は **まだ cluster に存在しない**。本 hotfix merge → Flux reconcile で初めて全リソースが apply される。

## Test plan

### Code-level

- [x] `kubectl get pods -n karpenter` が `No resources found` (PR #273 merge 後の状態) を確認
- [x] Flux Kustomization が `False / NodePool dry-run failed` を表示することを確認
- [x] nodepool.yaml の修正後 `make hydrate` で manifest.yaml が `WhenEmptyOrUnderutilized` を含むことを確認

### Cluster-level (CI / merge 後)

- [ ] CI が Hydrate Kubernetes (production) workflow auto-run
- [ ] Flux Kustomization が `Ready=True` に復旧
- [ ] `kubectl get pods -n karpenter` で 2 pod (replicas: 2) Running、karpenter_bootstrap MNG 上に配置
- [ ] `kubectl get nodepool system-components` で `Ready=True`
- [ ] `kubectl get ec2nodeclass system-components` で `Ready=True`
- [ ] その後 USER GATE 2 (Plan 2 PR 2 の) cordon + drain migration を再開

## Related

- Plan 2 PR 2: #273 (merged)
- Plan 2 完了後の learnings PR で「Karpenter v1+ では `consolidationPolicy: WhenEmptyOrUnderutilized` を使う (v0.x の `WhenUnderutilized` は廃止)」を L? として記録予定

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated cluster node consolidation configuration to improve resource efficiency by enabling consolidation when nodes are empty or underutilized.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->