### PR TITLE
fix(eks): observability DaemonSets PriorityClass system-node-critical

### DIFF
--- a/kubernetes/components/fluent-bit/production/values.yaml.gotmpl
+++ b/kubernetes/components/fluent-bit/production/values.yaml.gotmpl
@@ -20,6 +20,15 @@ updateStrategy:
     maxUnavailable: 2
 
 # =============================================================================
+# Priority Class
+# =============================================================================
+# Cluster 全 node の logs collection は observability の前提条件であり、DaemonSet
+# 完全性 (= 各 node に 1 pod 必須) を保証する。EKS / Cilium / EBS CSI 等の他
+# system DaemonSets と同 priority に揃え、CPU 逼迫 node でも preempt 動作で
+# 確実に schedule する。
+priorityClassName: system-node-critical
+
+# =============================================================================
 # ServiceAccount (Decision 8: Pod Identity 不要)
 # =============================================================================
 # AWS access 不要 (OTel Collector gRPC push のみ)、default SA で OK

--- a/kubernetes/components/prometheus-operator/production/values.yaml.gotmpl
+++ b/kubernetes/components/prometheus-operator/production/values.yaml.gotmpl
@@ -175,6 +175,10 @@ alertmanager:
 # Prometheus Node Exporter
 # =============================================================================
 prometheus-node-exporter:
+  # Cluster 全 node の metrics 収集は observability の前提条件であり、DaemonSet
+  # 完全性 (= 各 node に 1 pod 必須) を保証する。EKS / Cilium / EBS CSI 等の他
+  # system DaemonSets と同 priority に揃える。
+  priorityClassName: system-node-critical
   hostRootFsMount:
     enabled: true
     mountPropagation: HostToContainer

--- a/kubernetes/manifests/production/fluent-bit/manifest.yaml
+++ b/kubernetes/manifests/production/fluent-bit/manifest.yaml
@@ -188,6 +188,7 @@ spec:
     spec:
       
       serviceAccountName: fluent-bit
+      priorityClassName: system-node-critical
       hostNetwork: false
       dnsPolicy: ClusterFirst
       containers:


### PR DESCRIPTION
## Summary

