### PR TITLE
fix(eks): Phase 3 Sub-project 4b — Fluent Bit rolling + OTel otlp_http

### DIFF
--- a/kubernetes/components/fluent-bit/production/values.yaml.gotmpl
+++ b/kubernetes/components/fluent-bit/production/values.yaml.gotmpl
@@ -8,6 +8,18 @@
 kind: DaemonSet
 
 # =============================================================================
+# Update Strategy
+# =============================================================================
+# maxUnavailable: 2 で rolling update を確実に進行させる。chart default の
+# maxUnavailable: 1 だと、scheduling 失敗で Pending 状態の pod が 1 つあるだけで
+# 他の pod の rolling 更新が完全停止するため、ConfigMap 変更が古い pod に
+# 反映されない (= production cluster の CPU 逼迫 node 等で発生する典型 pattern)。
+updateStrategy:
+  type: RollingUpdate
+  rollingUpdate:
+    maxUnavailable: 2
+
+# =============================================================================
 # ServiceAccount (Decision 8: Pod Identity 不要)
 # =============================================================================
 # AWS access 不要 (OTel Collector gRPC push のみ)、default SA で OK

--- a/kubernetes/components/opentelemetry-collector/production/values.yaml.gotmpl
+++ b/kubernetes/components/opentelemetry-collector/production/values.yaml.gotmpl
@@ -65,11 +65,11 @@ serviceMonitor:
 # chart default で全 pipeline (traces / logs / metrics) が pre-configure されており、
 # 各 pipeline で必要な exporter のみ override する方針:
 #   - traces: otlp/tempo exporter で Tempo に export
-#   - logs: otlphttp/loki exporter で Loki OTLP endpoint (/otlp) に push
+#   - logs: otlp_http/loki exporter で Loki OTLP endpoint (/otlp) に push
 #   - metrics: chart default の debug exporter のまま (= Phase 4 で Beyla source 接続時に再 design)
 #
 # NOTE: contrib `loki` exporter は 2024-07 deprecate / 2024-11 削除済 (issue #38374)。
-# Loki 3.0+ は OTLP HTTP を native ingest するため、`otlphttp` exporter で
+# Loki 3.0+ は OTLP HTTP を native ingest するため、`otlp_http` exporter で
 # `/otlp` endpoint に直接 push する (Grafana Loki 公式 docs 推奨)。
 config:
   exporters:
@@ -79,7 +79,7 @@ config:
       tls:
         insecure: true
     # Loki OTLP exporter: Fluent Bit からの logs を Loki gateway に OTLP HTTP で push
-    otlphttp/loki:
+    otlp_http/loki:
       endpoint: http://loki-gateway.monitoring.svc.cluster.local:80/otlp
       tls:
         insecure: true
@@ -95,9 +95,9 @@ config:
         receivers:
           - otlp
       logs:
-        # chart default の exporters: [debug] を otlphttp/loki に override
+        # chart default の exporters: [debug] を otlp_http/loki に override
         exporters:
-          - otlphttp/loki
+          - otlp_http/loki
         processors:
           - memory_limiter
           - batch

--- a/kubernetes/manifests/production/fluent-bit/manifest.yaml
+++ b/kubernetes/manifests/production/fluent-bit/manifest.yaml
@@ -174,6 +174,10 @@ spec:
     matchLabels:
       app.kubernetes.io/name: fluent-bit
       app.kubernetes.io/instance: fluent-bit
+  updateStrategy:
+    rollingUpdate:
+      maxUnavailable: 2
+    type: RollingUpdate
   template:
     metadata:
       labels:

--- a/kubernetes/manifests/production/opentelemetry-collector/manifest.yaml
+++ b/kubernetes/manifests/production/opentelemetry-collector/manifest.yaml
@@ -36,7 +36,7 @@ data:
         endpoint: tempo.monitoring.svc.cluster.local:4317
         tls:
           insecure: true
-      otlphttp/loki:
+      otlp_http/loki:
         endpoint: http://loki-gateway.monitoring.svc.cluster.local:80/otlp
         tls:
           insecure: true
@@ -80,7 +80,7 @@ data:
       pipelines:
         logs:
           exporters:
-          - otlphttp/loki
+          - otlp_http/loki
           processors:
           - memory_limiter
           - batch
@@ -200,7 +200,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 3e1a08251fa0a7af9776772df2d9be068021e56df940b665df4718699e95e675
+        checksum/config: 50d9d69412144ef21b6925a0f50e3beb98529329e93b2c2a761f89ab3532eef1
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector


### PR DESCRIPTION
## Summary

PR #302 merge 後の post-flight verification で発覚した **2 件の追加 issue** に対する **runtime fix**:

1. **Fluent Bit DaemonSet rolling update が stuck** = 4b ConfigMap 変更 (= OTLP gRPC 切替) が古い running pods に反映されていない
2. **OTel Collector の `otlphttp` exporter alias は deprecated** = canonical name `otlp_http` に rename 推奨

両 issue を 1 PR で fix する (= GitOps clean、Sub-project 4a で確立した atomic 修正 pattern)。

## Issue 1: Fluent Bit rolling update stuck

### 観測症状

