### PR TITLE
fix(eks): Phase 3 Sub-project 4b — OTel Collector logs to otlphttp/loki

### DIFF
--- a/kubernetes/components/opentelemetry-collector/production/values.yaml.gotmpl
+++ b/kubernetes/components/opentelemetry-collector/production/values.yaml.gotmpl
@@ -65,8 +65,12 @@ serviceMonitor:
 # chart default で全 pipeline (traces / logs / metrics) が pre-configure されており、
 # 各 pipeline で必要な exporter のみ override する方針:
 #   - traces: otlp/tempo exporter で Tempo に export
-#   - logs: loki exporter で Loki gateway に push (= Fluent Bit からの logs を受信)
+#   - logs: otlphttp/loki exporter で Loki OTLP endpoint (/otlp) に push
 #   - metrics: chart default の debug exporter のまま (= Phase 4 で Beyla source 接続時に再 design)
+#
+# NOTE: contrib `loki` exporter は 2024-07 deprecate / 2024-11 削除済 (issue #38374)。
+# Loki 3.0+ は OTLP HTTP を native ingest するため、`otlphttp` exporter で
+# `/otlp` endpoint に直接 push する (Grafana Loki 公式 docs 推奨)。
 config:
   exporters:
     # Tempo exporter: traces を gRPC で push
@@ -74,14 +78,11 @@ config:
       endpoint: tempo.monitoring.svc.cluster.local:4317
       tls:
         insecure: true
-    # Loki exporter: Fluent Bit からの logs を Loki gateway に push
-    loki:
-      endpoint: http://loki-gateway.monitoring.svc.cluster.local:80/loki/api/v1/push
-      default_labels_enabled:
-        # exporter label は cardinality 抑制のため抑止
-        exporter: false
-        # job=fluentbit 等の identification label は維持
-        job: true
+    # Loki OTLP exporter: Fluent Bit からの logs を Loki gateway に OTLP HTTP で push
+    otlphttp/loki:
+      endpoint: http://loki-gateway.monitoring.svc.cluster.local:80/otlp
+      tls:
+        insecure: true
   service:
     pipelines:
       traces:
@@ -94,9 +95,9 @@ config:
         receivers:
           - otlp
       logs:
-        # chart default の exporters: [debug] を loki に override
+        # chart default の exporters: [debug] を otlphttp/loki に override
         exporters:
-          - loki
+          - otlphttp/loki
         processors:
           - memory_limiter
           - batch

--- a/kubernetes/manifests/production/opentelemetry-collector/manifest.yaml
+++ b/kubernetes/manifests/production/opentelemetry-collector/manifest.yaml
@@ -32,13 +32,12 @@ data:
   relay: |
     exporters:
       debug: {}
-      loki:
-        default_labels_enabled:
-          exporter: false
-          job: true
-        endpoint: http://loki-gateway.monitoring.svc.cluster.local:80/loki/api/v1/push
       otlp/tempo:
         endpoint: tempo.monitoring.svc.cluster.local:4317
+        tls:
+          insecure: true
+      otlphttp/loki:
+        endpoint: http://loki-gateway.monitoring.svc.cluster.local:80/otlp
         tls:
           insecure: true
     extensions:
@@ -81,7 +80,7 @@ data:
       pipelines:
         logs:
           exporters:
-          - loki
+          - otlphttp/loki
           processors:
           - memory_limiter
           - batch
@@ -201,7 +200,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: c533df52ab69009b870bbcdb2a977f3acffea3a7f484e537fde9a65a4710ac93
+        checksum/config: 3e1a08251fa0a7af9776772df2d9be068021e56df940b665df4718699e95e675
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector


### PR DESCRIPTION
## Summary

PR #296 (Phase 3 Sub-project 4b) merge 後の **post-flight verification で発覚した persistent issue** に対する **runtime fix** (= Sub-project 2 / 3 で確立した fix forward pattern)。OTel Collector contrib v0.151.0 では **`loki` exporter が removal 済** (= 2024-07 deprecate / 2024-11 removal、[issue #38374](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/38374))、その結果新 pod が config parse error で `CrashLoopBackOff`、logs 経路が断絶。Loki 3.0+ の **native OTLP HTTP ingestion** ([Grafana 公式 docs](https://grafana.com/docs/loki/latest/send-data/otel/)) に切替えて修正する。

## Root cause

### 観測症状
```
$ kubectl get pods -n monitoring -l app.kubernetes.io/name=opentelemetry-collector
opentelemetry-collector-6b4c486bcc-vk7nz   1/1     Running            0            28h    (= 4a deploy 時の old pod、debug exporter のまま)
opentelemetry-collector-6d59d66956-v9ggg   0/1     CrashLoopBackOff   4 (9s ago)   109s   (= 4b deploy の new pod、config parse error)
```