Phase 3 Sub-project 4b の Lessons Learned (= PR #304) で flag した **DaemonSet PriorityClass audit** に対する **systemic fix**。observability stack の 2 DaemonSets (= `fluent-bit` / `prometheus-node-exporter`) に `priorityClassName: system-node-critical` を追加し、CPU 逼迫 node でも preempt 動作で確実に schedule する状態を確立する。

## Background: cluster DaemonSet audit 結果

| DaemonSet | Namespace | PriorityClass (Before) | CPU req | Status |
|---|---|---|---|---|
| aws-node (= VPC CNI) | kube-system | ✅ system-node-critical | 25m | 安全 |
| cilium | kube-system | ✅ system-node-critical | (none) | 安全 |
| cilium-envoy | kube-system | ✅ system-node-critical | (none) | 安全 |
| ebs-csi-node | kube-system | ✅ system-node-critical | 10m | 安全 |
| eks-pod-identity-agent | kube-system | ✅ system-node-critical | (none) | 安全 |
| **fluent-bit** | **monitoring** | ❌ none | **100m** | **🚨 risk** |
| **kube-prometheus-stack-prometheus-node-exporter** | **monitoring** | ❌ none | **100m** | **🚨 risk** |

EKS managed addons (= aws-node / ebs-csi / eks-pod-identity) と Cilium chart は default で `system-node-critical` を設定済。**panicboat-managed observability stack の 2 DaemonSets だけ PriorityClass が無い** = 同 deadlock pattern (Sub-project 4b で発覚) を踏むリスク。

## Concrete observability gap (= 本 PR の motivation)

`fluent-bit-n9t8q` が `ip-10-0-39-100` で 24h+ Pending 状態:
- **ip-10-0-39-100 上の 27 critical pods の logs が Loki に collect されていない**:
  - flux-system 5 controllers (= GitOps reconciliation)
  - monitoring 5 (= mimir-distributor / querier / query-scheduler / kube-state-metrics / prometheus-operator)
  - keda 3
  - kube-system 11 (= cilium / coredns / ebs-csi / hubble / aws-node 等)
  - external-dns 1
- production incident 時に **このノードの logs だけ Grafana Loki query で hit せず、blind spot 化**
- DaemonSet 完全性 (= Phase 3 design 原則) と矛盾

PriorityClass `system-node-critical` (= value 2,000,001,000) で fluent-bit が ip-10-0-39-100 上の lowest-priority pod を preempt して schedule、coverage gap を解消。

## Fix

### 1. Fluent Bit (`kubernetes/components/fluent-bit/production/values.yaml.gotmpl`)

```diff
+# =============================================================================
+# Priority Class
+# =============================================================================
+# Cluster 全 node の logs collection は observability の前提条件であり、DaemonSet
+# 完全性 (= 各 node に 1 pod 必須) を保証する。EKS / Cilium / EBS CSI 等の他
+# system DaemonSets と同 priority に揃え、CPU 逼迫 node でも preempt 動作で
+# 確実に schedule する。
+priorityClassName: system-node-critical
```

### 2. Prometheus node-exporter (`kubernetes/components/prometheus-operator/production/values.yaml.gotmpl`)

```diff
 prometheus-node-exporter:
+  # Cluster 全 node の metrics 収集は observability の前提条件であり、DaemonSet
+  # 完全性 (= 各 node に 1 pod 必須) を保証する。EKS / Cilium / EBS CSI 等の他
+  # system DaemonSets と同 priority に揃える。
+  priorityClassName: system-node-critical
   hostRootFsMount:
     enabled: true
```

## Decision rationale

- **`system-node-critical` を選ぶ理由**: panicboat の他 system DaemonSets (= aws-node / cilium / ebs-csi-node / eks-pod-identity-agent) と **consistency** 確保。Kubernetes 公式は "system component 専用" と書くが、観測 DaemonSet (Fluent Bit, node-exporter) には industry standard practice (= Datadog, Grafana Agent, fluentd 等の主要 vendor も同様に設定)
- **node-exporter も同時 fix する理由**: 現在 5/5 schedule 済で可視化されていなかったが、次の chart upgrade / rolling update / cluster 状態変化で同 deadlock を踏む latent risk。今 surgical に fix する方が future incident 予防として ROI 高い
- **対象を 2 DaemonSets に限定**: 他 5 DaemonSets は既に `system-node-critical` 済、追加 audit は不要

## Test plan (post-merge verification)

### 直接的影響
- [ ] Fluent Bit `priorityClassName: system-node-critical` が hydrated manifest に反映、DaemonSet status で確認
- [ ] node-exporter 同上
- [ ] ip-10-0-39-100 上の fluent-bit Pending 解消 (= preempt 動作で 1 controller pod を立ち退き、fluent-bit pod schedule)
- [ ] preempted controller pod (= flux / keda / monitoring いずれか) が他 node に re-schedule、Ready 復帰
- [ ] Grafana Loki Explore で ip-10-0-39-100 由来 logs が hit するようになる (= blind spot 解消、`{node="ip-10-0-39-100..."}` で確認)

### regression なきこと
- [ ] node-exporter rolling update も同 PriorityClass で進行 (= 全 5 nodes に re-schedule)
- [ ] preempted controller の re-schedule 中の Mimir / Loki ingestion 中断は数秒以内
- [ ] 既存 4b path (= OTel Collector → Loki) に regression なし

## Sub-project 4b learnings 適用

| Learning | 本 fix での適用 |
|---|---|
| **4b-L2 (DaemonSet rolling update default が deadlock)** | Phase 4 引き継ぎ事項 #11 (= Helm chart default DaemonSet `maxUnavailable: 1` 運用 risk audit) の延長として、PriorityClass audit も systemic 確立 |
| **4b-L4 (fix forward pattern の安定性)** | Sub-project 4b で確立した standard runbook を Phase 4 cleanup task に再適用 |
| **3-L8 (post-flight check)** | DaemonSet PriorityClass audit を post-flight check の standard 項目に追加すべき |

## Phase 4 引き継ぎ事項 update

本 PR で **#11 (= DaemonSet PriorityClass audit)** を解消。残り 10 件を Phase 4 brainstorming で扱う。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Configured critical priority scheduling for logging and monitoring infrastructure components to ensure their reliable operation across all cluster nodes.
  * Enhanced rolling update strategy for logging service to allow more concurrent pod disruptions, reducing deployment delays.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->