### PR TITLE
fix(aws/karpenter): attach node SG to bootstrap MNG for cross-node pod traffic

### DIFF
--- a/aws/eks/lookup/main.tf
+++ b/aws/eks/lookup/main.tf
@@ -5,3 +5,20 @@ data "aws_eks_cluster" "this" {
 }
 
 data "aws_caller_identity" "current" {}
+
+# Node security group created by terraform-aws-modules/eks parent module.
+# Naming pattern: `eks-${cluster_name}-node-${random_suffix}` (terraform-aws-
+# modules/eks v21 default). This SG allows node-to-node pod-network traffic
+# and must be attached to MNGs (parent module auto-wires it for in-module
+# MNGs, but standalone eks-managed-node-group submodule requires explicit
+# pass-through via `vpc_security_group_ids`).
+data "aws_security_group" "node" {
+  vpc_id = data.aws_eks_cluster.this.vpc_config[0].vpc_id
+
+  # terraform-aws-modules/eks v21 sets the Name tag to `eks-${cluster_name}-node`
+  # (no random suffix; the suffix is only on the SG's `GroupName` attribute).
+  filter {
+    name   = "tag:Name"
+    values = ["eks-${var.environment}-node"]
+  }
+}

--- a/aws/eks/lookup/outputs.tf
+++ b/aws/eks/lookup/outputs.tf
@@ -8,6 +8,12 @@ output "cluster" {
     endpoint                   = data.aws_eks_cluster.this.endpoint
     cluster_security_group_id  = data.aws_eks_cluster.this.vpc_config[0].cluster_security_group_id
 
+    # Node security group (created by terraform-aws-modules/eks parent module).
+    # Required by standalone `eks-managed-node-group` submodule for node-to-node
+    # pod-network traffic (cluster_primary_security_group_id alone allows only
+    # control plane → node, not node-to-node).
+    node_security_group_id     = data.aws_security_group.node.id
+
     # Cluster info needed by the standalone `eks-managed-node-group` submodule's
     # AL2023 user data generator (auto-wired when MNGs live inside `module "eks"`,
     # but standalone submodule requires explicit pass-through).

--- a/aws/karpenter/modules/main.tf
+++ b/aws/karpenter/modules/main.tf
@@ -72,6 +72,13 @@ module "karpenter_bootstrap" {
   # Cluster primary SG must be attached to nodes for cluster API access
   cluster_primary_security_group_id = module.eks.cluster.cluster_security_group_id
 
+  # Node SG (from parent module "eks") required for node-to-node pod-network
+  # traffic. Standalone eks-managed-node-group submodule does NOT attach this
+  # automatically (unlike when MNGs live inside `module "eks"`), causing
+  # cross-node pod traffic (e.g., bootstrap pod → CoreDNS on system node) to
+  # be silently dropped. Sourced from aws/eks/lookup via tag-based discovery.
+  vpc_security_group_ids = [module.eks.cluster.node_security_group_id]
+
   ami_type       = "AL2023_ARM_64_STANDARD"
   instance_types = var.bootstrap_instance_types
   capacity_type  = "ON_DEMAND"

--- a/kubernetes/components/karpenter/production/kustomization/nodepool.yaml
+++ b/kubernetes/components/karpenter/production/kustomization/nodepool.yaml
@@ -42,7 +42,9 @@ spec:
           values: ["medium", "large", "xlarge", "2xlarge", "4xlarge"]
       expireAfter: 720h  # 30 days
   disruption:
-    consolidationPolicy: WhenUnderutilized
+    # Karpenter v1+ valid values: WhenEmpty | WhenEmptyOrUnderutilized
+    # (v0.x の WhenUnderutilized は廃止。spec/plan の値が古かった)
+    consolidationPolicy: WhenEmptyOrUnderutilized
     consolidateAfter: 30s
   limits:
     cpu: "200"

--- a/kubernetes/manifests/production/karpenter/manifest.yaml
+++ b/kubernetes/manifests/production/karpenter/manifest.yaml
@@ -2239,7 +2239,7 @@ metadata:
 spec:
   disruption:
     consolidateAfter: 30s
-    consolidationPolicy: WhenUnderutilized
+    consolidationPolicy: WhenEmptyOrUnderutilized
   limits:
     cpu: "200"
   template:


### PR DESCRIPTION
## Summary

PR #274 merge 後、Karpenter pods が DNS resolution failure で crashlooping していた問題の hotfix。Standalone `eks-managed-node-group` submodule に node-to-node SG を明示 attach する。

## Symptom

```
Karpenter logs:
{"level":"ERROR","message":"ec2 api connectivity check failed",
 "error":"dial tcp: lookup ec2.ap-northeast-1.amazonaws.com: i/o timeout"}

Karpenter pod status: 0/1 Running, 4 restarts (crashloop)

DNS test from bootstrap node:
- Cluster Service IP (172.20.0.10:53): TCP timeout
- Direct CoreDNS pod IP (10.0.34.194:53): TCP timeout
```

## Root cause

EKS node SGs are split into 2 by terraform-aws-modules/eks parent module:

| SG | 役割 | system MNG | bootstrap MNG (before fix) |
|---|---|---|---|
| `cluster_primary_security_group_id` (`eks-cluster-sg-...`) | Control plane ↔ node API access | ✅ | ✅ |
| **node SG (`eks-${env}-node`)** | **Node-to-node pod traffic** | ✅ (parent module attach) | ❌ |

Parent `module "eks"` automatically attaches the **node SG** to in-module MNGs via `vpc_security_group_ids`. The standalone `eks-managed-node-group` submodule (used by aws/karpenter/) does NOT do this — must be passed explicitly.

Without the node SG, pods on bootstrap nodes silently couldn't reach pods on system nodes (e.g., CoreDNS), causing all DNS resolution + downstream AWS API calls to timeout.

## Fix

1. `aws/eks/lookup/main.tf`: `data "aws_security_group" "node"` を追加 (tag-based discovery: `Name = eks-${env}-node`)
2. `aws/eks/lookup/outputs.tf`: `cluster.node_security_group_id` を expose
3. `aws/karpenter/modules/main.tf`: `module "karpenter_bootstrap"` に `vpc_security_group_ids = [module.eks.cluster.node_security_group_id]` を追加

## Test plan

### Code-level

- [x] `aws/eks/lookup/` で `terraform validate` 成功
- [x] `aws/karpenter/envs/production` で `terragrunt validate` 成功
- [x] `terragrunt plan`: `Plan: 0 to add, 2 to change, 0 to destroy` (launch template + node group rolling-update via `update_config.max_unavailable_percentage=33`)

### Cluster-level (CI / merge 後)

- [ ] CI が `Deploy Terragrunt (karpenter:production)` apply 完了
- [ ] Bootstrap MNG node の SG attachment 確認: `aws ec2 describe-instances --query 'Reservations[].Instances[].SecurityGroups[]'` で **2 つの SG** (cluster primary + node SG)
- [ ] Karpenter pod が `1/1 Running` に復旧
- [ ] `kubectl logs -n karpenter deploy/karpenter --tail=20` でエラーなし、leader lease acquired
- [ ] `kubectl get nodepool system-components` で `Ready=True`
- [ ] 続いて Plan 2 PR 2 USER GATE 2 (cordon + drain migration) を実行

## Related

- Plan 2 PR 1: #271 + #272 (hotfix), Plan 2 PR 2: #273, hotfix #274 (consolidationPolicy)
- Plan 2 完了後の learnings PR で「standalone `eks-managed-node-group` submodule 利用時は `vpc_security_group_ids` に node SG (parent module 作成) も渡す必要がある」を L? として記録予定