### PR TITLE
feat(eks): Phase 3 Sub-project 3 — Logs stack (Loki + Fluent Bit)

### DIFF
--- a/docs/superpowers/plans/2026-05-06-eks-production-observability-logs-stack.md
+++ b/docs/superpowers/plans/2026-05-06-eks-production-observability-logs-stack.md
@@ -1,0 +1,1345 @@
+# EKS Production: Observability Logs Stack (Phase 3 Sub-project 3) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** panicboat EKS production cluster に logs collection + long-term S3 storage + Grafana 連携の logs stack を deploy。`grafana-community/loki` v13.6.0 (SingleBinary mode、Loki 3.7.1) + `fluent/fluent-bit` v0.57.3 を `monitoring` namespace に deploy、Sub-project 1 で provision 済の AWS infra (`loki-559744160976` bucket + `eks-production-loki` IAM role + `loki` Pod Identity SA) を活用、Sub-project 2 で確立した ServiceMonitor pattern + Grafana datasource 統合 path に従う。
+
+**Architecture:** Fluent Bit DaemonSet が container logs を tail → Loki Gateway 経由で SingleBinary に直接 push (= 中間状態、Sub-project 4 で OTel Collector 経由に switching)、Pod Identity 経由で S3 long-term storage。Mimir Microservices との非対称性は意図的選択 (両 chart の official position に従った結果)。
+
+**Tech Stack:** Helm + helmfile / `grafana-community/loki` v13.6.0 (Loki 3.7.1) / `fluent/fluent-bit` v0.57.3 (Fluent Bit 5.0.3) / EBS gp3 PVC / EKS Pod Identity / S3 backend (Sub-project 1 outputs)
+
+**Spec:** `docs/superpowers/specs/2026-05-06-eks-production-observability-logs-stack-design.md`
+
+---
+
+## File Structure
+
+新規作成 / 変更ファイル:
+
+**Kubernetes 新規 (loki/production):**
+```
+kubernetes/components/loki/production/
+├── helmfile.yaml                      # grafana-community/loki chart v13.6.0
+└── values.yaml.gotmpl                 # SingleBinary mode + S3 backend + Pod Identity
+```
+
+**Kubernetes 新規 (fluent-bit/production):**
+```
+kubernetes/components/fluent-bit/production/
+├── helmfile.yaml                      # fluent/fluent-bit chart v0.57.3
+└── values.yaml.gotmpl                 # tail input + Kubernetes filter + Loki HTTP output
+```
+
+**Kubernetes 変更 (production):**
+```
+kubernetes/helmfile.yaml.gotmpl                                 # production env values block に loki cross-stack values 追加
+kubernetes/components/prometheus-operator/production/values.yaml.gotmpl   # Grafana datasources に Loki entry 追加
+kubernetes/manifests/production/kustomization.yaml              # ./loki + ./fluent-bit を resources に追加
+```
+
+**Kubernetes 自動生成 (production hydrate output):**
+```
+kubernetes/manifests/production/loki/{kustomization.yaml, manifest.yaml}
+kubernetes/manifests/production/fluent-bit/{kustomization.yaml, manifest.yaml}
+kubernetes/manifests/production/prometheus-operator/manifest.yaml         # 再 hydrate
+```
+
+**Kubernetes 変更 (local migration、Decision 6):**
+```
+kubernetes/components/loki/local/helmfile.yaml      # chart: grafana/loki → grafana-community/loki, version: 7.0.0 → 13.6.0
+kubernetes/components/loki/local/values.yaml        # chart schema 変更分の修正
+kubernetes/manifests/local/loki/manifest.yaml       # 再 hydrate
+```
+
+---
+
+## Task 0: Pre-flight + branch state verify
+
+**Files:** (確認のみ、変更なし)
+
+- [ ] **Step 1: Branch state 確認**
+
+```bash
+cd /Users/takanokenichi/GitHub/panicboat/platform/.claude/worktrees/feat/eks-production-observability-logs-stack
+git fetch origin main
+git log --oneline origin/main..HEAD
+```
+
+Expected: spec commit 1 つのみ ahead (= `4653af7 docs(eks): Phase 3 Sub-project 3 ...`)
+
+- [ ] **Step 2: aws/eks-logs/ resource 存在確認**
+
+```bash
+cd aws/eks-logs/envs/production
+TG_TF_PATH=tofu terragrunt init -upgrade
+terragrunt state list 2>&1 | tee /tmp/eks-logs-state.txt
+```
+
+Expected: 8 resources
+```
+aws_eks_pod_identity_association.this
+aws_iam_role.s3_access
+aws_iam_role_policy.s3_access
+module.s3.aws_s3_bucket.this[0]
+module.s3.aws_s3_bucket_lifecycle_configuration.this[0]
+module.s3.aws_s3_bucket_public_access_block.this[0]
+module.s3.aws_s3_bucket_server_side_encryption_configuration.this[0]
+module.s3.aws_s3_bucket_versioning.this[0]
+```
+
+- [ ] **Step 3: S3 bucket actual existence (base role)**
+
+```bash
+zsh -ic 'unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_SESSION_TOKEN
+aws s3api head-bucket --bucket loki-559744160976
+aws s3api get-bucket-location --bucket loki-559744160976'
+```
+
+Expected: 200 OK + `LocationConstraint: ap-northeast-1`
+
+- [ ] **Step 4: Pod Identity Association 確認 (base role)**
+
+```bash
+zsh -ic 'unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_SESSION_TOKEN
+aws eks list-pod-identity-associations --cluster-name eks-production --region ap-northeast-1 \
+  --query "associations[?serviceAccount==\`loki\`]"'
+```
+
+Expected:
+```json
+[
+    {
+        "namespace": "monitoring",
+        "serviceAccount": "loki",
+        "associationArn": "arn:aws:eks:ap-northeast-1:559744160976:podidentityassociation/eks-production/a-...",
+        "associationId": "a-..."
+    }
+]
+```
+
+- [ ] **Step 5: Cluster state 確認 (kubectl context)**
+
+```bash
+zsh -ic 'eks-login production >/dev/null 2>&1
+kubectl get storageclass gp3
+kubectl get pods -n monitoring | grep -E "prometheus|alertmanager|grafana|mimir"'
+```
+
+Expected:
+- `gp3` StorageClass exists (provisioner: `ebs.csi.aws.com`)
+- monitoring ns に Prometheus / Alertmanager / Grafana / Mimir 全 component が `Running` (Sub-project 2 stack 稼働中)
+
+- [ ] **Step 6: 既存 local component の現状確認**
+
+```bash
+cd /Users/takanokenichi/GitHub/panicboat/platform/.claude/worktrees/feat/eks-production-observability-logs-stack
+grep -A 3 "chart: grafana/loki" kubernetes/components/loki/local/helmfile.yaml
+grep -A 3 "chart: fluent/fluent-bit" kubernetes/components/fluent-bit/local/helmfile.yaml
+```
+
+Expected:
+- loki/local: `chart: grafana/loki` + `version: "7.0.0"` (= GEL only chart、Decision 5/6 で migration 対象)
+- fluent-bit/local: `chart: fluent/fluent-bit` + `version: "0.57.3"` (= touched しない)
+
+---
+
+## Task 1: local Loki chart migration (`grafana/loki` v7.0.0 → `grafana-community/loki` v13.6.0)
+
+**Files:**
+- Modify: `kubernetes/components/loki/local/helmfile.yaml`
+- Modify: `kubernetes/components/loki/local/values.yaml`
+- Modify (auto-generated): `kubernetes/manifests/local/loki/manifest.yaml`
+
+**Context:** Sub-project 2 brainstorming で発見、Decision 5/6 で確定。grafana/loki chart は 2026/3/16 に GEL only に分離、OSS continuation は grafana-community/loki。local cluster (k3d) で chart 切替を verify した上で production 新規 deploy に進む (= Decision 6 で local migration を本 sub-project の scope に含めた)。
+
+- [ ] **Step 1: helm repo add (grafana-community)**
+
+```bash
+helm repo add grafana-community https://grafana-community.github.io/helm-charts
+helm repo update grafana-community
+helm search repo grafana-community/loki --version 13.6.0
+```
+
+Expected: `grafana-community/loki  13.6.0  3.7.1  Helm chart for Grafana Loki ...` 出力
+
+- [ ] **Step 2: helmfile.yaml の chart + version を update**
+
+`kubernetes/components/loki/local/helmfile.yaml`:
+
+```yaml
+# =============================================================================
+# Loki Helmfile for local
+# =============================================================================
+# Loki is a log aggregation system designed for efficiency and ease of
+# operation. It receives logs from the OTel Collector and provides querying
+# capabilities in Grafana.
+#
+# NOTE: 2026/3/16 に grafana/loki chart が GEL only に分離、OSS continuation は
+# grafana-community/loki に移行。本 sub-project (Phase 3 Sub-project 3) で
+# chart を切替する (Decision 5/6)。
+# =============================================================================
+environments:
+  local:
+---
+repositories:
+  - name: grafana-community
+    url: https://grafana-community.github.io/helm-charts
+
+releases:
+  - name: loki
+    namespace: monitoring
+    chart: grafana-community/loki
+    version: "13.6.0"
+    values:
+      - values.yaml
+```
+
+- [ ] **Step 3: local values.yaml の chart schema 互換性確認 + 修正**
+
+現状の `kubernetes/components/loki/local/values.yaml` を read して、新 chart (grafana-community/loki v13.6.0) の schema との互換性を確認する。
+
+```bash
+# 現状の values.yaml を確認
+cat kubernetes/components/loki/local/values.yaml
+# 新 chart の default values で対応する key を確認
+helm show values grafana-community/loki --version 13.6.0 2>/dev/null | grep -B 1 -A 3 -E "^(deploymentMode|loki:|singleBinary|gateway|test):" | head -40
+```
+
+main check points:
+- `deploymentMode: SingleBinary` → 維持 (chart で valid な値)
+- `loki.auth_enabled: false` → 維持
+- `loki.commonConfig.replication_factor: 1` → 維持
+- `loki.storage.type: 'filesystem'` → 維持 (local は filesystem、production は s3)
+- `loki.schemaConfig` → 必要なら追加 (= chart default は空、local では `useTestSchema: true` で省略可)
+
+values.yaml schema mismatch があれば修正。chart v6.x → v13.x の version 番号 jump があるが、values 構造は continuous evolution と推察。実装段階で `helmfile template` を実行して error なければ schema 互換と判断 (Step 4 で確認)。
+
+- [ ] **Step 4: helmfile template で local manifest を render**
+
+```bash
+cd kubernetes
+make hydrate-component COMPONENT=loki ENV=local
+```
+
+Expected:
+- error なく完了
+- `kubernetes/manifests/local/loki/manifest.yaml` が再生成される
+- 中身に `helm.sh/chart: loki-13.6.0` が含まれる
+
+```bash
+grep "helm.sh/chart" kubernetes/manifests/local/loki/manifest.yaml | head -3
+```
+
+Expected: `helm.sh/chart: loki-13.6.0`
+
+- [ ] **Step 5: k3d local cluster で deploy verify**
+
+(任意の k3d cluster が起動している前提、もしくは `make phase1 phase2 phase3` で新規 setup)
+
+```bash
+# k3d cluster で kubectl apply
+kubectl apply -k kubernetes/manifests/local/loki/
+
+# 30 秒待機後に Pod 状態確認
+sleep 30
+kubectl get pods -n monitoring -l app.kubernetes.io/instance=loki
+```
+
+Expected: Loki SingleBinary Pod が `1/1 Running` (or `2/2 Running`、chart 内蔵 sidecar による)、Loki Gateway Deployment が `1/1 Running`
+
+- [ ] **Step 6: local Fluent Bit との接続確認 (= 既存設計、touched なし)**
+
+local の Fluent Bit は OTel Collector 経由で Loki に push する設計 (= README.md の最終形)。新 Loki chart のサービス名 `loki` (or `loki-gateway`) が変わっていないことを確認:
+
+```bash
+kubectl get svc -n monitoring -l app.kubernetes.io/instance=loki
+```
+
+Expected: `loki` / `loki-gateway` / `loki-headless` / `loki-memberlist` services が存在
+
+(local の OTel Collector → Loki 接続は Sub-project 4 でアクセス確認、本 sub-project では production の中間状態 = Fluent Bit → Loki 直接 のみ scope)
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add kubernetes/components/loki/local/helmfile.yaml \
+        kubernetes/components/loki/local/values.yaml \
+        kubernetes/manifests/local/loki/manifest.yaml
+git commit -s -m "feat(kubernetes/components/loki/local): migrate to grafana-community/loki v13.6.0
+
+2026/3/16 に grafana/loki chart は GEL only に分離 (= OSS panicboat には不適切)。
+OSS continuation は grafana-community/loki で active maintenance、最新 v13.6.0
+(Loki 3.7.1) に切替する。
+
+chart schema は continuous evolution で local values.yaml は概ね互換、必要箇所のみ
+修正。production 新規 deploy (Phase 3 Sub-project 3 Task 2-) に向けた前提整備。
+
+Refs: docs/superpowers/specs/2026-05-06-eks-production-observability-logs-stack-design.md
+      Decision 5: chart = grafana-community/loki v13.6.0 (organizational migration)
+      Decision 6: local migration = Sub-project 3 のスコープに含める"
+```
+
+---
+
+## Task 2: production Loki component (`kubernetes/components/loki/production/`)
+
+**Files:**
+- Create: `kubernetes/components/loki/production/helmfile.yaml`
+- Create: `kubernetes/components/loki/production/values.yaml.gotmpl`
+
+**Context:** Sub-project 2 (mimir/production) と同形 pattern を踏襲。SingleBinary mode + S3 backend + Pod Identity + ServiceMonitor enable + 30d retention + 1-2 min flush 間隔 (Decision 11 軽減策)。
+
+- [ ] **Step 1: helmfile.yaml を作成**
+
+`kubernetes/components/loki/production/helmfile.yaml`:
+
+```yaml
+# =============================================================================
+# Loki Helmfile for production
+# =============================================================================
+# Phase 3 Sub-project 3 で deploy する Logs stack の Loki 本体。
+# SingleBinary mode (= chart 内蔵の Monolithic deploy、9 Pod Microservices ではなく
+# 1-2 Pod 構成、small production OK の Loki 公式 position に準拠)。
+# S3 backend は Sub-project 1 で provision 済の loki-559744160976 を Pod Identity
+# 経由でアクセス。
+#
+# Decision references:
+# - D2: SingleBinary mode (HA upgrade path 保持)
+# - D3: tenancy=anonymous + retention=30d + auth_enabled=false (Mimir 対称)
+# - D5: chart = grafana-community/loki v13.6.0 (Loki 3.7.1)
+# - D11: HA upgrade path 明示、WAL flush 1-2 min + retry buffer filesystem-backed
+# =============================================================================
+environments:
+  production:
+    # NOTE: helmfile v1.4 は親 helmfile.yaml.gotmpl の environments values を
+    # 子 helmfile に auto-inherit しないため、ここで再定義する。
+    # 値は kubernetes/helmfile.yaml.gotmpl の production env block と
+    # 同期すること (loki.bucketName / loki.bucketPathPrefix)。
+    values:
+      - loki:
+          bucketName: loki-559744160976
+          bucketPathPrefix: production
+---
+repositories:
+  - name: grafana-community
+    url: https://grafana-community.github.io/helm-charts
+
+releases:
+  - name: loki
+    namespace: monitoring
+    chart: grafana-community/loki
+    version: "13.6.0"
+    values:
+      - values.yaml.gotmpl
+```
+
+- [ ] **Step 2: values.yaml.gotmpl を作成**
+
+`kubernetes/components/loki/production/values.yaml.gotmpl`:
+
+```yaml
+# Loki Configuration for production
+# SingleBinary mode + S3 backend (Sub-project 1 outputs) + Pod Identity (loki SA)
+
+# =============================================================================
+# Deployment Mode (Decision 2)
+# =============================================================================
+# SingleBinary = chart 内蔵の monolithic deploy。1 StatefulSet (replicas=1) で
+# distributor / ingester / querier / query-frontend / store-gateway / compactor
+# を全部 in-process。small production 向け、HA は将来 SimpleScalable に upgrade。
+deploymentMode: SingleBinary
+
+# =============================================================================
+# Loki Core Configuration
+# =============================================================================
+loki:
+  # 1 tenant 運用 (panicboat) のため auth 不要 (Decision 3)
+  auth_enabled: false
+
+  # -------------------------------------------------------------------------
+  # Common Config
+  # -------------------------------------------------------------------------
+  commonConfig:
+    path_prefix: /var/loki
+    # SingleBinary 1 replica なので replication_factor=1 (Decision 2)
+    # HA upgrade 時は SimpleScalable 3 replicas + replication_factor=3 に変更
+    replication_factor: 1
+
+  # -------------------------------------------------------------------------
+  # Storage Config (S3 backend, Sub-project 1 outputs)
+  # -------------------------------------------------------------------------
+  storage:
+    type: s3
+    bucketNames:
+      chunks: {{ .Values.loki.bucketName }}
+      ruler: {{ .Values.loki.bucketName }}
+    s3:
+      region: ap-northeast-1
+      # AWS S3 native = path style 不要 (= virtual-hosted style)
+      s3ForcePathStyle: false
+      # AWS_ENDPOINT_URL 不要 (= default endpoint)
+      endpoint: null
+      # Pod Identity 経由のため access key 不要
+      accessKeyId: null
+      secretAccessKey: null
+
+  # -------------------------------------------------------------------------
+  # Schema Config (TSDB schema = Loki 3.x recommended)
+  # -------------------------------------------------------------------------
+  schemaConfig:
+    configs:
+      - from: "2024-01-01"
+        store: tsdb
+        object_store: s3
+        schema: v13
+        index:
+          # env prefix で IAM policy s3:prefix=production と整合 (Sub-project 1 D11 IAM 3-statement)
+          prefix: production_index_
+          period: 24h
+
+  # -------------------------------------------------------------------------
+  # Storage Config (env prefix for IAM policy compat)
+  # -------------------------------------------------------------------------
+  storage_config:
+    aws:
+      # bucket 内 path prefix (= IAM policy s3:prefix=production と整合)
+      bucketnames: {{ .Values.loki.bucketName }}
+      region: ap-northeast-1
+      s3forcepathstyle: false
+    tsdb_shipper:
+      # local cache (= Loki Pod の PVC 内に index cache を保持、S3 query 高速化)
+      active_index_directory: /var/loki/tsdb-index
+      cache_location: /var/loki/tsdb-cache
+      shared_store: s3
+
+  # -------------------------------------------------------------------------
+  # Limits Config (retention 30d、Decision 3)
+  # -------------------------------------------------------------------------
+  limits_config:
+    # logs entry の最大保持期間 = aws/eks-logs/ S3 lifecycle 30d と整合
+    retention_period: 720h
+    # 1 stream あたりのログ entry rate 制限 (= burst protection)
+    ingestion_rate_mb: 4
+    ingestion_burst_size_mb: 6
+
+  # -------------------------------------------------------------------------
+  # Compactor (retention enforcement)
+  # -------------------------------------------------------------------------
+  compactor:
+    # S3 上の chunks を retention に基づき削除する (= aws/eks-logs/ S3 lifecycle と
+    # 同 30d、Loki 側でも明示的に enforce)
+    retention_enabled: true
+    retention_delete_delay: 2h
+
+  # -------------------------------------------------------------------------
+  # Ingester (= flush 間隔短縮、Decision 11 軽減策)
+  # -------------------------------------------------------------------------
+  ingester:
+    # WAL chunk を S3 に flush する間隔 (default は 5 min、AZ 障害時のロスト window
+    # を縮小するため 2 min に短縮)
+    chunk_idle_period: 2m
+    # max chunk age = 古い chunk を強制 flush
+    max_chunk_age: 5m
+
+# =============================================================================
+# ServiceAccount (Pod Identity for S3 access)
+# =============================================================================
+serviceAccount:
+  create: true
+  # aws/eks-logs/ で provision 済の Pod Identity Association が
+  # monitoring/loki SA を IAM role eks-production-loki に紐付け済
+  name: loki
+  # Pod Identity は IRSA と異なり annotation 不要 (cluster-side で managed)
+  annotations: {}
+
+# =============================================================================
+# SingleBinary StatefulSet (Decision 2)
+# =============================================================================
+singleBinary:
+  enabled: true
+  replicas: 1
+
+  # PVC: WAL + boltdb-shipper local cache を gp3 10Gi
+  persistence:
+    enabled: true
+    storageClass: gp3
+    size: 10Gi
+
+  # Resources (small production)
+  resources:
+    requests:
+      cpu: 500m
+      memory: 1Gi
+    limits:
+      cpu: 1
+      memory: 2Gi
+
+  # PodDisruptionBudget は 1 replica なので minAvailable=0 (= 強制 evict 可能)
+  # default の `enabled: true` のままだと replicas=1 で minAvailable=1 になる
+  # 可能性があり、node drain 時に block する。明示的に disable。
+  podDisruptionBudget:
+    enabled: false
+
+# =============================================================================
+# Loki Gateway (chart 内蔵 nginx)
+# =============================================================================
+gateway:
+  enabled: true
+  replicas: 1
+  resources:
+    requests:
+      cpu: 50m
+      memory: 64Mi
+    limits:
+      cpu: 200m
+      memory: 256Mi
+  # Gateway は stateless (PVC なし)、1 replica + RollingUpdate で OK
+  # (= Sub-project 2 L3 の Multi-Attach 罠は PVC なしのため発生しない)
+
+# =============================================================================
+# Disable subcomponents (SingleBinary mode で不要)
+# =============================================================================
+# SimpleScalable / Distributed mode の component を全 disable
+read:
+  replicas: 0
+write:
+  replicas: 0
+backend:
+  replicas: 0
+
+# Cache (memcached-based、small production では不要)
+chunksCache:
+  enabled: false
+resultsCache:
+  enabled: false
+
+# Test (helm test 用、production では不要)
+test:
+  enabled: false
+
+# Loki Canary (= synthetic canary、small production では不要)
+lokiCanary:
+  enabled: false
+
+# Tabler-manager (= deprecated component、Loki 3.x では使わない)
+tableManager:
+  enabled: false
+
+# Network policy (panicboat では Cilium で別途管理、chart 内蔵は使わない)
+networkPolicy:
+  enabled: false
+
+# =============================================================================
+# Monitoring (ServiceMonitor for Prometheus auto-scrape)
+# =============================================================================
+monitoring:
+  # Self-monitoring metrics を Prometheus が scrape
+  serviceMonitor:
+    enabled: true
+    # kube-prometheus-stack の ServiceMonitor selector に乗るための label
+    labels:
+      release: kube-prometheus-stack
+    interval: 15s
+
+  # Prometheus Rules (= alerting rules)、Phase 4 で alertmanager 設定時に有効化
+  rules:
+    enabled: false
+
+  # Loki dashboards (chart 内蔵 ConfigMap)、Phase 4 で別途 Grafana に投入
+  dashboards:
+    enabled: false
+
+  # Self monitoring (= Loki が自分自身の logs を query する仕組み)、不要
+  selfMonitoring:
+    enabled: false
+    grafanaAgent:
+      installOperator: false
+```
+
+- [ ] **Step 3: helmfile template で render verify**
+
+```bash
+cd kubernetes
+make hydrate-component COMPONENT=loki ENV=production
+```
+
+Expected:
+- error なく完了
+- `kubernetes/manifests/production/loki/manifest.yaml` が新規生成される
+- 中身に以下が含まれる:
+  - `kind: StatefulSet` (loki SingleBinary)
+  - `kind: Deployment` (loki-gateway)
+  - `kind: ServiceMonitor` (Prometheus auto-scrape)
+  - `kind: ServiceAccount` (name: loki)
+  - `loki.storage.bucketnames: loki-559744160976`
+  - `replication_factor: 1`
+
+```bash
+grep -E "kind:|name: loki$|replication_factor|bucketnames|storageClass" kubernetes/manifests/production/loki/manifest.yaml | head -20
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add kubernetes/components/loki/production/
+git commit -s -m "feat(kubernetes/components/loki): add production env (SingleBinary mode + S3 backend)
+
+Phase 3 Sub-project 3 で deploy する Logs stack の Loki 本体。
+grafana-community/loki v13.6.0 (Loki 3.7.1) chart の SingleBinary mode で
+1 StatefulSet + 1 Gateway Deployment 構成、Pod Identity (loki SA) 経由で
+S3 (loki-559744160976) backend にアクセス。
+
+主要設定:
+- deploymentMode: SingleBinary (Decision 2)
+- replication_factor: 1 (small production、HA upgrade path 保持)
+- retention: 30d (= aws/eks-logs/ S3 lifecycle 30d と整合、Decision 3)
+- auth_enabled: false (1 tenant anonymous、Decision 3)
+- WAL flush 2 min (Decision 11 軽減策で AZ 障害時のロスト window 縮小)
+- ServiceMonitor enabled (Sub-project 2 確立 pattern、Decision 9)
+- gp3 PVC 10Gi (Sub-project 2 で provision 済 StorageClass 再利用)
+- TSDB schema v13 + production_index_ prefix (IAM policy s3:prefix=production と整合)
+
+Refs: docs/superpowers/specs/2026-05-06-eks-production-observability-logs-stack-design.md
+      Decision 2 / 3 / 5 / 9 / 11"
+```
+
+---
+
+## Task 3: production Fluent Bit component (`kubernetes/components/fluent-bit/production/`)
+
+**Files:**
+- Create: `kubernetes/components/fluent-bit/production/helmfile.yaml`
+- Create: `kubernetes/components/fluent-bit/production/values.yaml.gotmpl`
+
+**Context:** DaemonSet (per node)、tail input + Kubernetes filter + **Loki HTTP output 直接 push** (= Decision 1 中間状態)。filesystem-backed retry buffer (Decision 11 軽減策)。
+
+- [ ] **Step 1: helmfile.yaml を作成**
+
+`kubernetes/components/fluent-bit/production/helmfile.yaml`:
+
+```yaml
+# =============================================================================
+# Fluent Bit Helmfile for production
+# =============================================================================
+# Phase 3 Sub-project 3 で deploy する Logs stack の log collector。
+# DaemonSet で各 node の container logs を tail、Loki Gateway に HTTP push。
+# (= Decision 1 中間状態、Sub-project 4 で OTel Collector 経由に switching)
+#
+# Decision references:
+# - D1: Logs flow path = Fluent Bit → Loki 直接 push (中間状態)
+# - D7: chart = fluent/fluent-bit v0.57.3 (Fluent Bit 5.0.3)
+# - D8: Pod Identity 不要 (Loki Gateway HTTP push のみ、AWS access なし)
+# - D9: ServiceMonitor enabled (Sub-project 2 確立 pattern)
+# - D11 軽減策: filesystem-backed retry buffer
+# =============================================================================
+environments:
+  production:
+---
+repositories:
+  - name: fluent
+    url: https://fluent.github.io/helm-charts
+
+releases:
+  - name: fluent-bit
+    namespace: monitoring
+    chart: fluent/fluent-bit
+    version: "0.57.3"
+    values:
+      - values.yaml.gotmpl
+```
+
+- [ ] **Step 2: values.yaml.gotmpl を作成**
+
+`kubernetes/components/fluent-bit/production/values.yaml.gotmpl`:
+
+```yaml
+# Fluent Bit Configuration for production
+# DaemonSet で container logs を tail、Loki Gateway に HTTP 直接 push (= Decision 1 中間状態)
+
+# =============================================================================
+# Deployment Kind
+# =============================================================================
+# 各 node の container logs を tail するため DaemonSet (= chart default)
+kind: DaemonSet
+
+# =============================================================================
+# ServiceAccount (Decision 8: Pod Identity 不要)
+# =============================================================================
+# AWS access 不要 (Loki HTTP push のみ)、default SA で OK
+serviceAccount:
+  create: true
+  annotations: {}
+
+# =============================================================================
+# Resources (lightweight per-node DaemonSet)
+# =============================================================================
+resources:
+  requests:
+    cpu: 100m
+    memory: 128Mi
+  limits:
+    cpu: 200m
+    memory: 256Mi
+
+# =============================================================================
+# Tolerations (= 全 node に乗るため、master/etcd 等の taint に対応)
+# =============================================================================
+tolerations:
+  - effect: NoSchedule
+    operator: Exists
+  - effect: NoExecute
+    operator: Exists
+
+# =============================================================================
+# Fluent Bit Config (production override)
+# =============================================================================
+config:
+  # -------------------------------------------------------------------------
+  # SERVICE Block
+  # -------------------------------------------------------------------------
+  service: |
+    [SERVICE]
+        Daemon Off
+        Flush 1
+        Log_Level info
+        Parsers_File /fluent-bit/etc/parsers.conf
+        Parsers_File /fluent-bit/etc/conf/custom_parsers.conf
+        HTTP_Server On
+        HTTP_Listen 0.0.0.0
+        HTTP_Port 2020
+        Health_Check On
+        # filesystem-backed buffer = node disk 利用、長時間 outage 耐性 (Decision 11 軽減策)
+        storage.path              /var/log/flb_storage/
+        storage.sync              normal
+        storage.checksum          off
+        storage.backlog.mem_limit 5M
+
+  # -------------------------------------------------------------------------
+  # INPUTS (= container logs tail)
+  # -------------------------------------------------------------------------
+  inputs: |
+    [INPUT]
+        Name              tail
+        Path              /var/log/containers/*.log
+        multiline.parser  docker, cri
+        Tag               kube.*
+        Mem_Buf_Limit     5MB
+        Skip_Long_Lines   On
+        Refresh_Interval  10
+        # storage.type filesystem = retry buffer を node disk に保存 (Decision 11)
+        storage.type      filesystem
+        # DB ファイルで読み取り position を記録、再起動時に resume
+        DB                /var/log/flb_storage/tail.db
+
+  # -------------------------------------------------------------------------
+  # FILTERS (= Kubernetes metadata 付与 + cardinality 制御 = Decision 4)
+  # -------------------------------------------------------------------------
+  filters: |
+    [FILTER]
+        Name                kubernetes
+        Match               kube.*
+        Kube_URL            https://kubernetes.default.svc:443
+        Kube_CA_File        /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+        Kube_Token_File     /var/run/secrets/kubernetes.io/serviceaccount/token
+        Kube_Tag_Prefix     kube.var.log.containers.
+        Merge_Log           On
+        Keep_Log            Off
+        K8S-Logging.Parser  On
+        K8S-Logging.Exclude On
+        Annotations         Off
+        Labels              On
+
+    # Decision 4 = 最小 labels (namespace / pod / container) + structured metadata で他保持
+    # nest filter で kubernetes_* 系 metadata を整形
+    [FILTER]
+        Name        nest
+        Match       kube.*
+        Operation   lift
+        Nested_under kubernetes
+        Add_prefix  k8s_
+
+  # -------------------------------------------------------------------------
+  # OUTPUTS (= Loki HTTP push、Decision 1 中間状態)
+  # -------------------------------------------------------------------------
+  outputs: |
+    [OUTPUT]
+        Name              loki
+        Match             kube.*
+        Host              loki-gateway.monitoring.svc.cluster.local
+        Port              80
+        # Loki API path (X-Scope-OrgID header は tenant_id で実装)
+        Uri               /loki/api/v1/push
+        # 1 tenant 運用 (= Decision 3)
+        tenant_id         anonymous
+        # Decision 4 labels = 最小 (namespace / pod / container)
+        labels            job=fluentbit, namespace=$kubernetes['namespace_name'], pod=$kubernetes['pod_name'], container=$kubernetes['container_name']
+        # 残りの k8s metadata は structured metadata で保持 (= cardinality cost なし)
+        structured_metadata node=$kubernetes['host'], stream=$stream
+        # remove kube_ prefix from log fields
+        remove_keys       kubernetes
+        # gzip 圧縮で帯域削減
+        compress          gzip
+        # retry settings
+        net.connect_timeout 10
+        Retry_Limit       no_limits
+        # storage = filesystem buffer (= retry の永続化)
+        storage.total_limit_size  5G
+
+# =============================================================================
+# Volumes & Volume Mounts (= filesystem buffer 用 hostPath)
+# =============================================================================
+# default の daemonSetVolumes / daemonSetVolumeMounts に追加
+daemonSetVolumes:
+  - name: varlog
+    hostPath:
+      path: /var/log
+  - name: varlibdockercontainers
+    hostPath:
+      path: /var/lib/docker/containers
+  - name: etcmachineid
+    hostPath:
+      path: /etc/machine-id
+      type: File
+  # Decision 11 軽減策 = filesystem buffer 永続化用の hostPath
+  - name: flb-storage
+    hostPath:
+      path: /var/log/flb_storage
+      type: DirectoryOrCreate
+
+daemonSetVolumeMounts:
+  - name: varlog
+    mountPath: /var/log
+  - name: varlibdockercontainers
+    mountPath: /var/lib/docker/containers
+    readOnly: true
+  - name: etcmachineid
+    mountPath: /etc/machine-id
+    readOnly: true
+  - name: flb-storage
+    mountPath: /var/log/flb_storage
+
+# =============================================================================
+# ServiceMonitor (Prometheus auto-scrape, Decision 9)
+# =============================================================================
+serviceMonitor:
+  enabled: true
+  # kube-prometheus-stack の ServiceMonitor selector に乗るための label
+  additionalLabels:
+    release: kube-prometheus-stack
+  interval: 15s
+
+# =============================================================================
+# Test (= helm test 用、production では不要)
+# =============================================================================
+testFramework:
+  enabled: false
+```
+
+- [ ] **Step 3: helmfile template で render verify**
+
+```bash
+cd kubernetes
+make hydrate-component COMPONENT=fluent-bit ENV=production
+```
+
+Expected:
+- error なく完了
+- `kubernetes/manifests/production/fluent-bit/manifest.yaml` が新規生成される
+- 中身に以下が含まれる:
+  - `kind: DaemonSet` (fluent-bit)
+  - `kind: ServiceMonitor` (Prometheus auto-scrape)
+  - `kind: ServiceAccount` (default name)
+  - `loki-gateway.monitoring.svc.cluster.local` 出力 OUTPUT block
+  - `tenant_id anonymous` 出力
+
+```bash
+grep -E "kind:|loki-gateway|tenant_id|storage.type filesystem" kubernetes/manifests/production/fluent-bit/manifest.yaml | head -10
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add kubernetes/components/fluent-bit/production/
+git commit -s -m "feat(kubernetes/components/fluent-bit): add production env (Loki direct push)
+
+Phase 3 Sub-project 3 で deploy する Logs stack の log collector。
+fluent/fluent-bit v0.57.3 (Fluent Bit 5.0.3) chart の DaemonSet で各 node の
+container logs を tail、Loki Gateway に HTTP 直接 push。
+
+Decision 1 中間状態 (= Fluent Bit → Loki 直接、Sub-project 4 で OTel
+Collector 経由に switching)。Decision 4 = 最小 labels (namespace / pod /
+container) + structured metadata で他 k8s metadata を保持、cardinality 制御。
+Decision 8 = Pod Identity 不要 (AWS access なし)。Decision 9 = ServiceMonitor
+enabled。Decision 11 軽減策 = filesystem-backed retry buffer (= node disk
+/var/log/flb_storage/、長時間 outage 耐性)。
+
+Refs: docs/superpowers/specs/2026-05-06-eks-production-observability-logs-stack-design.md
+      Decision 1 / 4 / 7 / 8 / 9 / 11"
+```
+
+---
+
+## Task 4: Cross-stack values + Grafana datasource update
+
+**Files:**
+- Modify: `kubernetes/helmfile.yaml.gotmpl`
+- Modify: `kubernetes/components/prometheus-operator/production/values.yaml.gotmpl`
+
+**Context:** Plan 1c-β L4 pattern (= placeholder 不採用、直接実値書き) を踏襲。Grafana datasource は Sub-project 2 で確立した pattern (= `datasources.yaml` に追加)、default は Mimir 維持 (Decision 10)。
+
+- [ ] **Step 1: kubernetes/helmfile.yaml.gotmpl の production env values block に loki cross-stack values を追加**
+
+現状の関連箇所:
+```bash
+grep -n -B 2 -A 20 "production:" kubernetes/helmfile.yaml.gotmpl | head -40
+```
+
+production env block の `mimir:` 直下に同形の `loki:` block を追加:
+
+```yaml
+# Before:
+environments:
+  production:
+    values:
+      - cluster:
+          name: eks-production
+        karpenter:
+          interruptionQueueName: Karpenter-eks-production
+        mimir:
+          bucketName: mimir-559744160976
+          bucketPathPrefix: production
+          podIdentityRoleName: eks-production-mimir
+
+# After:
+environments:
+  production:
+    values:
+      - cluster:
+          name: eks-production
+        karpenter:
+          interruptionQueueName: Karpenter-eks-production
+        mimir:
+          bucketName: mimir-559744160976
+          bucketPathPrefix: production
+          podIdentityRoleName: eks-production-mimir
+        loki:
+          # Source: aws/eks-logs/envs/production terragrunt output
+          bucketName: loki-559744160976
+          bucketPathPrefix: production
+          podIdentityRoleName: eks-production-loki
+```
+
+(具体的な diff 箇所は実装段階で確定、上記は概念例)
+
+- [ ] **Step 2: kubernetes/components/prometheus-operator/production/values.yaml.gotmpl の Grafana datasource に Loki entry を追加**
+
+現状の `datasources.yaml.datasources` block を確認:
+
+```bash
+grep -n -B 2 -A 30 "datasources:" kubernetes/components/prometheus-operator/production/values.yaml.gotmpl | head -50
+```
+
+Mimir entry の後に Loki entry を追加 (Mimir / Prometheus と並列、`isDefault: false`、Decision 10):
+
+```yaml
+grafana:
+  datasources:
+    datasources.yaml:
+      apiVersion: 1
+      datasources:
+        - name: Mimir
+          uid: mimir
+          type: prometheus
+          url: http://mimir-distributed-gateway.monitoring.svc.cluster.local/prometheus
+          access: proxy
+          isDefault: true       # Mimir = default (Decision 10)
+          jsonData:
+            httpMethod: POST
+            timeInterval: 30s
+        - name: Prometheus (local)
+          uid: prometheus-local
+          type: prometheus
+          url: http://prometheus-operated.monitoring.svc.cluster.local:9090
+          access: proxy
+          isDefault: false
+          jsonData:
+            httpMethod: POST
+            timeInterval: 30s
+        # Phase 3 Sub-project 3 (Logs stack)
+        - name: Loki
+          uid: loki
+          type: loki
+          url: http://loki-gateway.monitoring.svc.cluster.local
+          access: proxy
+          isDefault: false      # Loki は default にしない (= Mimir 維持、Decision 10)
+          jsonData:
+            # 1 tenant 運用 (= Decision 3)
+            httpHeaderName1: X-Scope-OrgID
+          secureJsonData:
+            httpHeaderValue1: anonymous
+```
+
+- [ ] **Step 3: helmfile template で prometheus-operator を再 hydrate**
+
+```bash
+cd kubernetes
+make hydrate-component COMPONENT=prometheus-operator ENV=production
+```
+
+Expected:
+- error なく完了
+- `kubernetes/manifests/production/prometheus-operator/manifest.yaml` で Loki datasource が新規追加された diff
+
+```bash
+git diff kubernetes/manifests/production/prometheus-operator/manifest.yaml | head -30
+```
+
+Expected: `name: Loki` / `type: loki` / `url: http://loki-gateway.monitoring.svc.cluster.local` の追加 diff が含まれる
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add kubernetes/helmfile.yaml.gotmpl \
+        kubernetes/components/prometheus-operator/production/values.yaml.gotmpl \
+        kubernetes/manifests/production/prometheus-operator/manifest.yaml
+git commit -s -m "feat(kubernetes): add Loki cross-stack values + Grafana datasource
+
+Phase 3 Sub-project 3 (Logs stack) のための cross-stack values を
+production env に追加 (= Plan 1c-β L4 pattern、placeholder 不採用)。
+
+1. kubernetes/helmfile.yaml.gotmpl
+   production env values block に loki: bucketName / bucketPathPrefix /
+   podIdentityRoleName を追加 (Sub-project 1 outputs と整合)。
+
+2. kubernetes/components/prometheus-operator/production/values.yaml.gotmpl
+   grafana.datasources.datasources.yaml.datasources に Loki entry 追加
+   (Mimir = default 維持、Loki = isDefault: false、Decision 10)。
+   X-Scope-OrgID: anonymous header で tenant 指定 (Decision 3)。
+
+Refs: docs/superpowers/specs/2026-05-06-eks-production-observability-logs-stack-design.md
+      Decision 3 / 9 / 10"
+```
+
+---
+
+## Task 5: Hydrate manifests + kustomization.yaml update
+
+**Files:**
+- Auto-generate: `kubernetes/manifests/production/loki/{kustomization.yaml, manifest.yaml}`
+- Auto-generate: `kubernetes/manifests/production/fluent-bit/{kustomization.yaml, manifest.yaml}`
+- Modify: `kubernetes/manifests/production/kustomization.yaml`
+
+**Context:** Sub-project 2 と同形の hydrate output。kustomization.yaml に新 component 2 つを resources として追加。
+
+- [ ] **Step 1: hydrate-index で manifests/production/ を再生成 + cleanup**
+
+```bash
+cd kubernetes
+make hydrate-index ENV=production
+```
+
+Expected:
+- `kubernetes/manifests/production/loki/kustomization.yaml` が新規作成される (`resources: [manifest.yaml]`)
+- `kubernetes/manifests/production/fluent-bit/kustomization.yaml` が新規作成される
+- 既存の loki / fluent-bit manifest.yaml も再生成
+
+確認:
+```bash
+ls kubernetes/manifests/production/loki/
+ls kubernetes/manifests/production/fluent-bit/
+```
+
+Expected: 各 dir に `kustomization.yaml` + `manifest.yaml` の 2 file
+
+- [ ] **Step 2: kubernetes/manifests/production/kustomization.yaml に追加**
+
+現状:
+```bash
+cat kubernetes/manifests/production/kustomization.yaml
+```
+
+Expected (Sub-project 2 完了時点):
+```yaml
+resources:
+  - ./00-namespaces
+  - ./aws-load-balancer-controller
+  - ./cilium
+  - ./external-dns
+  - ./gateway-api
+  - ./karpenter
+  - ./keda
+  - ./metrics-server
+  - ./mimir
+  - ./prometheus-operator
+  - ./storage-class
+```
+
+`./fluent-bit` と `./loki` を **アルファベット順** で追加 (= `./external-dns` の前と `./keda` の後):
+
+```yaml
+resources:
+  - ./00-namespaces
+  - ./aws-load-balancer-controller
+  - ./cilium
+  - ./external-dns
+  - ./fluent-bit
+  - ./gateway-api
+  - ./karpenter
+  - ./keda
+  - ./loki
+  - ./metrics-server
+  - ./mimir
+  - ./prometheus-operator
+  - ./storage-class
+```
+
+- [ ] **Step 3: kustomize build で全体 manifest を render verify**
+
+```bash
+kubectl kustomize kubernetes/manifests/production/ > /tmp/production-rendered.yaml
+echo "Total resources: $(grep -c '^kind:' /tmp/production-rendered.yaml)"
+echo ""
+echo "=== loki resources ==="
+grep -B 1 "name: loki" /tmp/production-rendered.yaml | grep "kind:" | sort | uniq -c
+echo ""
+echo "=== fluent-bit resources ==="
+grep -B 1 "name: fluent-bit" /tmp/production-rendered.yaml | grep "kind:" | sort | uniq -c
+echo ""
+echo "=== Loki datasource entry in Grafana cm ==="
+grep -A 3 "name: Loki" /tmp/production-rendered.yaml | head -10
+```
+
+Expected:
+- error なく完了
+- Loki resource: StatefulSet 1 + Deployment (gateway) 1 + Service 数件 + ServiceMonitor 1 + ConfigMap 1 + ServiceAccount 1
+- Fluent Bit resource: DaemonSet 1 + Service 1 + ServiceMonitor 1 + ConfigMap 1 + ServiceAccount 1
+- Grafana datasources cm に `name: Loki` entry が含まれる
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add kubernetes/manifests/production/loki/ \
+        kubernetes/manifests/production/fluent-bit/ \
+        kubernetes/manifests/production/kustomization.yaml
+git commit -s -m "chore(kubernetes/manifests): hydrate loki + fluent-bit for production
+
+Phase 3 Sub-project 3 (Logs stack) の helmfile template 結果を hydrate。
+kustomization.yaml に ./fluent-bit + ./loki を追加 (alphabetical order)。
+
+manifest.yaml の中身は components/loki/production/ + components/fluent-bit/production/
+の helmfile.yaml + values.yaml.gotmpl から auto-generated (= make hydrate-index)。
+
+Refs: docs/superpowers/specs/2026-05-06-eks-production-observability-logs-stack-design.md"
+```
+
+---
+
+## Task 6: PR push + Pre-flight check + Ready for review
+
+**Files:** (= no file changes、PR 操作のみ)
+
+**Context:** Sub-project 2 L4 learnings 適用。Pre-flight check 全件 ✅ を PR description に記録してから Ready for review に切替。
+
+- [ ] **Step 1: branch 状態を確認**
+
+```bash
+cd /Users/takanokenichi/GitHub/panicboat/platform/.claude/worktrees/feat/eks-production-observability-logs-stack
+git log --oneline origin/main..HEAD
+```
+
+Expected: 6 commits ahead (Task 1 から Task 5 まで + spec commit)
+```
+<sha> chore(kubernetes/manifests): hydrate loki + fluent-bit for production
+<sha> feat(kubernetes): add Loki cross-stack values + Grafana datasource
+<sha> feat(kubernetes/components/fluent-bit): add production env (Loki direct push)
+<sha> feat(kubernetes/components/loki): add production env (SingleBinary mode + S3 backend)
+<sha> feat(kubernetes/components/loki/local): migrate to grafana-community/loki v13.6.0
+<sha> docs(eks): Phase 3 Sub-project 3 (Observability Logs stack) design spec
+```
+
+- [ ] **Step 2: branch を origin に push**
+
+```bash
+git push -u origin HEAD
+```
+
+Expected: `branch 'feat/eks-production-observability-logs-stack' set up to track 'origin/feat/eks-production-observability-logs-stack'`
+
+- [ ] **Step 3: Draft PR を作成 (Pre-flight check 結果を含む)**
+
+PR title: `feat(eks): Phase 3 Sub-project 3 — Logs stack (Loki SingleBinary + Fluent Bit)`
+
+PR body は以下:
+
+```markdown
+## Summary
+
+Phase 3 Sub-project 3 (Logs stack) の implementation。`grafana-community/loki` v13.6.0 (SingleBinary mode、Loki 3.7.1) + `fluent/fluent-bit` v0.57.3 を `monitoring` namespace に deploy。Sub-project 1 で provision 済の AWS infra (`loki-559744160976` bucket + `eks-production-loki` IAM role + `loki` Pod Identity SA) を活用、Sub-project 2 で確立した ServiceMonitor pattern + Grafana datasource 統合 path に従う。
+
+**Architecture (中間状態):** Fluent Bit DaemonSet が container logs を tail → Loki Gateway 経由で SingleBinary に直接 push (= Decision 1)、Pod Identity 経由で S3 long-term storage。Sub-project 4 で OTel Collector deploy 後に Fluent Bit → OTel Collector → Loki に switching 予定。
+
+## Spec
+
+`docs/superpowers/specs/2026-05-06-eks-production-observability-logs-stack-design.md` (12 Decisions、Sub-project 2 learnings 全項目適用)
+
+## Notable Decisions
+
+- **D1**: Logs flow = Fluent Bit → Loki 直接 push (中間状態)
+- **D2**: Loki SingleBinary (Mimir Microservices と非対称、両 chart の official position 準拠)
+- **D5**: chart = `grafana-community/loki` v13.6.0 (`grafana/loki` が GEL only に分離した結果として OSS continuation chart に移行)
+- **D6**: local migration を本 sub-project に含める
+- **D11**: HA upgrade path 明示 (1 replica で start、必要なら SimpleScalable + multi-AZ)
+
+## Pre-flight check
+
+- [x] aws/eks-logs/ terragrunt state 8 resources confirmed (Task 0 Step 2)
+- [x] S3 bucket loki-559744160976 head-bucket 200 OK (Task 0 Step 3)
+- [x] Pod Identity Association monitoring/loki exists (Task 0 Step 4)
+- [x] gp3 StorageClass exists (Task 0 Step 5)
+- [x] Sub-project 2 stack all Running (Task 0 Step 5)
+- [x] local migration verified on k3d (Task 1 Step 5)
+
+## Test plan (post-flight, after merge)
+
+### 10 分以内
+- [ ] Loki SingleBinary `1/1 Running`
+- [ ] Loki Gateway `1/1 Running`
+- [ ] Fluent Bit DaemonSet が全 node で `1/1 Running`
+- [ ] PVC `storage-loki-0` Bound (gp3 10Gi)
+- [ ] Prometheus targets で `loki` / `fluent-bit` が `UP`
+
+### 30 分以内
+- [ ] S3 (`loki-559744160976/production/`) に chunks 出現
+- [ ] Grafana Explore で `{namespace="monitoring"}` query が logs を返す
+- [ ] Sub-project 2 stack regression なし (Mimir / Prometheus / Alertmanager / Grafana 全 Running、Mimir gateway `/ready` OK)
+
+## Sub-project 2 learnings 適用
+
+| Sub-project 2 learnings | 本 PR での適用 |
+|---|---|
+| L1 (chart upgrade での upstream changelog 確認) | D5: grafana/loki → grafana-community/loki organizational migration |
+| L2 (chart auto-generated ConfigMap と values override の衝突) | Sub-project 2 の `defaultDatasourceEnabled: false` 設定継続、新たな衝突は発生しない |
+| L3 (EBS RWO + RollingUpdate → Recreate) | Loki SingleBinary は StatefulSet (OrderedReady)、Loki Gateway は Deployment + PVC なし、新規 Recreate 設定不要 |
+| L4 (Spec verification を pre-flight / post-flight 分割) | 本 PR description に Pre-flight check section 明示 |
+| L5 (Flux suspend pattern) | 通常 deploy で進める、問題発見時のみ reactive 発動 |
+| L6 (gp3 StorageClass) | Sub-project 2 で provision 済再利用 |
+| L7 (Pod Identity webhook injection) | 新規 deploy のため初回起動時に正しく injection、force-delete シナリオなし |
+| L8 (storage_prefix 英数字制約) | Loki でも `production` (slash なし) を採用 |
+
+## Rollback 手順 (想定外障害時)
+
+```bash
+flux suspend kustomization flux-system
+kubectl delete -k kubernetes/manifests/production/loki/
+kubectl delete -k kubernetes/manifests/production/fluent-bit/
+kubectl get pods -n monitoring | grep -v loki | grep -v fluent-bit  # Sub-project 2 影響なき確認
+gh pr create --title "revert: Phase 3 Sub-project 3 (Logs stack)" ...
+flux reconcile source git flux-system
+flux resume kustomization flux-system
+```
+
+aws/eks-logs/ は Sub-project 1 で provision 済 = AWS-side rollback 不要。
+```
+
+```bash
+gh pr create --draft \
+  --title "feat(eks): Phase 3 Sub-project 3 — Logs stack (Loki SingleBinary + Fluent Bit)" \
+  --body "$(<above body>)"
+```
+
+Expected: PR URL 出力 (例: `https://github.com/panicboat/platform/pull/<N>`)
+
+- [ ] **Step 4: PR URL を確認**
+
+```bash
+gh pr view --json title,url,isDraft --jq '.'
+```
+
+Expected:
+```json
+{
+    "isDraft": true,
+    "title": "feat(eks): Phase 3 Sub-project 3 — Logs stack (Loki SingleBinary + Fluent Bit)",
+    "url": "https://github.com/panicboat/platform/pull/<N>"
+}
+```
+
+PR title 文字数: ≤ 70 visible chars 確認 (= Sub-project 2 PR title 教訓、`wc -m` で 100 以下に収める)。
+
+```bash
+echo -n "feat(eks): Phase 3 Sub-project 3 — Logs stack (Loki SingleBinary + Fluent Bit)" | wc -m
+```
+
+Expected: ≤ 100 (em dash の 3 byte 含む)、visible chars ≤ 70
+
+(ここで USER GATE: PR review + Ready for review + merge は user 操作)
+
+---
+
+## Self-review
+
+### Spec coverage
+
+| Spec section | 実装 task | カバレッジ |
+|---|---|---|
+| Architecture (mermaid) | Task 2 / 3 / 5 | ✅ Loki + Fluent Bit + ServiceMonitor + Grafana datasource すべて Task で網羅 |
+| Components table | Task 2 / 3 | ✅ Fluent Bit DaemonSet / Loki Gateway / Loki SingleBinary / ServiceMonitor / Grafana datasource すべてカバー |
+| Data flow (Step 1-6 + side flows) | Task 2 / 3 | ✅ container stdout → tail → kubernetes filter → Loki HTTP push → S3 を全 step 実装 |
+| AWS infra (Sub-project 1 利用) | Task 0 (verify only) | ✅ pre-flight check で existence 確認、変更なし |
+| Decision 1 (中間状態) | Task 3 (Fluent Bit Loki output 直接 push) | ✅ |
+| Decision 2 (SingleBinary) | Task 2 (deploymentMode: SingleBinary) | ✅ |
+| Decision 3 (anonymous + 30d + auth disabled) | Task 2 (auth_enabled: false / retention_period: 720h / tenant_id: anonymous) | ✅ |
+| Decision 4 (最小 labels + structured metadata) | Task 3 (Loki output labels block + structured_metadata block) | ✅ |
+| Decision 5 (grafana-community/loki v13.6.0) | Task 1 (local migration) + Task 2 (production new) | ✅ |
+| Decision 6 (local migration) | Task 1 | ✅ |
+| Decision 7 (fluent/fluent-bit v0.57.3) | Task 3 (helmfile.yaml chart version) | ✅ |
+| Decision 8 (Pod Identity 不要) | Task 3 (serviceAccount.create: true、annotations なし) | ✅ |
+| Decision 9 (ServiceMonitor + Grafana datasource) | Task 2 (Loki monitoring.serviceMonitor) + Task 3 (Fluent Bit serviceMonitor) + Task 4 (datasources.yaml に Loki 追加) | ✅ |
+| Decision 10 (Mimir = default 維持) | Task 4 (Loki: isDefault: false) | ✅ |
+| Decision 11 (HA upgrade path 明示) | Task 2 (replicas: 1 + WAL flush 2 min) + Task 3 (filesystem buffer) | ✅ |
+| Decision 12 (Mimir 非対称) | (実装事項なし、spec note のみ) | ✅ |
+| Test plan (pre-flight 6 + post-flight 13) | Task 0 (pre-flight) + Task 6 (PR description で post-flight 明示) | ✅ |
+
+### Placeholder scan
+
+- [x] "TBD" / "TODO" / "FIXME" 等の placeholder なし
+- [x] 各 Step で actual code block (helmfile.yaml / values.yaml.gotmpl / commit message) を完全に書き出し済
+- [x] "Similar to Task N" 形式の reference なし (= 各 task の code を完全 transcribe)
+
+### Type / naming consistency
+
+- [x] SA name `loki` は Task 2 + Task 0 (pre-flight check) + spec で一貫
+- [x] Bucket name `loki-559744160976` は Task 2 / Task 4 / Task 0 で一貫
+- [x] Service name `loki-gateway.monitoring.svc.cluster.local` は Task 3 (Fluent Bit OUTPUT Host) + Task 4 (Grafana datasource url) で一貫
+- [x] Tenant ID `anonymous` は Task 3 / Task 4 で一貫
+- [x] Storage class `gp3` は Task 2 で参照、Sub-project 2 の既存 component と一貫
+- [x] kube-prometheus-stack ServiceMonitor selector label `release: kube-prometheus-stack` は Task 2 (Loki) + Task 3 (Fluent Bit) で一貫
+
+### CLAUDE.md 準拠
+
+- [x] 出力言語日本語 (見出し英語、本文日本語)
+- [x] コミット `-s` (Signed-off-by) 全 task の commit step で指定
+- [x] `Co-Authored-By` 不付与 (全 commit message に無し)
+- [x] PR は `--draft` (Task 6 Step 3)
+- [x] 新規ブランチ初回 push: `git push -u origin HEAD` (Task 6 Step 2)
+- [x] Conventional Commits 全 commit が `feat(scope):` / `chore(scope):` 形式
+
+### Plan 1c-β / Plan 2 / Plan tuning / Sub-project 1 / 2 の知見反映
+
+- [x] **Plan 1c-β L1 (IRSA random suffix)** → 本 plan は Pod Identity 採用で IRSA 不使用
+- [x] **Plan 1c-β L4 (REPLACE_FROM_TERRAGRUNT_OUTPUT 不要)** → Task 4 で helmfile.yaml.gotmpl に直接実値 (`loki-559744160976`) を書く、placeholder pattern 不採用
+- [x] **Plan 1c-β L5 (squash merge 後 branch reset rollback)** → Task 0 Step 1 で `git fetch origin main && git log --oneline origin/main..HEAD` 確認
+- [x] **Plan 2 L7 (spec/plan divergence)** → 本 plan の brainstorming 中に判明した chart の organizational migration (= grafana/loki → grafana-community/loki) を spec で明示記録 (Decision 5)
+- [x] **Sub-project 1 L1 (IAM policy 3 statement)** → 本 sub-project は IAM 触らないため non-applicable
+- [x] **Sub-project 1 L2 (Plan の sibling tasks 間 comment style 一致)** → 本 plan は sibling tasks 無し (各 task が unique)
+- [x] **Sub-project 1 L3 (resource count expected の精度)** → 本 plan の Task 5 Step 3 で expected resource count を range で書く (= Loki StatefulSet 1 + Deployment 1 + Service 数件)
+- [x] **Sub-project 1 L4 (two-stage review が plan-level oversight catch)** → 本 plan の implementation でも subagent-driven-development で 2-stage review を継続
+- [x] **Sub-project 1 L5 (sibling stacks symmetric)** → 本 plan は sibling stack 無し
+- [x] **Sub-project 2 L1 (chart upgrade での upstream changelog 確認)** → Decision 5 で grafana/loki → grafana-community/loki organizational migration を発見、spec / plan に明示記録
+- [x] **Sub-project 2 L2 (chart auto-generated ConfigMap 衝突)** → Sub-project 2 PR #289 の `defaultDatasourceEnabled: false` 設定が既存、新たな衝突なし
+- [x] **Sub-project 2 L3 (EBS RWO + RollingUpdate → Recreate)** → Loki SingleBinary は StatefulSet、Gateway は PVC なし、新規 Recreate 不要
+- [x] **Sub-project 2 L4 (Spec verification を pre-flight / post-flight 分割)** → Task 0 (pre-flight 6 件) + Task 6 PR description (post-flight 13 件) で明示分離
+- [x] **Sub-project 2 L5 (Flux suspend pattern)** → Spec Test plan section に Rollback 手順として明示
+- [x] **Sub-project 2 L6 (gp3 StorageClass)** → Sub-project 2 で provision 済再利用、本 sub-project では作らない
+- [x] **Sub-project 2 L7 (Pod Identity webhook injection は Pod 作成時のみ)** → 新規 deploy のため初回起動時に正しく injection
+- [x] **Sub-project 2 L8 (storage_prefix 英数字制約)** → Loki schema config の `prefix: production_index_` で英数字 + underscore のみ使用、slash 不要 = Mimir L8 適用済

--- a/docs/superpowers/specs/2026-05-06-eks-production-observability-logs-stack-design.md
+++ b/docs/superpowers/specs/2026-05-06-eks-production-observability-logs-stack-design.md
@@ -1,0 +1,455 @@
+# EKS Production: Observability Logs Stack (Phase 3 Sub-project 3) Design Spec
+
+**Status:** Draft (brainstorming 完了、user review 待ち)
+
+**Goal:** panicboat EKS production cluster (`eks-production` / ap-northeast-1 / account 559744160976) に **logs collection + long-term S3 storage + Grafana 連携** の logs stack を deploy する。Sub-project 1 で provision 済の AWS infra (`loki-559744160976` bucket / `eks-production-loki` IAM role / `loki` Pod Identity SA) を活用し、Sub-project 2 で確立した monitoring namespace + ServiceMonitor pattern + Grafana datasource 統合 path に従う。
+
+**Architecture summary:** `grafana-community/loki` v13.6.0 (SingleBinary mode、Loki 3.7.1) + `fluent/fluent-bit` v0.57.3 を `monitoring` namespace に deploy。Fluent Bit DaemonSet が container logs を tail → Loki Gateway 経由で SingleBinary に直接 push (= 中間状態、Sub-project 4 で OTel Collector 経由に switching)、Pod Identity 経由で S3 long-term storage。
+
+**Tech Stack:** Helm + helmfile / `grafana-community/loki` v13.6.0 (Loki 3.7.1) / `fluent/fluent-bit` v0.57.3 (Fluent Bit 5.0.3) / EBS gp3 PVC / EKS Pod Identity / S3 backend (Sub-project 1 outputs)
+
+---
+
+## Architecture
+
+### Sub-project 3 完了時 (中間状態)
+
+```mermaid
+graph LR
+  subgraph EKS["EKS production cluster"]
+    Pods[Container Pods] -->|stdout| FB[Fluent Bit DaemonSet]
+    FB -->|HTTP push X-Scope-OrgID| LokiGW[Loki Gateway nginx]
+    LokiGW --> Loki[Loki SingleBinary StatefulSet]
+    Loki --> S3L[(loki-559744160976)]
+
+    subgraph Mon["Sub-project 2 monitoring layer"]
+      Prom[Prometheus]
+      Mimir[Mimir Microservices]
+    end
+    Prom -.->|scrape /metrics| Loki
+    Prom -.->|scrape /metrics| FB
+    Prom -->|remote_write| Mimir
+    Mimir --> S3M[(mimir-559744160976)]
+
+    Graf[Grafana] -.->|query| Loki
+    Graf -.->|query| Mimir
+  end
+
+  S3L -.->|30d lifecycle| D1[delete]
+  S3M -.->|90d lifecycle| D2[delete]
+```
+
+- 実線 (`-->`): main data flow (stdout → Fluent Bit → Loki → S3)
+- 点線 (`-.->`): sidecar/monitoring path (scrape, query, lifecycle)
+
+### Sub-project 4 完了時 (最終形)
+
+Sub-project 4 で OTel Collector が deploy された後、Fluent Bit → OTel Collector → Loki に switching (= `kubernetes/README.md` の architecture diagram と一致)。本 spec では中間状態のみ実装、switching は Sub-project 4 spec で扱う。
+
+---
+
+## Components
+
+| Component | k8s kind | replicas | image / appVersion | resources (request) | PVC | SA / Pod Identity |
+|---|---|---|---|---|---|---|
+| **Fluent Bit** | DaemonSet | per node | `fluent/fluent-bit` v0.57.3 (Fluent Bit 5.0.3) | 100m CPU / 128Mi mem | — (stateless) | default (= K8s API + Loki HTTP のみ、AWS access 不要) |
+| **Loki Gateway** | Deployment | 1 (PVC なし、Recreate 不要) | nginx (chart-managed) | 50m / 64Mi | — | default (= chart 内 routing のみ) |
+| **Loki SingleBinary** | StatefulSet | 1 | `grafana-community/loki` v13.6.0 (Loki 3.7.1) | 500m / 1Gi (limit: 1 CPU / 2Gi) | **10Gi gp3** (WAL + boltdb-shipper local cache) | **`loki`** (Pod Identity → IAM role `eks-production-loki` → S3 `loki-559744160976`) |
+| **ServiceMonitor (Loki)** | (subchart resource) | — | — | — | — | Prometheus が auto-scrape (Sub-project 2 確立 pattern) |
+| **ServiceMonitor (Fluent Bit)** | (subchart resource) | — | — | — | — | 同上 |
+| **Grafana datasource (Loki)** | ConfigMap entry | — | (existing Grafana) | — | — | `prometheus-operator/production/values.yaml.gotmpl` の `grafana.datasources.datasources.yaml` に追加 |
+
+### Fluent Bit DaemonSet
+
+- input: `tail /var/log/containers/*.log` (= 各 node の container logs)
+- filter: `kubernetes` filter で k8s metadata を付与 + Decision 4 で確定した最小 labels (`namespace`, `pod`, `container`) のみ exposing、他は structured metadata
+- output: `loki` HTTP output plugin で `http://loki-gateway.monitoring.svc.cluster.local/loki/api/v1/push` に push、header `X-Scope-OrgID: anonymous`
+- AWS access 不要 (= Loki gateway 経由のみ、SA は default)
+- retry buffer: filesystem-backed (= node disk 利用、長時間 outage 耐性確保、Decision 11 軽減策)
+
+### Loki Gateway
+
+- chart の subchart で nginx を deploy する設計 (`grafana-community/loki` v13.6.0 の標準)
+- HTTP entry point、SingleBinary StatefulSet headless service に upstream
+- chart 内蔵で values の `gateway.enabled: true` (default) のみ確認
+
+### Loki SingleBinary
+
+- chart values で `deploymentMode: SingleBinary` (= chart 内蔵の SingleBinary section enable)
+- Storage: `loki.storage.type: s3` + `loki.storage.s3.{bucketnames, region, s3forcepathstyle}` = `loki-559744160976` / `ap-northeast-1`
+- Schema config: TSDB schema (= Loki 3.x recommended、boltdb-shipper の後継)
+- PVC: `singleBinary.persistence.enabled: true` + `storageClass: gp3` + `size: 10Gi`
+- Pod Identity: `serviceAccount.name: loki` (= aws/eks-logs/ で provision 済 Association)
+- StatefulSet: `singleBinary.replicas: 1` (= small production)
+- WAL flush 間隔: 1-2 min (= Decision 11 軽減策、AZ 障害時のロスト window 縮小)
+
+---
+
+## Data flow
+
+### Main flow (logs ingestion path)
+
+```
+[Step 1]  container stdout/stderr
+              ↓ (containerd writes)
+[Step 2]  /var/log/containers/<pod>_<ns>_<container>-<id>.log  (node disk)
+              ↓ (Fluent Bit tail input + position file)
+[Step 3]  Fluent Bit DaemonSet (per node)
+              ↓ kubernetes filter: k8s metadata 付与 + 最小 labels exposing
+              ↓ HTTP POST (X-Scope-OrgID: anonymous)
+[Step 4]  loki-gateway.monitoring.svc.cluster.local/loki/api/v1/push
+              ↓ HTTP forward (nginx reverse proxy)
+[Step 5]  Loki SingleBinary (StatefulSet)
+              ↓ distributor → ingester (in-process)
+              ↓ ingester: WAL に write (PVC, gp3 10Gi) + memory chunk 構築
+              ↓ flush 間隔 (1-2 min) で
+[Step 6]  S3 (loki-559744160976/production/<chunks>)
+```
+
+### Side flows
+
+**Prometheus self-monitoring** (Sub-project 2 既存 ServiceMonitor pattern):
+```
+Prometheus -.scrape.→ Loki:3100/metrics      (= loki_ingester_memory_streams 等)
+Prometheus -.scrape.→ Fluent Bit:2020/metrics (= fluentbit_input_records_total 等)
+Prometheus → remote_write → Mimir → S3 (mimir-559744160976)
+```
+
+**Grafana query** (visualization):
+```
+Grafana --query→ Loki Gateway → SingleBinary (in-memory + S3 chunks)
+Grafana --query→ Mimir (existing)
+```
+
+### Failure modes
+
+| 失敗箇所 | 保護機構 | 結果 |
+|---|---|---|
+| **Step 1-2**: containerd log rotation | Fluent Bit tail position file (`/var/log/flb_storage/`) | 再起動後 resume、ロストなし |
+| **Step 3**: Fluent Bit Pod crash | DaemonSet が同 node で auto-restart (= position file 同 hostPath) | 再起動後 resume、ロストなし |
+| **Step 4**: Loki Gateway crash | Gateway は stateless (replicas=1)、自動再起動 | 数秒の outage、Fluent Bit retry buffer に保持 |
+| **Step 5a**: SingleBinary crash + PVC 健在 | StatefulSet 自動再起動、WAL replay | 未 flush data も保持、ロストなし |
+| **Step 5b**: SingleBinary 長時間 outage (~数十分) | Fluent Bit retry buffer (filesystem-backed) | retry 容量超過で **drop** ⚠️ |
+| **Step 5c**: PVC 損失 (AZ 障害) | (なし) | 未 flush data ロスト ⚠️ (= 数分分) |
+| **Step 6**: S3 一時 outage | Loki ingester が retry、WAL に保持し続ける | S3 復旧後 flush、ロストなし |
+
+通常運用では Step 5a / Step 1-4 で auto-recovery、ロストなし。例外シナリオ (5b / 5c) は許容判断 (Decision 11 で reversibility 確保)。
+
+### Cardinality 制御 (Decision 4)
+
+Fluent Bit Kubernetes filter で k8s metadata を 2 種類に分類:
+
+| 種類 | 例 | Loki 側の取扱い |
+|---|---|---|
+| **Labels (low cardinality)** | `namespace`, `pod`, `container` | Loki index に登録、query で `{namespace="..."}` 高速 filter |
+| **Structured metadata (no cardinality cost)** | 全 k8s labels (`app.kubernetes.io/*`), annotations, node, log_level | Loki が chunks の per-entry metadata として保存、query 時 `\| label_format` 等で filter |
+
+---
+
+## AWS infra
+
+### Sub-project 3 では AWS-side 変更なし
+
+aws/eks-logs/ stack は **Sub-project 1 (PR #283) で provision 完了済**。Sub-project 2 (Mimir) と異なり rename は不要 (= 元々 `loki-` 命名で確定済)。
+
+### 利用する既存リソース
+
+| Resource | Identifier | 用途 |
+|---|---|---|
+| S3 bucket | `loki-559744160976` (ap-northeast-1) | Loki chunks long-term storage |
+| S3 lifecycle | 30d retention | Loki log chunks auto-delete |
+| S3 SSE | AES256 (SSE-S3) | bucket-level rest encryption |
+| S3 versioning | Disabled | logs immutable + 30d auto-delete |
+| IAM role | `eks-production-loki` (ARN: `arn:aws:iam::559744160976:role/eks-production-loki`) | Pod Identity 用 |
+| IAM policy (3 statement) | BucketLevelListing (s3:prefix=production) / BucketLocation / ObjectLevelOperations | Sub-project 1 L1 で正規化された 3-statement structure |
+| Pod Identity Association | `monitoring/loki` SA → `eks-production-loki` IAM role | EKS Pod Identity (cluster-side managed) |
+
+### Cross-stack reference flow
+
+```
+aws/eks-logs/envs/production (terragrunt)
+  ↓ outputs: bucket_name / bucket_path_prefix / pod_identity_role_name
+kubernetes/helmfile.yaml.gotmpl (production env values block)
+  ↓ Plan 1c-β L4 pattern (placeholder 不採用、直接実値書き)
+kubernetes/components/loki/production/{helmfile.yaml, values.yaml.gotmpl}
+  ↓ helmfile v1.x cross-helmfile values 制約で 2 箇所 transcribe
+helm template / Loki values:
+  - serviceAccount.name: loki
+  - loki.storage.s3.bucketnames: loki-559744160976
+  - loki.storage.s3.region: ap-northeast-1
+  - loki.storage.s3.s3forcepathstyle: false
+  - common: storage_prefix: "production"  (= Sub-project 2 L8 適用、slash 不要)
+```
+
+---
+
+## Decisions
+
+### Decision 1: Logs flow path = 中間状態で start、最終形は Sub-project 4 で
+
+- **採用**: Fluent Bit → Loki 直接 push (= Sub-project 3 完了時の中間状態)
+- **理由**: Sub-project 3 単独完結 + early observability + Sub-project 4 待たずに deploy 可能
+- **将来 path**: Sub-project 4 で OTel Collector deploy 後に Fluent Bit → OTel Collector → Loki に switching、`kubernetes/README.md` の architecture diagram の最終形と一致
+- **不採用**: 「local 踏襲で OTel Collector 経由」(= Sub-project 4 完了まで logs 流れない)
+
+### Decision 2: Loki deployment mode = SingleBinary
+
+- **採用**: SingleBinary (= Loki 公式 docs `Monolithic`)
+- **理由**: panicboat は small production = Loki 公式の SingleBinary 推奨範囲、9 Pod Microservices は over-engineering、リソース効率最良
+- **HA upgrade path**: 必要になったら SimpleScalable (= 3 deploy + replication_factor=3 + multi-AZ) に migration、chart の同 values で mode 切替可能
+- **不採用**: SimpleScalable / Distributed (= 現時点で over-engineering)
+
+### Decision 3: tenancy + retention + auth = anonymous + 30d + disabled (Mimir 対称)
+
+- **採用**: tenant=`anonymous` (1 tenant) / retention=30d / auth_enabled=false / header `X-Scope-OrgID: anonymous`
+- **理由**: panicboat 1 tenant 運用、aws/eks-logs/ S3 lifecycle 30d と整合、Mimir (Sub-project 2) と対称
+- **trade-off**: 30d 以前のログは S3 lifecycle で auto-delete = recovery 不可、application audit log 用途には別途長期保存が必要 (= 本 sub-project 範囲外)
+
+### Decision 4: log labels = 最小 (Q4) + reversibility 明示
+
+- **採用**: labels = `namespace`, `pod`, `container` (3 labels) + structured metadata で他の k8s 情報を保持
+- **理由**: Loki 公式 "Fewer labels is better"、cardinality 安全、検索性は structured metadata + LogQL filter で確保
+- **reversibility**:
+  - A → C (label 拡張) 移行は **forward / low cost** (Fluent Bit values の minor edit、既存 LogQL は後方互換)
+  - C → A (label 削減) 移行は **backward / high cost** (LogQL クエリ書き換え + Grafana dashboard 再設計)
+  - **A から start するのが conservative**
+- **移行 trigger**: 実装段階で Loki self-metrics (`loki_ingester_memory_streams`, `loki_request_duration_seconds`) を ServiceMonitor で expose、移行判断データを蓄積
+
+### Decision 5: chart = grafana-community/loki v13.6.0 (organizational migration)
+
+- **採用**: `grafana-community/loki` v13.6.0 (Loki 3.7.1)
+- **理由**: 2026/3/16 に grafana/loki chart が GEL only に分離、OSS continuation は grafana-community が maintenance、最新 active version
+- **不採用**:
+  - `grafana/loki` v7.0.0+ (= GEL only、OSS panicboat は使用すべきでない、license 観点)
+  - `grafana/loki` v6.55.0 (= deprecated path、新 features 停止)
+  - bitnami/grafana-mimir 系 (= Sub-project 2 brainstorming で有償化懸念により除外済)
+
+### Decision 6: local migration = Sub-project 3 のスコープに含める
+
+- **採用**: production と並行で local の `grafana/loki` v7.0.0 → `grafana-community/loki` v13.6.0 へ migration
+- **理由**: license 問題解消 (= GEL only chart の OSS 利用回避)、local / production 構成統一
+- **不採用**: 「local 放置 + production のみ移行」(= 構成乖離が永続化)
+- **scope**: Loki chart 切替のみ、Fluent Bit は **touched しない** (local は既存設計 = Fluent Bit → OTel Collector → Loki = README.md 最終形を維持)
+
+### Decision 7: Fluent Bit chart = fluent/fluent-bit v0.57.3
+
+- **採用**: `fluent/fluent-bit` v0.57.3 (Fluent Bit 5.0.3) = local 揃い、最新と一致
+- **理由**: Fluent project は CNCF graduated、active maintenance、organizational change 無し
+
+### Decision 8: Fluent Bit Pod Identity 不要
+
+- **採用**: Fluent Bit は default SA (= Pod Identity 設定なし)
+- **理由**: Loki Gateway への HTTP push のみ、AWS 直接アクセス無し
+- **trade-off**: 将来 Fluent Bit が S3 直接 output (= aws_s3 plugin) を使う設計に変えた場合は Pod Identity が必要、その時点で aws/eks-logs/ で `fluent-bit` SA 用 Association を追加 + chart values 修正
+
+### Decision 9: ServiceMonitor + Grafana datasource = Sub-project 2 と同形
+
+- **採用**:
+  - Loki: `monitoring.serviceMonitor.enabled: true` (chart 内蔵設定)
+  - Fluent Bit: `serviceMonitor.enabled: true` (chart 内蔵設定)
+  - Grafana datasource: `kubernetes/components/prometheus-operator/production/values.yaml.gotmpl` の `grafana.datasources.datasources.yaml.datasources` に Loki entry 追加
+- **理由**: Sub-project 2 で確立した kube-prometheus-stack auto-scrape pattern を踏襲、新 chart や別 mechanism 不要
+
+### Decision 10: Grafana datasource default = Mimir 維持
+
+- **採用**: Mimir = `isDefault: true` (Sub-project 2 既存)、Loki = `isDefault: false` (= 追加)
+- **理由**: Grafana の Explore / Dashboard で datasource 指定なしの場合は Mimir (metrics) が default、Loki は明示指定 (= Logs query は Explore で datasource 切替が直感的)
+- **不採用**: Loki を default 化 (= metrics query が壊れる)
+
+### Decision 11: HA upgrade path 明示
+
+- **採用**: 1 replica SingleBinary で start、必要なら SimpleScalable + multi-AZ + replication_factor=3 に upgrade
+- **trigger**:
+  - Loki Pod 長時間 outage で Fluent Bit retry buffer 容量超過の事象を観測
+  - AZ 障害で未 flush data ロスト発生
+  - log volume が SingleBinary 1 replica の処理能力 (~20 GB/day) を超える
+- **mitigation 軽減策** (Sub-project 3 内で実施):
+  - WAL flush 間隔を 1-2 min に設定 (AZ 障害時のロスト window 縮小)
+  - Fluent Bit retry buffer を filesystem-backed に設定 (= node disk 利用、長時間 outage 耐性 up)
+
+### Decision 12: Mimir Microservices との非対称性 = 意図的
+
+- **採用**: Sub-project 2 (Mimir) は Microservices 9 Pod、Sub-project 3 (Loki) は SingleBinary 1-2 Pod
+- **理由**: 両 chart の official position に従った結果
+  - Loki 公式: SingleBinary が small/medium production OK
+  - Mimir 公式: production には Microservices 推奨 (chart 事情も含む = `grafana/mimir-distributed` chart は Microservices 専用)
+- **note**: Mimir Microservices の over-engineering retrospective は **Sub-project 2.5 として別途保留** (今回の Sub-project 3 brainstorming 中に発見、ただし scope creep 回避のため別 sub-project)、Mimir docs の正確な position は memory file `mimir-mode-knowledge.md` を参照
+
+---
+
+## Test plan (= Sub-project 2 L4 learnings 適用、pre-flight / post-flight 分割)
+
+### Pre-flight check (= PR draft 中に完了 → Ready for review への gate)
+
+| # | check | コマンド / 確認方法 | expected |
+|---|---|---|---|
+| 1 | aws/eks-logs/ resource 存在 | `cd aws/eks-logs/envs/production && terragrunt state list` | 8 resources (S3 bucket + 5 sub-resources + IAM role + Pod Identity Association) |
+| 2 | S3 bucket 存在 (base role) | `aws s3api head-bucket --bucket loki-559744160976` | 200 OK |
+| 3 | Pod Identity Association | `aws eks list-pod-identity-associations --cluster-name eks-production --query 'associations[?serviceAccount==\`loki\`]'` | 1 association |
+| 4 | gp3 StorageClass | `kubectl get storageclass gp3` | provisioner=`ebs.csi.aws.com` (Sub-project 2 で provision 済再利用) |
+| 5 | monitoring namespace + Sub-project 2 stack 稼働 | `kubectl get pods -n monitoring \| grep -E "prometheus\|alertmanager\|grafana\|mimir"` | 全 Running |
+| 6 | local cluster (k3d) で migration 成功 | `make phase3` → `kubectl get pods -n monitoring \| grep -E "loki\|fluent-bit"` | local で `grafana-community/loki` v13.6.0 + `fluent/fluent-bit` v0.57.3 deploy 成功 + logs が Loki に流れる |
+
+PR description にチェック必須:
+```
+## Pre-flight check
+- [x] aws/eks-logs/ terragrunt state 8 resources confirmed
+- [x] S3 bucket loki-559744160976 head-bucket 200 OK
+- [x] Pod Identity Association monitoring/loki exists
+- [x] gp3 StorageClass exists
+- [x] Sub-project 2 stack all Running
+- [x] local migration verified on k3d
+```
+
+### Post-flight check (= merge 後の Flux 反映後 verify)
+
+| # | check | コマンド | expected |
+|---|---|---|---|
+| 1 | Pod 全件 Ready | `kubectl get pods -n monitoring -l app.kubernetes.io/instance=loki` | Loki SingleBinary `1/1`、Loki Gateway `1/1` Running |
+| 2 | Fluent Bit DaemonSet | `kubectl get pods -n monitoring -l app.kubernetes.io/name=fluent-bit -o wide` | 全 node で 1/1 Running |
+| 3 | PVC bound | `kubectl get pvc -n monitoring storage-loki-0` | Bound, gp3 10Gi |
+| 4 | Pod Identity injection | `kubectl get pod -n monitoring loki-0 -o jsonpath='{.spec.containers[0].env[*].name}'` | `AWS_CONTAINER_CREDENTIALS_FULL_URI` 含む |
+| 5 | Loki API ready | `kubectl exec -n monitoring deploy/loki-gateway -- wget -qO- http://localhost/ready` | `ready` |
+| 6 | ServiceMonitor scrape (Prometheus) | Prometheus UI: `Status → Targets` | `loki` / `fluent-bit` targets が UP |
+| 7 | Self-metrics → Mimir | Grafana で `loki_ingester_memory_streams` query | 数値が返る (= Mimir に remote_write 成功) |
+| 8 | Fluent Bit → Loki data flow | `kubectl logs -n monitoring -l app.kubernetes.io/name=fluent-bit \| grep loki` | output success log |
+| 9 | Loki labels API | `kubectl exec -n monitoring deploy/loki-gateway -- curl -s -H 'X-Scope-OrgID: anonymous' http://localhost/loki/api/v1/labels` | `["namespace","pod","container",...]` |
+| 10 | S3 chunks flush (~10 min 後) | base role で `aws s3 ls s3://loki-559744160976/production/` | chunks 出現 |
+| 11 | Grafana Loki datasource | Grafana UI: `Connections → Data sources → Loki` | `Save & test` で 緑 |
+| 12 | Grafana Explore で logs query | `{namespace="monitoring"}` | logs 表示 |
+| 13 | Sub-project 2 regression なし | `kubectl get pods -n monitoring \| grep -v loki \| grep -v fluent-bit` | Mimir / Prometheus / Alertmanager / Grafana 全 Running、Mimir gateway `/ready` OK |
+
+### Concrete success criteria (= Sub-project 2 L8 learnings 適用)
+
+> **merge 後 10 分以内** に以下を達成:
+> - Loki SingleBinary `1/1 Running`
+> - Loki Gateway `1/1 Running`
+> - Fluent Bit DaemonSet が全 node で `1/1 Running`
+> - PVC `storage-loki-0` Bound
+> - Prometheus targets で `loki` / `fluent-bit` が `UP`
+>
+> **merge 後 30 分以内** に:
+> - S3 (`loki-559744160976/production/`) に chunks 出現
+> - Grafana Explore で `{namespace="monitoring"}` query が logs を返す
+
+### Deploy 方針 (= 通常 deploy)
+
+Sub-project 3 は initial deploy のみ + cross-stack 影響が小さいため、**通常 deploy (= merge → Flux 自動反映)** で進める。L5 (Flux suspend pattern) は **問題発見時のみ reactive 発動**。
+
+理由:
+- Sub-project 2 で 5 root causes のリスクは Sub-project 3 では大半が catch 可能 (gp3 既存、Multi-Attach は SingleBinary StatefulSet なので発生しない、chart 互換性は local pre-flight で確認)
+- L4 pre-flight check + post-flight check で safety を担保
+
+### Rollback 手順 (想定外障害時、= Sub-project 2 L5 Flux suspend pattern)
+
+```bash
+# 1. Flux suspend
+flux suspend kustomization flux-system
+
+# 2. K8s-side rollback (manifest delete or revert PR)
+kubectl delete -k kubernetes/manifests/production/loki/
+kubectl delete -k kubernetes/manifests/production/fluent-bit/
+
+# 3. Sub-project 2 stack への影響なきこと確認
+kubectl get pods -n monitoring | grep -v loki | grep -v fluent-bit
+
+# 4. PR revert (= main revert commit)
+gh pr create --title "revert: Phase 3 Sub-project 3 (Logs stack)" ...
+
+# 5. revert merge 後に Flux resume
+flux reconcile source git flux-system
+flux resume kustomization flux-system
+```
+
+aws/eks-logs/ は Sub-project 1 で provision 済 = **AWS-side rollback 不要**。
+
+---
+
+## File structure
+
+### 新規作成 (production env)
+
+```
+kubernetes/components/loki/production/
+├── helmfile.yaml              # chart: grafana-community/loki v13.6.0 (Loki 3.7.1)
+└── values.yaml.gotmpl         # SingleBinary mode + S3 backend + Pod Identity (loki SA)
+
+kubernetes/components/fluent-bit/production/
+├── helmfile.yaml              # chart: fluent/fluent-bit v0.57.3 (Fluent Bit 5.0.3)
+└── values.yaml.gotmpl         # tail input + Kubernetes filter + Loki HTTP output (直接 push)
+```
+
+### 新規生成 (hydrate 結果、auto-generated)
+
+```
+kubernetes/manifests/production/loki/
+├── kustomization.yaml         # resources: manifest.yaml
+└── manifest.yaml              # helmfile template 結果
+
+kubernetes/manifests/production/fluent-bit/
+├── kustomization.yaml         # resources: manifest.yaml
+└── manifest.yaml              # helmfile template 結果
+```
+
+### 変更 (production env)
+
+```
+kubernetes/helmfile.yaml.gotmpl
+└── production env values block に追加:
+    loki:
+      bucketName: loki-559744160976
+      bucketPathPrefix: production
+      podIdentityRoleName: eks-production-loki
+
+kubernetes/components/prometheus-operator/production/values.yaml.gotmpl
+└── grafana.datasources.datasources.yaml.datasources に Loki entry 追加 (Mimir / Prometheus と並列)
+
+kubernetes/manifests/production/kustomization.yaml
+└── resources に追加:
+    - ./fluent-bit
+    - ./loki
+```
+
+### 変更 (local env、Decision 6: local migration)
+
+```
+kubernetes/components/loki/local/helmfile.yaml
+└── chart: grafana/loki → grafana-community/loki, version: 7.0.0 → 13.6.0
+
+kubernetes/components/loki/local/values.yaml
+└── chart schema 変更分の修正 (deploymentMode: SingleBinary は維持、storage 設定等の compat 確認)
+
+kubernetes/manifests/local/loki/manifest.yaml
+└── auto-generated re-hydrate
+```
+
+local の **Fluent Bit は touched しない**: local は既存設計 (= Fluent Bit → OTel Collector → Loki = README.md 最終形と一致) を維持、Decision 1 で確定した production の中間状態 (= Fluent Bit → Loki 直接) は production env のみ適用。Sub-project 4 で OTel Collector が production に deploy された後、production も最終形に switching。
+
+### 変更しないファイル
+
+- **AWS-side**: aws/eks-logs/* は touched なし (Sub-project 1 で provision 完了済)
+- **kubernetes/README.md**: Sub-project 3 では update しない (= architecture diagram は最終形を維持、Sub-project 4 で OTel deploy 完了時に Logs path も最終形に揃ったことを確認)
+- **kubernetes/components/prometheus-operator/local/**: Sub-project 2 で touched 済、Sub-project 3 では追加変更なし
+
+---
+
+## Sub-project 2 learnings の適用サマリ
+
+| Sub-project 2 learnings | 本 sub-project での適用 |
+|---|---|
+| **L1 (chart upgrade での upstream changelog 確認)** | Decision 5 で `grafana/loki` v7.0.0 → `grafana-community/loki` への organizational migration を発見、適切な OSS chart に切替 |
+| **L2 (chart auto-generated ConfigMap と values override の衝突)** | Decision 9 で kube-prometheus-stack の Grafana datasource 設定 (Sub-project 2 で `defaultDatasourceEnabled: false` 設定済) を継続、新たな衝突は発生しない |
+| **L3 (EBS RWO + RollingUpdate → Recreate)** | Loki SingleBinary は StatefulSet (OrderedReady で問題回避)、Loki Gateway は Deployment + PVC なし、新規 Recreate 設定不要 |
+| **L4 (Spec verification を pre-flight / post-flight 分割)** | Test plan section で明示分離、PR description チェックリスト形式 |
+| **L5 (Flux suspend pattern)** | Rollback 手順に明示、通常 deploy では reactive 発動 |
+| **L6 (gp3 StorageClass)** | Sub-project 2 で provision 済 → 再利用、本 sub-project では作らない |
+| **L7 (Pod Identity webhook injection は Pod 作成時のみ)** | 新規 deploy のため初回起動時に正しく injection、Mimir のような rename force-delete シナリオは発生しない |
+| **L8 (storage_prefix 英数字制約)** | Loki でも `production` (slash なし) を採用、Mimir 同様の挙動を予防 |
+
+---
+
+## Sub-project 1 / 2 の knowledge の継承
+
+- **Sub-project 1 L1 (IAM policy 3 statement)**: aws/eks-logs/ は Sub-project 1 で正規化済、本 sub-project では IAM 触らない
+- **Plan 1c-β L4 (REPLACE_FROM_TERRAGRUNT_OUTPUT 不要)**: kubernetes/helmfile.yaml.gotmpl に直接実値書き、placeholder pattern 不採用
+- **Plan tuning L1 (IAM name_prefix 38 chars limit)**: 本 sub-project は IAM 触らないため non-applicable

--- a/kubernetes/components/fluent-bit/production/helmfile.yaml
+++ b/kubernetes/components/fluent-bit/production/helmfile.yaml
@@ -1,0 +1,28 @@
+# =============================================================================
+# Fluent Bit Helmfile for production
+# =============================================================================
+# Phase 3 Sub-project 3 で deploy する Logs stack の log collector。
+# DaemonSet で各 node の container logs を tail、Loki Gateway に HTTP push。
+# (= Decision 1 中間状態、Sub-project 4 で OTel Collector 経由に switching)
+#
+# Decision references:
+# - D1: Logs flow path = Fluent Bit → Loki 直接 push (中間状態)
+# - D7: chart = fluent/fluent-bit v0.57.3 (Fluent Bit 5.0.3)
+# - D8: Pod Identity 不要 (Loki Gateway HTTP push のみ、AWS access なし)
+# - D9: ServiceMonitor enabled (Sub-project 2 確立 pattern)
+# - D11 軽減策: filesystem-backed retry buffer
+# =============================================================================
+environments:
+  production:
+---
+repositories:
+  - name: fluent
+    url: https://fluent.github.io/helm-charts
+
+releases:
+  - name: fluent-bit
+    namespace: monitoring
+    chart: fluent/fluent-bit
+    version: "0.57.3"
+    values:
+      - values.yaml.gotmpl

--- a/kubernetes/components/fluent-bit/production/values.yaml.gotmpl
+++ b/kubernetes/components/fluent-bit/production/values.yaml.gotmpl
@@ -160,7 +160,9 @@ daemonSetVolumeMounts:
 serviceMonitor:
   enabled: true
   # kube-prometheus-stack の ServiceMonitor selector に乗るための label
-  additionalLabels:
+  # NOTE: chart v0.57.3 の template は `.Values.serviceMonitor.selector` から
+  # label を読む (= `additionalLabels` は chart values で commented out の dead key)
+  selector:
     release: kube-prometheus-stack
   interval: 15s
 

--- a/kubernetes/components/fluent-bit/production/values.yaml.gotmpl
+++ b/kubernetes/components/fluent-bit/production/values.yaml.gotmpl
@@ -1,0 +1,171 @@
+# Fluent Bit Configuration for production
+# DaemonSet で container logs を tail、Loki Gateway に HTTP 直接 push (= Decision 1 中間状態)
+
+# =============================================================================
+# Deployment Kind
+# =============================================================================
+# 各 node の container logs を tail するため DaemonSet (= chart default)
+kind: DaemonSet
+
+# =============================================================================
+# ServiceAccount (Decision 8: Pod Identity 不要)
+# =============================================================================
+# AWS access 不要 (Loki HTTP push のみ)、default SA で OK
+serviceAccount:
+  create: true
+  annotations: {}
+
+# =============================================================================
+# Resources (lightweight per-node DaemonSet)
+# =============================================================================
+resources:
+  requests:
+    cpu: 100m
+    memory: 128Mi
+  limits:
+    cpu: 200m
+    memory: 256Mi
+
+# =============================================================================
+# Tolerations (= 全 node に乗るため、master/etcd 等の taint に対応)
+# =============================================================================
+tolerations:
+  - effect: NoSchedule
+    operator: Exists
+  - effect: NoExecute
+    operator: Exists
+
+# =============================================================================
+# Fluent Bit Config (production override)
+# =============================================================================
+config:
+  # -------------------------------------------------------------------------
+  # SERVICE Block
+  # -------------------------------------------------------------------------
+  service: |
+    [SERVICE]
+        Daemon Off
+        Flush 1
+        Log_Level info
+        Parsers_File /fluent-bit/etc/parsers.conf
+        Parsers_File /fluent-bit/etc/conf/custom_parsers.conf
+        HTTP_Server On
+        HTTP_Listen 0.0.0.0
+        HTTP_Port 2020
+        Health_Check On
+        # filesystem-backed buffer = node disk 利用、長時間 outage 耐性 (Decision 11 軽減策)
+        storage.path              /var/log/flb_storage/
+        storage.sync              normal
+        storage.checksum          off
+        storage.backlog.mem_limit 5M
+
+  # -------------------------------------------------------------------------
+  # INPUTS (= container logs tail)
+  # -------------------------------------------------------------------------
+  inputs: |
+    [INPUT]
+        Name              tail
+        Path              /var/log/containers/*.log
+        multiline.parser  docker, cri
+        Tag               kube.*
+        Mem_Buf_Limit     5MB
+        Skip_Long_Lines   On
+        Refresh_Interval  10
+        # storage.type filesystem = retry buffer を node disk に保存 (Decision 11)
+        storage.type      filesystem
+        # DB ファイルで読み取り position を記録、再起動時に resume
+        DB                /var/log/flb_storage/tail.db
+
+  # -------------------------------------------------------------------------
+  # FILTERS (= Kubernetes metadata 付与 + cardinality 制御 = Decision 4)
+  # -------------------------------------------------------------------------
+  filters: |
+    [FILTER]
+        Name                kubernetes
+        Match               kube.*
+        Kube_URL            https://kubernetes.default.svc:443
+        Kube_CA_File        /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+        Kube_Token_File     /var/run/secrets/kubernetes.io/serviceaccount/token
+        Kube_Tag_Prefix     kube.var.log.containers.
+        Merge_Log           On
+        Keep_Log            Off
+        K8S-Logging.Parser  On
+        K8S-Logging.Exclude On
+        Annotations         Off
+        Labels              On
+
+  # -------------------------------------------------------------------------
+  # OUTPUTS (= Loki HTTP push、Decision 1 中間状態)
+  # -------------------------------------------------------------------------
+  outputs: |
+    [OUTPUT]
+        Name              loki
+        Match             kube.*
+        Host              loki-gateway.monitoring.svc.cluster.local
+        Port              80
+        # Loki API path
+        Uri               /loki/api/v1/push
+        # 1 tenant 運用 (= Decision 3)
+        tenant_id         anonymous
+        # Decision 4 labels = 最小 (namespace / pod / container)
+        labels            job=fluentbit, namespace=$kubernetes['namespace_name'], pod=$kubernetes['pod_name'], container=$kubernetes['container_name']
+        # 残りの k8s metadata は structured metadata で保持 (= cardinality cost なし)
+        structured_metadata node=$kubernetes['host'], stream=$stream
+        # remove kubernetes prefix from log fields (= structured_metadata で保持済)
+        remove_keys       kubernetes
+        # gzip 圧縮で帯域削減
+        compress          gzip
+        # retry settings
+        net.connect_timeout 10
+        Retry_Limit       no_limits
+        # storage = filesystem buffer (= retry の永続化)
+        storage.total_limit_size  5G
+
+# =============================================================================
+# Volumes & Volume Mounts (= filesystem buffer 用 hostPath)
+# =============================================================================
+# default の daemonSetVolumes / daemonSetVolumeMounts に追加
+daemonSetVolumes:
+  - name: varlog
+    hostPath:
+      path: /var/log
+  - name: varlibdockercontainers
+    hostPath:
+      path: /var/lib/docker/containers
+  - name: etcmachineid
+    hostPath:
+      path: /etc/machine-id
+      type: File
+  # Decision 11 軽減策 = filesystem buffer 永続化用の hostPath
+  - name: flb-storage
+    hostPath:
+      path: /var/log/flb_storage
+      type: DirectoryOrCreate
+
+daemonSetVolumeMounts:
+  - name: varlog
+    mountPath: /var/log
+  - name: varlibdockercontainers
+    mountPath: /var/lib/docker/containers
+    readOnly: true
+  - name: etcmachineid
+    mountPath: /etc/machine-id
+    readOnly: true
+  - name: flb-storage
+    mountPath: /var/log/flb_storage
+
+# =============================================================================
+# ServiceMonitor (Prometheus auto-scrape, Decision 9)
+# =============================================================================
+serviceMonitor:
+  enabled: true
+  # kube-prometheus-stack の ServiceMonitor selector に乗るための label
+  additionalLabels:
+    release: kube-prometheus-stack
+  interval: 15s
+
+# =============================================================================
+# Test (= helm test 用、production では不要)
+# =============================================================================
+testFramework:
+  enabled: false

--- a/kubernetes/components/loki/local/helmfile.yaml
+++ b/kubernetes/components/loki/local/helmfile.yaml
@@ -4,18 +4,22 @@
 # Loki is a log aggregation system designed for efficiency and ease of
 # operation. It receives logs from the OTel Collector and provides querying
 # capabilities in Grafana.
+#
+# NOTE: 2026/3/16 に grafana/loki chart が GEL only に分離、OSS continuation は
+# grafana-community/loki に移行。本 sub-project (Phase 3 Sub-project 3) で
+# chart を切替する (Decision 5/6)。
 # =============================================================================
 environments:
   local:
 ---
 repositories:
-  - name: grafana
-    url: https://grafana.github.io/helm-charts
+  - name: grafana-community
+    url: https://grafana-community.github.io/helm-charts
 
 releases:
   - name: loki
     namespace: monitoring
-    chart: grafana/loki
-    version: "7.0.0"
+    chart: grafana-community/loki
+    version: "13.6.0"
     values:
       - values.yaml

--- a/kubernetes/components/loki/local/values.yaml
+++ b/kubernetes/components/loki/local/values.yaml
@@ -5,7 +5,8 @@
 # Deployment Mode
 # =============================================================================
 # TODO: (production) Use "distributed" mode for high availability in production
-deploymentMode: SingleBinary
+# NOTE: "SingleBinary" は grafana-community/loki v13 で deprecated。正式名称は "Monolithic"
+deploymentMode: Monolithic
 
 # =============================================================================
 # Loki Configuration
@@ -98,7 +99,9 @@ gateway:
 # =============================================================================
 # Cache Configuration
 # =============================================================================
-results_cache:
+# NOTE: grafana-community/loki v13 では snake_case の results_cache は camelCase の
+# resultsCache に変更された
+resultsCache:
   enabled: false
 
 chunksCache:
@@ -117,10 +120,7 @@ write:
 # =============================================================================
 # Monitoring
 # =============================================================================
+# NOTE: grafana-community/loki v13 では monitoring.selfMonitoring セクションは削除された
 monitoring:
   serviceMonitor:
     enabled: true
-  selfMonitoring:
-    enabled: false
-    grafanaAgent:
-      installOperator: false

--- a/kubernetes/components/loki/production/helmfile.yaml
+++ b/kubernetes/components/loki/production/helmfile.yaml
@@ -1,0 +1,37 @@
+# =============================================================================
+# Loki Helmfile for production
+# =============================================================================
+# Phase 3 Sub-project 3 で deploy する Logs stack の Loki 本体。
+# SingleBinary mode (= chart 内蔵の Monolithic deploy、9 Pod Microservices ではなく
+# 1-2 Pod 構成、small production OK の Loki 公式 position に準拠)。
+# S3 backend は Sub-project 1 で provision 済の loki-559744160976 を Pod Identity
+# 経由でアクセス。
+#
+# Decision references:
+# - D2: SingleBinary mode (HA upgrade path 保持)
+# - D3: tenancy=anonymous + retention=30d + auth_enabled=false (Mimir 対称)
+# - D5: chart = grafana-community/loki v13.6.0 (Loki 3.7.1)
+# - D11: HA upgrade path 明示、WAL flush 1-2 min + retry buffer filesystem-backed
+# =============================================================================
+environments:
+  production:
+    # NOTE: helmfile v1.4 は親 helmfile.yaml.gotmpl の environments values を
+    # 子 helmfile に auto-inherit しないため、ここで再定義する。
+    # 値は kubernetes/helmfile.yaml.gotmpl の production env block と
+    # 同期すること (loki.bucketName / loki.bucketPathPrefix)。
+    values:
+      - loki:
+          bucketName: loki-559744160976
+          bucketPathPrefix: production
+---
+repositories:
+  - name: grafana-community
+    url: https://grafana-community.github.io/helm-charts
+
+releases:
+  - name: loki
+    namespace: monitoring
+    chart: grafana-community/loki
+    version: "13.6.0"
+    values:
+      - values.yaml.gotmpl

--- a/kubernetes/components/loki/production/values.yaml.gotmpl
+++ b/kubernetes/components/loki/production/values.yaml.gotmpl
@@ -30,6 +30,12 @@ loki:
   # -------------------------------------------------------------------------
   # Storage Config (S3 backend, Sub-project 1 outputs)
   # -------------------------------------------------------------------------
+  # NOTE: chart v13 で `loki.storage.bucketNames.{chunks, ruler}` は chart の独自
+  # abstraction で、rendered manifest の `common.storage.s3.bucketnames` には届かない
+  # (= 空文字列のまま)。runtime では `storage_config.aws.bucketnames` (下記) と
+  # `ruler.storage.s3.bucketnames` 経由で bucket 参照されるため動作影響なし。Loki が
+  # common.storage を fallback で参照するパスで起動失敗が観測された場合は
+  # `loki.commonConfig.storage` を明示的に s3 設定する追加 fix を実施する。
   storage:
     type: s3
     bucketNames:
@@ -67,11 +73,6 @@ loki:
       bucketnames: {{ .Values.loki.bucketName }}
       region: ap-northeast-1
       s3forcepathstyle: false
-    tsdb_shipper:
-      # local cache (= Loki Pod の PVC 内に index cache を保持、S3 query 高速化)
-      active_index_directory: /var/loki/tsdb-index
-      cache_location: /var/loki/tsdb-cache
-      shared_store: s3
 
   # -------------------------------------------------------------------------
   # Limits Config (retention 30d、Decision 3)
@@ -182,7 +183,7 @@ test:
 lokiCanary:
   enabled: false
 
-# Tabler-manager (= deprecated component、Loki 3.x では使わない)
+# Table-manager (= deprecated component、Loki 3.x では使わない)
 tableManager:
   enabled: false
 

--- a/kubernetes/components/loki/production/values.yaml.gotmpl
+++ b/kubernetes/components/loki/production/values.yaml.gotmpl
@@ -1,0 +1,212 @@
+# Loki Configuration for production
+# Monolithic mode (= 公式 docs の "Single Binary Mode") + S3 backend (Sub-project 1 outputs) + Pod Identity (loki SA)
+
+# =============================================================================
+# Deployment Mode (Decision 2)
+# =============================================================================
+# Monolithic = chart 内蔵の single binary deploy (= 公式 docs の "Single Binary Mode")。
+# 1 StatefulSet (replicas=1) で distributor / ingester / querier / query-frontend /
+# store-gateway / compactor を全部 in-process。small production 向け、HA は将来
+# SimpleScalable に upgrade。
+# NOTE: chart v13 で `SingleBinary` は削除され `Monolithic` に rename された。
+deploymentMode: Monolithic
+
+# =============================================================================
+# Loki Core Configuration
+# =============================================================================
+loki:
+  # 1 tenant 運用 (panicboat) のため auth 不要 (Decision 3)
+  auth_enabled: false
+
+  # -------------------------------------------------------------------------
+  # Common Config
+  # -------------------------------------------------------------------------
+  commonConfig:
+    path_prefix: /var/loki
+    # SingleBinary 1 replica なので replication_factor=1 (Decision 2)
+    # HA upgrade 時は SimpleScalable 3 replicas + replication_factor=3 に変更
+    replication_factor: 1
+
+  # -------------------------------------------------------------------------
+  # Storage Config (S3 backend, Sub-project 1 outputs)
+  # -------------------------------------------------------------------------
+  storage:
+    type: s3
+    bucketNames:
+      chunks: {{ .Values.loki.bucketName }}
+      ruler: {{ .Values.loki.bucketName }}
+    s3:
+      region: ap-northeast-1
+      # AWS S3 native = path style 不要 (= virtual-hosted style)
+      s3ForcePathStyle: false
+      # AWS_ENDPOINT_URL 不要 (= default endpoint)
+      endpoint: null
+      # Pod Identity 経由のため access key 不要
+      accessKeyId: null
+      secretAccessKey: null
+
+  # -------------------------------------------------------------------------
+  # Schema Config (TSDB schema = Loki 3.x recommended)
+  # -------------------------------------------------------------------------
+  schemaConfig:
+    configs:
+      - from: "2024-01-01"
+        store: tsdb
+        object_store: s3
+        schema: v13
+        index:
+          # env prefix で IAM policy s3:prefix=production と整合
+          prefix: production_index_
+          period: 24h
+
+  # -------------------------------------------------------------------------
+  # Storage Config (env prefix for IAM policy compat)
+  # -------------------------------------------------------------------------
+  storage_config:
+    aws:
+      bucketnames: {{ .Values.loki.bucketName }}
+      region: ap-northeast-1
+      s3forcepathstyle: false
+    tsdb_shipper:
+      # local cache (= Loki Pod の PVC 内に index cache を保持、S3 query 高速化)
+      active_index_directory: /var/loki/tsdb-index
+      cache_location: /var/loki/tsdb-cache
+      shared_store: s3
+
+  # -------------------------------------------------------------------------
+  # Limits Config (retention 30d、Decision 3)
+  # -------------------------------------------------------------------------
+  limits_config:
+    # logs entry の最大保持期間 = aws/eks-logs/ S3 lifecycle 30d と整合
+    retention_period: 720h
+    # 1 stream あたりのログ entry rate 制限 (= burst protection)
+    ingestion_rate_mb: 4
+    ingestion_burst_size_mb: 6
+
+  # -------------------------------------------------------------------------
+  # Compactor (retention enforcement)
+  # -------------------------------------------------------------------------
+  compactor:
+    # S3 上の chunks を retention に基づき削除する (= aws/eks-logs/ S3 lifecycle と
+    # 同 30d、Loki 側でも明示的に enforce)
+    retention_enabled: true
+    retention_delete_delay: 2h
+
+  # -------------------------------------------------------------------------
+  # Ingester (= flush 間隔短縮、Decision 11 軽減策)
+  # -------------------------------------------------------------------------
+  ingester:
+    # WAL chunk を S3 に flush する間隔 (default は 5 min、AZ 障害時のロスト window
+    # を縮小するため 2 min に短縮)
+    chunk_idle_period: 2m
+    # max chunk age = 古い chunk を強制 flush
+    max_chunk_age: 5m
+
+# =============================================================================
+# ServiceAccount (Pod Identity for S3 access)
+# =============================================================================
+serviceAccount:
+  create: true
+  # aws/eks-logs/ で provision 済の Pod Identity Association が
+  # monitoring/loki SA を IAM role eks-production-loki に紐付け済
+  name: loki
+  # Pod Identity は IRSA と異なり annotation 不要 (cluster-side で managed)
+  annotations: {}
+
+# =============================================================================
+# SingleBinary StatefulSet (Decision 2)
+# =============================================================================
+singleBinary:
+  enabled: true
+  replicas: 1
+
+  # PVC: WAL + boltdb-shipper local cache を gp3 10Gi
+  persistence:
+    enabled: true
+    storageClass: gp3
+    size: 10Gi
+
+  # Resources (small production)
+  resources:
+    requests:
+      cpu: 500m
+      memory: 1Gi
+    limits:
+      cpu: 1
+      memory: 2Gi
+
+  # PodDisruptionBudget は 1 replica なので minAvailable=0 (= 強制 evict 可能)
+  # default の `enabled: true` のままだと replicas=1 で minAvailable=1 になる
+  # 可能性があり、node drain 時に block する。明示的に disable。
+  podDisruptionBudget:
+    enabled: false
+
+# =============================================================================
+# Loki Gateway (chart 内蔵 nginx)
+# =============================================================================
+gateway:
+  enabled: true
+  replicas: 1
+  resources:
+    requests:
+      cpu: 50m
+      memory: 64Mi
+    limits:
+      cpu: 200m
+      memory: 256Mi
+  # Gateway は stateless (PVC なし)、1 replica + RollingUpdate で OK
+  # (= Sub-project 2 L3 の Multi-Attach 罠は PVC なしのため発生しない)
+
+# =============================================================================
+# Disable subcomponents (Monolithic mode で不要)
+# =============================================================================
+# SimpleScalable / Distributed mode の component を全 disable
+read:
+  replicas: 0
+write:
+  replicas: 0
+backend:
+  replicas: 0
+
+# Cache (memcached-based、small production では不要)
+chunksCache:
+  enabled: false
+resultsCache:
+  enabled: false
+
+# Test (helm test 用、production では不要)
+test:
+  enabled: false
+
+# Loki Canary (= synthetic canary、small production では不要)
+lokiCanary:
+  enabled: false
+
+# Tabler-manager (= deprecated component、Loki 3.x では使わない)
+tableManager:
+  enabled: false
+
+# Network policy (panicboat では Cilium で別途管理、chart 内蔵は使わない)
+networkPolicy:
+  enabled: false
+
+# =============================================================================
+# Monitoring (ServiceMonitor for Prometheus auto-scrape)
+# =============================================================================
+# NOTE: chart v13 で monitoring.selfMonitoring section は削除されたため記述しない
+monitoring:
+  # Self-monitoring metrics を Prometheus が scrape
+  serviceMonitor:
+    enabled: true
+    # kube-prometheus-stack の ServiceMonitor selector に乗るための label
+    labels:
+      release: kube-prometheus-stack
+    interval: 15s
+
+  # Prometheus Rules (= alerting rules)、Phase 4 で alertmanager 設定時に有効化
+  rules:
+    enabled: false
+
+  # Loki dashboards (chart 内蔵 ConfigMap)、Phase 4 で別途 Grafana に投入
+  dashboards:
+    enabled: false

--- a/kubernetes/components/prometheus-operator/production/values.yaml.gotmpl
+++ b/kubernetes/components/prometheus-operator/production/values.yaml.gotmpl
@@ -46,9 +46,8 @@ grafana:
       defaultDatasourceEnabled: false
 
   # -------------------------------------------------------------------------
-  # Data Sources (Mimir primary、Prometheus local secondary)
+  # Data Sources (Mimir primary、Prometheus local secondary、Loki logs)
   # -------------------------------------------------------------------------
-  # NOTE: Loki / Tempo data sources は Sub-project 3 / 4 で additionalDataSources に追加
   datasources:
     datasources.yaml:
       apiVersion: 1
@@ -71,6 +70,18 @@ grafana:
           jsonData:
             httpMethod: POST
             timeInterval: 30s
+        # Phase 3 Sub-project 3 (Logs stack)
+        - name: Loki
+          uid: loki
+          type: loki
+          url: http://loki-gateway.monitoring.svc.cluster.local
+          access: proxy
+          isDefault: false
+          jsonData:
+            # 1 tenant 運用 (= Decision 3)
+            httpHeaderName1: X-Scope-OrgID
+          secureJsonData:
+            httpHeaderValue1: anonymous
 
 # =============================================================================
 # Prometheus Configuration

--- a/kubernetes/helmfile.yaml.gotmpl
+++ b/kubernetes/helmfile.yaml.gotmpl
@@ -50,6 +50,11 @@ environments:
           # verification 用 (helmfile values としては unused、Pod Identity Association は
           # aws/eks-metrics/ 側で provision 済)。
           podIdentityRoleName: eks-production-mimir
+        loki:
+          # Source: aws/eks-logs/envs/production terragrunt output
+          bucketName: loki-559744160976
+          bucketPathPrefix: production
+          podIdentityRoleName: eks-production-loki
   # TODO: (staging) Uncomment and configure when staging cluster is provisioned
   # staging:
   #   values:

--- a/kubernetes/manifests/local/loki/manifest.yaml
+++ b/kubernetes/manifests/local/loki/manifest.yaml
@@ -6,12 +6,26 @@ metadata:
   name: loki-canary
   namespace: monitoring
   labels:
-    helm.sh/chart: loki-7.0.0
+    helm.sh/chart: loki-13.6.0
     app.kubernetes.io/name: loki
     app.kubernetes.io/instance: loki
-    app.kubernetes.io/version: "3.6.7"
+    app.kubernetes.io/version: "3.7.1"
     app.kubernetes.io/component: canary
-automountServiceAccountToken: true
+automountServiceAccountToken: false
+---
+# Source: loki/templates/memcached/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: loki-memcached
+  namespace: monitoring
+  labels:
+    helm.sh/chart: loki-13.6.0
+    app.kubernetes.io/name: loki
+    app.kubernetes.io/instance: loki
+    app.kubernetes.io/version: "3.7.1"
+    app.kubernetes.io/component: memcached
+automountServiceAccountToken: false
 ---
 # Source: loki/templates/serviceaccount.yaml
 apiVersion: v1
@@ -20,10 +34,10 @@ metadata:
   name: loki
   namespace: monitoring
   labels:
-    helm.sh/chart: loki-7.0.0
+    helm.sh/chart: loki-13.6.0
     app.kubernetes.io/name: loki
     app.kubernetes.io/instance: loki
-    app.kubernetes.io/version: "3.6.7"
+    app.kubernetes.io/version: "3.7.1"
 automountServiceAccountToken: true
 ---
 # Source: loki/templates/config.yaml
@@ -33,10 +47,10 @@ metadata:
   name: loki
   namespace: monitoring
   labels:
-    helm.sh/chart: loki-7.0.0
+    helm.sh/chart: loki-13.6.0
     app.kubernetes.io/name: loki
     app.kubernetes.io/instance: loki
-    app.kubernetes.io/version: "3.6.7"
+    app.kubernetes.io/version: "3.7.1"
 data:
   config.yaml: |
     
@@ -64,6 +78,9 @@ data:
       scheduler_address: ""
     index_gateway:
       mode: simple
+    ingester:
+      wal:
+        flush_on_shutdown: true
     limits_config:
       allow_structured_metadata: true
       max_cache_freshness_per_query: 10m
@@ -82,25 +99,20 @@ data:
       split_queries_by_interval: 15m
       volume_enabled: true
     memberlist:
+      abort_if_cluster_join_fails: true
+      advertise_addr: ${HASH_RING_INSTANCE_ADDR}
+      advertise_port: 7946
+      bind_port: 7946
       join_members:
       - loki-memberlist.monitoring.svc.cluster.local
+      max_join_backoff: 1m
+      max_join_retries: 10
+      min_join_backoff: 1s
+      rejoin_interval: 90s
     pattern_ingester:
       enabled: true
     query_range:
       align_queries_with_step: true
-      cache_results: true
-      results_cache:
-        cache:
-          background:
-            writeback_buffer: 500000
-            writeback_goroutines: 1
-            writeback_size_limit: 500MB
-          default_validity: 12h
-          memcached_client:
-            addresses: dnssrvnoa+_memcached-client._tcp.loki-results-cache.monitoring.svc.cluster.local
-            consistent_hash: true
-            timeout: 500ms
-            update_interval: 1m
     ruler:
       storage:
         type: local
@@ -118,10 +130,18 @@ data:
         schema: v13
         store: tsdb
     server:
+      graceful_shutdown_timeout: 5s
       grpc_listen_port: 9095
+      grpc_server_max_concurrent_streams: 1000
+      grpc_server_max_recv_msg_size: 104857600
+      grpc_server_max_send_msg_size: 104857600
+      grpc_server_min_time_between_pings: 10s
+      grpc_server_ping_without_stream_allowed: true
       http_listen_port: 3100
-      http_server_read_timeout: 600s
-      http_server_write_timeout: 600s
+      http_server_idle_timeout: 30s
+      http_server_read_timeout: 10m0s
+      http_server_write_timeout: 10m0s
+      log_level: info
     storage_config:
       bloom_shipper:
         working_directory: /var/loki/data/bloomshipper
@@ -146,10 +166,10 @@ metadata:
   name: loki-runtime
   namespace: monitoring
   labels:
-    helm.sh/chart: loki-7.0.0
+    helm.sh/chart: loki-13.6.0
     app.kubernetes.io/name: loki
     app.kubernetes.io/instance: loki
-    app.kubernetes.io/version: "3.6.7"
+    app.kubernetes.io/version: "3.7.1"
 data:
   runtime-config.yaml: |
     {}
@@ -159,10 +179,10 @@ kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   labels:
-    helm.sh/chart: loki-7.0.0
+    helm.sh/chart: loki-13.6.0
     app.kubernetes.io/name: loki
     app.kubernetes.io/instance: loki
-    app.kubernetes.io/version: "3.6.7"
+    app.kubernetes.io/version: "3.7.1"
   name: loki-clusterrole
 rules:
 - apiGroups: [""] # "" indicates the core API group
@@ -175,10 +195,10 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: loki-clusterrolebinding
   labels:
-    helm.sh/chart: loki-7.0.0
+    helm.sh/chart: loki-13.6.0
     app.kubernetes.io/name: loki
     app.kubernetes.io/instance: loki
-    app.kubernetes.io/version: "3.6.7"
+    app.kubernetes.io/version: "3.7.1"
 subjects:
   - kind: ServiceAccount
     name: loki
@@ -195,10 +215,10 @@ metadata:
   name: loki-canary
   namespace: monitoring
   labels:
-    helm.sh/chart: loki-7.0.0
+    helm.sh/chart: loki-13.6.0
     app.kubernetes.io/name: loki
     app.kubernetes.io/instance: loki
-    app.kubernetes.io/version: "3.6.7"
+    app.kubernetes.io/version: "3.7.1"
     app.kubernetes.io/component: canary
   annotations:
 spec:
@@ -213,35 +233,78 @@ spec:
     app.kubernetes.io/instance: loki
     app.kubernetes.io/component: canary
 ---
-# Source: loki/templates/results-cache/service-results-cache-headless.yaml
+# Source: loki/templates/monolithic/service.yaml
 apiVersion: v1
 kind: Service
 metadata:
-  name: loki-results-cache
+  name: "loki"
+  namespace: "monitoring"
   labels:
-    helm.sh/chart: loki-7.0.0
+    helm.sh/chart: loki-13.6.0
     app.kubernetes.io/name: loki
     app.kubernetes.io/instance: loki
-    app.kubernetes.io/version: "3.6.7"
-    app.kubernetes.io/component: "memcached-results-cache"
+    app.kubernetes.io/version: "3.7.1"
+    app.kubernetes.io/component: "single-binary"
   annotations:
-    {}
-  namespace: "monitoring"
 spec:
   type: ClusterIP
-  clusterIP: None
+  publishNotReadyAddresses: true
   ports:
-    - name: memcached-client
-      port: 11211
-      targetPort: client
     - name: http-metrics
-      port: 9150
+      port: 3100
       targetPort: http-metrics
-    
+      protocol: TCP
+    - name: grpc
+      port: 9095
+      targetPort: grpc
+      protocol: TCP
+    - name: grpclb
+      port: 9096
+      targetPort: grpc
+      protocol: TCP
   selector:
+    
     app.kubernetes.io/name: loki
     app.kubernetes.io/instance: loki
-    app.kubernetes.io/component: "memcached-results-cache"
+    app.kubernetes.io/component: "single-binary"
+---
+# Source: loki/templates/monolithic/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: "loki-headless"
+  namespace: monitoring
+  labels:
+    helm.sh/chart: loki-13.6.0
+    app.kubernetes.io/name: loki
+    app.kubernetes.io/instance: loki
+    app.kubernetes.io/version: "3.7.1"
+    app.kubernetes.io/component: "single-binary"
+    prometheus.io/service-monitor: "false"
+    variant: headless
+  annotations:
+spec:
+  clusterIP: None
+  type: ClusterIP
+  publishNotReadyAddresses: true
+  ports:
+    - name: http-metrics
+      port: 3100
+      targetPort: http-metrics
+      protocol: TCP
+    - name: grpc
+      port: 9095
+      targetPort: grpc
+      protocol: TCP
+    - name: grpclb
+      port: 9096
+      targetPort: grpc
+      protocol: TCP
+  selector:
+    
+    app.kubernetes.io/name: loki
+    app.kubernetes.io/instance: loki
+    app.kubernetes.io/component: "single-binary"
 ---
 # Source: loki/templates/service-memberlist.yaml
 apiVersion: v1
@@ -250,10 +313,10 @@ metadata:
   name: loki-memberlist
   namespace: monitoring
   labels:
-    helm.sh/chart: loki-7.0.0
+    helm.sh/chart: loki-13.6.0
     app.kubernetes.io/name: loki
     app.kubernetes.io/instance: loki
-    app.kubernetes.io/version: "3.6.7"
+    app.kubernetes.io/version: "3.7.1"
   annotations:
 spec:
   type: ClusterIP
@@ -268,59 +331,6 @@ spec:
     app.kubernetes.io/instance: loki
     app.kubernetes.io/part-of: memberlist
 ---
-# Source: loki/templates/single-binary/service-headless.yaml
-apiVersion: v1
-kind: Service
-metadata:
-  name: loki-headless
-  namespace: monitoring
-  labels:
-    helm.sh/chart: loki-7.0.0
-    app.kubernetes.io/name: loki
-    app.kubernetes.io/instance: loki
-    app.kubernetes.io/version: "3.6.7"
-    variant: headless
-    prometheus.io/service-monitor: "false"
-  annotations:
-spec:
-  clusterIP: None
-  ports:
-    - name: http-metrics
-      port: 3100
-      targetPort: http-metrics
-      protocol: TCP
-  selector:
-    app.kubernetes.io/name: loki
-    app.kubernetes.io/instance: loki
----
-# Source: loki/templates/single-binary/service.yaml
-apiVersion: v1
-kind: Service
-metadata:
-  name: loki
-  namespace: monitoring
-  labels:
-    helm.sh/chart: loki-7.0.0
-    app.kubernetes.io/name: loki
-    app.kubernetes.io/instance: loki
-    app.kubernetes.io/version: "3.6.7"
-  annotations:
-spec:
-  type: ClusterIP
-  ports:
-    - name: http-metrics
-      port: 3100
-      targetPort: http-metrics
-      protocol: TCP
-    - name: grpc
-      port: 9095
-      targetPort: grpc
-      protocol: TCP
-  selector:
-    app.kubernetes.io/name: loki
-    app.kubernetes.io/instance: loki
-    app.kubernetes.io/component: single-binary
----
 # Source: loki/templates/loki-canary/daemonset.yaml
 apiVersion: apps/v1
 kind: DaemonSet
@@ -328,10 +338,10 @@ metadata:
   name: loki-canary
   namespace: monitoring
   labels:
-    helm.sh/chart: loki-7.0.0
+    helm.sh/chart: loki-13.6.0
     app.kubernetes.io/name: loki
     app.kubernetes.io/instance: loki
-    app.kubernetes.io/version: "3.6.7"
+    app.kubernetes.io/version: "3.7.1"
     app.kubernetes.io/component: canary
 spec:
   selector:
@@ -345,35 +355,39 @@ spec:
     type: RollingUpdate
   template:
     metadata:
+      annotations:
+        kubectl.kubernetes.io/default-container: "canary"
       labels:
+        helm.sh/chart: loki-13.6.0
         app.kubernetes.io/name: loki
         app.kubernetes.io/instance: loki
+        app.kubernetes.io/version: "3.7.1"
         app.kubernetes.io/component: canary
     spec:
       serviceAccountName: loki-canary
-      
+      enableServiceLinks: true
+      automountServiceAccountToken: false
       securityContext:
         fsGroup: 10001
         fsGroupChangePolicy: OnRootMismatch
         runAsGroup: 10001
         runAsNonRoot: true
         runAsUser: 10001
+        seccompProfile:
+          type: RuntimeDefault
+      terminationGracePeriodSeconds: 30
+      volumes:
+        - name: temp
+          emptyDir: {}
       containers:
-        - name: loki-canary
-          image: docker.io/grafana/loki-canary:3.6.7
+        - name: canary
+          image: docker.io/grafana/loki-canary:3.7.1
           imagePullPolicy: IfNotPresent
           args:
             - -addr=loki.monitoring.svc.cluster.local.:3100
             - -labelname=pod
             - -labelvalue=$(POD_NAME)
             - -push=true
-          securityContext:
-            allowPrivilegeEscalation: false
-            capabilities:
-              drop:
-              - ALL
-            readOnlyRootFilesystem: true
-          volumeMounts:
           ports:
             - name: http-metrics
               containerPort: 3500
@@ -383,156 +397,47 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.name
-            
+            - name: GOGC
+              value: "80"
+            - name: HASH_RING_INSTANCE_ADDR
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
+            seccompProfile:
+              type: RuntimeDefault
+          livenessProbe:
+            httpGet:
+              path: /metrics
+              port: http-metrics
+            initialDelaySeconds: 15
+            timeoutSeconds: 1
           readinessProbe:
             httpGet:
               path: /metrics
               port: http-metrics
             initialDelaySeconds: 15
             timeoutSeconds: 1
-      volumes:
+          volumeMounts:
+            - name: temp
+              mountPath: /tmp
 ---
-# Source: loki/templates/results-cache/statefulset-results-cache.yaml
-apiVersion: apps/v1
-kind: StatefulSet
-metadata:
-  name: loki-results-cache
-  labels:
-    helm.sh/chart: loki-7.0.0
-    app.kubernetes.io/name: loki
-    app.kubernetes.io/instance: loki
-    app.kubernetes.io/version: "3.6.7"
-    app.kubernetes.io/component: "memcached-results-cache"
-    name: "memcached-results-cache"
-  annotations:
-    {}
-  namespace: "monitoring"
-spec:
-  podManagementPolicy: Parallel
-  replicas: 1
-  selector:
-    matchLabels:
-      app.kubernetes.io/name: loki
-      app.kubernetes.io/instance: loki
-      app.kubernetes.io/component: "memcached-results-cache"
-      name: "memcached-results-cache"
-  updateStrategy:
-    type: RollingUpdate
-  serviceName: loki-results-cache
-  template:
-    metadata:
-      labels:
-        app.kubernetes.io/name: loki
-        app.kubernetes.io/instance: loki
-        app.kubernetes.io/component: "memcached-results-cache"
-        name: "memcached-results-cache"
-      annotations:
-    spec:
-      serviceAccountName: loki
-      securityContext:
-        fsGroup: 11211
-        runAsGroup: 11211
-        runAsNonRoot: true
-        runAsUser: 11211
-      initContainers:
-        []
-      nodeSelector:
-        {}
-      affinity:
-        {}
-      topologySpreadConstraints:
-        []
-      tolerations:
-        []
-      terminationGracePeriodSeconds: 60
-      containers:
-        - name: memcached
-          image: memcached:1.6.39-alpine
-          imagePullPolicy: IfNotPresent
-          resources:
-            limits:
-              memory: 1229Mi
-            requests:
-              cpu: 500m
-              memory: 1229Mi
-          ports:
-            - containerPort: 11211
-              name: client
-          args:
-            - -m 1024
-            - --extended=modern,track_sizes
-            - -I 5m
-            - -c 16384
-            - -v
-            - -u 11211
-          env:
-          envFrom:
-          securityContext:
-            allowPrivilegeEscalation: false
-            capabilities:
-              drop:
-              - ALL
-            readOnlyRootFilesystem: true
-          readinessProbe:
-            failureThreshold: 6
-            initialDelaySeconds: 5
-            periodSeconds: 5
-            tcpSocket:
-              port: client
-            timeoutSeconds: 3
-          livenessProbe:
-            failureThreshold: 3
-            initialDelaySeconds: 30
-            periodSeconds: 10
-            tcpSocket:
-              port: client
-            timeoutSeconds: 5
-        - name: exporter
-          image: prom/memcached-exporter:v0.15.4
-          imagePullPolicy: IfNotPresent
-          ports:
-            - containerPort: 9150
-              name: http-metrics
-          args:
-            - "--memcached.address=localhost:11211"
-            - "--web.listen-address=0.0.0.0:9150"
-          resources:
-            limits: {}
-            requests: {}
-          securityContext:
-            allowPrivilegeEscalation: false
-            capabilities:
-              drop:
-              - ALL
-            readOnlyRootFilesystem: true
-          readinessProbe:
-            failureThreshold: 3
-            httpGet:
-              path: /metrics
-              port: http-metrics
-            initialDelaySeconds: 5
-            periodSeconds: 5
-            timeoutSeconds: 3
-          livenessProbe:
-            failureThreshold: 3
-            httpGet:
-              path: /metrics
-              port: http-metrics
-            initialDelaySeconds: 30
-            periodSeconds: 10
-            timeoutSeconds: 5
----
-# Source: loki/templates/single-binary/statefulset.yaml
+# Source: loki/templates/monolithic/statefulset.yaml
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: loki
   namespace: monitoring
   labels:
-    helm.sh/chart: loki-7.0.0
+    helm.sh/chart: loki-13.6.0
     app.kubernetes.io/name: loki
     app.kubernetes.io/instance: loki
-    app.kubernetes.io/version: "3.6.7"
+    app.kubernetes.io/version: "3.7.1"
     app.kubernetes.io/component: single-binary
     app.kubernetes.io/part-of: memberlist
 spec:
@@ -555,32 +460,61 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 3b13e7db83892f17afa0a6501e54db9d626515d01ce320331d16276440f9eaa0
-        storage/size: "5Gi"
+        checksum/config: 91d9566b82923043fcdde38ae1de62b0f60b07e73693cd802645a7285f16a10c
+        storage/size: 5Gi
         kubectl.kubernetes.io/default-container: "loki"
       labels:
+        helm.sh/chart: loki-13.6.0
         app.kubernetes.io/name: loki
         app.kubernetes.io/instance: loki
+        app.kubernetes.io/version: "3.7.1"
         app.kubernetes.io/component: single-binary
         app.kubernetes.io/part-of: memberlist
     spec:
       serviceAccountName: loki
-      automountServiceAccountToken: true
       enableServiceLinks: true
-      
+      automountServiceAccountToken: true
       securityContext:
         fsGroup: 10001
         fsGroupChangePolicy: OnRootMismatch
         runAsGroup: 10001
         runAsNonRoot: true
         runAsUser: 10001
+        seccompProfile:
+          type: RuntimeDefault
       terminationGracePeriodSeconds: 30
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchLabels:
+                app.kubernetes.io/component: single-binary
+                app.kubernetes.io/instance: 'loki'
+                app.kubernetes.io/name: 'loki'
+            topologyKey: kubernetes.io/hostname
+      volumes:
+        - name: temp
+          emptyDir: {}
+        - name: config
+          configMap:
+            name: loki
+            items:
+              - key: "config.yaml"
+                path: "config.yaml"
+        - name: runtime-config
+          configMap:
+            name: loki-runtime
+        - name: sc-rules-volume
+          emptyDir: {}
+        - name: sc-rules-temp
+          emptyDir: {}
       containers:
         - name: loki
-          image: docker.io/grafana/loki:3.6.7
+          image: docker.io/grafana/loki:3.7.1
           imagePullPolicy: IfNotPresent
           args:
             - -config.file=/etc/loki/config/config.yaml
+            - -config.expand-env=true
             - -target=all
           ports:
             - name: http-metrics
@@ -592,12 +526,31 @@ spec:
             - name: http-memberlist
               containerPort: 7946
               protocol: TCP
+          env:
+            - name: GOMEMLIMIT
+              value: 870MiB
+            - name: GOGC
+              value: "80"
+            - name: HASH_RING_INSTANCE_ADDR
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:
               drop:
               - ALL
             readOnlyRootFilesystem: true
+            seccompProfile:
+              type: RuntimeDefault
+          livenessProbe:
+            failureThreshold: 10
+            httpGet:
+              path: /loki/api/v1/status/buildinfo
+              port: http-metrics
+            periodSeconds: 30
+            successThreshold: 1
+            timeoutSeconds: 1
           readinessProbe:
             failureThreshold: 3
             httpGet:
@@ -608,14 +561,14 @@ spec:
             successThreshold: 1
             timeoutSeconds: 1
           volumeMounts:
-            - name: tmp
-              mountPath: /tmp
             - name: config
               mountPath: /etc/loki/config
             - name: runtime-config
               mountPath: /etc/loki/runtime-config
             - name: storage
               mountPath: /var/loki
+            - name: temp
+              mountPath: /tmp
             - name: sc-rules-volume
               mountPath: "/rules"
           resources:
@@ -626,8 +579,38 @@ spec:
               cpu: 200m
               memory: 512Mi
         - name: loki-sc-rules
-          image: docker.io/kiwigrid/k8s-sidecar:2.5.0
+          image: docker.io/kiwigrid/k8s-sidecar:2.7.1
           imagePullPolicy: IfNotPresent
+          ports:
+            - name: http-sidecar
+              containerPort: 8080
+              protocol: TCP
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
+            seccompProfile:
+              type: RuntimeDefault
+          livenessProbe:
+                failureThreshold: 3
+                httpGet:
+                  path: /healthz
+                  port: http-sidecar
+                initialDelaySeconds: 30
+                periodSeconds: 30
+                successThreshold: 1
+                timeoutSeconds: 1
+          readinessProbe:
+                failureThreshold: 3
+                httpGet:
+                  path: /healthz
+                  port: http-sidecar
+                initialDelaySeconds: 3
+                periodSeconds: 10
+                successThreshold: 1
+                timeoutSeconds: 1
           env:
             - name: METHOD
               value: WATCH
@@ -643,40 +626,13 @@ spec:
               value: "60"
             - name: LOG_LEVEL
               value: "INFO"
-          securityContext:
-            allowPrivilegeEscalation: false
-            capabilities:
-              drop:
-              - ALL
-            readOnlyRootFilesystem: true
+            - name: HEALTH_PORT
+              value: "8080"
           volumeMounts:
-            - name: tmp
+            - name: sc-rules-temp
               mountPath: /tmp
             - name: sc-rules-volume
               mountPath: "/rules"
-      affinity:
-        podAntiAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-          - labelSelector:
-              matchLabels:
-                app.kubernetes.io/component: single-binary
-                app.kubernetes.io/instance: 'loki'
-                app.kubernetes.io/name: 'loki'
-            topologyKey: kubernetes.io/hostname
-      volumes:
-        - name: tmp
-          emptyDir: {}
-        - name: config
-          configMap:
-            name: loki
-            items:
-              - key: "config.yaml"
-                path: "config.yaml"
-        - name: runtime-config
-          configMap:
-            name: loki-runtime
-        - name: sc-rules-volume
-          emptyDir: {}
   volumeClaimTemplates:
     - apiVersion: v1
       kind: PersistentVolumeClaim

--- a/kubernetes/manifests/production/fluent-bit/kustomization.yaml
+++ b/kubernetes/manifests/production/fluent-bit/kustomization.yaml
@@ -1,0 +1,2 @@
+resources:
+  - manifest.yaml

--- a/kubernetes/manifests/production/fluent-bit/manifest.yaml
+++ b/kubernetes/manifests/production/fluent-bit/manifest.yaml
@@ -1,0 +1,261 @@
+---
+# Source: fluent-bit/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: fluent-bit
+  namespace: monitoring
+  labels:
+    helm.sh/chart: fluent-bit-0.57.3
+    app.kubernetes.io/name: fluent-bit
+    app.kubernetes.io/instance: fluent-bit
+    app.kubernetes.io/version: "5.0.3"
+    app.kubernetes.io/managed-by: Helm
+---
+# Source: fluent-bit/templates/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: fluent-bit
+  namespace: monitoring
+  labels:
+    helm.sh/chart: fluent-bit-0.57.3
+    app.kubernetes.io/name: fluent-bit
+    app.kubernetes.io/instance: fluent-bit
+    app.kubernetes.io/version: "5.0.3"
+    app.kubernetes.io/managed-by: Helm
+data:
+  custom_parsers.conf: |
+    [PARSER]
+        Name docker_no_time
+        Format json
+        Time_Keep Off
+        Time_Key time
+        Time_Format %Y-%m-%dT%H:%M:%S.%L
+    
+  fluent-bit.conf: |
+    [SERVICE]
+        Daemon Off
+        Flush 1
+        Log_Level info
+        Parsers_File /fluent-bit/etc/parsers.conf
+        Parsers_File /fluent-bit/etc/conf/custom_parsers.conf
+        HTTP_Server On
+        HTTP_Listen 0.0.0.0
+        HTTP_Port 2020
+        Health_Check On
+        # filesystem-backed buffer = node disk 利用、長時間 outage 耐性 (Decision 11 軽減策)
+        storage.path              /var/log/flb_storage/
+        storage.sync              normal
+        storage.checksum          off
+        storage.backlog.mem_limit 5M
+    
+    [INPUT]
+        Name              tail
+        Path              /var/log/containers/*.log
+        multiline.parser  docker, cri
+        Tag               kube.*
+        Mem_Buf_Limit     5MB
+        Skip_Long_Lines   On
+        Refresh_Interval  10
+        # storage.type filesystem = retry buffer を node disk に保存 (Decision 11)
+        storage.type      filesystem
+        # DB ファイルで読み取り position を記録、再起動時に resume
+        DB                /var/log/flb_storage/tail.db
+    
+    [FILTER]
+        Name                kubernetes
+        Match               kube.*
+        Kube_URL            https://kubernetes.default.svc:443
+        Kube_CA_File        /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+        Kube_Token_File     /var/run/secrets/kubernetes.io/serviceaccount/token
+        Kube_Tag_Prefix     kube.var.log.containers.
+        Merge_Log           On
+        Keep_Log            Off
+        K8S-Logging.Parser  On
+        K8S-Logging.Exclude On
+        Annotations         Off
+        Labels              On
+    
+    [OUTPUT]
+        Name              loki
+        Match             kube.*
+        Host              loki-gateway.monitoring.svc.cluster.local
+        Port              80
+        # Loki API path
+        Uri               /loki/api/v1/push
+        # 1 tenant 運用 (= Decision 3)
+        tenant_id         anonymous
+        # Decision 4 labels = 最小 (namespace / pod / container)
+        labels            job=fluentbit, namespace=$kubernetes['namespace_name'], pod=$kubernetes['pod_name'], container=$kubernetes['container_name']
+        # 残りの k8s metadata は structured metadata で保持 (= cardinality cost なし)
+        structured_metadata node=$kubernetes['host'], stream=$stream
+        # remove kubernetes prefix from log fields (= structured_metadata で保持済)
+        remove_keys       kubernetes
+        # gzip 圧縮で帯域削減
+        compress          gzip
+        # retry settings
+        net.connect_timeout 10
+        Retry_Limit       no_limits
+        # storage = filesystem buffer (= retry の永続化)
+        storage.total_limit_size  5G
+---
+# Source: fluent-bit/templates/clusterrole.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: fluent-bit
+  labels:
+    helm.sh/chart: fluent-bit-0.57.3
+    app.kubernetes.io/name: fluent-bit
+    app.kubernetes.io/instance: fluent-bit
+    app.kubernetes.io/version: "5.0.3"
+    app.kubernetes.io/managed-by: Helm
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - namespaces
+      - pods
+    verbs:
+      - get
+      - list
+      - watch
+---
+# Source: fluent-bit/templates/clusterrolebinding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: fluent-bit
+  labels:
+    helm.sh/chart: fluent-bit-0.57.3
+    app.kubernetes.io/name: fluent-bit
+    app.kubernetes.io/instance: fluent-bit
+    app.kubernetes.io/version: "5.0.3"
+    app.kubernetes.io/managed-by: Helm
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: fluent-bit
+subjects:
+  - kind: ServiceAccount
+    name: fluent-bit
+    namespace: monitoring
+---
+# Source: fluent-bit/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: fluent-bit
+  namespace: monitoring
+  labels:
+    helm.sh/chart: fluent-bit-0.57.3
+    app.kubernetes.io/name: fluent-bit
+    app.kubernetes.io/instance: fluent-bit
+    app.kubernetes.io/version: "5.0.3"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  type: ClusterIP
+  ports:
+    - port: 2020
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    app.kubernetes.io/name: fluent-bit
+    app.kubernetes.io/instance: fluent-bit
+---
+# Source: fluent-bit/templates/daemonset.yaml
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: fluent-bit
+  namespace: monitoring
+  labels:
+    helm.sh/chart: fluent-bit-0.57.3
+    app.kubernetes.io/name: fluent-bit
+    app.kubernetes.io/instance: fluent-bit
+    app.kubernetes.io/version: "5.0.3"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: fluent-bit
+      app.kubernetes.io/instance: fluent-bit
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: fluent-bit
+        app.kubernetes.io/instance: fluent-bit
+      annotations:
+        checksum/config: b82d3d3f47ce49225fc87c53159733eb28d8c736f2f007850dec503eb815a61b
+    spec:
+      
+      serviceAccountName: fluent-bit
+      hostNetwork: false
+      dnsPolicy: ClusterFirst
+      containers:
+        - name: fluent-bit
+          image: "cr.fluentbit.io/fluent/fluent-bit:5.0.3"
+          imagePullPolicy: IfNotPresent
+          command:
+            - /fluent-bit/bin/fluent-bit
+          args:
+            - --workdir=/fluent-bit/etc
+            - --config=/fluent-bit/etc/conf/fluent-bit.conf
+          ports:
+            - name: http
+              containerPort: 2020
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /
+              port: http
+          readinessProbe:
+            httpGet:
+              path: /api/v2/health
+              port: http
+          resources:
+            limits:
+              cpu: 200m
+              memory: 256Mi
+            requests:
+              cpu: 100m
+              memory: 128Mi
+          volumeMounts:
+            - name: config
+              mountPath: /fluent-bit/etc/conf
+            - mountPath: /var/log
+              name: varlog
+            - mountPath: /var/lib/docker/containers
+              name: varlibdockercontainers
+              readOnly: true
+            - mountPath: /etc/machine-id
+              name: etcmachineid
+              readOnly: true
+            - mountPath: /var/log/flb_storage
+              name: flb-storage
+      volumes:
+        - name: config
+          configMap:
+            name: fluent-bit
+        - hostPath:
+            path: /var/log
+          name: varlog
+        - hostPath:
+            path: /var/lib/docker/containers
+          name: varlibdockercontainers
+        - hostPath:
+            path: /etc/machine-id
+            type: File
+          name: etcmachineid
+        - hostPath:
+            path: /var/log/flb_storage
+            type: DirectoryOrCreate
+          name: flb-storage
+      tolerations:
+        - effect: NoSchedule
+          operator: Exists
+        - effect: NoExecute
+          operator: Exists
+

--- a/kubernetes/manifests/production/kustomization.yaml
+++ b/kubernetes/manifests/production/kustomization.yaml
@@ -6,6 +6,7 @@ resources:
   - ./gateway-api
   - ./karpenter
   - ./keda
+  - ./loki
   - ./metrics-server
   - ./mimir
   - ./prometheus-operator

--- a/kubernetes/manifests/production/kustomization.yaml
+++ b/kubernetes/manifests/production/kustomization.yaml
@@ -3,6 +3,7 @@ resources:
   - ./aws-load-balancer-controller
   - ./cilium
   - ./external-dns
+  - ./fluent-bit
   - ./gateway-api
   - ./karpenter
   - ./keda

--- a/kubernetes/manifests/production/loki/kustomization.yaml
+++ b/kubernetes/manifests/production/loki/kustomization.yaml
@@ -1,0 +1,2 @@
+resources:
+  - manifest.yaml

--- a/kubernetes/manifests/production/loki/manifest.yaml
+++ b/kubernetes/manifests/production/loki/manifest.yaml
@@ -162,11 +162,8 @@ data:
         max_per_second: 20
         up_to: 3
       tsdb_shipper:
-        active_index_directory: /var/loki/tsdb-index
-        cache_location: /var/loki/tsdb-cache
         index_gateway_client:
           server_address: ""
-        shared_store: s3
       use_thanos_objstore: false
     tracing:
       enabled: false
@@ -991,7 +988,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 55fe1393e2f13d7dcc93e5919ade67b2d9378fd62f76900a8506c42e492a79bb
+        checksum/config: a67f78d79e4cf8b2ac40d624f1dd2c0fd6b4f050cfcd98442fbe6d9fd430e78e
         storage/size: 10Gi
         kubectl.kubernetes.io/default-container: "loki"
       labels:

--- a/kubernetes/manifests/production/loki/manifest.yaml
+++ b/kubernetes/manifests/production/loki/manifest.yaml
@@ -1,0 +1,1179 @@
+---
+# Source: loki/templates/gateway/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: loki-gateway
+  namespace: monitoring
+  labels:
+    helm.sh/chart: loki-13.6.0
+    app.kubernetes.io/name: loki
+    app.kubernetes.io/instance: loki
+    app.kubernetes.io/version: "3.7.1"
+    app.kubernetes.io/component: gateway
+automountServiceAccountToken: false
+---
+# Source: loki/templates/memcached/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: loki-memcached
+  namespace: monitoring
+  labels:
+    helm.sh/chart: loki-13.6.0
+    app.kubernetes.io/name: loki
+    app.kubernetes.io/instance: loki
+    app.kubernetes.io/version: "3.7.1"
+    app.kubernetes.io/component: memcached
+automountServiceAccountToken: false
+---
+# Source: loki/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: loki
+  namespace: monitoring
+  labels:
+    helm.sh/chart: loki-13.6.0
+    app.kubernetes.io/name: loki
+    app.kubernetes.io/instance: loki
+    app.kubernetes.io/version: "3.7.1"
+automountServiceAccountToken: true
+---
+# Source: loki/templates/config.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: loki
+  namespace: monitoring
+  labels:
+    helm.sh/chart: loki-13.6.0
+    app.kubernetes.io/name: loki
+    app.kubernetes.io/instance: loki
+    app.kubernetes.io/version: "3.7.1"
+data:
+  config.yaml: |
+    
+    auth_enabled: false
+    bloom_build:
+      builder:
+        planner_address: ""
+      enabled: false
+    bloom_gateway:
+      client:
+        addresses: ""
+      enabled: false
+    common:
+      compactor_grpc_address: 'loki.monitoring.svc.cluster.local:9095'
+      path_prefix: /var/loki
+      replication_factor: 1
+      storage:
+        s3:
+          bucketnames: ""
+          insecure: false
+          region: ap-northeast-1
+          s3forcepathstyle: false
+    compactor:
+      retention_delete_delay: 2h
+      retention_enabled: true
+    frontend:
+      scheduler_address: ""
+      tail_proxy_url: ""
+    frontend_worker:
+      scheduler_address: ""
+    index_gateway:
+      mode: simple
+    ingester:
+      chunk_idle_period: 2m
+      max_chunk_age: 5m
+      wal:
+        flush_on_shutdown: true
+    limits_config:
+      ingestion_burst_size_mb: 6
+      ingestion_rate_mb: 4
+      max_cache_freshness_per_query: 10m
+      query_timeout: 300s
+      reject_old_samples: true
+      reject_old_samples_max_age: 168h
+      retention_period: 720h
+      split_queries_by_interval: 15m
+      volume_enabled: true
+    memberlist:
+      abort_if_cluster_join_fails: true
+      advertise_addr: ${HASH_RING_INSTANCE_ADDR}
+      advertise_port: 7946
+      bind_port: 7946
+      join_members:
+      - loki-memberlist.monitoring.svc.cluster.local
+      max_join_backoff: 1m
+      max_join_retries: 10
+      min_join_backoff: 1s
+      rejoin_interval: 90s
+    pattern_ingester:
+      enabled: false
+    query_range:
+      align_queries_with_step: true
+    ruler:
+      storage:
+        s3:
+          bucketnames: loki-559744160976
+          insecure: false
+          region: ap-northeast-1
+          s3forcepathstyle: false
+        type: s3
+      wal:
+        dir: /var/loki/ruler-wal
+    runtime_config:
+      file: /etc/loki/runtime-config/runtime-config.yaml
+    schema_config:
+      configs:
+      - from: "2024-01-01"
+        index:
+          period: 24h
+          prefix: production_index_
+        object_store: s3
+        schema: v13
+        store: tsdb
+    server:
+      graceful_shutdown_timeout: 5s
+      grpc_listen_port: 9095
+      grpc_server_max_concurrent_streams: 1000
+      grpc_server_max_recv_msg_size: 104857600
+      grpc_server_max_send_msg_size: 104857600
+      grpc_server_min_time_between_pings: 10s
+      grpc_server_ping_without_stream_allowed: true
+      http_listen_port: 3100
+      http_server_idle_timeout: 30s
+      http_server_read_timeout: 10m0s
+      http_server_write_timeout: 10m0s
+      log_level: info
+    storage_config:
+      aws:
+        bucketnames: loki-559744160976
+        region: ap-northeast-1
+        s3forcepathstyle: false
+      bloom_shipper:
+        working_directory: /var/loki/data/bloomshipper
+      boltdb_shipper:
+        index_gateway_client:
+          server_address: ""
+      hedging:
+        at: 250ms
+        max_per_second: 20
+        up_to: 3
+      tsdb_shipper:
+        active_index_directory: /var/loki/tsdb-index
+        cache_location: /var/loki/tsdb-cache
+        index_gateway_client:
+          server_address: ""
+        shared_store: s3
+      use_thanos_objstore: false
+    tracing:
+      enabled: false
+---
+# Source: loki/templates/gateway/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: loki-gateway
+  namespace: monitoring
+  labels:
+    helm.sh/chart: loki-13.6.0
+    app.kubernetes.io/name: loki
+    app.kubernetes.io/instance: loki
+    app.kubernetes.io/version: "3.7.1"
+    app.kubernetes.io/component: gateway
+data:
+  nginx.conf: |
+    worker_processes  5;  ## Default: 1
+    error_log  /dev/stderr;
+    pid        /tmp/nginx.pid;
+    worker_rlimit_nofile 8192;
+    
+    events {
+      worker_connections  4096;  ## Default: 1024
+    }
+    
+    http {
+      client_body_temp_path /tmp/client_temp;
+      proxy_temp_path       /tmp/proxy_temp_path;
+      fastcgi_temp_path     /tmp/fastcgi_temp;
+      uwsgi_temp_path       /tmp/uwsgi_temp;
+      scgi_temp_path        /tmp/scgi_temp;
+    
+      client_max_body_size  4M;
+    
+      proxy_read_timeout    600; ## 10 minutes
+      proxy_send_timeout    600;
+      proxy_connect_timeout 600;
+    
+      proxy_http_version    1.1;
+    
+      default_type application/octet-stream;
+      log_format   main '$remote_addr - $remote_user [$time_local]  $status '
+            '"$request" $body_bytes_sent "$http_referer" '
+            '"$http_user_agent" "$http_x_forwarded_for"';
+      # Exclude specific requests from logging
+      map $request_uri $track {
+        default 1;
+        ~^/$ 0;
+        ~^/health 0;
+        ~^/metrics 0;
+      }
+    
+      # simple_upstream preset
+      log_format access_log_exporter '$http_host\t$request_method\t$status\t$request_completion\t$request_time\t$request_length\t$bytes_sent\t$upstream_addr\t$upstream_connect_time\t$upstream_header_time\t$upstream_response_time\t$request_uri';
+      access_log syslog:server=127.0.0.1:8514,nohostname access_log_exporter if=$track;
+      access_log   /dev/stderr  main;
+    
+      sendfile     on;
+      tcp_nopush   on;
+      resolver kube-dns.kube-system.svc.cluster.local.;
+    
+      # if the X-Query-Tags header is empty, set a noop= without a value as empty values are not logged
+      map $http_x_query_tags $query_tags {
+        ""        "noop=";            # When header is empty, set noop=
+        default   $http_x_query_tags; # Otherwise, preserve the original value
+      }
+    
+      server {
+        listen             8080;
+        listen             [::]:8080;
+    
+        location = / {
+          
+          return 200 'OK';
+          auth_basic off;
+        }
+    
+        location = /stub_status {
+          stub_status on;
+          satisfy any;
+          access_log off;
+          allow 127.0.0.1;
+          deny all;
+          server_tokens on;  # expose nginx version
+        }
+    
+        ########################################################
+        # Configure backend targets
+        location ^~ /ui {
+          
+          set $backend     "http://loki.monitoring.svc.cluster.local:3100";
+          proxy_pass       $backend$request_uri;
+        }
+    
+        # Distributor
+        location = /api/prom/push {
+          
+          set $backend     "http://loki.monitoring.svc.cluster.local:3100";
+          proxy_pass       $backend$request_uri;
+        }
+        location = /loki/api/v1/push {
+          
+          set $backend     "http://loki.monitoring.svc.cluster.local:3100";
+          proxy_pass       $backend$request_uri;
+        }
+        location = /distributor/ring {
+          
+          set $backend     "http://loki.monitoring.svc.cluster.local:3100";
+          proxy_pass       $backend$request_uri;
+        }
+        location = /otlp/v1/logs {
+          
+          set $backend     "http://loki.monitoring.svc.cluster.local:3100";
+          proxy_pass       $backend$request_uri;
+        }
+    
+        # Ingester
+        location = /flush {
+          
+          set $backend     "http://loki.monitoring.svc.cluster.local:3100";
+          proxy_pass       $backend$request_uri;
+        }
+        location ^~ /ingester/ {
+          
+          set $backend     "http://loki.monitoring.svc.cluster.local:3100";
+          proxy_pass       $backend$request_uri;
+        }
+        location = /ingester {
+          
+          internal;        # to suppress 301
+        }
+    
+        # Ring
+        location = /ring {
+          
+          set $backend     "http://loki.monitoring.svc.cluster.local:3100";
+          proxy_pass       $backend$request_uri;
+        }
+    
+        # MemberListKV
+        location = /memberlist {
+          
+          set $backend     "http://loki.monitoring.svc.cluster.local:3100";
+          proxy_pass       $backend$request_uri;
+        }
+    
+        # Ruler
+        location = /ruler/ring {
+          
+          set $backend     "http://loki.monitoring.svc.cluster.local:3100";
+          proxy_pass       $backend$request_uri;
+        }
+        location = /api/prom/rules {
+          
+          set $backend     "http://loki.monitoring.svc.cluster.local:3100";
+          proxy_pass       $backend$request_uri;
+        }
+        location ^~ /api/prom/rules/ {
+          
+          set $backend     "http://loki.monitoring.svc.cluster.local:3100";
+          proxy_pass       $backend$request_uri;
+        }
+        location = /loki/api/v1/rules {
+          
+          set $backend     "http://loki.monitoring.svc.cluster.local:3100";
+          proxy_pass       $backend$request_uri;
+        }
+        location ^~ /loki/api/v1/rules/ {
+          
+          set $backend     "http://loki.monitoring.svc.cluster.local:3100";
+          proxy_pass       $backend$request_uri;
+        }
+        location = /prometheus/api/v1/alerts {
+          
+          set $backend     "http://loki.monitoring.svc.cluster.local:3100";
+          proxy_pass       $backend$request_uri;
+        }
+        location = /prometheus/api/v1/rules {
+          
+          set $backend     "http://loki.monitoring.svc.cluster.local:3100";
+          proxy_pass       $backend$request_uri;
+        }
+    
+        # Compactor
+        location = /compactor/ring {
+          
+          set $backend     "http://loki.monitoring.svc.cluster.local:3100";
+          proxy_pass       $backend$request_uri;
+        }
+        location = /loki/api/v1/delete {
+          
+          set $backend     "http://loki.monitoring.svc.cluster.local:3100";
+          proxy_pass       $backend$request_uri;
+        }
+        location = /loki/api/v1/cache/generation_numbers {
+          
+          set $backend     "http://loki.monitoring.svc.cluster.local:3100";
+          proxy_pass       $backend$request_uri;
+        }
+    
+        # IndexGateway
+        location = /indexgateway/ring {
+          
+          set $backend     "http://loki.monitoring.svc.cluster.local:3100";
+          proxy_pass       $backend$request_uri;
+        }
+    
+        # QueryScheduler
+        location = /scheduler/ring {
+          
+          set $backend     "http://loki.monitoring.svc.cluster.local:3100";
+          proxy_pass       $backend$request_uri;
+        }
+    
+        # Config
+        location = /config {
+          
+          set $backend     "http://loki.monitoring.svc.cluster.local:3100";
+          proxy_pass       $backend$request_uri;
+        }
+    
+        # QueryFrontend, Querier
+        location = /api/prom/tail {
+          proxy_set_header Upgrade $http_upgrade;
+          proxy_set_header Connection "upgrade";
+          
+          set $backend     "http://loki.monitoring.svc.cluster.local:3100";
+          proxy_pass       $backend$request_uri;
+        }
+        location = /loki/api/v1/tail {
+          proxy_set_header Upgrade $http_upgrade;
+          proxy_set_header Connection "upgrade";
+          
+          set $backend     "http://loki.monitoring.svc.cluster.local:3100";
+          proxy_pass       $backend$request_uri;
+        }
+        location ^~ /api/prom/ {
+          
+          set $backend     "http://loki.monitoring.svc.cluster.local:3100";
+          proxy_pass       $backend$request_uri;
+        }
+        location = /api/prom {
+          
+          internal;        # to suppress 301
+        }
+        location ^~ /loki/api/v1/ {
+          # pass custom headers set by Grafana as X-Query-Tags which are logged as key/value pairs in metrics.go log messages
+          proxy_set_header X-Query-Tags "${query_tags},user=${http_x_grafana_user},dashboard_id=${http_x_dashboard_uid},dashboard_title=${http_x_dashboard_title},panel_id=${http_x_panel_id},panel_title=${http_x_panel_title},source_rule_uid=${http_x_rule_uid},rule_name=${http_x_rule_name},rule_folder=${http_x_rule_folder},rule_version=${http_x_rule_version},rule_source=${http_x_rule_source},rule_type=${http_x_rule_type}";
+          
+          set $backend     "http://loki.monitoring.svc.cluster.local:3100";
+          proxy_pass       $backend$request_uri;
+        }
+        location = /loki/api/v1 {
+          
+          internal;        # to suppress 301
+        }
+      }
+    }
+  access-log-exporter.yaml: |
+    presets:
+      loki:
+        metrics:
+          - name: "http_requests_total"
+            type: "counter"
+            help: "The total number of client requests."
+            labels:
+              - name: "host"
+                lineIndex: 0
+              - name: "method"
+                lineIndex: 1
+              - name: "status"
+                lineIndex: 2
+              - name: "path"
+                lineIndex: 11
+                replacements:
+                  - regexp: "^$"
+                    replacement: "/"
+                  - regexp: "^(.+)\\?.+"
+                    replacement: "$1"
+
+          - name: "http_requests_completed_total"
+            type: "counter"
+            help: "The total number of completed requests."
+            valueIndex: 3
+            replacements:
+              - string: "OK"
+                replacement: "1"
+            labels:
+              - name: "host"
+                lineIndex: 0
+              - name: "method"
+                lineIndex: 1
+              - name: "status"
+                lineIndex: 2
+              - name: "path"
+                lineIndex: 11
+                replacements:
+                  - regexp: "^$"
+                    replacement: "/"
+                  - regexp: "^(.+)\\?.+"
+                    replacement: "$1"
+
+          - name: "http_request_size_bytes"
+            type: "histogram"
+            buckets: [ 10,1000,100000,1000000,5000000,50000000,200000000 ]
+            help: "The request length (including request line, header, and request body)"
+            valueIndex: 5
+            labels:
+              - name: "host"
+                lineIndex: 0
+              - name: "method"
+                lineIndex: 1
+              - name: "status"
+                lineIndex: 2
+              - name: "path"
+                lineIndex: 11
+                replacements:
+                  - regexp: "^$"
+                    replacement: "/"
+                  - regexp: "^(.+)\\?.+"
+                    replacement: "$1"
+
+          - name: "http_response_size_bytes"
+            type: "histogram"
+            buckets: [ 10,1000,100000,1000000,5000000,50000000,200000000 ]
+            help: "The response length (including request line, header, and request body)"
+            valueIndex: 6
+            labels:
+              - name: "host"
+                lineIndex: 0
+              - name: "method"
+                lineIndex: 1
+              - name: "status"
+                lineIndex: 2
+              - name: "path"
+                lineIndex: 11
+                replacements:
+                  - regexp: "^$"
+                    replacement: "/"
+                  - regexp: "^(.+)\\?.+"
+                    replacement: "$1"
+
+          - name: "http_request_duration_seconds"
+            type: "histogram"
+            buckets: [ .005, .01, .025, .05, .1, .25, .5, 1, 2.5, 5, 10 ]
+            help: "The time spent on receiving and response the response to the client"
+            valueIndex: 4
+            math:
+              enabled: true
+              div: 1000
+            labels:
+              - name: "host"
+                lineIndex: 0
+              - name: "method"
+                lineIndex: 1
+              - name: "status"
+                lineIndex: 2
+              - name: "path"
+                lineIndex: 11
+                replacements:
+                  - regexp: "^$"
+                    replacement: "/"
+                  - regexp: "^(.+)\\?.+"
+                    replacement: "$1"
+
+          - name: "http_upstream_connect_duration_seconds"
+            type: "histogram"
+            buckets: [ .005, .01, .025, .05, .1, .25, .5, 1, 2.5, 5, 10 ]
+            help: "The time spent on establishing a connection with the upstream server"
+            valueIndex: 8
+            math:
+              enabled: true
+              div: 1000
+            upstream:
+              enabled: true
+              addrLineIndex: 7
+              excludes: []
+            labels:
+              - name: "host"
+                lineIndex: 0
+              - name: "method"
+                lineIndex: 1
+              - name: "status"
+                lineIndex: 2
+              - name: "path"
+                lineIndex: 11
+                replacements:
+                  - regexp: "^$"
+                    replacement: "/"
+                  - regexp: "^(.+)\\?.+"
+                    replacement: "$1"
+
+          - name: "http_upstream_header_duration_seconds"
+            type: "histogram"
+            help: "The time spent on receiving the response header from the upstream server"
+            buckets: [ .005, .01, .025, .05, .1, .25, .5, 1, 2.5, 5, 10 ]
+            valueIndex: 9
+            math:
+              enabled: true
+              div: 1000
+            upstream:
+              enabled: true
+              addrLineIndex: 7
+              excludes: []
+            labels:
+              - name: "host"
+                lineIndex: 0
+              - name: "method"
+                lineIndex: 1
+              - name: "status"
+                lineIndex: 2
+              - name: "path"
+                lineIndex: 11
+                replacements:
+                  - regexp: "^$"
+                    replacement: "/"
+                  - regexp: "^(.+)\\?.+"
+                    replacement: "$1"
+
+          - name: "http_upstream_request_duration_seconds"
+            type: "histogram"
+            help: "The time spent on receiving the response from the upstream server"
+            buckets: [ .005, .01, .025, .05, .1, .25, .5, 1, 2.5, 5, 10 ]
+            valueIndex: 10
+            math:
+              enabled: true
+              div: 1000
+            upstream:
+              enabled: true
+              addrLineIndex: 7
+              excludes: []
+            labels:
+              - name: "host"
+                lineIndex: 0
+              - name: "method"
+                lineIndex: 1
+              - name: "status"
+                lineIndex: 2
+              - name: "path"
+                lineIndex: 11
+                replacements:
+                  - regexp: "^$"
+                    replacement: "/"
+                  - regexp: "^(.+)\\?.+"
+                    replacement: "$1"
+---
+# Source: loki/templates/runtime-configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: loki-runtime
+  namespace: monitoring
+  labels:
+    helm.sh/chart: loki-13.6.0
+    app.kubernetes.io/name: loki
+    app.kubernetes.io/instance: loki
+    app.kubernetes.io/version: "3.7.1"
+data:
+  runtime-config.yaml: |
+    {}
+---
+# Source: loki/templates/backend/clusterrole.yaml
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  labels:
+    helm.sh/chart: loki-13.6.0
+    app.kubernetes.io/name: loki
+    app.kubernetes.io/instance: loki
+    app.kubernetes.io/version: "3.7.1"
+  name: loki-clusterrole
+rules:
+- apiGroups: [""] # "" indicates the core API group
+  resources: ["configmaps", "secrets"]
+  verbs: ["get", "watch", "list"]
+---
+# Source: loki/templates/backend/clusterrolebinding.yaml
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: loki-clusterrolebinding
+  labels:
+    helm.sh/chart: loki-13.6.0
+    app.kubernetes.io/name: loki
+    app.kubernetes.io/instance: loki
+    app.kubernetes.io/version: "3.7.1"
+subjects:
+  - kind: ServiceAccount
+    name: loki
+    namespace: monitoring
+roleRef:
+  kind: ClusterRole
+  name: loki-clusterrole
+  apiGroup: rbac.authorization.k8s.io
+---
+# Source: loki/templates/gateway/service-exporter.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: loki-gateway-exporter
+  namespace: monitoring
+  labels:
+    helm.sh/chart: loki-13.6.0
+    app.kubernetes.io/name: loki
+    app.kubernetes.io/instance: loki
+    app.kubernetes.io/version: "3.7.1"
+    app.kubernetes.io/component: gateway
+  annotations:
+spec:
+  type: ClusterIP
+  ports:
+    - name: http-metrics
+      port: 4040
+      targetPort: http-metrics
+      protocol: TCP
+  selector:
+    app.kubernetes.io/name: loki
+    app.kubernetes.io/instance: loki
+    app.kubernetes.io/component: gateway
+---
+# Source: loki/templates/gateway/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: loki-gateway
+  namespace: monitoring
+  labels:
+    helm.sh/chart: loki-13.6.0
+    app.kubernetes.io/name: loki
+    app.kubernetes.io/instance: loki
+    app.kubernetes.io/version: "3.7.1"
+    app.kubernetes.io/component: gateway
+    prometheus.io/service-monitor: "false"
+  annotations:
+spec:
+  type: ClusterIP
+  ports:
+    - name: http
+      port: 80
+      targetPort: http
+      protocol: TCP
+  selector:
+    app.kubernetes.io/name: loki
+    app.kubernetes.io/instance: loki
+    app.kubernetes.io/component: gateway
+---
+# Source: loki/templates/monolithic/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: "loki"
+  namespace: "monitoring"
+  labels:
+    helm.sh/chart: loki-13.6.0
+    app.kubernetes.io/name: loki
+    app.kubernetes.io/instance: loki
+    app.kubernetes.io/version: "3.7.1"
+    app.kubernetes.io/component: "single-binary"
+  annotations:
+spec:
+  type: ClusterIP
+  publishNotReadyAddresses: true
+  ports:
+    - name: http-metrics
+      port: 3100
+      targetPort: http-metrics
+      protocol: TCP
+    - name: grpc
+      port: 9095
+      targetPort: grpc
+      protocol: TCP
+    - name: grpclb
+      port: 9096
+      targetPort: grpc
+      protocol: TCP
+  selector:
+    
+    app.kubernetes.io/name: loki
+    app.kubernetes.io/instance: loki
+    app.kubernetes.io/component: "single-binary"
+---
+# Source: loki/templates/monolithic/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: "loki-headless"
+  namespace: monitoring
+  labels:
+    helm.sh/chart: loki-13.6.0
+    app.kubernetes.io/name: loki
+    app.kubernetes.io/instance: loki
+    app.kubernetes.io/version: "3.7.1"
+    app.kubernetes.io/component: "single-binary"
+    prometheus.io/service-monitor: "false"
+    variant: headless
+  annotations:
+spec:
+  clusterIP: None
+  type: ClusterIP
+  publishNotReadyAddresses: true
+  ports:
+    - name: http-metrics
+      port: 3100
+      targetPort: http-metrics
+      protocol: TCP
+    - name: grpc
+      port: 9095
+      targetPort: grpc
+      protocol: TCP
+    - name: grpclb
+      port: 9096
+      targetPort: grpc
+      protocol: TCP
+  selector:
+    
+    app.kubernetes.io/name: loki
+    app.kubernetes.io/instance: loki
+    app.kubernetes.io/component: "single-binary"
+---
+# Source: loki/templates/service-memberlist.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: loki-memberlist
+  namespace: monitoring
+  labels:
+    helm.sh/chart: loki-13.6.0
+    app.kubernetes.io/name: loki
+    app.kubernetes.io/instance: loki
+    app.kubernetes.io/version: "3.7.1"
+  annotations:
+spec:
+  type: ClusterIP
+  clusterIP: None
+  ports:
+    - name: tcp
+      port: 7946
+      targetPort: http-memberlist
+      protocol: TCP
+  selector:
+    app.kubernetes.io/name: loki
+    app.kubernetes.io/instance: loki
+    app.kubernetes.io/part-of: memberlist
+---
+# Source: loki/templates/gateway/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: loki-gateway
+  namespace: monitoring
+  labels:
+    helm.sh/chart: loki-13.6.0
+    app.kubernetes.io/name: loki
+    app.kubernetes.io/instance: loki
+    app.kubernetes.io/version: "3.7.1"
+    app.kubernetes.io/component: gateway
+spec:
+  replicas: 1
+  strategy:
+    type: RollingUpdate
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: loki
+      app.kubernetes.io/instance: loki
+      app.kubernetes.io/component: gateway
+  template:
+    metadata:
+      annotations:
+        checksum/config: 471169c21d031188ed64777b5da0f2ff569db867e615552374df77e2eec52949
+      labels:
+        app.kubernetes.io/name: loki
+        app.kubernetes.io/instance: loki
+        app.kubernetes.io/component: gateway
+    spec:
+      serviceAccountName: loki-gateway
+      automountServiceAccountToken: false
+      enableServiceLinks: true
+      
+      securityContext:
+        fsGroup: 101
+        runAsGroup: 101
+        runAsNonRoot: true
+        runAsUser: 101
+        seccompProfile:
+          type: RuntimeDefault
+      terminationGracePeriodSeconds: 30
+      containers:
+        - name: nginx
+          image: docker.io/nginxinc/nginx-unprivileged:1.30-alpine
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+          readinessProbe:
+            httpGet:
+              path: /
+              port: http
+            initialDelaySeconds: 15
+            timeoutSeconds: 1
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
+            seccompProfile:
+              type: RuntimeDefault
+          volumeMounts:
+            - name: config
+              mountPath: /etc/nginx
+            - name: tmp
+              mountPath: /tmp
+            - name: docker-entrypoint-d-override
+              mountPath: /docker-entrypoint.d
+          resources:
+            limits:
+              cpu: 200m
+              memory: 256Mi
+            requests:
+              cpu: 50m
+              memory: 64Mi
+        - name: exporter
+          image: ghcr.io/jkroepke/access-log-exporter:0.3.11
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 4040
+              name: http-metrics
+            - containerPort: 8514
+              name: syslog
+          args:
+            - --nginx.scrape-url
+            - http://127.0.0.1:8080/stub_status
+            - --preset
+            - loki
+          resources:
+            limits: {}
+            requests: {}
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            privileged: false
+            readOnlyRootFilesystem: true
+            runAsGroup: 65532
+            runAsNonRoot: true
+            runAsUser: 65532
+            seccompProfile:
+              type: RuntimeDefault
+          readinessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /health
+              port: http-metrics
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            timeoutSeconds: 3
+          livenessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /health
+              port: http-metrics
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            timeoutSeconds: 5
+          volumeMounts:
+            - name: config
+              mountPath: /config.yaml
+              subPath: access-log-exporter.yaml
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchLabels:
+                app.kubernetes.io/component: gateway
+                app.kubernetes.io/instance: 'loki'
+                app.kubernetes.io/name: 'loki'
+            topologyKey: kubernetes.io/hostname
+      volumes:
+        - name: config
+          configMap:
+            name: loki-gateway
+        - name: tmp
+          emptyDir: {}
+        - name: docker-entrypoint-d-override
+          emptyDir: {}
+---
+# Source: loki/templates/monolithic/statefulset.yaml
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: loki
+  namespace: monitoring
+  labels:
+    helm.sh/chart: loki-13.6.0
+    app.kubernetes.io/name: loki
+    app.kubernetes.io/instance: loki
+    app.kubernetes.io/version: "3.7.1"
+    app.kubernetes.io/component: single-binary
+    app.kubernetes.io/part-of: memberlist
+spec:
+  replicas: 1
+  podManagementPolicy: Parallel
+  updateStrategy:
+    rollingUpdate:
+      partition: 0
+  serviceName: loki-headless
+  revisionHistoryLimit: 10
+  
+  persistentVolumeClaimRetentionPolicy:
+    whenDeleted: Delete
+    whenScaled: Delete
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: loki
+      app.kubernetes.io/instance: loki
+      app.kubernetes.io/component: single-binary
+  template:
+    metadata:
+      annotations:
+        checksum/config: 55fe1393e2f13d7dcc93e5919ade67b2d9378fd62f76900a8506c42e492a79bb
+        storage/size: 10Gi
+        kubectl.kubernetes.io/default-container: "loki"
+      labels:
+        helm.sh/chart: loki-13.6.0
+        app.kubernetes.io/name: loki
+        app.kubernetes.io/instance: loki
+        app.kubernetes.io/version: "3.7.1"
+        app.kubernetes.io/component: single-binary
+        app.kubernetes.io/part-of: memberlist
+    spec:
+      serviceAccountName: loki
+      enableServiceLinks: true
+      automountServiceAccountToken: true
+      securityContext:
+        fsGroup: 10001
+        fsGroupChangePolicy: OnRootMismatch
+        runAsGroup: 10001
+        runAsNonRoot: true
+        runAsUser: 10001
+        seccompProfile:
+          type: RuntimeDefault
+      terminationGracePeriodSeconds: 30
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchLabels:
+                app.kubernetes.io/component: single-binary
+                app.kubernetes.io/instance: 'loki'
+                app.kubernetes.io/name: 'loki'
+            topologyKey: kubernetes.io/hostname
+      volumes:
+        - name: temp
+          emptyDir: {}
+        - name: config
+          configMap:
+            name: loki
+            items:
+              - key: "config.yaml"
+                path: "config.yaml"
+        - name: runtime-config
+          configMap:
+            name: loki-runtime
+        - name: sc-rules-volume
+          emptyDir: {}
+        - name: sc-rules-temp
+          emptyDir: {}
+      containers:
+        - name: loki
+          image: docker.io/grafana/loki:3.7.1
+          imagePullPolicy: IfNotPresent
+          args:
+            - -config.file=/etc/loki/config/config.yaml
+            - -config.expand-env=true
+            - -target=all
+          ports:
+            - name: http-metrics
+              containerPort: 3100
+              protocol: TCP
+            - name: grpc
+              containerPort: 9095
+              protocol: TCP
+            - name: http-memberlist
+              containerPort: 7946
+              protocol: TCP
+          env:
+            - name: GOMEMLIMIT
+              value: 1740MiB
+            - name: GOGC
+              value: "80"
+            - name: HASH_RING_INSTANCE_ADDR
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
+            seccompProfile:
+              type: RuntimeDefault
+          livenessProbe:
+            failureThreshold: 10
+            httpGet:
+              path: /loki/api/v1/status/buildinfo
+              port: http-metrics
+            periodSeconds: 30
+            successThreshold: 1
+            timeoutSeconds: 1
+          readinessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /ready
+              port: http-metrics
+            initialDelaySeconds: 15
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          volumeMounts:
+            - name: config
+              mountPath: /etc/loki/config
+            - name: runtime-config
+              mountPath: /etc/loki/runtime-config
+            - name: storage
+              mountPath: /var/loki
+            - name: temp
+              mountPath: /tmp
+            - name: sc-rules-volume
+              mountPath: "/rules"
+          resources:
+            limits:
+              cpu: 1
+              memory: 2Gi
+            requests:
+              cpu: 500m
+              memory: 1Gi
+        - name: loki-sc-rules
+          image: docker.io/kiwigrid/k8s-sidecar:2.7.1
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: http-sidecar
+              containerPort: 8080
+              protocol: TCP
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
+            seccompProfile:
+              type: RuntimeDefault
+          livenessProbe:
+                failureThreshold: 3
+                httpGet:
+                  path: /healthz
+                  port: http-sidecar
+                initialDelaySeconds: 30
+                periodSeconds: 30
+                successThreshold: 1
+                timeoutSeconds: 1
+          readinessProbe:
+                failureThreshold: 3
+                httpGet:
+                  path: /healthz
+                  port: http-sidecar
+                initialDelaySeconds: 3
+                periodSeconds: 10
+                successThreshold: 1
+                timeoutSeconds: 1
+          env:
+            - name: METHOD
+              value: WATCH
+            - name: LABEL
+              value: "loki_rule"
+            - name: FOLDER
+              value: "/rules"
+            - name: RESOURCE
+              value: "both"
+            - name: WATCH_SERVER_TIMEOUT
+              value: "60"
+            - name: WATCH_CLIENT_TIMEOUT
+              value: "60"
+            - name: LOG_LEVEL
+              value: "INFO"
+            - name: HEALTH_PORT
+              value: "8080"
+          volumeMounts:
+            - name: sc-rules-temp
+              mountPath: /tmp
+            - name: sc-rules-volume
+              mountPath: "/rules"
+  volumeClaimTemplates:
+    - apiVersion: v1
+      kind: PersistentVolumeClaim
+      metadata:
+        name: storage
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        storageClassName: gp3
+        resources:
+          requests:
+            storage: "10Gi"
+


### PR DESCRIPTION
## Summary

Phase 3 Sub-project 3 (Logs stack) の implementation。`grafana-community/loki` v13.6.0 (SingleBinary mode、Loki 3.7.1) + `fluent/fluent-bit` v0.57.3 を `monitoring` namespace に deploy。Sub-project 1 で provision 済の AWS infra (`loki-559744160976` bucket + `eks-production-loki` IAM role + `loki` Pod Identity SA) を活用、Sub-project 2 で確立した ServiceMonitor pattern + Grafana datasource 統合 path に従う。

**Architecture (中間状態):** Fluent Bit DaemonSet が container logs を tail → Loki Gateway 経由で SingleBinary に直接 push (= Decision 1)、Pod Identity 経由で S3 long-term storage。Sub-project 4 で OTel Collector deploy 後に Fluent Bit → OTel Collector → Loki に switching 予定。

## Spec / Plan

- Spec: `docs/superpowers/specs/2026-05-06-eks-production-observability-logs-stack-design.md` (12 Decisions、Sub-project 2 learnings 全項目適用)
- Plan: `docs/superpowers/plans/2026-05-06-eks-production-observability-logs-stack.md` (7 tasks)

## Notable Decisions

- **D1**: Logs flow = Fluent Bit → Loki 直接 push (中間状態)
- **D2**: Loki SingleBinary (Mimir Microservices と非対称、両 chart の official position 準拠)
- **D5**: chart = `grafana-community/loki` v13.6.0 (`grafana/loki` が GEL only に分離した結果として OSS continuation chart に移行)
- **D6**: local migration を本 sub-project に含める
- **D11**: HA upgrade path 明示 (1 replica で start、必要なら SimpleScalable + multi-AZ)

## Commits (9)

```
3fc5404 chore(kubernetes/manifests): hydrate fluent-bit + add to kustomization
3ecfa9d feat(eks): add Loki cross-stack values + Grafana datasource
611f56f fix(eks): use serviceMonitor.selector for Fluent Bit kube-prom label
74e9218 feat(eks): add production Fluent Bit (DaemonSet + Loki direct push)
8fe0157 fix(eks): drop Loki redundant tsdb_shipper + clarify common.storage
b29d1d4 feat(eks): add production Loki (Monolithic + S3 + Pod Identity)
fad99fb feat(kubernetes/components/loki/local): migrate to grafana-community/loki v13.6.0
cc0322c docs(eks): Phase 3 Sub-project 3 (Observability Logs stack) implementation plan
4653af7 docs(eks): Phase 3 Sub-project 3 (Observability Logs stack) design spec
```

## Pre-flight check

- [x] aws/eks-logs/ resource 存在 (S3 bucket + IAM role + Pod Identity Association、Task 0)
- [x] S3 bucket `loki-559744160976` head-bucket 200 OK + region ap-northeast-1 (Task 0)
- [x] Pod Identity Association `monitoring/loki` exists (Task 0)
- [x] gp3 StorageClass exists (= Sub-project 2 で provision 済再利用、Task 0)
- [x] Sub-project 2 stack 全 Pod Running (Task 0)
- [x] local Loki chart v7.0.0 → v13.6.0 migration verified (Task 1、k3d cluster なしで helmfile template + manifest sanity check)
- [x] kustomize build success (= 338 resources)、Loki + Fluent Bit + Grafana datasource entry 全件確認 (Task 5)

## Implementation review

各 task で subagent-driven-development の two-stage review (spec compliance + code quality) を実施:

| Task | implementer commit | spec review | code review |
|---|---|---|---|
| Task 1 | `fad99fb` | ✅ SPEC_COMPLIANT | APPROVED_WITH_NITS (polish のみ) |
| Task 2 | `b29d1d4` + fix `8fe01579` | ✅ SPEC_COMPLIANT | APPROVED_WITH_NITS → fix で resolve |
| Task 3 | `74e9218` + fix `611f56f` | ✅ SPEC_COMPLIANT | runtime fix (= serviceMonitor.selector key) |
| Task 4 | `3ecfa9d` | ✅ SPEC_COMPLIANT | ✅ APPROVED |
| Task 5 | `3fc5404` | ✅ APPROVED | ✅ APPROVED |

主要 fix:
1. **`storage_config.tsdb_shipper` redundant override 削除** (Task 2 fix `8fe01579`): Loki 2.x boltdb-shipper 時代の concept、Loki 3.7.1 では schema_config から自動決定
2. **`serviceMonitor.additionalLabels` → `selector` key 名修正** (Task 3 fix `611f56f`): chart v0.57.3 で `additionalLabels` は dead key、`selector` が正しい。修正なしだと runtime で Prometheus auto-scrape が機能しない potential issue
3. **chart v13 schema breaking changes 対応**: `deploymentMode: SingleBinary` → `Monolithic` rename / `monitoring.selfMonitoring` 削除 / `resultsCache:` camelCase

## Test plan (post-flight, after merge)

### 10 分以内
- [ ] Loki SingleBinary `1/1 Running`
- [ ] Loki Gateway `1/1 Running`
- [ ] Fluent Bit DaemonSet が全 node で `1/1 Running`
- [ ] PVC `storage-loki-0` Bound (gp3 10Gi)
- [ ] Prometheus targets で `loki` / `fluent-bit` が `UP`

### 30 分以内
- [ ] S3 (`loki-559744160976/production/`) に chunks 出現
- [ ] Grafana Explore で `{namespace="monitoring"}` query が logs を返す
- [ ] Sub-project 2 stack regression なし (Mimir / Prometheus / Alertmanager / Grafana 全 Running、Mimir gateway `/ready` OK)

## Sub-project 2 learnings 適用

| Sub-project 2 learnings | 本 PR での適用 |
|---|---|
| L1 (chart upgrade での upstream changelog 確認) | D5: `grafana/loki` → `grafana-community/loki` organizational migration を発見、適切な OSS chart に切替 |
| L2 (chart auto-generated ConfigMap と values override の衝突) | Sub-project 2 PR #289 の `defaultDatasourceEnabled: false` 設定継続、新たな衝突なし。Loki side では Task 2 fix `8fe01579` で `common.storage` NOTE 追加 |
| L3 (EBS RWO + RollingUpdate → Recreate) | Loki SingleBinary は StatefulSet (OrderedReady)、Loki Gateway は Deployment + PVC なし、新規 Recreate 不要 |
| L4 (Spec verification を pre-flight / post-flight 分割) | 本 PR description に Pre-flight check + Test plan 明示分離 |
| L5 (Flux suspend pattern) | 通常 deploy で進める、問題発見時のみ reactive 発動 (= Rollback 手順は spec に記録済) |
| L6 (gp3 StorageClass) | Sub-project 2 で provision 済再利用 |
| L7 (Pod Identity webhook injection) | 新規 deploy のため初回起動時に正しく injection、force-delete シナリオなし |
| L8 (storage_prefix 英数字制約) | Loki でも `production` (slash なし) を採用、TSDB schema index prefix `production_index_` も英数字 + underscore |

## Rollback 手順 (想定外障害時)

```bash
flux suspend kustomization flux-system
kubectl delete -k kubernetes/manifests/production/loki/
kubectl delete -k kubernetes/manifests/production/fluent-bit/
kubectl get pods -n monitoring | grep -v loki | grep -v fluent-bit  # Sub-project 2 影響なき確認
gh pr create --title "revert: Phase 3 Sub-project 3 (Logs stack)" ...
flux reconcile source git flux-system
flux resume kustomization flux-system
```

aws/eks-logs/ は Sub-project 1 で provision 済 = AWS-side rollback 不要。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added comprehensive observability logging stack implementation with log collection and centralized storage.
  * Deployed production Fluent Bit configuration for collecting logs from Kubernetes environments.
  * Deployed production Loki configuration with S3-backed storage for log aggregation and querying.
  * Integrated Loki with Grafana to enable log visualization and exploration.

* **Documentation**
  * Added detailed implementation plan and design specification for the observability logs stack.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->