```
DaemonSet: desiredNumberScheduled=5, numberReady=4, numberUnavailable=1, updatedNumberScheduled=1
- 4 pods (54qjj, 5jz4f, k4bhp, z84ps) Running 34h、checksum=b82d... (= OLD config = Loki direct)
- 1 pod (n9t8q) Pending、checksum=84ea... (= NEW config = OTLP gRPC、ip-10-0-39-100 で CPU 不足で schedule 失敗)
```

### Root cause

`updateStrategy.rollingUpdate.maxUnavailable: 1` (= chart default) のため、scheduling 失敗で Pending 状態の pod が 1 つあるだけで rolling update が完全停止。`numberUnavailable=1` (= Pending) が制約を埋めて、他 4 つの running pod の更新が始まらない。

具体的には:
- ip-10-0-39-100 node が CPU 95% 使用 (= Karpenter consolidation 不可、Phase 4 candidate)
- DaemonSet が ip-10-0-39-100 に新 pod を schedule 試行 → Pending
- Pending pod が numberUnavailable=1 を埋める → maxUnavailable=1 制約で 4 nodes の rolling 進行不可
- 結果: 4 nodes の Fluent Bit は **OLD ConfigMap で動作中** (= Loki direct push、4b の OTel path bypass)

### Fix

`kubernetes/components/fluent-bit/production/values.yaml.gotmpl`:

```yaml
updateStrategy:
  type: RollingUpdate
  rollingUpdate:
    maxUnavailable: 2
```

`maxUnavailable: 2` = scheduling 失敗の Pending pod 1 つを許容しつつ、追加で 1 pod の rolling 更新を進められる。**実質的には 4 nodes は逐次 1 つずつ rolling される** (= production safe)。

## Issue 2: `otlphttp` exporter alias deprecated

### 観測症状

PR #302 merge 後の OTel Collector log:
```
warn  "otlphttp" alias is deprecated; use "otlp_http" instead
```

PR #302 で採用した `otlphttp/loki:` の `otlphttp` 部分が deprecated alias、canonical name は `otlp_http`。動作はするが warning 永続化。

### Fix

`kubernetes/components/opentelemetry-collector/production/values.yaml.gotmpl`:

```diff
   exporters:
-    otlphttp/loki:
+    otlp_http/loki:
       endpoint: http://loki-gateway.monitoring.svc.cluster.local:80/otlp
   service:
     pipelines:
       logs:
-        exporters: [otlphttp/loki]
+        exporters: [otlp_http/loki]
```

加えて values comment 内の `otlphttp` を `otlp_http` に rename。

## Sub-project 1-4a learnings 適用

| Learning | 本 fix での適用 |
|---|---|
| **3-L1 (chart 内部固定 path 問題)** | Fluent Bit chart の `updateStrategy` が chart default `{}` で実質 maxUnavailable=1 になる挙動を実装段階で精査 = 既 deploy 済 chart でも default 動作の re-verify が必要 |
| **3-L8 (post-flight check)** | PR #302 merge 後の post-flight で「OTel Collector 起動確認」だけでなく「Fluent Bit が実際に OTel Collector に push しているか」 (= Loki access log で確認) も必須 |
| **3-L9 (公式 docs 引用)** | OTel Collector の deprecation warning を log で発見 → 公式 docs (`otlp_http` canonical name) に従って rename |
| **4a-L2 (transient と決めつけない)** | Fluent Bit pod の checksum annotation を比較して **真の persistent issue** と判定 (= 起動時刻 34h ago vs 4b merge ~30h ago の差で判明) |
| **4a-L3 (5-step checklist)** | Step 1 (時刻情報 = 起動時刻 vs ConfigMap checksum 変更時刻)、Step 4 (kubectl get -o jsonpath で完全表示) で root cause 特定 |

## Test plan (post-flight, after merge)

- [ ] Fluent Bit DaemonSet rolling update が進行 (= 4 old pods が逐次 NEW config の new pods に置換)
- [ ] 4 fluent-bit pods (= ip-10-0-39-100 を除く 4 nodes) が NEW checksum (`84ea...` 系) になる
- [ ] OTel Collector の `:4317` (OTLP gRPC) に Fluent Bit からの inbound 接続が確立 (= `kubectl logs -n monitoring -l app=opentelemetry-collector | grep -i fluent`)
- [ ] Loki gateway access log で `POST /otlp` 経由 (= Fluent-Bit user-agent 不在、OTel Collector からの内部 IP 由来) を確認
- [ ] OTel Collector log で `"otlphttp" alias is deprecated` warning が消える
- [ ] Grafana Loki Explore `{job="fluentbit"}` で過去 5 分以内の log entry > 0
- [ ] 既存 Tempo traces path に regression なし

## Phase 4 引き継ぎ (= 本 PR scope 外)

- **ip-10-0-39-100 の CPU 逼迫**: Karpenter consolidation 不可状態、5th node の fluent-bit が永続的に Pending。fluent-bit のみならず他 DaemonSet も影響受ける可能性、cluster scheduling 全体の design re-evaluation 候補

## Rollback

- Issue 1 fix (= maxUnavailable: 2): values.yaml.gotmpl から `updateStrategy` block を削除して revert PR
- Issue 2 fix (= otlp_http rename): `otlp_http/loki` を `otlphttp/loki` に戻して revert PR (= 動作は同じ、warning 復活のみ)

両 issue とも production logs path への影響は **fix forward 方向に positive** (= rollback で悪化する)、rollback はほぼ想定不要。
