### PR TITLE
feat(eks): Phase 3 Sub-project 4a — Traces foundation (Tempo + OTel)

### DIFF
--- a/docs/superpowers/plans/2026-05-06-eks-production-observability-traces-stack-foundation.md
+++ b/docs/superpowers/plans/2026-05-06-eks-production-observability-traces-stack-foundation.md
@@ -1,0 +1,995 @@
+# EKS Production: Observability Traces Stack Foundation (Phase 3 Sub-project 4a) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** panicboat EKS production cluster に traces collection 基盤を deploy。`grafana/tempo` v1.24.4 (Monolithic mode、Tempo 2.9.0) + `opentelemetry/opentelemetry-collector` v0.153.0 を `monitoring` namespace に deploy。Sub-project 1 で provision 済 + Sub-project 3 fix で bucket-wide IAM 適用済の AWS infra を活用、Sub-project 2 / 3 で確立した monitoring namespace + ServiceMonitor pattern + Grafana datasource 統合 path に従う。本 sub-project (4a) 完了時は traces pipeline 基盤が ready、Sub-project 4b で sources (Beyla / Hubble / Fluent Bit) を接続して data flow 成立。
+
+**Architecture:** Tempo Monolithic StatefulSet で S3 backend (`tempo-559744160976`) に Pod Identity 経由でアクセス。OTel Collector Deployment で OTLP receivers + Tempo exporter のみの **traces pipeline** を 4a で完成、metrics / logs pipelines は 4b で追加。Mimir / Loki / Tempo 3 stack で application retention OFF + S3 lifecycle 担保 + bucket-wide IAM + application-level prefix env scope の panicboat pattern が完全に揃う。
+
+**Tech Stack:** Helm + helmfile / `grafana/tempo` v1.24.4 (Tempo 2.9.0) / `opentelemetry/opentelemetry-collector` v0.153.0 (= contrib 0.151.0) / EBS gp3 PVC / EKS Pod Identity / S3 backend (Sub-project 1 outputs)
+
+**Spec:** `docs/superpowers/specs/2026-05-06-eks-production-observability-traces-stack-foundation-design.md`
+
+---
+
+## File Structure
+
+新規作成 / 変更ファイル:
+
+**Kubernetes 新規 (tempo/production):**
+```
+kubernetes/components/tempo/production/
+├── helmfile.yaml                      # grafana/tempo chart v1.24.4
+└── values.yaml.gotmpl                 # Monolithic mode + S3 backend + Pod Identity
+```
+
+**Kubernetes 新規 (opentelemetry-collector/production):**
+```
+kubernetes/components/opentelemetry-collector/production/
+├── helmfile.yaml                      # opentelemetry/opentelemetry-collector chart v0.153.0
+└── values.yaml.gotmpl                 # Deployment mode + traces pipeline (= 4a 範囲)
+```
+
+**Kubernetes 変更 (production):**
+```
+kubernetes/helmfile.yaml.gotmpl                                        # production env values block に tempo cross-stack values 追加
+kubernetes/components/prometheus-operator/production/values.yaml.gotmpl   # Grafana datasources に Tempo entry 追加
+kubernetes/manifests/production/kustomization.yaml                     # ./tempo + ./opentelemetry-collector を resources に追加 (auto-insert)
+kubernetes/manifests/production/prometheus-operator/manifest.yaml      # 再 hydrate (= datasources Secret 反映)
+```
+
+**Kubernetes 自動生成 (production hydrate output):**
+```
+kubernetes/manifests/production/tempo/{kustomization.yaml, manifest.yaml}
+kubernetes/manifests/production/opentelemetry-collector/{kustomization.yaml, manifest.yaml}
+```
+
+**変更しないファイル**: aws/eks-traces/* / kubernetes/components/*/local/* / kubernetes/README.md / kubernetes/components/{beyla,opentelemetry,fluent-bit,cilium}/production/
+
+---
+
+## Task 0: Pre-flight + branch state verify
+
+**Files:** (確認のみ、変更なし)
+
+- [ ] **Step 1: Branch state 確認**
+
+```bash
+cd /Users/takanokenichi/GitHub/panicboat/platform/.claude/worktrees/feat/eks-production-observability-traces-stack-foundation
+git fetch origin main
+git log --oneline origin/main..HEAD
+```
+
+Expected: spec commit 1 つのみ ahead (= `0f5ae57 docs(eks): Phase 3 Sub-project 4a (Traces foundation) design spec`)
+
+- [ ] **Step 2: aws/eks-traces/ resource 存在確認 (terragrunt state)**
+
+```bash
+cd aws/eks-traces/envs/production
+TG_TF_PATH=tofu terragrunt state list 2>&1 | tee /tmp/eks-traces-state.txt
+```
+
+Expected: 8 resources
+```
+aws_eks_pod_identity_association.this
+aws_iam_role.pod_identity
+aws_iam_role_policy.s3_access
+module.s3.aws_s3_bucket.this[0]
+module.s3.aws_s3_bucket_lifecycle_configuration.this[0]
+module.s3.aws_s3_bucket_public_access_block.this[0]
+module.s3.aws_s3_bucket_server_side_encryption_configuration.this[0]
+module.s3.aws_s3_bucket_versioning.this[0]
+```
+
+- [ ] **Step 3: S3 bucket actual existence + lifecycle (base role)**
+
+```bash
+zsh -ic 'unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_SESSION_TOKEN
+aws s3api head-bucket --bucket tempo-559744160976
+aws s3api get-bucket-location --bucket tempo-559744160976
+aws s3api get-bucket-lifecycle-configuration --bucket tempo-559744160976 --query "Rules[*].Expiration.Days"'
+```
+
+Expected: 200 OK + `LocationConstraint: ap-northeast-1` + `[7]` (= 7d retention)
+
+- [ ] **Step 4: Pod Identity Association 確認 (base role)**
+
+```bash
+zsh -ic 'unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_SESSION_TOKEN
+aws eks list-pod-identity-associations --cluster-name eks-production --region ap-northeast-1 \
+  --query "associations[?serviceAccount==\`tempo\`]"'
+```
+
+Expected:
+```json
+[
+    {
+        "namespace": "monitoring",
+        "serviceAccount": "tempo",
+        "associationArn": "arn:aws:eks:ap-northeast-1:559744160976:podidentityassociation/eks-production/a-...",
+        "associationId": "a-..."
+    }
+]
+```
+
+- [ ] **Step 5: IAM bucket-wide 確認 (Sub-project 3 fix 反映)**
+
+```bash
+zsh -ic 'unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_SESSION_TOKEN
+aws iam get-role-policy --role-name eks-production-tempo --policy-name s3-access \
+  --query "PolicyDocument.Statement[?Sid==\`ObjectLevelOperations\`].Resource"'
+```
+
+Expected: `["arn:aws:s3:::tempo-559744160976/*"]` (= bucket-wide、Sub-project 3 fix で `${bucket}/${env}/*` から拡張済)
+
+- [ ] **Step 6: Cluster state 確認 (kubectl context)**
+
+```bash
+zsh -ic 'eks-login production >/dev/null 2>&1
+echo "--- gp3 StorageClass ---"
+kubectl get storageclass gp3
+echo ""
+echo "--- Sub-project 2 / 3 stack 稼働状態 ---"
+kubectl get pods -n monitoring | grep -E "prometheus|alertmanager|grafana|mimir|loki|fluent-bit"'
+```
+
+Expected:
+- `gp3` StorageClass exists (provisioner: `ebs.csi.aws.com`)
+- monitoring ns に Prometheus / Alertmanager / Grafana / Mimir / Loki / Fluent Bit 全 component が `Running`
+
+- [ ] **Step 7: Flux state 確認 (suspended でないこと)**
+
+```bash
+zsh -ic 'eks-login production >/dev/null 2>&1
+flux get kustomizations 2>&1'
+```
+
+Expected: `flux-system` `SUSPENDED=False`、`READY=True`、`Applied revision: main@sha1:e2df912` (= 直近 main = Sub-project 3 learnings PR #293 merge 済) もしくはそれ以降の commit
+
+---
+
+## Task 1: production Tempo component (`kubernetes/components/tempo/production/`)
+
+**Files:**
+- Create: `kubernetes/components/tempo/production/helmfile.yaml`
+- Create: `kubernetes/components/tempo/production/values.yaml.gotmpl`
+
+**Context:** Sub-project 2 (mimir/production) / Sub-project 3 (loki/production) と同形 pattern を踏襲。Tempo Monolithic mode + S3 backend (`tempo-559744160976`) + Pod Identity (`tempo` SA) + ServiceMonitor enable + 7d retention は S3 lifecycle で担保 (application retention OFF)。
+
+### Step 1: helmfile.yaml を作成
+
+```yaml
+# =============================================================================
+# Tempo Helmfile for production
+# =============================================================================
+# Phase 3 Sub-project 4a で deploy する Traces stack の Tempo 本体。
+# Monolithic mode (= chart 内蔵の single binary deploy、distributor + ingester +
+# querier + compactor を 1 process に統合、small production OK の Tempo 公式
+# position に準拠)。S3 backend は Sub-project 1 で provision 済の
+# tempo-559744160976 を Pod Identity 経由でアクセス。
+#
+# Decision references:
+# - D3: Monolithic mode (HA upgrade path 保持、Phase 4 で grafana/tempo-distributed への切替検討)
+# - D5: application retention OFF (chart default)、S3 lifecycle 7d で担保
+# - D7: bucket-wide IAM (Sub-project 3 fix で 3 stack 同型済) + application-level
+#       prefix env scope (s3.prefix: production)
+# - D8: multitenancy OFF (1 tenant 運用、Mimir / Loki と対称)
+# - D12: PVC 10Gi gp3 (WAL + 短期 compactor cache)
+# =============================================================================
+environments:
+  production:
+    # NOTE: helmfile v1.4 は親 helmfile.yaml.gotmpl の environments values を
+    # 子 helmfile に auto-inherit しないため、ここで再定義する。
+    # 値は kubernetes/helmfile.yaml.gotmpl の production env block と
+    # 同期すること (tempo.bucketName / tempo.bucketPathPrefix)。
+    values:
+      - tempo:
+          bucketName: tempo-559744160976
+          bucketPathPrefix: production
+---
+repositories:
+  - name: grafana
+    url: https://grafana.github.io/helm-charts
+
+releases:
+  - name: tempo
+    namespace: monitoring
+    chart: grafana/tempo
+    version: "1.24.4"
+    values:
+      - values.yaml.gotmpl
+```
+
+### Step 2: values.yaml.gotmpl を作成
+
+```yaml
+# Tempo Configuration for production
+# Monolithic mode + S3 backend (Sub-project 1 outputs) + Pod Identity (tempo SA)
+
+# =============================================================================
+# Tempo Core Configuration
+# =============================================================================
+tempo:
+  # 1 tenant 運用 (panicboat) のため multitenancy OFF (Decision 8)
+  multitenancyEnabled: false
+
+  # -------------------------------------------------------------------------
+  # Resources (small production)
+  # -------------------------------------------------------------------------
+  resources:
+    requests:
+      cpu: 200m
+      memory: 512Mi
+    limits:
+      cpu: 1
+      memory: 2Gi
+
+  # -------------------------------------------------------------------------
+  # Storage Config (S3 backend, Sub-project 1 outputs)
+  # -------------------------------------------------------------------------
+  storage:
+    trace:
+      backend: s3
+      s3:
+        bucket: {{ .Values.tempo.bucketName }}
+        endpoint: s3.ap-northeast-1.amazonaws.com
+        # application-level env scope (= Sub-project 3 L2 適用、IAM bucket-wide と整合)
+        prefix: {{ .Values.tempo.bucketPathPrefix }}
+        # AWS S3 native (HTTPS) = insecure: false (default)
+        # Pod Identity 経由のため access_key / secret_key 不要
+
+  # -------------------------------------------------------------------------
+  # Receivers (= 4b で OTel Collector からの OTLP 受信用、4a では未接続)
+  # -------------------------------------------------------------------------
+  receivers:
+    otlp:
+      protocols:
+        grpc:
+          endpoint: 0.0.0.0:4317
+        http:
+          endpoint: 0.0.0.0:4318
+
+  # -------------------------------------------------------------------------
+  # Retention 機能は OFF (= chart default に任せる、Decision 5)
+  # -------------------------------------------------------------------------
+  # NOTE: 3 stack で application retention は OFF + S3 lifecycle で uniform 担保
+  # の panicboat pattern (Sub-project 3 L4 適用)。Tempo 内 retention 機能は
+  # per-tenant rules 等の advanced feature 用、panicboat の uniform 7d retention
+  # は aws/eks-traces/ S3 lifecycle で担保。
+
+  # -------------------------------------------------------------------------
+  # Metrics generator は OFF (= advanced features、Phase 4 で再検討)
+  # -------------------------------------------------------------------------
+  metricsGenerator:
+    enabled: false
+
+# =============================================================================
+# ServiceAccount (Pod Identity for S3 access)
+# =============================================================================
+serviceAccount:
+  create: true
+  # aws/eks-traces/ で provision 済の Pod Identity Association が
+  # monitoring/tempo SA を IAM role eks-production-tempo に紐付け済
+  name: tempo
+  # Pod Identity は IRSA と異なり annotation 不要 (cluster-side で managed)
+  annotations: {}
+
+# =============================================================================
+# Persistence (= WAL + 短期 compactor cache、Decision 12)
+# =============================================================================
+persistence:
+  enabled: true
+  storageClassName: gp3
+  size: 10Gi
+  accessModes:
+    - ReadWriteOnce
+
+# =============================================================================
+# Service Configuration
+# =============================================================================
+service:
+  type: ClusterIP
+
+# =============================================================================
+# ServiceMonitor (Prometheus auto-scrape, Decision 9)
+# =============================================================================
+# NOTE: chart の serviceMonitor key 名は `additionalLabels` (Tempo chart 固有)。
+# OTel Collector chart の `extraLabels` とは別 key 名なので注意 (Sub-project 3 L3
+# = chart probe / serviceMonitor key 確認の実装段階精査の結果)。
+serviceMonitor:
+  enabled: true
+  additionalLabels:
+    release: kube-prometheus-stack
+  interval: 15s
+```
+
+### Step 3: helmfile template で render verify
+
+```bash
+cd /Users/takanokenichi/GitHub/panicboat/platform/.claude/worktrees/feat/eks-production-observability-traces-stack-foundation/kubernetes
+make hydrate-component COMPONENT=tempo ENV=production
+```
+
+Expected:
+- error なく完了
+- `kubernetes/manifests/production/tempo/manifest.yaml` が新規生成される
+- 中身に以下が含まれる:
+  - `kind: StatefulSet` (tempo)
+  - `kind: Service` (tempo)
+  - `kind: ServiceMonitor` (Prometheus auto-scrape) — local の CRD 不在で skip される可能性あり、production deploy 時には正常生成
+  - `kind: ServiceAccount` (name: tempo)
+  - `bucket: tempo-559744160976` (storage.trace.s3)
+  - `prefix: production` (storage.trace.s3)
+  - `multitenancy_enabled: false` (Tempo runtime config)
+  - `storageClassName: gp3`
+
+確認:
+```bash
+grep -E "kind:|bucket:|prefix:|multitenancy_enabled|storageClassName" kubernetes/manifests/production/tempo/manifest.yaml | head -20
+```
+
+### Step 4: Commit
+
+```bash
+git add kubernetes/components/tempo/production/
+git commit -s -m "feat(eks): add production Tempo (Monolithic + S3 + Pod Identity)
+
+Phase 3 Sub-project 4a で deploy する Traces stack の Tempo 本体。
+grafana/tempo v1.24.4 (Tempo 2.9.0) chart の Monolithic mode で 1 StatefulSet
+構成、Pod Identity (tempo SA) 経由で S3 (tempo-559744160976) backend に
+アクセス。
+
+主要設定:
+- multitenancyEnabled: false (1 tenant 運用、Decision 8)
+- storage.trace.backend: s3 + s3.prefix: production (= application-level
+  env scope、Sub-project 3 L2 適用、IAM bucket-wide と整合)
+- application retention は OFF (chart default、Decision 5)、S3 lifecycle 7d
+  で uniform 担保 = 3 stack 一貫 pattern (Mimir/Loki/Tempo)
+- metricsGenerator: false (advanced features、Phase 4 で再検討)
+- ServiceMonitor enabled with additionalLabels: release: kube-prometheus-stack
+  (Tempo chart 固有 key、Sub-project 3 L3 で chart 別 key 名確認済)
+- gp3 PVC 10Gi (Sub-project 2 で provision 済 StorageClass 再利用)
+
+Refs: docs/superpowers/specs/2026-05-06-eks-production-observability-traces-stack-foundation-design.md
+      Decision 3 / 5 / 7 / 8 / 9 / 12"
+```
+
+`echo -n "feat(eks): add production Tempo (Monolithic + S3 + Pod Identity)" | wc -m` で文字数確認 (= 概ね 65 chars、≤ 72 OK)。
+
+---
+
+## Task 2: production OTel Collector component (`kubernetes/components/opentelemetry-collector/production/`)
+
+**Files:**
+- Create: `kubernetes/components/opentelemetry-collector/production/helmfile.yaml`
+- Create: `kubernetes/components/opentelemetry-collector/production/values.yaml.gotmpl`
+
+**Context:** OTel Collector Deployment mode + 4a では traces pipeline のみ (= receivers OTLP + Tempo exporter)。chart default の logs / metrics pipelines は active のまま放置 (= 4b で source 接続、4a では effective に inactive)。Sub-project 3 L3 適用で chart-specific key 名 (`extraLabels` for serviceMonitor、`ports.metrics.enabled: true` 必須) を実装段階で精査。
+
+### Step 1: helmfile.yaml を作成
+
+```yaml
+# =============================================================================
+# OpenTelemetry Collector Helmfile for production
+# =============================================================================
+# Phase 3 Sub-project 4a で deploy する Traces stack の OTel Collector。
+# Deployment mode で 1 replica の集約 hub として deploy。4a では OTLP receivers
+# + Tempo exporter のみの traces pipeline を完成、metrics / logs pipelines は
+# 4b で sources (Beyla / Hubble / Fluent Bit) 接続と同時に追加。
+#
+# Decision references:
+# - D2: OpenTelemetry Operator は production deploy しない (YAGNI)
+# - D4: Deployment + replicas=1 (集約 hub、HA upgrade path 保持)
+# - D6: chart version v0.153.0 (= local 揃い、最新と一致)
+# - D11: 4a では traces pipeline のみ scope、metrics / logs は 4b で追加
+# =============================================================================
+environments:
+  production:
+---
+repositories:
+  - name: opentelemetry
+    url: https://open-telemetry.github.io/opentelemetry-helm-charts
+
+releases:
+  - name: opentelemetry-collector
+    namespace: monitoring
+    chart: opentelemetry/opentelemetry-collector
+    version: "0.153.0"
+    values:
+      - values.yaml.gotmpl
+```
+
+### Step 2: values.yaml.gotmpl を作成
+
+```yaml
+# OpenTelemetry Collector Configuration for production
+# Deployment mode + 4a では traces pipeline only (Decision 11、metrics/logs は 4b で追加)
+
+# =============================================================================
+# Deployment Mode (Decision 4)
+# =============================================================================
+mode: deployment
+replicaCount: 1
+
+# =============================================================================
+# Image (contrib for k8sattributes processor 等の拡張機能、4b で利用)
+# =============================================================================
+image:
+  repository: otel/opentelemetry-collector-contrib
+  tag: 0.151.0
+
+# =============================================================================
+# Resources (small production)
+# =============================================================================
+resources:
+  requests:
+    cpu: 100m
+    memory: 256Mi
+  limits:
+    cpu: 500m
+    memory: 1Gi
+
+# =============================================================================
+# Service Configuration
+# =============================================================================
+service:
+  type: ClusterIP
+
+# =============================================================================
+# Ports (= metrics port を必ず enable、ServiceMonitor 用)
+# =============================================================================
+# NOTE: chart README に明記「The metrics port is disabled by default. However
+# you need to enable the port in order to use the ServiceMonitor」。Sub-project 3
+# L3 (chart probe / port enable 設定の実装段階精査) を適用、明示的に enable する。
+ports:
+  metrics:
+    enabled: true
+    containerPort: 8888
+    servicePort: 8888
+    protocol: TCP
+
+# =============================================================================
+# ServiceMonitor (Prometheus auto-scrape, Decision 9)
+# =============================================================================
+# NOTE: chart の serviceMonitor key 名は `extraLabels` (OTel Collector chart 固有)。
+# Tempo chart の `additionalLabels`、fluent-bit chart の `selector` とは別 key
+# 名なので注意 (Sub-project 3 L3 = chart 固有 key 確認の実装段階精査の結果)。
+serviceMonitor:
+  enabled: true
+  extraLabels:
+    release: kube-prometheus-stack
+  metricsEndpoints:
+    - port: metrics
+      interval: 15s
+
+# =============================================================================
+# Collector Config (4a 範囲 = traces pipeline のみ override、Decision 11)
+# =============================================================================
+# NOTE: chart default で logs / metrics pipelines も pre-configure されるが、
+# 4a では source 未接続 (= 4b で wire up 予定) のため effective に inactive。
+# 4b で metrics / logs sources (Hubble / Beyla / Fluent Bit) を接続するときに
+# pipelines を実利用化する。本 4a で override するのは:
+#   1. exporters: otlp/tempo を追加 (= traces を Tempo に export)
+#   2. service.pipelines.traces: chart default の exporters [debug] を
+#      [otlp/tempo] に上書き
+config:
+  exporters:
+    # 4a で追加: Tempo exporter (4b で metrics / logs exporters 追加予定)
+    otlp/tempo:
+      endpoint: tempo.monitoring.svc.cluster.local:4317
+      tls:
+        insecure: true
+  service:
+    pipelines:
+      traces:
+        # chart default の exporters: [debug] を override、Tempo に export
+        exporters:
+          - otlp/tempo
+        # processors / receivers は chart default を継承 (= memory_limiter + batch / otlp)
+        processors:
+          - memory_limiter
+          - batch
+        receivers:
+          - otlp
+```
+
+### Step 3: helmfile template で render verify
+
+```bash
+cd /Users/takanokenichi/GitHub/panicboat/platform/.claude/worktrees/feat/eks-production-observability-traces-stack-foundation/kubernetes
+make hydrate-component COMPONENT=opentelemetry-collector ENV=production
+```
+
+Expected:
+- error なく完了
+- `kubernetes/manifests/production/opentelemetry-collector/manifest.yaml` が新規生成される
+- 中身に以下が含まれる:
+  - `kind: Deployment` (opentelemetry-collector)
+  - `kind: Service` (opentelemetry-collector + opentelemetry-collector-monitoring)
+  - `kind: ConfigMap` (opentelemetry-collector の config)
+  - `kind: ServiceMonitor` (Prometheus auto-scrape) — local の CRD 不在で skip される可能性あり
+  - `kind: ServiceAccount` (default name)
+  - ConfigMap 内 config に `otlp/tempo` exporter + `tempo.monitoring.svc.cluster.local:4317` endpoint
+  - ConfigMap 内 service.pipelines.traces に `exporters: [otlp/tempo]`
+  - service の `metrics` port (= 8888) が expose されている
+
+確認:
+```bash
+grep -E "kind:|otlp/tempo|tempo.monitoring|port: 8888|metrics" kubernetes/manifests/production/opentelemetry-collector/manifest.yaml | head -15
+```
+
+### Step 4: Commit
+
+```bash
+git add kubernetes/components/opentelemetry-collector/production/
+git commit -s -m "feat(eks): add production OTel Collector (Deployment + traces pipeline)
+
+Phase 3 Sub-project 4a で deploy する Traces stack の集約 hub。
+opentelemetry/opentelemetry-collector v0.153.0 (= contrib 0.151.0) chart の
+Deployment mode で 1 replica、OTLP receivers (gRPC + HTTP) + Tempo exporter
+の traces pipeline を 4a で完成。metrics / logs pipelines は 4b で source
+接続と同時に追加 (Decision 11)。
+
+主要設定:
+- mode: deployment (Decision 4、集約 hub)
+- replicaCount: 1 (small production、HA upgrade path 保持)
+- image: contrib (= k8sattributes processor 等の拡張機能、4b で利用)
+- ports.metrics.enabled: true (ServiceMonitor 用、chart README に明記の必須設定)
+- serviceMonitor.extraLabels.release: kube-prometheus-stack (chart 固有 key、
+  Sub-project 3 L3 で chart 別 key 名確認済)
+- config.exporters.otlp/tempo: tempo.monitoring.svc.cluster.local:4317
+- config.service.pipelines.traces.exporters: [otlp/tempo] (chart default の
+  [debug] を override)
+
+chart default の logs / metrics pipelines は active のまま放置 (= 4b で
+source 接続予定、4a では effective に inactive、debug exporter で stdout
+に何も流れない)。
+
+Refs: docs/superpowers/specs/2026-05-06-eks-production-observability-traces-stack-foundation-design.md
+      Decision 2 / 4 / 6 / 9 / 11"
+```
+
+`echo -n "feat(eks): add production OTel Collector (Deployment + traces pipeline)" | wc -m` で文字数確認 (= 概ね 70 chars、≤ 72 OK)。
+
+---
+
+## Task 3: Cross-stack values + Grafana datasource update
+
+**Files:**
+- Modify: `kubernetes/helmfile.yaml.gotmpl`
+- Modify: `kubernetes/components/prometheus-operator/production/values.yaml.gotmpl`
+
+**Context:** Plan 1c-β L4 pattern (= placeholder 不採用、直接実値書き) を踏襲。Grafana datasource は Sub-project 2 / 3 で確立した pattern (= `datasources.yaml` に追加)、default は Mimir 維持 (Decision 10)。
+
+### Step 1: kubernetes/helmfile.yaml.gotmpl の production env values block に tempo cross-stack values を追加
+
+現状の関連箇所を確認:
+```bash
+grep -n -B 2 -A 30 "production:" kubernetes/helmfile.yaml.gotmpl | head -50
+```
+
+production env block の `loki:` 直下に同形の `tempo:` block を追加 (alphabetical ではなく既存 mimir / loki の順序で後ろに、Sub-project 3 で確立した pattern):
+
+`kubernetes/helmfile.yaml.gotmpl` の production env values block 内、`loki:` block の終端 (`podIdentityRoleName: eks-production-loki`) の **直後** に以下を挿入:
+
+```yaml
+        tempo:
+          # Source: aws/eks-traces/envs/production terragrunt output
+          bucketName: tempo-559744160976
+          bucketPathPrefix: production
+          podIdentityRoleName: eks-production-tempo
+```
+
+確認 (実装後):
+```bash
+grep -A 4 "tempo:" kubernetes/helmfile.yaml.gotmpl
+```
+
+Expected: `bucketName: tempo-559744160976` + `bucketPathPrefix: production` + `podIdentityRoleName: eks-production-tempo`
+
+### Step 2: kubernetes/components/prometheus-operator/production/values.yaml.gotmpl で Grafana datasource に Tempo entry を追加
+
+現状の `grafana.datasources.datasources.yaml.datasources` block を確認:
+```bash
+grep -n -B 2 -A 50 "datasources:" kubernetes/components/prometheus-operator/production/values.yaml.gotmpl | head -60
+```
+
+`Loki` entry の **後ろ** に Tempo entry を追加 (Mimir = default 維持、Tempo = `isDefault: false`、Decision 10):
+
+`Loki` entry の最後 (`secureJsonData.httpHeaderValue1: anonymous` 行) の **直後** に以下を挿入:
+
+```yaml
+        # Phase 3 Sub-project 4a (Traces stack foundation)
+        - name: Tempo
+          uid: tempo
+          type: tempo
+          url: http://tempo.monitoring.svc.cluster.local:3200
+          access: proxy
+          isDefault: false
+          jsonData:
+            # 1 tenant 運用 (= Decision 8、multitenancy OFF)
+            httpMethod: GET
+            tracesToLogsV2:
+              datasourceUid: loki
+            tracesToMetrics:
+              datasourceUid: mimir
+```
+
+加えて、section header コメントを更新 (= Sub-project 3 で `# Data Sources (Mimir primary、Prometheus local secondary、Loki logs)` とした箇所):
+
+```yaml
+  # -------------------------------------------------------------------------
+  # Data Sources (Mimir primary、Prometheus local secondary、Loki logs、Tempo traces)
+  # -------------------------------------------------------------------------
+```
+
+確認:
+```bash
+grep -B 1 -A 12 "name: Tempo" kubernetes/components/prometheus-operator/production/values.yaml.gotmpl
+```
+
+Expected: 上記 Tempo entry 全体が返る。
+
+### Step 3: Re-hydrate prometheus-operator manifest
+
+```bash
+cd /Users/takanokenichi/GitHub/panicboat/platform/.claude/worktrees/feat/eks-production-observability-traces-stack-foundation/kubernetes
+make hydrate-component COMPONENT=prometheus-operator ENV=production
+```
+
+Expected:
+- error なく完了
+- `kubernetes/manifests/production/prometheus-operator/manifest.yaml` の Grafana datasources Secret (= `kube-prometheus-stack-grafana` Secret) で `name: Tempo` entry が含まれる diff
+
+確認:
+```bash
+git diff kubernetes/manifests/production/prometheus-operator/manifest.yaml | head -40
+```
+
+Expected: `name: Tempo` / `type: tempo` / `url: http://tempo.monitoring.svc.cluster.local:3200` の追加 diff が含まれる。
+
+### Step 4: Commit
+
+```bash
+git add kubernetes/helmfile.yaml.gotmpl \
+        kubernetes/components/prometheus-operator/production/values.yaml.gotmpl \
+        kubernetes/manifests/production/prometheus-operator/manifest.yaml
+git commit -s -m "feat(eks): add Tempo cross-stack values + Grafana datasource
+
+Phase 3 Sub-project 4a Task 3: Tempo integration の cross-stack 連携。
+
+1. kubernetes/helmfile.yaml.gotmpl
+   production env values block に tempo: bucketName / bucketPathPrefix /
+   podIdentityRoleName を追加 (Sub-project 1 outputs と整合、Plan 1c-β L4
+   pattern で直接実値書き)。
+
+2. kubernetes/components/prometheus-operator/production/values.yaml.gotmpl
+   grafana.datasources.datasources.yaml.datasources に Tempo entry 追加。
+   Mimir = default 維持 (Decision 10)、Tempo = isDefault: false。
+   tracesToLogs / tracesToMetrics で Loki / Mimir との correlation を設定。
+
+3. prometheus-operator manifest を再 hydrate、datasources Secret 反映。
+
+Refs: docs/superpowers/specs/2026-05-06-eks-production-observability-traces-stack-foundation-design.md
+      Decision 9 / 10"
+```
+
+`echo -n "feat(eks): add Tempo cross-stack values + Grafana datasource" | wc -m` で文字数確認 (= 60 chars、≤ 72 OK)。
+
+---
+
+## Task 4: Hydrate manifests + kustomization update
+
+**Files:**
+- Auto-generate: `kubernetes/manifests/production/tempo/{kustomization.yaml, manifest.yaml}`
+- Auto-generate: `kubernetes/manifests/production/opentelemetry-collector/{kustomization.yaml, manifest.yaml}`
+- Modify: `kubernetes/manifests/production/kustomization.yaml`
+
+**Context:** Sub-project 3 で確認した `make hydrate-index` の auto-insert 挙動で、`kustomization.yaml` に `./tempo` + `./opentelemetry-collector` が alphabetical 位置に追加される。
+
+### Step 1: hydrate-index で manifests/production/ を再生成 + cleanup
+
+```bash
+cd /Users/takanokenichi/GitHub/panicboat/platform/.claude/worktrees/feat/eks-production-observability-traces-stack-foundation/kubernetes
+make hydrate-index ENV=production
+```
+
+Expected:
+- `kubernetes/manifests/production/tempo/kustomization.yaml` が新規作成される (`resources: [manifest.yaml]`)
+- `kubernetes/manifests/production/opentelemetry-collector/kustomization.yaml` が新規作成される
+- 既存の tempo / opentelemetry-collector manifest.yaml も再生成
+- `kubernetes/manifests/production/kustomization.yaml` の resources に `./tempo` + `./opentelemetry-collector` が auto-insert される
+
+確認:
+```bash
+ls kubernetes/manifests/production/tempo/
+ls kubernetes/manifests/production/opentelemetry-collector/
+cat kubernetes/manifests/production/kustomization.yaml
+```
+
+Expected (`kubernetes/manifests/production/kustomization.yaml`):
+```yaml
+resources:
+  - ./00-namespaces
+  - ./aws-load-balancer-controller
+  - ./cilium
+  - ./external-dns
+  - ./fluent-bit
+  - ./gateway-api
+  - ./karpenter
+  - ./keda
+  - ./loki
+  - ./metrics-server
+  - ./mimir
+  - ./opentelemetry-collector  # ← 4a で auto-insert (alphabetical: mimir < opentelemetry-collector < prometheus-operator)
+  - ./prometheus-operator
+  - ./storage-class
+  - ./tempo                    # ← 4a で auto-insert (alphabetical: storage-class < tempo)
+```
+
+15 entries (= 13 既存 + ./tempo + ./opentelemetry-collector の 2 件追加)。
+
+### Step 2: kustomize build で全体 manifest を render verify
+
+```bash
+kubectl kustomize kubernetes/manifests/production/ > /tmp/production-rendered.yaml
+echo "Total resources: $(grep -c '^kind:' /tmp/production-rendered.yaml)"
+echo ""
+echo "=== Tempo resources (kind 別) ==="
+grep -B 1 "name: tempo$\|name: tempo-" /tmp/production-rendered.yaml | grep "kind:" | sort | uniq -c
+echo ""
+echo "=== OTel Collector resources (kind 別) ==="
+grep -B 1 "name: opentelemetry-collector" /tmp/production-rendered.yaml | grep "kind:" | sort | uniq -c
+echo ""
+echo "=== Tempo datasource entry in Grafana Secret ==="
+grep -A 5 "name: Tempo" /tmp/production-rendered.yaml | head -8
+```
+
+Expected:
+- error なく完了
+- Tempo resource: StatefulSet 1 + Service 数件 + ServiceAccount 1 + ConfigMap 1
+- OTel Collector resource: Deployment 1 + Service 1 + ServiceAccount 1 + ConfigMap 1
+- Grafana datasources Secret に `name: Tempo` entry 含む
+
+### Step 3: Commit
+
+```bash
+git add kubernetes/manifests/production/tempo/ \
+        kubernetes/manifests/production/opentelemetry-collector/ \
+        kubernetes/manifests/production/kustomization.yaml
+git commit -s -m "chore(kubernetes/manifests): hydrate tempo + opentelemetry-collector
+
+Phase 3 Sub-project 4a Task 4: hydrate-index で全 component 再 hydrate、
+kustomization.yaml の resources list に ./tempo + ./opentelemetry-collector
+を alphabetical 位置に auto-insert (Sub-project 3 で確認した make hydrate-index
+の挙動)。
+
+manifest.yaml は components/{tempo,opentelemetry-collector}/production/ の
+helmfile.yaml + values.yaml.gotmpl から auto-generated。
+
+Refs: docs/superpowers/specs/2026-05-06-eks-production-observability-traces-stack-foundation-design.md"
+```
+
+`echo -n "chore(kubernetes/manifests): hydrate tempo + opentelemetry-collector" | wc -m` で文字数確認 (= 67 chars、≤ 72 OK)。
+
+---
+
+## Task 5: PR push + Pre-flight check + Ready for review
+
+**Files:** (= no file changes、PR 操作のみ)
+
+**Context:** Sub-project 3 L4 learnings 適用。Pre-flight check 全件 ✅ を PR description に記録してから Ready for review に切替。
+
+### Step 1: branch 状態を確認
+
+```bash
+cd /Users/takanokenichi/GitHub/panicboat/platform/.claude/worktrees/feat/eks-production-observability-traces-stack-foundation
+git log --oneline origin/main..HEAD
+```
+
+Expected: 5 commits ahead (Task 1 から Task 4 まで + spec commit)
+```
+<sha> chore(kubernetes/manifests): hydrate tempo + opentelemetry-collector
+<sha> feat(eks): add Tempo cross-stack values + Grafana datasource
+<sha> feat(eks): add production OTel Collector (Deployment + traces pipeline)
+<sha> feat(eks): add production Tempo (Monolithic + S3 + Pod Identity)
+<sha> docs(eks): Phase 3 Sub-project 4a (Traces foundation) design spec
+```
+
+### Step 2: branch を origin に push
+
+```bash
+git push 2>&1 | tail -3
+```
+
+Expected: branch が track 設定済 (Sub-project 4a の spec commit で `git push -u origin HEAD` 済の前提)
+
+### Step 3: Draft PR を作成 (Pre-flight check 結果を含む)
+
+PR title (≤ 72 chars 確認):
+```bash
+echo -n "feat(eks): Phase 3 Sub-project 4a — Traces foundation (Tempo + OTel)" | wc -m
+```
+
+Expected: 70 chars (em dash 含む、visible ≈ 67 chars、Sub-project 2 / 3 の PR title 命名 pattern と整合)
+
+PR body は以下:
+
+```markdown
+## Summary
+
+Phase 3 Sub-project 4a (Traces stack foundation) の implementation。`grafana/tempo` v1.24.4 (Monolithic mode、Tempo 2.9.0) + `opentelemetry/opentelemetry-collector` v0.153.0 を `monitoring` namespace に deploy。Sub-project 1 で provision 済の AWS infra (`tempo-559744160976` bucket + `eks-production-tempo` IAM role + `tempo` Pod Identity SA) + Sub-project 3 fix で適用済の bucket-wide IAM を活用、Sub-project 2 / 3 で確立した ServiceMonitor pattern + Grafana datasource 統合 path に従う。
+
+**Architecture (4a 完了時):** Tempo Monolithic StatefulSet で S3 backend に Pod Identity 経由でアクセス。OTel Collector Deployment で OTLP receivers + Tempo exporter のみの **traces pipeline** を完成。**source 未接続** = Beyla / Hubble / Fluent Bit から OTLP push は Sub-project 4b で wire up。
+
+## Spec / Plan
+
+- Spec: `docs/superpowers/specs/2026-05-06-eks-production-observability-traces-stack-foundation-design.md` (13 Decisions、Sub-project 3 learnings 全項目適用)
+- Plan: `docs/superpowers/plans/2026-05-06-eks-production-observability-traces-stack-foundation.md` (6 tasks)
+
+## Notable Decisions
+
+- **D1**: Sub-project 4 を 4a + 4b に分割 (= 4b は別途 brainstorming)
+- **D2**: OTel Operator は production deploy しない (YAGNI、Beyla 採用済)
+- **D3**: Tempo Monolithic (small production OK、Loki と対称、Mimir Microservices と非対称)
+- **D5**: application retention OFF (chart default)、S3 lifecycle 7d で uniform 担保 (= 3 stack 一貫 pattern)
+- **D11**: 4a では traces pipeline のみ、metrics / logs は 4b で追加
+- **D13**: 3 stack (Mimir / Loki / Tempo) で application retention OFF + S3 lifecycle 担保 + bucket-wide IAM + application-level prefix env scope の panicboat pattern が完全に揃う
+
+## Pre-flight check
+
+- [ ] aws/eks-traces/ terragrunt state 8 resources confirmed (Task 0 Step 2)
+- [ ] S3 bucket tempo-559744160976 head-bucket 200 OK + lifecycle 7d (Task 0 Step 3)
+- [ ] Pod Identity Association monitoring/tempo exists (Task 0 Step 4)
+- [ ] IAM ObjectLevelOperations Resource bucket-wide (Sub-project 3 fix 反映、Task 0 Step 5)
+- [ ] gp3 StorageClass exists (Task 0 Step 6)
+- [ ] Sub-project 2 / 3 stack all Running (Task 0 Step 6)
+- [ ] Flux not suspended (Task 0 Step 7)
+
+## Test plan (post-flight, after merge)
+
+### 10 分以内
+- [ ] Tempo `tempo-0` `1/1 Running` (StatefulSet)
+- [ ] OTel Collector `1/1 Running` (Deployment)
+- [ ] PVC `tempo-tempo-0` Bound (gp3 10Gi)
+- [ ] Prometheus targets で `tempo` / `opentelemetry-collector` が `UP`
+
+### 30 分以内
+- [ ] Tempo S3 backend ready (= Pod Identity 動作確認、Tempo logs で `s3 backend` 接続成功)
+- [ ] OTel Collector startup 成功 (= Tempo gRPC connection established)
+- [ ] self-metrics (`tempo_*` / `otelcol_*`) が Mimir に remote_write されて Grafana で query 可能
+- [ ] Grafana Tempo datasource `Save & test` で 緑
+- [ ] Sub-project 2 / 3 stack regression なし
+
+**注**: 4a では source 未接続のため **actual traces data は流れない**。実 traces 検証は 4b で source 接続後。
+
+## Sub-project 3 learnings 適用
+
+| Sub-project 3 learnings | 本 PR での適用 |
+|---|---|
+| L1 (chart 内部固定 path 問題) | Tempo は `s3.prefix` で path 制御可能、Loki のような問題なし |
+| L2 (IAM 公式準拠) | Sub-project 3 fix で 3 stack 同型済 → そのまま利用、Tempo は `s3.prefix: production` で application-level env scope |
+| L3 (chart probe / serviceMonitor key 確認) | Tempo: `additionalLabels` / OTel Collector: `extraLabels` + `ports.metrics.enabled: true` 必須 を実装段階で精査済 |
+| L4 (uniform retention は S3 lifecycle で) | Tempo application retention 設定なし、S3 lifecycle 7d で担保 = 3 stack 一貫 pattern |
+| L5 (Flux suspend pattern) | 通常 deploy で進める、問題発見時のみ reactive 発動 |
+| L6 (Loki `auth_enabled: false` 時 internal default) | Tempo は `multitenancyEnabled: false` で 1 tenant 運用、Mimir / Loki と対称 |
+| L7 (sibling stack symmetric) | 3 stack 同型 IAM 維持 (Sub-project 3 fix で適用済) |
+| L8 (post-flight check) | 13 項目を Test plan で明示 |
+| L9 (公式 docs 引用) | Tempo 公式 IAM template と整合確認済 (Sub-project 3 fix の bucket-wide が公式形式) |
+| L10 (Phase 3 全体 9 件 runtime issue) | 本 sub-project は 4a / 4b 分割 + L1-L9 適用で runtime issue 数 minimize 目標 |
+
+## Rollback 手順 (想定外障害時)
+
+```bash
+flux suspend kustomization flux-system
+kubectl delete -k kubernetes/manifests/production/tempo/
+kubectl delete -k kubernetes/manifests/production/opentelemetry-collector/
+kubectl get pods -n monitoring | grep -v -E "tempo|opentelemetry-collector"  # Sub-project 2 / 3 影響なき確認
+gh pr create --title "revert: Phase 3 Sub-project 4a (Traces stack foundation)" ...
+flux reconcile source git flux-system
+flux resume kustomization flux-system
+```
+
+aws/eks-traces/ は Sub-project 1 で provision 済 + Sub-project 3 fix で IAM 適用済 = AWS-side rollback 不要。
+```
+
+```bash
+gh pr create --draft \
+  --title "feat(eks): Phase 3 Sub-project 4a — Traces foundation (Tempo + OTel)" \
+  --body "$(<above body>)"
+```
+
+Expected: PR URL 出力 (例: `https://github.com/panicboat/platform/pull/<N>`)
+
+### Step 4: PR URL を確認
+
+```bash
+gh pr view --json title,url,isDraft --jq '.'
+```
+
+Expected:
+```json
+{
+    "isDraft": true,
+    "title": "feat(eks): Phase 3 Sub-project 4a — Traces foundation (Tempo + OTel)",
+    "url": "https://github.com/panicboat/platform/pull/<N>"
+}
+```
+
+(ここで USER GATE: PR review + Ready for review + merge は user 操作)
+
+---
+
+## Self-review
+
+### Spec coverage
+
+| Spec section | 実装 task | カバレッジ |
+|---|---|---|
+| Architecture (mermaid) | Task 1 / 2 / 3 / 4 | ✅ Tempo + OTel Collector + ServiceMonitor + Grafana datasource すべて Task で網羅 |
+| Components table | Task 1 / 2 | ✅ Tempo Monolithic / OTel Collector Deployment / ServiceMonitor / Grafana datasource すべてカバー |
+| Data flow (Step 1-4 + side flows) | Task 1 / 2 | ✅ OTel Collector → Tempo → S3 path、Prometheus scrape path を全 step 実装 |
+| AWS infra (Sub-project 1 + Sub-project 3 fix 利用) | Task 0 (verify only) | ✅ pre-flight check で existence + IAM bucket-wide 反映確認、変更なし |
+| Decision 1 (4a + 4b 分割) | (構成決定、本 plan は 4a 範囲) | ✅ |
+| Decision 2 (OTel Operator なし) | (= 本 plan で deploy しない、Operator 関連 task 不在) | ✅ |
+| Decision 3 (Tempo Monolithic) | Task 1 (chart: grafana/tempo) | ✅ |
+| Decision 4 (OTel Collector Deployment + replicas=1) | Task 2 (mode: deployment + replicaCount: 1) | ✅ |
+| Decision 5 (retention OFF + S3 lifecycle) | Task 1 (retention 設定なし、NOTE で意図記録) | ✅ |
+| Decision 6 (chart version local 揃え) | Task 1 / 2 (helmfile.yaml chart version) | ✅ |
+| Decision 7 (bucket-wide IAM + s3.prefix) | Task 0 (verify) + Task 1 (s3.prefix: production) | ✅ |
+| Decision 8 (multitenancy OFF) | Task 1 (multitenancyEnabled: false) | ✅ |
+| Decision 9 (ServiceMonitor + Grafana datasource) | Task 1 / 2 (ServiceMonitor) + Task 3 (Grafana datasource) | ✅ |
+| Decision 10 (Mimir = default 維持) | Task 3 (Tempo: isDefault: false) | ✅ |
+| Decision 11 (4a traces pipeline のみ) | Task 2 (config に exporters/otlp/tempo + service.pipelines.traces 上書き) | ✅ |
+| Decision 12 (Tempo PVC 10Gi gp3) | Task 1 (persistence.storageClassName: gp3 + size: 10Gi) | ✅ |
+| Decision 13 (3 stack 一貫 pattern) | (= 設計レベルの確認、本 plan の各 task で具体実装、Sub-project 4a 完了時に整合) | ✅ |
+| Test plan (pre-flight 7 + post-flight 13) | Task 0 (pre-flight 7) + Task 5 (PR description で post-flight 13 明示) | ✅ |
+
+### Placeholder scan
+
+- [x] "TBD" / "TODO" / "FIXME" 等の placeholder なし
+- [x] 各 Step で actual code block (helmfile.yaml / values.yaml.gotmpl / commit message) を完全に書き出し済
+- [x] "Similar to Task N" 形式の reference なし
+
+### Type / naming consistency
+
+- [x] SA name `tempo` は Task 1 + Task 0 (pre-flight check) + spec で一貫
+- [x] Bucket name `tempo-559744160976` は Task 1 / Task 3 / Task 0 で一貫
+- [x] Service name `tempo.monitoring.svc.cluster.local` は Task 2 (OTel Collector exporter endpoint) + Task 3 (Grafana datasource url) で一貫 (port は Tempo 4317 / 3200 で各用途別)
+- [x] OTel Collector chart `extraLabels` (= Tempo `additionalLabels` と異なる、Sub-project 3 L3 確認済)
+- [x] OTel Collector `ports.metrics.enabled: true` は ServiceMonitor 用、chart README の必須設定 (Task 2 で明示)
+- [x] kube-prometheus-stack ServiceMonitor selector label `release: kube-prometheus-stack` は Task 1 (Tempo) + Task 2 (OTel Collector) で一貫
+
+### CLAUDE.md 準拠
+
+- [x] 出力言語日本語 (見出し英語、本文日本語)
+- [x] コミット `-s` (Signed-off-by) 全 task の commit step で指定
+- [x] `Co-Authored-By` 不付与 (全 commit message に無し)
+- [x] PR は `--draft` (Task 5 Step 3)
+- [x] Conventional Commits 全 commit が `feat(eks):` / `chore(kubernetes/manifests):` / `docs(eks):` 形式
+- [x] commit subject ≤ 72 chars 全 task で wc -m 確認
+
+### Plan 1c-β / Plan 2 / Plan tuning / Sub-project 1-3 の知見反映
+
+- [x] **Plan 1c-β L4 (REPLACE_FROM_TERRAGRUNT_OUTPUT 不要)** → Task 3 で helmfile.yaml.gotmpl に直接実値 (`tempo-559744160976`) を書く、placeholder pattern 不採用
+- [x] **Plan 1c-β L5 (squash merge 後 branch reset rollback)** → Task 0 Step 1 で `git fetch origin main && git log --oneline origin/main..HEAD` 確認
+- [x] **Sub-project 1 L1 (IAM policy 3 statement)** → 本 sub-project は IAM 触らない (= Sub-project 3 fix で確立済の bucket-wide pattern を verify のみ)
+- [x] **Sub-project 1 L5 (sibling stacks symmetric)** → 3 stack の IAM template は同型維持 (Sub-project 3 fix で適用済)、本 plan は K8s-side のみ追加
+- [x] **Sub-project 2 L1 (chart upgrade での upstream changelog 確認)** → Tempo + OTel Collector chart の最新 version は local 揃い、organizational migration なしを確認済 (Decision 6)
+- [x] **Sub-project 2 L2 (chart auto-generated ConfigMap 衝突)** → Sub-project 2 PR #289 の `defaultDatasourceEnabled: false` 設定継続、新たな衝突なし
+- [x] **Sub-project 2 L3 (EBS RWO + RollingUpdate → Recreate)** → Tempo は StatefulSet (OrderedReady)、OTel Collector は Deployment + PVC なし、新規 Recreate 設定不要
+- [x] **Sub-project 2 L4 (Spec verification を pre-flight / post-flight 分割)** → Task 0 (pre-flight 7 件) + Task 5 PR description (post-flight 13 件) で明示分離
+- [x] **Sub-project 2 L5 (Flux suspend pattern)** → Spec Test plan section に Rollback 手順として明示
+- [x] **Sub-project 2 L6 (gp3 StorageClass)** → Sub-project 2 で provision 済再利用、本 sub-project では作らない
+- [x] **Sub-project 2 L7 (Pod Identity webhook injection は Pod 作成時のみ)** → 新規 deploy のため初回起動時に正しく injection
+- [x] **Sub-project 2 L8 (storage_prefix 英数字制約)** → Tempo `s3.prefix: production` で英数字のみ、slash 不要 = Mimir / Loki と整合
+- [x] **Sub-project 3 L1 (chart 内部固定 path 問題)** → Tempo は `s3.prefix` で全 path 制御可能、Loki のような問題なしを確認
+- [x] **Sub-project 3 L2 (IAM 公式準拠)** → Sub-project 3 fix で 3 stack bucket-wide IAM 同型済、Tempo はそのまま利用
+- [x] **Sub-project 3 L3 (chart probe / serviceMonitor key 確認)** → Tempo `additionalLabels` / OTel Collector `extraLabels` + `ports.metrics.enabled: true` を実装段階で精査済、Task 1 / 2 の values で正しい key を使用
+- [x] **Sub-project 3 L4 (uniform retention は S3 lifecycle で)** → Tempo application retention OFF (chart default)、S3 lifecycle 7d で担保
+- [x] **Sub-project 3 L5 (Flux suspend pattern)** → Rollback 手順として明示、通常 deploy で進める
+- [x] **Sub-project 3 L6 (Loki `auth_enabled: false` 時 default tenant `fake`)** → Tempo は `multitenancyEnabled: false` で 1 tenant 運用、将来 multi-tenant 化時に tenant ID を 3 stack で揃える前提
+- [x] **Sub-project 3 L7 (sibling stack symmetric)** → 本 sub-project は Tempo 単独追加、3 stack IAM template は Sub-project 3 fix で同型済
+- [x] **Sub-project 3 L8 (post-flight check)** → 13 項目を spec / PR description で明示
+- [x] **Sub-project 3 L9 (公式 docs 引用)** → Tempo 公式 docs を spec の Decisions section で direct citation
+- [x] **Sub-project 3 L10 (Phase 3 全体 9 件 runtime issue)** → 4a / 4b 分割 + L1-L9 適用で runtime issue 数 minimize 目標

--- a/docs/superpowers/specs/2026-05-06-eks-production-observability-traces-stack-foundation-design.md
+++ b/docs/superpowers/specs/2026-05-06-eks-production-observability-traces-stack-foundation-design.md
@@ -1,0 +1,494 @@
+# EKS Production: Observability Traces Stack Foundation (Phase 3 Sub-project 4a) Design Spec
+
+**Status:** Draft (brainstorming 完了、user review 待ち)
+
+**Goal:** panicboat EKS production cluster (`eks-production` / ap-northeast-1 / account 559744160976) に **traces collection 基盤** を deploy する。Sub-project 1 で provision 済の AWS infra (`tempo-559744160976` bucket / `eks-production-tempo` IAM role / `tempo` Pod Identity SA) + Sub-project 3 fix で適用済の bucket-wide IAM を活用、Sub-project 2 / 3 で確立した monitoring namespace + ServiceMonitor pattern + Grafana datasource 統合 path に従う。本 sub-project (= 4a) 完了時は **traces pipeline 基盤** が ready、Sub-project 4b で sources (Beyla / Hubble / Fluent Bit) を接続して data flow を成立させる。
+
+**Architecture summary:** `grafana/tempo` v1.24.4 (Monolithic mode、Tempo 2.9.0) を deploy + `opentelemetry/opentelemetry-collector` v0.153.0 を Deployment mode で deploy。OTel Collector は OTLP receivers (gRPC + HTTP) + Tempo exporter のみの **traces pipeline** を 4a で完成、metrics / logs pipelines は 4b で追加。Pod Identity 経由で S3 long-term storage、Grafana datasource に Tempo を追加。
+
+**Tech Stack:** Helm + helmfile / `grafana/tempo` v1.24.4 (Tempo 2.9.0) / `opentelemetry/opentelemetry-collector` v0.153.0 (otel-collector-contrib 0.151.0) / EBS gp3 PVC / EKS Pod Identity / S3 backend (Sub-project 1 outputs)
+
+---
+
+## Architecture
+
+### Sub-project 4a 完了時 (= traces pipeline 基盤 ready、source 未接続)
+
+```mermaid
+graph LR
+  subgraph EKS["EKS production cluster"]
+    OTel[OTel Collector Deployment<br/>OTLP receivers gRPC + HTTP] -->|otlp exporter| Tempo[Tempo Monolithic<br/>StatefulSet]
+    Tempo --> S3T[(tempo-559744160976)]
+
+    subgraph Mon["Sub-project 2/3 monitoring layer"]
+      Prom[Prometheus]
+      Mimir[Mimir]
+      Loki[Loki]
+    end
+    Prom -.->|scrape /metrics| OTel
+    Prom -.->|scrape /metrics| Tempo
+    Prom -->|remote_write| Mimir
+
+    Graf[Grafana] -.->|query| Tempo
+    Graf -.->|query| Mimir
+    Graf -.->|query| Loki
+
+    subgraph Future["Sub-project 4b (source 接続予定)"]
+      Beyla[Beyla DaemonSet]
+      Hubble[Hubble OTLP]
+      FB[Fluent Bit DaemonSet]
+    end
+    Beyla -.->|OTLP 4b予定| OTel
+    Hubble -.->|OTLP 4b予定| OTel
+    FB -.->|OTLP 4b予定| OTel
+  end
+
+  S3T -.->|7d lifecycle| D1[delete]
+```
+
+- 実線 (`-->`): 4a で deploy + active な path (Tempo へ traces 書き込み path、4b 後に実 traces が流れる)
+- 点線 (`-.->`): 4b で接続予定 / monitoring scrape (= HTTP request 方向、actual data flow は逆) / Grafana query / lifecycle
+
+### Sub-project 4b 完了時 (= 最終形、kubernetes/README.md と一致)
+
+OTel Collector に metrics / logs pipelines を追加 + source 3 系 (Beyla / Hubble / Fluent Bit) を接続して data flow 成立。これは Sub-project 4b で別途 brainstorming する。本 spec では touched しない。
+
+### Sub-project 2 / 3 との pattern 整合 + 3 stack 一貫 pattern 確立
+
+| 観点 | Mimir | Loki | Tempo |
+|---|---|---|---|
+| chart | grafana/mimir-distributed | grafana-community/loki | grafana/tempo |
+| deployment mode | Microservices | SingleBinary (Monolithic) | Monolithic |
+| application retention | OFF (chart default) | `retention_enabled: false` (明示) | OFF (chart default) |
+| S3 lifecycle | 90d | 30d | 7d |
+| IAM Resource | bucket-wide | bucket-wide | bucket-wide |
+| application-level env scope | `storage_prefix: production` | `schemaConfig.index.prefix: production_index_` | `s3.prefix: production` |
+| tenancy | 1 tenant | 1 tenant | 1 tenant (`multitenancy_enabled: false`) |
+| ServiceMonitor | enabled | enabled | enabled |
+| Grafana datasource | default | non-default | non-default |
+
+**Sub-project 4a 完了時点で 3 stack 一貫 pattern が完全に揃う** (= panicboat の observability backend 設計が確立)。
+
+---
+
+## Components
+
+### Component table
+
+| Component | k8s kind | replicas | image / chart version | resources (request → limit) | PVC | SA / Pod Identity |
+|---|---|---|---|---|---|---|
+| **Tempo Monolithic** | StatefulSet | 1 | `grafana/tempo` v1.24.4 (Tempo 2.9.0) | 200m CPU / 512Mi → 1 CPU / 2Gi | **10Gi gp3** (WAL + 短期 compactor cache) | **`tempo`** (Pod Identity → IAM role `eks-production-tempo` → S3 `tempo-559744160976`) |
+| **OTel Collector** | Deployment | 1 (PVC なし、Recreate 不要) | `opentelemetry/opentelemetry-collector` v0.153.0 (= contrib 0.151.0) | 100m / 256Mi → 500m / 1Gi | — (stateless) | default (= AWS access 不要、4a では Tempo に gRPC export のみ) |
+| **ServiceMonitor (Tempo)** | (subchart) | — | — | — | — | Prometheus が auto-scrape (Sub-project 2 確立 pattern) |
+| **ServiceMonitor (OTel Collector)** | (subchart) | — | — | — | — | 同上 (= self-metrics scrape) |
+| **Grafana datasource (Tempo)** | ConfigMap entry | — | (existing Grafana) | — | — | `prometheus-operator/production/values.yaml.gotmpl` の `grafana.datasources.datasources.yaml` に追加 |
+
+### Tempo Monolithic
+
+- chart values で `tempo.storage.trace.backend: s3` + `s3.{bucket: tempo-559744160976, region: ap-northeast-1, prefix: production}`
+- `multitenancy_enabled: false` (= 1 tenant 運用)
+- Pod Identity: `serviceAccount.name: tempo`
+- StatefulSet `replicas: 1` (= small production)
+- PVC: WAL + 短期 compactor cache (Pod 起動時のロスト window 縮小、Sub-project 3 L11 と同思想)
+- application-level retention: **設定しない** (= chart default に任せる、3 stack 一貫 pattern、Decision 5)
+
+### OTel Collector (4a 範囲)
+
+- chart values で `mode: deployment` + `replicas: 1`
+- image: `otel/opentelemetry-collector-contrib:0.151.0` (= local 踏襲、k8sattributes processor 等の拡張機能を 4b で利用)
+- config:
+  - **receivers**: OTLP gRPC (`:4317`) + HTTP (`:4318`) を expose (= 4b で source 接続用)
+  - **processors**: `batch` + `memory_limiter` (= 標準 hygiene)
+  - **exporters**: **otlp/tempo** のみ (= traces を Tempo に export)
+  - **service.pipelines.traces**: 上記 receivers / processors / exporters を wire
+  - metrics / logs pipeline は **4b で追加** (Decision 11)
+
+### Sub-project 3 learnings 適用
+
+| Sub-project 3 learnings | 本 sub-project での適用 |
+|---|---|
+| L1 (chart 内部固定 path 問題) | Tempo は `s3.prefix` で全 path 制御可能、Loki のような問題なし |
+| L2 (IAM 公式準拠) | Sub-project 3 fix で 3 stack 同型済 → そのまま利用、Tempo は `s3.prefix: production` で application-level env scope |
+| **L3 (chart probe 確認)** | **実装段階** で Tempo / OTel Collector の chart default readinessProbe / livenessProbe を精査、`Retry_Limit` 等の application policy と矛盾しないか確認 |
+| L4 (S3 lifecycle で uniform 担保) | application retention 設定なし、S3 lifecycle 7d で担保 |
+| L5 (Flux suspend pattern) | Rollback 手順として明示記録 |
+| L6 (gp3 StorageClass) | Sub-project 2 で provision 済再利用 |
+| L7 (Pod Identity webhook injection) | 新規 deploy のため初回起動時に正しく injection |
+| L9 (公式 docs 引用) | Tempo 公式 ([S3 configuration](https://grafana.com/docs/tempo/latest/configuration/s3/)) と整合確認済 |
+
+---
+
+## Data flow
+
+### Sub-project 4a 完了時 (= 基盤 ready、source 未接続)
+
+```
+[STEP 1]  (4b で接続予定: Beyla / Hubble / Fluent Bit から OTLP push)
+              ↓ OTLP gRPC :4317 / HTTP :4318
+[STEP 2]  OTel Collector Deployment
+            │ receivers: otlp { protocols: { grpc, http } }
+            │ processors: batch + memory_limiter
+            ▼ exporters: otlp/tempo
+[STEP 3]  Tempo Monolithic StatefulSet (= distributor + ingester + querier + compactor 一体)
+            │ ingester: WAL に write (PVC, gp3 10Gi) + memory chunk 構築
+            ▼ flush 間隔で
+[STEP 4]  S3 (tempo-559744160976/production/<traces>)
+```
+
+**4a 完了時点では Step 1 (source) が無いため、Step 2-4 は空動作** (= receivers が listen、Tempo は idle)。動作 verification は **4b で source 接続後** に実 traces が流れるかで判定。ただし 4a で **OTel Collector → Tempo の internal connectivity** は確認可能 (= OTel Collector logs で Tempo gRPC connection が established)。
+
+### Side flows (4a で active)
+
+**Prometheus self-monitoring** (Sub-project 2 / 3 と同 pattern):
+```
+Prometheus -.scrape.→ Tempo:3200/metrics       (= tempo_distributor_spans_received_total 等)
+Prometheus -.scrape.→ OTel Collector:8888/metrics (= otelcol_receiver_accepted_spans 等、self-metrics)
+Prometheus → remote_write → Mimir → S3 (mimir-559744160976)
+```
+
+**注**: "scrape" の矢印方向は HTTP request の方向 (= Prometheus → OTel Collector に GET /metrics)、actual data flow (= metrics 値の動き) は逆方向。Sub-project 2 / 3 と同じく、kube-prometheus-stack auto-scrape pattern を踏襲。
+
+**Grafana query** (4a で datasource 追加):
+```
+Grafana --query→ Tempo:3200/api (TraceQL) → Tempo Monolithic (in-memory + S3 chunks)
+```
+
+4a 完了時は **traces data 不在のため Grafana で trace query しても empty result**。
+
+### Failure modes (4a 範囲)
+
+| 失敗箇所 | 4a での影響 | 保護機構 / 復旧 |
+|---|---|---|
+| OTel Collector Pod crash | 単一 SPOF だが 4a では source 未接続のため影響なし | Deployment が auto-restart (~数秒) |
+| Tempo Monolithic crash + PVC 健在 | StatefulSet 自動再起動、WAL replay | 未 flush traces (4b 後) 保持、ロストなし |
+| Tempo S3 access fail (IAM/Pod Identity 問題) | Tempo `/ready` が 503 を返す可能性 | Sub-project 3 fix で IAM bucket-wide で integration 確認済 |
+| PVC 損失 (AZ 障害) | 新 PVC 作成、WAL 失われる、未 flush traces ロスト (4b 後) | 4a では source 未接続のため影響軽微 |
+
+### 4b で実装される内容 (= 参考)
+
+- OTel Collector に **metrics + logs pipelines 追加** (= Hubble / Beyla / Fluent Bit からの receive を route)
+- **Beyla** から OTLP traces / metrics push
+- **Hubble** から OTLP network traces push (Cilium values 修正)
+- **Fluent Bit** OUTPUT を Loki 直接 → OTel Collector OTLP に switching、OTel Collector で `loki` exporter で Loki に書き戻し
+
+---
+
+## AWS infra
+
+### Sub-project 4a では AWS-side 変更なし
+
+aws/eks-traces/ stack は **Sub-project 1 (PR #283) で provision 完了済** + Sub-project 3 fix (PR #292) で **IAM policy が bucket-wide に拡張済** (= 3 stack 同型)。Tempo 採用に必要な resource は既に揃っている。
+
+### 利用する既存リソース
+
+| Resource | Identifier | 用途 |
+|---|---|---|
+| S3 bucket | `tempo-559744160976` (ap-northeast-1) | Tempo traces long-term storage |
+| S3 lifecycle | **7d retention** (= traces high-volume / short-lived debugging data) | application retention は OFF、S3 lifecycle で uniform 担保 |
+| S3 SSE | AES256 (SSE-S3) | bucket-level rest encryption |
+| S3 versioning | Disabled | traces immutable + 7d auto-delete |
+| IAM role | `eks-production-tempo` (ARN: `arn:aws:iam::559744160976:role/eks-production-tempo`) | Pod Identity 用 |
+| IAM policy (3 statement) | BucketLevelListing / BucketLocation / ObjectLevelOperations (= **bucket-wide** Resource、Sub-project 3 fix で 3 stack 同型化済) | env scope は application-level prefix で担保 (Sub-project 3 L2) |
+| Pod Identity Association | `monitoring/tempo` SA → `eks-production-tempo` IAM role | EKS Pod Identity (cluster-side managed) |
+
+### Cross-stack reference flow
+
+```
+aws/eks-traces/envs/production (terragrunt)
+  ↓ outputs: bucket_name / bucket_path_prefix / pod_identity_role_name
+kubernetes/helmfile.yaml.gotmpl (production env values block)
+  ↓ Plan 1c-β L4 pattern (placeholder 不採用、直接実値書き)
+kubernetes/components/tempo/production/{helmfile.yaml, values.yaml.gotmpl}
+  ↓ helmfile v1.x cross-helmfile values 制約で 2 箇所 transcribe
+helm template / Tempo values:
+  - serviceAccount.name: tempo
+  - tempo.storage.trace.backend: s3
+  - tempo.storage.trace.s3.bucket: tempo-559744160976
+  - tempo.storage.trace.s3.endpoint: s3.ap-northeast-1.amazonaws.com
+  - tempo.storage.trace.s3.prefix: production  (= Sub-project 3 L2 適用、application-level env scope)
+```
+
+---
+
+## Decisions
+
+### Decision 1: Sub-project 4 を 4a + 4b に分割
+
+- **採用**: 4a = Tempo + OTel Collector deploy / 4b = Beyla + Hubble OTLP + Fluent Bit OTel switching + metrics/logs pipelines
+- **理由**: 6 component changes は Sub-project 2 と同程度のスコープ、4a で traces 基盤を ready にしてから 4b で source wiring する方が runtime issue を catch しやすい
+- **不採用**: 1 sub-project で全部 (= scope creep) / 3 sub-project に細分化 (= 過剰)
+
+### Decision 2: OpenTelemetry Operator は production deploy しない (YAGNI)
+
+- **採用**: Operator なし、OTel Collector chart のみ deploy
+- **理由**: panicboat では Operator の active use case が無い (= local も "future use" のみで未使用)。Beyla で eBPF auto-instrumentation 採用済のため Operator の auto-instrumentation 機能は不要
+- **不採用**: Operator + Collector 両方 deploy (= local 踏襲、ただし inactive operator の overhead)
+- **reversibility**: 必要になったら追加可能 (= 新規 component を後で追加するのは straightforward)
+
+### Decision 3: Tempo deployment mode = Monolithic
+
+- **採用**: `grafana/tempo` chart v1.24.4 (Monolithic 専用 chart)
+- **理由**: panicboat は small production = Tempo 公式の "Recommended for small clusters" 範囲。Loki SingleBinary と対称、Mimir Microservices だけが scale 用 production deploy
+- **HA upgrade path**: 必要なら `grafana/tempo-distributed` chart に切替、Phase 4 で再検討
+- **不採用**: Distributed (= Mimir と整合だが over-engineering)
+
+### Decision 4: OTel Collector deployment mode = Deployment + replicas=1
+
+- **採用**: `mode: deployment`、replicas=1 (= 集約 hub pattern)
+- **理由**: 小規模 production OK、リソース最小、source は Service 経由で接続。Beyla / Fluent Bit / Hubble の retry buffer で短時間 outage を許容
+- **HA upgrade path**: 必要なら Phase 4 で replicas=2 に拡張
+- **不採用**: DaemonSet (= aggregate / batch が node 単位で複雑) / replicas=2 (= small production で over-engineering)
+
+### Decision 5: Tempo retention = OFF (chart default、S3 lifecycle 7d で担保)
+
+- **採用**: application retention 設定なし (= chart default に任せる)、S3 lifecycle 7d で uniform 担保
+- **理由**: Sub-project 3 L4 と一貫、3 stack で **application retention OFF + S3 lifecycle 担保** の panicboat pattern を確立
+- **不採用**: `compactor.compaction.block_retention` 明示設定 (= "あえて設定すると混乱を招く")
+
+### Decision 6: chart version = local 揃え (Tempo v1.24.4 / OTel Collector v0.153.0)
+
+- **採用**: 両 chart とも local と最新が一致
+- **理由**: Sub-project 2 / 3 で確立した pattern、Sub-project 3 で経験した chart organizational migration (= grafana/loki split) は本 sub-project の 2 chart で **発生していない**
+
+### Decision 7: Tempo IAM = bucket-wide (Sub-project 3 fix で 3 stack 同型済) + application-level env scope
+
+- **採用**:
+  - IAM Resource: `[arn:aws:s3:::tempo-559744160976, arn:aws:s3:::tempo-559744160976/*]` (= bucket-wide、Sub-project 3 fix で 3 stack 同型適用済)
+  - application-level env scope: `tempo.storage.trace.s3.prefix: production`
+- **理由**: Sub-project 3 L2 適用、Loki / Tempo / Mimir 公式準拠 + 3 sibling stack symmetric 維持
+
+### Decision 8: Tempo tenancy = 1 tenant (`multitenancy_enabled: false`)
+
+- **採用**: chart default の `multitenancy_enabled: false` (= 1 tenant 運用)
+- **理由**: panicboat 1 tenant 運用、Mimir / Loki と対称
+- **note**: 将来 multi-tenant 化する場合 (Phase 4 等) は 3 stack で tenant ID を揃える (Sub-project 3 L6 = `auth_enabled: false` 時 Loki internal default = `fake` の知見と整合)
+
+### Decision 9: ServiceMonitor + Grafana datasource = Sub-project 2 / 3 と同形
+
+- **採用**:
+  - Tempo: `serviceMonitor.enabled: true` (chart 内蔵設定) + `release: kube-prometheus-stack` selector label
+  - OTel Collector: 同上 (= self-metrics scrape)
+  - Grafana datasource: `prometheus-operator/production/values.yaml.gotmpl` の `grafana.datasources.datasources.yaml.datasources` に Tempo entry 追加
+- **理由**: Sub-project 2 / 3 で確立した kube-prometheus-stack auto-scrape pattern を踏襲
+- **Sub-project 3 L3 注意**: 実装段階で各 chart の readinessProbe 設定を精査 (= Fluent Bit `additionalLabels` dead key 問題の再発防止)
+
+### Decision 10: Grafana datasource default = Mimir 維持
+
+- **採用**: Mimir = `isDefault: true` (Sub-project 2 既存)、Tempo / Loki = `isDefault: false`
+- **理由**: Grafana の Explore / Dashboard で datasource 指定なしの場合は Mimir (metrics) が default、Tempo / Loki は明示指定 (= Logs / Traces query は Explore で datasource 切替が直感的)
+
+### Decision 11: 4a での OTel Collector pipeline scope = traces のみ
+
+- **採用**:
+  - receivers: OTLP gRPC `:4317` + HTTP `:4318` (= 4b で source 接続用)
+  - processors: `batch` + `memory_limiter` (= 標準 hygiene)
+  - exporters: `otlp/tempo` のみ (= Tempo に export)
+  - service.pipelines.traces: 上記を wire
+- **不採用**: 4a で metrics / logs pipelines も pre-configure (= source 未接続で仮想動作確認になる、scope 拡大)
+- **4b で追加**: metrics / logs pipelines + source 接続を同時に行う
+
+### Decision 12: Tempo PVC = 10Gi gp3 (WAL + 短期 compactor cache)
+
+- **採用**: `tempo.persistence.{enabled: true, storageClass: gp3, size: 10Gi}`
+- **理由**: ingester WAL + 短期 compactor cache を Pod 再起動越しに保持 (Sub-project 3 L11 軽減策と同思想)
+- **gp3 StorageClass**: Sub-project 2 で provision 済再利用 (= Sub-project 2 L6 適用、本 sub-project では作らない)
+- **Sub-project 2 L3 / Multi-Attach**: StatefulSet なので Multi-Attach 罠は発生しない、podDisruptionBudget は 1 replica 用に明示 disable
+
+### Decision 13: 3 stack 一貫 pattern の確立 (= panicboat の observability backend 設計)
+
+本 sub-project で 3 stack の design pattern が完全に揃う (= Component table の整合性表参照)。
+
+**Phase 4 / 将来の見直し候補:**
+- bucket-per-env への migration (= AWS multi-tenant best practice、Sub-project 3 L2 で flag 済)
+- multi-tenant 化 (Phase 4 advanced features)
+- application-level retention rules (= per-tenant / per-stream 差分 retention)
+- HA upgrade (= Tempo Distributed / Loki SimpleScalable / OTel Collector replicas=2)
+
+---
+
+## Test plan (= Sub-project 3 L4 適用、pre-flight / post-flight 分割)
+
+### Pre-flight check (= PR draft 中に完了 → Ready for review への gate)
+
+| # | check | コマンド / 確認方法 | expected |
+|---|---|---|---|
+| 1 | aws/eks-traces/ resource 存在 | `cd aws/eks-traces/envs/production && terragrunt state list` | 8 resources |
+| 2 | S3 bucket + lifecycle 確認 | `aws s3api head-bucket --bucket tempo-559744160976` + `get-bucket-lifecycle-configuration` | 200 OK + lifecycle 7d |
+| 3 | Pod Identity Association | `aws eks list-pod-identity-associations --cluster-name eks-production --query 'associations[?serviceAccount==\`tempo\`]'` | 1 association |
+| 4 | IAM bucket-wide (Sub-project 3 fix 反映確認) | `aws iam get-role-policy --role-name eks-production-tempo --policy-name s3-access --query 'PolicyDocument.Statement[?Sid==\`ObjectLevelOperations\`].Resource'` | `"arn:aws:s3:::tempo-559744160976/*"` (= bucket-wide) |
+| 5 | gp3 StorageClass | `kubectl get storageclass gp3` | provisioner=`ebs.csi.aws.com` |
+| 6 | Sub-project 2 / 3 stack 全 Running | `kubectl get pods -n monitoring \| grep -E "prometheus\|alertmanager\|grafana\|mimir\|loki\|fluent-bit"` | 全 Running |
+| 7 | local cluster (k3d) で migration 成功 (任意) | `make phase3` → `kubectl get pods -n monitoring \| grep -E "tempo\|opentelemetry-collector"` | local で chart 互換性確認、k3d cluster なしの場合は skip OK |
+
+PR description にチェック必須:
+```
+## Pre-flight check
+- [x] aws/eks-traces/ terragrunt state 8 resources confirmed
+- [x] S3 bucket tempo-559744160976 head-bucket 200 OK + lifecycle 7d
+- [x] Pod Identity Association monitoring/tempo exists
+- [x] IAM ObjectLevelOperations Resource bucket-wide (Sub-project 3 fix 反映)
+- [x] gp3 StorageClass exists
+- [x] Sub-project 2 / 3 stack all Running
+- [ ] local migration verified on k3d (任意)
+```
+
+### Post-flight check (= merge 後の Flux 反映後 verify)
+
+**注意**: 4a では source 未接続なので、actual traces data は流れない。verification は **infrastructure ready** + **self-metrics flow** を中心に。
+
+| # | check | コマンド | expected |
+|---|---|---|---|
+| 1 | Tempo Pod Running | `kubectl get pod -n monitoring tempo-0` | `1/1 Running` (StatefulSet) |
+| 2 | OTel Collector Pod Running | `kubectl get pods -n monitoring -l app.kubernetes.io/name=opentelemetry-collector` | `1/1 Running` (Deployment) |
+| 3 | PVC Bound | `kubectl get pvc -n monitoring -l app.kubernetes.io/instance=tempo` | gp3 10Gi Bound |
+| 4 | Pod Identity injection (Tempo) | `kubectl get pod -n monitoring tempo-0 -o jsonpath='{.spec.containers[0].env[*].name}'` | `AWS_CONTAINER_CREDENTIALS_FULL_URI` 含む |
+| 5 | Tempo `/ready` | `kubectl exec -n monitoring tempo-0 -- wget -qO- http://localhost:3200/ready` | `ready` |
+| 6 | OTel Collector `/` (health) | `kubectl exec -n monitoring deploy/opentelemetry-collector -- wget -qO- http://localhost:13133/` | 200 OK |
+| 7 | ServiceMonitor scrape (Prometheus) | Prometheus UI: `Status → Targets` | `tempo` / `opentelemetry-collector` targets が UP |
+| 8 | Self-metrics → Mimir | Grafana で `tempo_distributor_spans_received_total` query | 数値が返る (= 4a 段階では値 0 で OK) |
+| 9 | Self-metrics → Mimir (OTel) | Grafana で `otelcol_receiver_accepted_spans` query | 同上 |
+| 10 | Tempo S3 connectivity (= Pod Identity 動作確認) | Tempo logs で `s3 backend` 接続成功 | `level=info msg="storage backend ready" backend=s3` 等 |
+| 11 | OTel Collector logs (= config 反映確認) | OTel Collector logs で startup 成功 | `Starting service` + `Everything is ready` |
+| 12 | Grafana Tempo datasource | Grafana UI: `Connections → Data sources → Tempo` | `Save & test` で 緑 |
+| 13 | Sub-project 2 / 3 regression なし | `kubectl get pods -n monitoring \| grep -v -E "tempo\|opentelemetry-collector"` | 全 Running、Mimir / Loki gateway `/ready` OK |
+
+### Concrete success criteria (= Sub-project 3 L8 適用)
+
+> **merge 後 10 分以内**:
+> - Tempo `tempo-0` `1/1 Running` (StatefulSet)
+> - OTel Collector `1/1 Running` (Deployment)
+> - PVC `tempo-tempo-0` Bound (gp3 10Gi)
+> - Prometheus targets で `tempo` / `opentelemetry-collector` が `UP`
+>
+> **merge 後 30 分以内**:
+> - Tempo S3 backend ready (= Pod Identity 動作確認)
+> - Grafana Explore で Tempo datasource 接続可能 (`Save & test` 緑)
+> - self-metrics (`tempo_*` / `otelcol_*`) が Mimir に remote_write されて Grafana で query 可能
+> - Sub-project 2 / 3 stack regression なし
+>
+> **注**: 4a 段階では source 未接続のため **actual traces data は流れない**。実 traces 検証は 4b で source 接続後。
+
+### Deploy 方針
+
+**通常 deploy** (= merge → Flux 自動反映)、L5 (Flux suspend pattern) は問題発見時のみ reactive 発動。理由 (Sub-project 3 と同):
+
+- 4a は initial deploy のみ + cross-stack 影響が小さい (= Tempo / OTel Collector の追加、Sub-project 2 / 3 既存 component への変更は Grafana datasource 1 entry 追加のみ)
+- L4 pre-flight check + post-flight check で safety を担保
+
+### Rollback 手順 (想定外障害時、= Sub-project 3 L5 Flux suspend pattern)
+
+```bash
+# 1. Flux suspend
+flux suspend kustomization flux-system
+
+# 2. K8s-side rollback
+kubectl delete -k kubernetes/manifests/production/tempo/
+kubectl delete -k kubernetes/manifests/production/opentelemetry-collector/
+
+# 3. Sub-project 2 / 3 stack への影響なきこと確認
+kubectl get pods -n monitoring | grep -v -E "tempo|opentelemetry-collector"
+
+# 4. PR revert (= main revert commit)
+gh pr create --title "revert: Phase 3 Sub-project 4a (Traces stack foundation)" ...
+
+# 5. revert merge 後に Flux resume
+flux reconcile source git flux-system
+flux resume kustomization flux-system
+```
+
+aws/eks-traces/ は Sub-project 1 で provision 済 + Sub-project 3 fix で IAM 適用済 = **AWS-side rollback 不要**。
+
+---
+
+## File structure
+
+### 新規作成 (production env)
+
+```
+kubernetes/components/tempo/production/
+├── helmfile.yaml                      # chart: grafana/tempo v1.24.4 (Tempo 2.9.0)
+└── values.yaml.gotmpl                 # Monolithic mode + S3 backend + Pod Identity (tempo SA)
+
+kubernetes/components/opentelemetry-collector/production/
+├── helmfile.yaml                      # chart: opentelemetry/opentelemetry-collector v0.153.0
+└── values.yaml.gotmpl                 # Deployment mode + OTLP receivers + Tempo exporter (= traces pipeline のみ)
+```
+
+### 新規生成 (hydrate 結果、auto-generated via `make hydrate-index`)
+
+```
+kubernetes/manifests/production/tempo/
+├── kustomization.yaml
+└── manifest.yaml
+
+kubernetes/manifests/production/opentelemetry-collector/
+├── kustomization.yaml
+└── manifest.yaml
+```
+
+### 変更 (production env)
+
+```
+kubernetes/helmfile.yaml.gotmpl
+└── production env values block に追加:
+    tempo:
+      bucketName: tempo-559744160976
+      bucketPathPrefix: production
+      podIdentityRoleName: eks-production-tempo
+
+kubernetes/components/prometheus-operator/production/values.yaml.gotmpl
+└── grafana.datasources.datasources.yaml.datasources に Tempo entry 追加 (Mimir / Prometheus / Loki と並列)
+
+kubernetes/manifests/production/kustomization.yaml
+└── resources に `./tempo` + `./opentelemetry-collector` を alphabetical 位置に auto-insert (Sub-project 3 で確認した make hydrate-index の挙動)
+
+kubernetes/manifests/production/prometheus-operator/manifest.yaml
+└── auto-generated 再 hydrate (= Tempo datasource entry 反映)
+```
+
+### 変更しないファイル
+
+- **AWS-side**: aws/eks-traces/* は touched なし (= Sub-project 1 で provision 済 + Sub-project 3 fix で IAM bucket-wide 適用済)
+- **local components**: `kubernetes/components/{tempo,opentelemetry-collector}/local/` は touched なし
+  - local Tempo chart `grafana/tempo` v1.24.4 は最新と一致 (= Sub-project 3 で経験した chart organizational migration **なし**)
+  - local OTel Collector chart `opentelemetry/opentelemetry-collector` v0.153.0 は最新と一致
+  - **OTel Operator (`opentelemetry/`)** は production deploy 対象外 (Decision 2)、ただし local には残す (= "future use" のため)
+- **kubernetes/README.md**: Sub-project 4a では update しない (= architecture diagram は最終形を維持、Sub-project 4b で sources 接続完了時に確認)
+- **kubernetes/components/{beyla,opentelemetry,fluent-bit,cilium}/production/**: Sub-project 4a では touched なし (= 4b 範囲)
+
+### File responsibility 設計原則
+
+| 設計原則 | 適用箇所 |
+|---|---|
+| 1 file 1 責務 | helmfile.yaml = chart install 定義、values.yaml.gotmpl = env-specific override の 2 file 分離 |
+| 既存 pattern 踏襲 | Sub-project 2 (mimir/production) / Sub-project 3 (loki/production / fluent-bit/production) と同形 |
+| manifests/production 配下 = auto-generated | hydrate 結果のみ commit、手 edit 禁止 |
+| kustomization.yaml = resources list のみ | append 形式で各 component を独立追加 (= `make hydrate-index` で auto-insert) |
+
+---
+
+## Sub-project 3 learnings の適用サマリ
+
+| Sub-project 3 learnings | 本 sub-project での適用 |
+|---|---|
+| **L1 (chart 内部固定 path 問題)** | Tempo は `s3.prefix` で全 path 制御可能、Loki のような問題なし |
+| **L2 (IAM 公式準拠)** | Sub-project 3 fix で 3 stack 同型済 → そのまま利用、Tempo は `s3.prefix: production` で application-level env scope |
+| **L3 (chart probe 確認)** | 実装段階で Tempo / OTel Collector の chart default readinessProbe / livenessProbe を精査 |
+| **L4 (S3 lifecycle で uniform 担保)** | Tempo application retention 設定なし、S3 lifecycle 7d で担保、3 stack 一貫 pattern 確立 |
+| **L5 (Flux suspend pattern)** | Rollback 手順として明示記録 |
+| **L6 (Loki `auth_enabled: false` 時 internal default tenant `fake`)** | Tempo は `multitenancy_enabled: false` で 1 tenant 運用、将来 multi-tenant 化時に tenant ID を 3 stack で揃える前提 |
+| **L7 (sibling stack symmetric 維持コスト評価)** | 3 stack で IAM template 同型維持済 (Sub-project 3 fix で適用)、本 sub-project は Tempo 単独追加 |
+| **L8 (post-flight check の確実性向上 = meta lesson)** | 13 項目の post-flight check を spec に明示、Phase 4 で自動化検討 |
+| **L9 (公式 docs 引用)** | Tempo 公式 docs ([S3 configuration](https://grafana.com/docs/tempo/latest/configuration/s3/)) を Decision section で direct citation、整合確認済 |
+| **L10 (Phase 3 全体 9 件の runtime issue = Phase 4 改善材料)** | 本 sub-project では runtime issue を minimize する design 採用 (= 4a / 4b 分割、source 未接続で 4a 完結、L1-L9 適用) |
+
+---
+
+## Sub-project 1 / 2 の knowledge の継承
+
+- **Sub-project 1 L1 (IAM policy 3 statement)**: aws/eks-traces/ は Sub-project 1 で正規化済 + Sub-project 3 fix で bucket-wide 適用済、本 sub-project では IAM 触らない
+- **Plan 1c-β L4 (REPLACE_FROM_TERRAGRUNT_OUTPUT 不要)**: kubernetes/helmfile.yaml.gotmpl に直接実値 (`tempo-559744160976`) を書く、placeholder pattern 不採用
+- **Plan tuning L1 (IAM name_prefix 38 chars limit)**: 本 sub-project は IAM 触らないため non-applicable
+- **Sub-project 2 L1 (chart upgrade での upstream changelog 確認)**: Tempo + OTel Collector chart の最新 version は local 揃い、organizational migration なしを確認済 (Decision 6)
+- **Sub-project 2 L2 (chart auto-generated ConfigMap 衝突)**: Sub-project 2 PR #289 の `defaultDatasourceEnabled: false` 設定継続、新たな衝突なし
+- **Sub-project 2 L3 (EBS RWO + RollingUpdate → Recreate)**: Tempo は StatefulSet (OrderedReady)、OTel Collector は Deployment + PVC なし、新規 Recreate 設定不要

--- a/kubernetes/components/opentelemetry-collector/production/helmfile.yaml
+++ b/kubernetes/components/opentelemetry-collector/production/helmfile.yaml
@@ -1,0 +1,28 @@
+# =============================================================================
+# OpenTelemetry Collector Helmfile for production
+# =============================================================================
+# Phase 3 Sub-project 4a で deploy する Traces stack の OTel Collector。
+# Deployment mode で 1 replica の集約 hub として deploy。4a では OTLP receivers
+# + Tempo exporter のみの traces pipeline を完成、metrics / logs pipelines は
+# 4b で sources (Beyla / Hubble / Fluent Bit) 接続と同時に追加。
+#
+# Decision references:
+# - D2: OpenTelemetry Operator は production deploy しない (YAGNI)
+# - D4: Deployment + replicas=1 (集約 hub、HA upgrade path 保持)
+# - D6: chart version v0.153.0 (= local 揃い、最新と一致)
+# - D11: 4a では traces pipeline のみ scope、metrics / logs は 4b で追加
+# =============================================================================
+environments:
+  production:
+---
+repositories:
+  - name: opentelemetry
+    url: https://open-telemetry.github.io/opentelemetry-helm-charts
+
+releases:
+  - name: opentelemetry-collector
+    namespace: monitoring
+    chart: opentelemetry/opentelemetry-collector
+    version: "0.153.0"
+    values:
+      - values.yaml.gotmpl

--- a/kubernetes/components/opentelemetry-collector/production/values.yaml.gotmpl
+++ b/kubernetes/components/opentelemetry-collector/production/values.yaml.gotmpl
@@ -1,0 +1,89 @@
+# OpenTelemetry Collector Configuration for production
+# Deployment mode + 4a では traces pipeline only (Decision 11、metrics/logs は 4b で追加)
+
+# =============================================================================
+# Deployment Mode (Decision 4)
+# =============================================================================
+mode: deployment
+replicaCount: 1
+
+# =============================================================================
+# Image (contrib for k8sattributes processor 等の拡張機能、4b で利用)
+# =============================================================================
+image:
+  repository: otel/opentelemetry-collector-contrib
+  tag: 0.151.0
+
+# =============================================================================
+# Resources (small production)
+# =============================================================================
+resources:
+  requests:
+    cpu: 100m
+    memory: 256Mi
+  limits:
+    cpu: 500m
+    memory: 1Gi
+
+# =============================================================================
+# Service Configuration
+# =============================================================================
+service:
+  type: ClusterIP
+
+# =============================================================================
+# Ports (= metrics port を必ず enable、ServiceMonitor 用)
+# =============================================================================
+# NOTE: chart README に明記「The metrics port is disabled by default. However
+# you need to enable the port in order to use the ServiceMonitor」。Sub-project 3
+# L3 (chart probe / port enable 設定の実装段階精査) を適用、明示的に enable する。
+ports:
+  metrics:
+    enabled: true
+    containerPort: 8888
+    servicePort: 8888
+    protocol: TCP
+
+# =============================================================================
+# ServiceMonitor (Prometheus auto-scrape, Decision 9)
+# =============================================================================
+# NOTE: chart の serviceMonitor key 名は `extraLabels` (OTel Collector chart 固有)。
+# Tempo chart の `additionalLabels`、fluent-bit chart の `selector` とは別 key
+# 名なので注意 (Sub-project 3 L3 = chart 固有 key 確認の実装段階精査の結果)。
+serviceMonitor:
+  enabled: true
+  extraLabels:
+    release: kube-prometheus-stack
+  metricsEndpoints:
+    - port: metrics
+      interval: 15s
+
+# =============================================================================
+# Collector Config (4a 範囲 = traces pipeline のみ override、Decision 11)
+# =============================================================================
+# NOTE: chart default で logs / metrics pipelines も pre-configure されるが、
+# 4a では source 未接続 (= 4b で wire up 予定) のため effective に inactive。
+# 4b で metrics / logs sources (Hubble / Beyla / Fluent Bit) を接続するときに
+# pipelines を実利用化する。本 4a で override するのは:
+#   1. exporters: otlp/tempo を追加 (= traces を Tempo に export)
+#   2. service.pipelines.traces: chart default の exporters [debug] を
+#      [otlp/tempo] に上書き
+config:
+  exporters:
+    # 4a で追加: Tempo exporter (4b で metrics / logs exporters 追加予定)
+    otlp/tempo:
+      endpoint: tempo.monitoring.svc.cluster.local:4317
+      tls:
+        insecure: true
+  service:
+    pipelines:
+      traces:
+        # chart default の exporters: [debug] を override、Tempo に export
+        exporters:
+          - otlp/tempo
+        # processors / receivers は chart default を継承 (= memory_limiter + batch / otlp)
+        processors:
+          - memory_limiter
+          - batch
+        receivers:
+          - otlp

--- a/kubernetes/components/prometheus-operator/production/values.yaml.gotmpl
+++ b/kubernetes/components/prometheus-operator/production/values.yaml.gotmpl
@@ -46,7 +46,7 @@ grafana:
       defaultDatasourceEnabled: false
 
   # -------------------------------------------------------------------------
-  # Data Sources (Mimir primary、Prometheus local secondary、Loki logs)
+  # Data Sources (Mimir primary、Prometheus local secondary、Loki logs、Tempo traces)
   # -------------------------------------------------------------------------
   datasources:
     datasources.yaml:
@@ -82,6 +82,20 @@ grafana:
             httpHeaderName1: X-Scope-OrgID
           secureJsonData:
             httpHeaderValue1: anonymous
+        # Phase 3 Sub-project 4a (Traces stack foundation)
+        - name: Tempo
+          uid: tempo
+          type: tempo
+          url: http://tempo.monitoring.svc.cluster.local:3200
+          access: proxy
+          isDefault: false
+          jsonData:
+            # 1 tenant 運用 (= Decision 8、multitenancy OFF)
+            httpMethod: GET
+            tracesToLogsV2:
+              datasourceUid: loki
+            tracesToMetrics:
+              datasourceUid: mimir
 
 # =============================================================================
 # Prometheus Configuration

--- a/kubernetes/components/tempo/production/helmfile.yaml
+++ b/kubernetes/components/tempo/production/helmfile.yaml
@@ -1,0 +1,39 @@
+# =============================================================================
+# Tempo Helmfile for production
+# =============================================================================
+# Phase 3 Sub-project 4a で deploy する Traces stack の Tempo 本体。
+# Monolithic mode (= chart 内蔵の single binary deploy、distributor + ingester +
+# querier + compactor を 1 process に統合、small production OK の Tempo 公式
+# position に準拠)。S3 backend は Sub-project 1 で provision 済の
+# tempo-559744160976 を Pod Identity 経由でアクセス。
+#
+# Decision references:
+# - D3: Monolithic mode (HA upgrade path 保持、Phase 4 で grafana/tempo-distributed への切替検討)
+# - D5: application retention OFF (chart default)、S3 lifecycle 7d で担保
+# - D7: bucket-wide IAM (Sub-project 3 fix で 3 stack 同型済) + application-level
+#       prefix env scope (s3.prefix: production)
+# - D8: multitenancy OFF (1 tenant 運用、Mimir / Loki と対称)
+# - D12: PVC 10Gi gp3 (WAL + 短期 compactor cache)
+# =============================================================================
+environments:
+  production:
+    # NOTE: helmfile v1.4 は親 helmfile.yaml.gotmpl の environments values を
+    # 子 helmfile に auto-inherit しないため、ここで再定義する。
+    # 値は kubernetes/helmfile.yaml.gotmpl の production env block と
+    # 同期すること (tempo.bucketName / tempo.bucketPathPrefix)。
+    values:
+      - tempo:
+          bucketName: tempo-559744160976
+          bucketPathPrefix: production
+---
+repositories:
+  - name: grafana
+    url: https://grafana.github.io/helm-charts
+
+releases:
+  - name: tempo
+    namespace: monitoring
+    chart: grafana/tempo
+    version: "1.24.4"
+    values:
+      - values.yaml.gotmpl

--- a/kubernetes/components/tempo/production/values.yaml.gotmpl
+++ b/kubernetes/components/tempo/production/values.yaml.gotmpl
@@ -1,0 +1,98 @@
+# Tempo Configuration for production
+# Monolithic mode + S3 backend (Sub-project 1 outputs) + Pod Identity (tempo SA)
+
+# =============================================================================
+# Tempo Core Configuration
+# =============================================================================
+tempo:
+  # 1 tenant 運用 (panicboat) のため multitenancy OFF (Decision 8)
+  multitenancyEnabled: false
+
+  # -------------------------------------------------------------------------
+  # Resources (small production)
+  # -------------------------------------------------------------------------
+  resources:
+    requests:
+      cpu: 200m
+      memory: 512Mi
+    limits:
+      cpu: 1
+      memory: 2Gi
+
+  # -------------------------------------------------------------------------
+  # Storage Config (S3 backend, Sub-project 1 outputs)
+  # -------------------------------------------------------------------------
+  storage:
+    trace:
+      backend: s3
+      s3:
+        bucket: {{ .Values.tempo.bucketName }}
+        endpoint: s3.ap-northeast-1.amazonaws.com
+        # application-level env scope (= Sub-project 3 L2 適用、IAM bucket-wide と整合)
+        prefix: {{ .Values.tempo.bucketPathPrefix }}
+        # AWS S3 native (HTTPS) = insecure: false (default)
+        # Pod Identity 経由のため access_key / secret_key 不要
+
+  # -------------------------------------------------------------------------
+  # Receivers (= 4b で OTel Collector からの OTLP 受信用、4a では未接続)
+  # -------------------------------------------------------------------------
+  receivers:
+    otlp:
+      protocols:
+        grpc:
+          endpoint: 0.0.0.0:4317
+        http:
+          endpoint: 0.0.0.0:4318
+
+  # -------------------------------------------------------------------------
+  # Retention 機能は OFF (= chart default に任せる、Decision 5)
+  # -------------------------------------------------------------------------
+  # NOTE: 3 stack で application retention は OFF + S3 lifecycle で uniform 担保
+  # の panicboat pattern (Sub-project 3 L4 適用)。Tempo 内 retention 機能は
+  # per-tenant rules 等の advanced feature 用、panicboat の uniform 7d retention
+  # は aws/eks-traces/ S3 lifecycle で担保。
+
+  # -------------------------------------------------------------------------
+  # Metrics generator は OFF (= advanced features、Phase 4 で再検討)
+  # -------------------------------------------------------------------------
+  metricsGenerator:
+    enabled: false
+
+# =============================================================================
+# ServiceAccount (Pod Identity for S3 access)
+# =============================================================================
+serviceAccount:
+  create: true
+  # aws/eks-traces/ で provision 済の Pod Identity Association が
+  # monitoring/tempo SA を IAM role eks-production-tempo に紐付け済
+  name: tempo
+  # Pod Identity は IRSA と異なり annotation 不要 (cluster-side で managed)
+  annotations: {}
+
+# =============================================================================
+# Persistence (= WAL + 短期 compactor cache、Decision 12)
+# =============================================================================
+persistence:
+  enabled: true
+  storageClassName: gp3
+  size: 10Gi
+  accessModes:
+    - ReadWriteOnce
+
+# =============================================================================
+# Service Configuration
+# =============================================================================
+service:
+  type: ClusterIP
+
+# =============================================================================
+# ServiceMonitor (Prometheus auto-scrape, Decision 9)
+# =============================================================================
+# NOTE: chart の serviceMonitor key 名は `additionalLabels` (Tempo chart 固有)。
+# OTel Collector chart の `extraLabels` とは別 key 名なので注意 (Sub-project 3 L3
+# = chart probe / serviceMonitor key 確認の実装段階精査の結果)。
+serviceMonitor:
+  enabled: true
+  additionalLabels:
+    release: kube-prometheus-stack
+  interval: 15s

--- a/kubernetes/components/tempo/production/values.yaml.gotmpl
+++ b/kubernetes/components/tempo/production/values.yaml.gotmpl
@@ -28,6 +28,7 @@ tempo:
       s3:
         bucket: {{ .Values.tempo.bucketName }}
         endpoint: s3.ap-northeast-1.amazonaws.com
+        region: ap-northeast-1
         # application-level env scope (= Sub-project 3 L2 適用、IAM bucket-wide と整合)
         prefix: {{ .Values.tempo.bucketPathPrefix }}
         # AWS S3 native (HTTPS) = insecure: false (default)
@@ -78,6 +79,17 @@ persistence:
   size: 10Gi
   accessModes:
     - ReadWriteOnce
+
+# =============================================================================
+# PodDisruptionBudget (1 replica 用に明示 disable)
+# =============================================================================
+# NOTE: chart default で PDB が enable の場合、replicas=1 で minAvailable=1 に
+# なり node drain 時に block する。Loki/production の SingleBinary podDisruptionBudget
+# と同じく明示 disable して node drain operations を安全に保つ。
+# (Tempo chart v1.24.4 は PDB テンプレートを持たないが、将来の chart upgrade に
+# 備えて明示 disable で意図を文書化する)
+podDisruptionBudget:
+  enabled: false
 
 # =============================================================================
 # Service Configuration

--- a/kubernetes/helmfile.yaml.gotmpl
+++ b/kubernetes/helmfile.yaml.gotmpl
@@ -55,6 +55,11 @@ environments:
           bucketName: loki-559744160976
           bucketPathPrefix: production
           podIdentityRoleName: eks-production-loki
+        tempo:
+          # Source: aws/eks-traces/envs/production terragrunt output
+          bucketName: tempo-559744160976
+          bucketPathPrefix: production
+          podIdentityRoleName: eks-production-tempo
   # TODO: (staging) Uncomment and configure when staging cluster is provisioned
   # staging:
   #   values:

--- a/kubernetes/manifests/production/00-namespaces/namespaces.yaml
+++ b/kubernetes/manifests/production/00-namespaces/namespaces.yaml
@@ -40,6 +40,16 @@ metadata:
     app.kubernetes.io/name: keda
 ---
 # =============================================================================
+# OpenTelemetry Collector Namespace
+# =============================================================================
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: opentelemetry-system
+  labels:
+    app.kubernetes.io/name: opentelemetry-collector
+---
+# =============================================================================
 # Monitoring Namespace
 # =============================================================================
 # This namespace contains the full observability stack:

--- a/kubernetes/manifests/production/kustomization.yaml
+++ b/kubernetes/manifests/production/kustomization.yaml
@@ -10,4 +10,6 @@ resources:
   - ./loki
   - ./metrics-server
   - ./mimir
+  - ./opentelemetry-collector
   - ./prometheus-operator
+  - ./tempo

--- a/kubernetes/manifests/production/opentelemetry-collector/kustomization.yaml
+++ b/kubernetes/manifests/production/opentelemetry-collector/kustomization.yaml
@@ -1,0 +1,2 @@
+resources:
+  - manifest.yaml

--- a/kubernetes/manifests/production/opentelemetry-collector/manifest.yaml
+++ b/kubernetes/manifests/production/opentelemetry-collector/manifest.yaml
@@ -1,0 +1,327 @@
+---
+# Source: opentelemetry-collector/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: opentelemetry-collector
+  namespace: monitoring
+  labels:
+    helm.sh/chart: opentelemetry-collector-0.153.0
+    app.kubernetes.io/name: opentelemetry-collector
+    app.kubernetes.io/instance: opentelemetry-collector
+    app.kubernetes.io/version: "0.151.0"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: opentelemetry-collector
+    app.kubernetes.io/component: standalone-collector
+---
+# Source: opentelemetry-collector/templates/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: opentelemetry-collector
+  namespace: monitoring
+  labels:
+    helm.sh/chart: opentelemetry-collector-0.153.0
+    app.kubernetes.io/name: opentelemetry-collector
+    app.kubernetes.io/instance: opentelemetry-collector
+    app.kubernetes.io/version: "0.151.0"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: opentelemetry-collector
+    app.kubernetes.io/component: standalone-collector
+data:
+  relay: |
+    exporters:
+      debug: {}
+      otlp/tempo:
+        endpoint: tempo.monitoring.svc.cluster.local:4317
+        tls:
+          insecure: true
+    extensions:
+      health_check:
+        endpoint: ${env:MY_POD_IP}:13133
+    processors:
+      batch: {}
+      memory_limiter:
+        check_interval: 5s
+        limit_percentage: 80
+        spike_limit_percentage: 25
+    receivers:
+      jaeger:
+        protocols:
+          grpc:
+            endpoint: ${env:MY_POD_IP}:14250
+          thrift_compact:
+            endpoint: ${env:MY_POD_IP}:6831
+          thrift_http:
+            endpoint: ${env:MY_POD_IP}:14268
+      otlp:
+        protocols:
+          grpc:
+            endpoint: ${env:MY_POD_IP}:4317
+          http:
+            endpoint: ${env:MY_POD_IP}:4318
+      prometheus:
+        config:
+          scrape_configs:
+          - job_name: opentelemetry-collector
+            scrape_interval: 10s
+            static_configs:
+            - targets:
+              - ${env:MY_POD_IP}:8888
+      zipkin:
+        endpoint: ${env:MY_POD_IP}:9411
+    service:
+      extensions:
+      - health_check
+      pipelines:
+        logs:
+          exporters:
+          - debug
+          processors:
+          - memory_limiter
+          - batch
+          receivers:
+          - otlp
+        metrics:
+          exporters:
+          - debug
+          processors:
+          - memory_limiter
+          - batch
+          receivers:
+          - otlp
+          - prometheus
+        traces:
+          exporters:
+          - otlp/tempo
+          processors:
+          - memory_limiter
+          - batch
+          receivers:
+          - otlp
+      telemetry:
+        metrics:
+          readers:
+          - pull:
+              exporter:
+                prometheus:
+                  host: ${env:MY_POD_IP}
+                  port: 8888
+        resource:
+          host.name: ${env:OTEL_K8S_NODE_NAME}
+          k8s.namespace.name: ${env:OTEL_K8S_NAMESPACE}
+          k8s.node.ip: ${env:OTEL_K8S_NODE_IP}
+          k8s.node.name: ${env:OTEL_K8S_NODE_NAME}
+          k8s.pod.ip: ${env:OTEL_K8S_POD_IP}
+          k8s.pod.name: ${env:OTEL_K8S_POD_NAME}
+---
+# Source: opentelemetry-collector/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: opentelemetry-collector
+  namespace: monitoring
+  labels:
+    helm.sh/chart: opentelemetry-collector-0.153.0
+    app.kubernetes.io/name: opentelemetry-collector
+    app.kubernetes.io/instance: opentelemetry-collector
+    app.kubernetes.io/version: "0.151.0"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: opentelemetry-collector
+    app.kubernetes.io/component: standalone-collector
+    component: standalone-collector
+spec:
+  type: ClusterIP
+  ports:
+    
+    - name: jaeger-compact
+      port: 6831
+      targetPort: 6831
+      protocol: UDP
+    - name: jaeger-grpc
+      port: 14250
+      targetPort: 14250
+      protocol: TCP
+    - name: jaeger-thrift
+      port: 14268
+      targetPort: 14268
+      protocol: TCP
+    - name: metrics
+      port: 8888
+      targetPort: 8888
+      protocol: TCP
+    - name: otlp
+      port: 4317
+      targetPort: 4317
+      protocol: TCP
+      appProtocol: grpc
+    - name: otlp-http
+      port: 4318
+      targetPort: 4318
+      protocol: TCP
+    - name: zipkin
+      port: 9411
+      targetPort: 9411
+      protocol: TCP
+  selector:
+    app.kubernetes.io/name: opentelemetry-collector
+    app.kubernetes.io/instance: opentelemetry-collector
+    component: standalone-collector
+  internalTrafficPolicy: Cluster
+---
+# Source: opentelemetry-collector/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: opentelemetry-collector
+  namespace: monitoring
+  labels:
+    helm.sh/chart: opentelemetry-collector-0.153.0
+    app.kubernetes.io/name: opentelemetry-collector
+    app.kubernetes.io/instance: opentelemetry-collector
+    app.kubernetes.io/version: "0.151.0"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: opentelemetry-collector
+    app.kubernetes.io/component: standalone-collector
+spec:
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: opentelemetry-collector
+      app.kubernetes.io/instance: opentelemetry-collector
+      component: standalone-collector
+  strategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      annotations:
+        checksum/config: 8ed5f3e11bd66da68bf85d440b0be40f36f09c5f5ad4e0547b1049094b8b8f72
+        
+      labels:
+        app.kubernetes.io/name: opentelemetry-collector
+        app.kubernetes.io/instance: opentelemetry-collector
+        component: standalone-collector
+        
+    spec:
+      
+      serviceAccountName: opentelemetry-collector
+      automountServiceAccountToken: true
+      securityContext:
+        {}
+      containers:
+        - name: opentelemetry-collector
+          args:
+            - --config=/conf/relay.yaml
+          securityContext:
+            {}
+          image: "otel/opentelemetry-collector-contrib:0.151.0"
+          imagePullPolicy: IfNotPresent
+          ports:
+            
+            - name: jaeger-compact
+              containerPort: 6831
+              protocol: UDP
+            - name: jaeger-grpc
+              containerPort: 14250
+              protocol: TCP
+            - name: jaeger-thrift
+              containerPort: 14268
+              protocol: TCP
+            - name: metrics
+              containerPort: 8888
+              protocol: TCP
+            - name: otlp
+              containerPort: 4317
+              protocol: TCP
+            - name: otlp-http
+              containerPort: 4318
+              protocol: TCP
+            - name: zipkin
+              containerPort: 9411
+              protocol: TCP
+          env:
+            - name: MY_POD_IP
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: status.podIP
+            - name: OTEL_K8S_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: OTEL_K8S_NODE_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.hostIP
+            - name: OTEL_K8S_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
+            - name: OTEL_K8S_POD_NAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.name
+            - name: OTEL_K8S_POD_IP
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: status.podIP
+            - name: GOMEMLIMIT
+              value: "819MiB"
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 13133
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 13133
+          resources:
+            limits:
+              cpu: 500m
+              memory: 1Gi
+            requests:
+              cpu: 100m
+              memory: 256Mi
+          volumeMounts:
+            - mountPath: /conf
+              name: opentelemetry-collector-configmap
+      terminationGracePeriodSeconds: 30
+      volumes:
+        - name: opentelemetry-collector-configmap
+          configMap:
+            name: opentelemetry-collector
+            items:
+              - key: relay
+                path: relay.yaml
+      hostNetwork: false
+      hostPID: false
+---
+# Source: opentelemetry-collector/templates/servicemonitor.yaml
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: opentelemetry-collector
+  namespace: monitoring
+  labels:
+    helm.sh/chart: opentelemetry-collector-0.153.0
+    app.kubernetes.io/name: opentelemetry-collector
+    app.kubernetes.io/instance: opentelemetry-collector
+    app.kubernetes.io/version: "0.151.0"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: opentelemetry-collector
+    app.kubernetes.io/component: standalone-collector
+    release: "kube-prometheus-stack"
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: opentelemetry-collector
+      app.kubernetes.io/instance: opentelemetry-collector
+      component: standalone-collector
+  endpoints:
+    - interval: 15s
+      port: metrics
+

--- a/kubernetes/manifests/production/tempo/kustomization.yaml
+++ b/kubernetes/manifests/production/tempo/kustomization.yaml
@@ -1,0 +1,2 @@
+resources:
+  - manifest.yaml

--- a/kubernetes/manifests/production/tempo/manifest.yaml
+++ b/kubernetes/manifests/production/tempo/manifest.yaml
@@ -1,0 +1,293 @@
+---
+# Source: tempo/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: tempo
+  namespace: monitoring
+  labels:
+    helm.sh/chart: tempo-1.24.4
+    app.kubernetes.io/name: tempo
+    app.kubernetes.io/instance: tempo
+    app.kubernetes.io/version: "2.9.0"
+    app.kubernetes.io/managed-by: Helm
+automountServiceAccountToken: true
+---
+# Source: tempo/templates/configmap-tempo.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: tempo
+  namespace: monitoring
+  labels:
+    helm.sh/chart: tempo-1.24.4
+    app.kubernetes.io/name: tempo
+    app.kubernetes.io/instance: tempo
+    app.kubernetes.io/version: "2.9.0"
+    app.kubernetes.io/managed-by: Helm
+data:
+  overrides.yaml: |
+    overrides:
+      {}
+  tempo.yaml: |
+    memberlist:
+      cluster_label: "tempo.monitoring"
+    multitenancy_enabled: false
+    usage_report:
+      reporting_enabled: true
+    compactor:
+      compaction:
+        block_retention: 24h
+    distributor:
+      receivers:
+            jaeger:
+              protocols:
+                grpc:
+                  endpoint: 0.0.0.0:14250
+                thrift_binary:
+                  endpoint: 0.0.0.0:6832
+                thrift_compact:
+                  endpoint: 0.0.0.0:6831
+                thrift_http:
+                  endpoint: 0.0.0.0:14268
+            opencensus: null
+            otlp:
+              protocols:
+                grpc:
+                  endpoint: 0.0.0.0:4317
+                http:
+                  endpoint: 0.0.0.0:4318
+    ingester:
+          {}
+    server:
+          http_listen_port: 3200
+    storage:
+          trace:
+            backend: s3
+            local:
+              path: /var/tempo/traces
+            s3:
+              bucket: tempo-559744160976
+              endpoint: s3.ap-northeast-1.amazonaws.com
+              prefix: production
+              region: ap-northeast-1
+            wal:
+              path: /var/tempo/wal
+    querier:
+          {}
+    query_frontend:
+          {}
+    overrides:
+          defaults: {}
+          per_tenant_override_config: /conf/overrides.yaml
+---
+# Source: tempo/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: tempo
+  namespace: monitoring
+  labels:
+    helm.sh/chart: tempo-1.24.4
+    app.kubernetes.io/name: tempo
+    app.kubernetes.io/instance: tempo
+    app.kubernetes.io/version: "2.9.0"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  type: ClusterIP
+  ports:  
+  - name: tempo-jaeger-thrift-compact
+    port: 6831
+    protocol: UDP
+    targetPort: 6831
+  - name: tempo-jaeger-thrift-binary
+    port: 6832
+    protocol: UDP
+    targetPort: 6832  
+  - name: tempo-prom-metrics
+    port: 3200
+    protocol: TCP
+    targetPort: 3200
+  - name: tempo-jaeger-thrift-http
+    port: 14268
+    protocol: TCP
+    targetPort: 14268
+  - name: grpc-tempo-jaeger
+    port: 14250
+    protocol: TCP
+    targetPort: 14250
+  - name: tempo-zipkin
+    port: 9411
+    protocol: TCP
+    targetPort: 9411
+  - name: tempo-otlp-legacy
+    port: 55680
+    protocol: TCP
+    targetPort: 55680
+  - name: tempo-otlp-http-legacy
+    port: 55681
+    protocol: TCP
+    targetPort: 55681
+  - name: grpc-tempo-otlp
+    port: 4317
+    protocol: TCP
+    targetPort: 4317
+  - name: tempo-otlp-http
+    port: 4318
+    protocol: TCP
+    targetPort: 4318
+  - name: tempo-opencensus
+    port: 55678
+    protocol: TCP
+    targetPort: 55678
+  selector:
+    app.kubernetes.io/name: tempo
+    app.kubernetes.io/instance: tempo
+---
+# Source: tempo/templates/statefulset.yaml
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: tempo
+  namespace: monitoring
+  labels:
+    helm.sh/chart: tempo-1.24.4
+    app.kubernetes.io/name: tempo
+    app.kubernetes.io/instance: tempo
+    app.kubernetes.io/version: "2.9.0"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: tempo
+      app.kubernetes.io/instance: tempo
+  serviceName: tempo-headless
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: tempo
+        app.kubernetes.io/instance: tempo
+      annotations:
+        checksum/config: 534d0042ccea663a2c5008515724c6ce56539d5e2cb48600ecd9e4a47612199f
+    spec:
+      serviceAccountName: tempo
+      automountServiceAccountToken: true
+      containers:
+      - args:
+        - -config.file=/conf/tempo.yaml
+        - -mem-ballast-size-mbs=1024
+        image: docker.io/grafana/tempo:2.9.0
+        imagePullPolicy: IfNotPresent
+        name: tempo
+        ports:
+        - containerPort: 3200
+          name: prom-metrics
+        - containerPort: 6831
+          name: jaeger-thrift-c
+          protocol: UDP
+        - containerPort: 6832
+          name: jaeger-thrift-b
+          protocol: UDP
+        - containerPort: 14268
+          name: jaeger-thrift-h
+        - containerPort: 14250
+          name: jaeger-grpc
+        - containerPort: 9411
+          name: zipkin
+        - containerPort: 55680
+          name: otlp-legacy
+        - containerPort: 4317
+          name: otlp-grpc
+        - containerPort: 55681
+          name: otlp-httplegacy
+        - containerPort: 4318
+          name: otlp-http
+        - containerPort: 55678
+          name: opencensus
+        livenessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /ready
+              port: 3200
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 5
+        readinessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /ready
+              port: 3200
+            initialDelaySeconds: 20
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 5
+        resources:
+          limits:
+            cpu: 1
+            memory: 2Gi
+          requests:
+            cpu: 200m
+            memory: 512Mi
+        env:
+        volumeMounts:
+        - mountPath: /conf
+          name: tempo-conf
+        - mountPath: /var/tempo
+          name: storage
+      securityContext:
+        fsGroup: 10001
+        runAsGroup: 10001
+        runAsNonRoot: true
+        runAsUser: 10001
+      volumes:
+      - configMap:
+          name: tempo
+        name: tempo-conf
+  updateStrategy:
+    type:
+      RollingUpdate
+  volumeClaimTemplates:
+    - apiVersion: v1
+      kind: PersistentVolumeClaim
+      metadata:
+        name: storage
+        annotations:
+          null
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: "10Gi"
+        storageClassName: gp3
+---
+# Source: tempo/templates/servicemonitor.yaml
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: tempo
+  namespace: monitoring
+  labels:
+    app: tempo
+    chart: tempo-1.24.4
+    heritage: Helm
+    release: kube-prometheus-stack
+spec:
+  selector:
+    matchLabels:
+      helm.sh/chart: tempo-1.24.4
+      app.kubernetes.io/name: tempo
+      app.kubernetes.io/instance: tempo
+      app.kubernetes.io/version: "2.9.0"
+      app.kubernetes.io/managed-by: Helm
+  namespaceSelector:
+    matchNames:
+      - "monitoring"
+  endpoints:
+    - port: tempo-prom-metrics
+      interval: 15s
+    - port: jaeger-metrics
+      interval: 15s
+


### PR DESCRIPTION
## Summary

Phase 3 Sub-project 4a (Traces stack foundation) の implementation。`grafana/tempo` v1.24.4 (Monolithic mode、Tempo 2.9.0) + `opentelemetry/opentelemetry-collector` v0.153.0 を `monitoring` namespace に deploy。Sub-project 1 で provision 済 + Sub-project 3 fix で bucket-wide IAM 適用済の AWS infra (`tempo-559744160976` bucket / `eks-production-tempo` IAM role / `tempo` Pod Identity SA) を活用、Sub-project 2 / 3 で確立した monitoring namespace + ServiceMonitor pattern + Grafana datasource 統合 path に従う。

**Architecture (4a 完了時):** Tempo Monolithic StatefulSet で S3 backend に Pod Identity 経由でアクセス。OTel Collector Deployment で OTLP receivers + Tempo exporter のみの **traces pipeline** を完成。**source 未接続** = Beyla / Hubble / Fluent Bit から OTLP push は Sub-project 4b で wire up。

## Spec / Plan

- Spec: `docs/superpowers/specs/2026-05-06-eks-production-observability-traces-stack-foundation-design.md` (13 Decisions、Sub-project 1-3 learnings 全項目適用)
- Plan: `docs/superpowers/plans/2026-05-06-eks-production-observability-traces-stack-foundation.md` (6 tasks)

## Notable Decisions

- **D1**: Sub-project 4 を 4a + 4b に分割 (= 4b は別途 brainstorming)
- **D2**: OTel Operator は production deploy しない (YAGNI、Beyla 採用済)
- **D3**: Tempo Monolithic (small production OK、Loki と対称、Mimir Microservices と非対称)
- **D5**: application retention OFF (chart default)、S3 lifecycle 7d で uniform 担保 (= 3 stack 一貫 pattern)
- **D11**: 4a では traces pipeline のみ、metrics / logs は 4b で追加
- **D13**: 3 stack (Mimir / Loki / Tempo) で application retention OFF + S3 lifecycle 担保 + bucket-wide IAM + application-level prefix env scope の panicboat pattern が完全に揃う

## Commits (7)

```
8e62b77 chore(kubernetes/manifests): hydrate tempo + opentelemetry-collector
05245e5 feat(eks): add Tempo cross-stack values + Grafana datasource
4ad0fce feat(eks): add production OTel Collector (Deployment + traces pipeline)
f3eb2b6 fix(eks): explicit region + PDB disable for Tempo (3 stack consistency)
8879833 feat(eks): add production Tempo (Monolithic + S3 + Pod Identity)
eb0863d docs(eks): Phase 3 Sub-project 4a (Traces foundation) implementation plan
0f5ae57 docs(eks): Phase 3 Sub-project 4a (Traces foundation) design spec
```

## Pre-flight check (Task 0 で controller 完了)

- [x] aws/eks-traces/ resource (S3 bucket + IAM role + Pod Identity Association、direct AWS API で確認)
- [x] S3 bucket tempo-559744160976 head-bucket 200 OK + lifecycle 7d
- [x] Pod Identity Association monitoring/tempo exists
- [x] IAM ObjectLevelOperations Resource bucket-wide (Sub-project 3 fix 反映: `arn:aws:s3:::tempo-559744160976/*`)
- [x] gp3 StorageClass exists
- [x] Sub-project 2 / 3 stack all Running
- [x] Flux not suspended

## Implementation review

各 task で subagent-driven-development の two-stage review (spec compliance + code quality):

| Task | implementer commit | spec review | code review |
|---|---|---|---|
| Task 1 | `8879833` + fix `f3eb2b6` | ✅ SPEC_COMPLIANT | APPROVED_WITH_NITS → fix で region + PDB 明示 |
| Task 2 | `4ad0fce` | ✅ SPEC_COMPLIANT | ✅ APPROVED |
| Task 3 | `05245e5` | ✅ SPEC_COMPLIANT (Webhook diff は順序変動) | ✅ APPROVED |
| Task 4 | `8e62b77` | ✅ APPROVED_WITH_NITS (Issue A/B は scope 外) | ✅ APPROVED |

主要 fix:
- **Task 1 fix `f3eb2b6`**: `region: ap-northeast-1` 明示 (3 stack consistency) + `podDisruptionBudget.enabled: false` 明示 (Loki と同 pattern、ただし Tempo chart v1.24.4 は PDB template を持たないため将来 chart upgrade 時の防衛的設定)

## Test plan (post-flight, after merge)

### 10 分以内
- [ ] Tempo `tempo-0` `1/1 Running` (StatefulSet)
- [ ] OTel Collector `1/1 Running` (Deployment)
- [ ] PVC `tempo-tempo-0` Bound (gp3 10Gi)
- [ ] Prometheus targets で `tempo` / `opentelemetry-collector` が `UP`

### 30 分以内
- [ ] Tempo S3 backend ready (= Pod Identity 動作確認、Tempo logs で `s3 backend` 接続成功)
- [ ] OTel Collector startup 成功 (= Tempo gRPC connection established)
- [ ] self-metrics (`tempo_*` / `otelcol_*`) が Mimir に remote_write されて Grafana で query 可能
- [ ] Grafana Tempo datasource `Save & test` で 緑
- [ ] Sub-project 2 / 3 stack regression なし

**注**: 4a では source 未接続のため **actual traces data は流れない**。実 traces 検証は 4b で source 接続後。

## Known limitations / scope-out findings (Task 4 review で flag)

### Issue A: `opentelemetry-system` namespace が production にも作成される

- 既存 `kubernetes/components/opentelemetry-collector/namespace.yaml` (top-level、共通) が `make hydrate-index` で production env にも反映
- production OTel Collector は `monitoring` namespace に deploy するため、**`opentelemetry-system` namespace は空のまま (= unused)**
- 害なし、ただし namespace 設計のクリーンアップは今後の課題 (= local 専用 namespace を subdirectory 分離する等)
- **Sub-project 4a / 4b の learnings で扱う**

### Issue B: gp3 StorageClass が Flux 管理外

- Sub-project 2 で gp3 StorageClass を `kubectl apply` で direct deploy、`kubernetes/manifests/production/storage-class/` (Flux 管理) には追加されていなかった
- 現状 cluster には gp3 StorageClass が存在 (= 全 component で正常動作中) だが、GitOps 管理の整合性が崩れている
- **Sub-project 4a の scope 外、別 PR で GitOps 管理化を検討**

## Sub-project 1-3 learnings 適用

| learnings | 本 PR での適用 |
|---|---|
| Sub-project 2 L1 (chart upgrade での upstream changelog 確認) | Tempo + OTel Collector chart の最新 version は local 揃い、organizational migration なしを確認済 |
| Sub-project 2 L4 (Spec verification を pre-flight / post-flight 分割) | pre-flight 7 件 (Task 0) + post-flight 13 件 (本 PR description) |
| Sub-project 2 L5 (Flux suspend pattern) | 通常 deploy で進める、問題発見時のみ reactive 発動 (= Rollback 手順は spec に記録済) |
| Sub-project 2 L6 (gp3 StorageClass) | Sub-project 2 で provision 済再利用 |
| Sub-project 3 L1 (chart 内部固定 path 問題) | Tempo は `s3.prefix` で path 制御可能、Loki のような問題なしを確認 |
| Sub-project 3 L2 (IAM 公式準拠) | Sub-project 3 fix で 3 stack 同型済 → そのまま利用 |
| Sub-project 3 L3 (chart 固有 key 確認) | Tempo `additionalLabels` / OTel Collector `extraLabels` + `ports.metrics.enabled: true` を実装段階で精査済 |
| Sub-project 3 L4 (uniform retention は S3 lifecycle で) | Tempo application retention 設定なし、S3 lifecycle 7d で担保 = 3 stack 一貫 pattern |
| Sub-project 3 L9 (公式 docs 引用) | Tempo 公式 IAM template と整合確認済 |

## Rollback 手順 (想定外障害時)

```bash
flux suspend kustomization flux-system
kubectl delete -k kubernetes/manifests/production/tempo/
kubectl delete -k kubernetes/manifests/production/opentelemetry-collector/
kubectl get pods -n monitoring | grep -v -E "tempo|opentelemetry-collector"  # Sub-project 2 / 3 影響なき確認
gh pr create --title "revert: Phase 3 Sub-project 4a (Traces stack foundation)" ...
flux reconcile source git flux-system
flux resume kustomization flux-system
```

aws/eks-traces/ は Sub-project 1 で provision 済 + Sub-project 3 fix で IAM 適用済 = AWS-side rollback 不要。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added distributed traces collection to the production EKS observability platform
  * Introduced traces storage and visualization integrated with Grafana
  * Enabled trace ingestion through a new Collector component

* **Documentation**
  * Added comprehensive implementation plan and design specifications for the traces stack foundation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->