### 新 pod の config parse error
```
Error: failed to get config: cannot unmarshal the configuration:
'exporters' unknown type: "loki" for id: "loki"
(valid values: [... otlp_http otlphttp prometheusremotewrite ... debug nop ...])
```

### Production impact
- Old pod の logs pipeline = chart default `[debug]` (= logs 受信するが Loki に書き出さず捨てる)
- New pod = 起動できないため logs 受信不可
- 結果: **Fluent Bit → OTel Collector まで届くが Loki に到達せず、production logs path が事実上 断絶**
- ただし production cluster は infra-only state、application logs 不在で実 impact 限定的
- Fluent Bit `storage.total_limit_size 5G` の disk buffer で fix までの logs 保持可

## Fix

`kubernetes/components/opentelemetry-collector/production/values.yaml.gotmpl`:

```diff
   exporters:
     otlp/tempo:
       endpoint: tempo.monitoring.svc.cluster.local:4317
       tls:
         insecure: true
-    # Loki exporter: Fluent Bit からの logs を Loki gateway に push
-    loki:
-      endpoint: http://loki-gateway.monitoring.svc.cluster.local:80/loki/api/v1/push
-      default_labels_enabled:
-        exporter: false
-        job: true
+    # Loki OTLP exporter: Fluent Bit からの logs を Loki gateway に OTLP HTTP で push
+    otlphttp/loki:
+      endpoint: http://loki-gateway.monitoring.svc.cluster.local:80/otlp
+      tls:
+        insecure: true
   service:
     pipelines:
       logs:
-        exporters: [loki]
+        exporters: [otlphttp/loki]
```

## Decision references

- **Loki OTLP native ingestion**: Loki 3.0+ で `/otlp` endpoint で OpenTelemetry logs を native ingest、`auth_enabled: false` のため tenant override 不要 (= Sub-project 3 設計と整合)。Grafana 公式 docs ([send-data/otel/](https://grafana.com/docs/loki/latest/send-data/otel/)) で `otlphttp` exporter + `endpoint: http://<loki-addr>/otlp` を direct citation
- **`loki` exporter deprecation timeline**: 2024-07 deprecate ([issue #33916](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/33916)) → 2024-09-11 removal ([issue #38374](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/38374)) → v0.151.0 (= panicboat 採用 image) では already removed
- **`tls.insecure: true`**: traces (otlp/tempo) と同 pattern、cluster 内 service 間で TLS 不要 (= Sub-project 4a Decision 4 同等)

## Sub-project 3 / 4a learnings 適用

| Learning | 本 fix での適用 |
|---|---|
| **3-L9 (公式 docs 直接 citation)** | 4b spec 作成時に OTel Collector contrib v0.151.0 の exporters 一覧を未確認 = 本 fix で **Grafana Loki 公式 docs + otel-collector-contrib issues #33916/#38374 を direct citation** |
| **4a-L2 (transient と決めつけない)** | 新 pod の `4 restarts in 109s` を時刻情報 + restart count で確認 = persistent と判定、L3 checklist 通り evidence を揃えてから fix 着手 |
| **4a-L3 (persistent vs transient checklist)** | Step 1 (時刻情報) + Step 3 (restart count) + Step 4 (kubectl describe) の組み合わせで真因特定 |
| **4a-L6 (不要な runtime fix の早期 abort)** | 本 fix は確実な persistent error (= config parse error) で fix 必須、abort 不要 |

## Test plan (post-flight, after merge)

- [ ] OTel Collector new pod (`fix-deploy`) Running 1/1、restartCount 0
- [ ] OTel Collector logs に `otlphttp/loki` exporter 接続成功 message
- [ ] Loki gateway に POST `/otlp` で 200 OK 応答 (= ingester logs で確認)
- [ ] Grafana Loki Explore で `{job="fluentbit"}` query で過去 5 分以内の log entry > 0
- [ ] Loki ingester ingestion rate が fix 後に正常化
- [ ] 既存 4a path (Tempo traces) は regression なし

## Rollback

万一 `otlphttp/loki` でも問題が出た場合の選択肢:

1. **Fluent Bit OUTPUT を一時的に Loki direct に戻す** (= Sub-project 3 中間状態に巻き戻し、`Name loki` + `Host loki-gateway`)
2. **Flux suspend → 4b 全体 revert** (= 過剰反応、最後の手段)
3. **OTel Collector の logs pipeline exporters を `[debug]` に戻す** (= chart default に戻す、logs ロスト継続だが crash 解消)

最も低リスクは選択肢 1 (= Sub-project 3 と同形に戻す)。
