### PR TITLE
fix(eks): oauth2-proxy 4 instances per backend (Phase 4-3 fix forward)

### DIFF
--- a/kubernetes/components/oauth2-proxy/production/helmfile.yaml
+++ b/kubernetes/components/oauth2-proxy/production/helmfile.yaml
@@ -1,10 +1,17 @@
 # =============================================================================
 # oauth2-proxy Helmfile for production
 # =============================================================================
-# oauth2-proxy/oauth2-proxy chart を 1 instance shared mode で deploy。
-# multi-upstream config で 4 backends (= grafana / hubble-ui / alertmanager /
-# prometheus) に Host header 経由 routing。Google OAuth gate + email
-# allowlist (= ConfigMap allowed-emails) で panicboat@gmail.com のみ通過。
+# oauth2-proxy/oauth2-proxy chart を 4 instances (= 1 per backend) で deploy。
+# 各 release は単一 upstream に reverse-proxy する (= host-based routing は ALB
+# で実施、各 Ingress backend が release ごとの Service を参照)。
+# cookie domain `.panicboat.net` + cookie_secret 共有 (= 4 release が同じ
+# ExternalSecret 由来 Secret を参照) で 4 hosts SSO 実現。
+# Google OAuth gate + email allowlist (= ConfigMap allowed-emails) で
+# panicboat@gmail.com のみ通過。
+#
+# NOTE: oauth2-proxy v7+ の `upstreams` config は path-based routing のみ対応
+# (= 単一 instance での host-based routing 不可、v7.15.2 で startup error
+# `multiple upstreams found with id "/"` を確認)、4 instances 構成が必須。
 # =============================================================================
 environments:
   production:
@@ -14,7 +21,25 @@ repositories:
     url: https://oauth2-proxy.github.io/manifests
 
 releases:
-  - name: oauth2-proxy
+  - name: oauth2-proxy-grafana
+    namespace: oauth2-proxy
+    chart: oauth2-proxy/oauth2-proxy
+    version: "10.4.3"
+    values:
+      - values.yaml.gotmpl
+  - name: oauth2-proxy-hubble
+    namespace: oauth2-proxy
+    chart: oauth2-proxy/oauth2-proxy
+    version: "10.4.3"
+    values:
+      - values.yaml.gotmpl
+  - name: oauth2-proxy-alertmanager
+    namespace: oauth2-proxy
+    chart: oauth2-proxy/oauth2-proxy
+    version: "10.4.3"
+    values:
+      - values.yaml.gotmpl
+  - name: oauth2-proxy-prometheus
     namespace: oauth2-proxy
     chart: oauth2-proxy/oauth2-proxy
     version: "10.4.3"

--- a/kubernetes/components/oauth2-proxy/production/kustomization/ingress-monitoring-uis.yaml
+++ b/kubernetes/components/oauth2-proxy/production/kustomization/ingress-monitoring-uis.yaml
@@ -2,8 +2,10 @@
 # Ingress: monitoring-uis IngressGroup
 # =============================================================================
 # 4 Ingresses (= grafana / hubble / alertmanager / prometheus) が同一 ALB を
-# IngressGroup `monitoring-uis` で共有。各 Ingress の backend は同 namespace の
-# oauth2-proxy Service。oauth2-proxy が Host header から upstream を選択。
+# IngressGroup `monitoring-uis` で共有。各 Ingress の backend は per-host の
+# oauth2-proxy release Service (= `oauth2-proxy-{grafana,hubble,alertmanager,
+# prometheus}`、各々 1 upstream へ reverse-proxy)。ALB が host header から
+# Service を選択 → oauth2-proxy が Google OAuth 認証 + 単一 backend へ転送。
 #
 # ACM cert auto-discovery: ALB Controller は wildcard cert *.panicboat.net を
 # 自動的に attach する (= Ingress.host が SAN にマッチ)。explicit
@@ -37,7 +39,7 @@ spec:
             pathType: Prefix
             backend:
               service:
-                name: oauth2-proxy
+                name: oauth2-proxy-grafana
                 port:
                   number: 80
 ---
@@ -66,7 +68,7 @@ spec:
             pathType: Prefix
             backend:
               service:
-                name: oauth2-proxy
+                name: oauth2-proxy-hubble
                 port:
                   number: 80
 ---
@@ -95,7 +97,7 @@ spec:
             pathType: Prefix
             backend:
               service:
-                name: oauth2-proxy
+                name: oauth2-proxy-alertmanager
                 port:
                   number: 80
 ---
@@ -124,6 +126,6 @@ spec:
             pathType: Prefix
             backend:
               service:
-                name: oauth2-proxy
+                name: oauth2-proxy-prometheus
                 port:
                   number: 80

--- a/kubernetes/components/oauth2-proxy/production/values.yaml.gotmpl
+++ b/kubernetes/components/oauth2-proxy/production/values.yaml.gotmpl
@@ -1,11 +1,36 @@
 # oauth2-proxy Configuration for production
-# Google OAuth で 4 monitoring UIs を gate、Host header 経由 4 backends に reverse-proxy。
+# 4 oauth2-proxy releases (= oauth2-proxy-{grafana,hubble,alertmanager,prometheus})
+# が本 values を共有、`.Release.Name` で upstream を切替。各 release は
+# 単一 upstream へ reverse-proxy、ALB が host-based に各 release Service へ振分。
 
 # =============================================================================
-# Replicas (HA = 2)
+# Upstream map (= release name → backend FQDN)
 # =============================================================================
-# 1 instance shared topology のため、SPOF 回避目的で 2 replicas に設定。
-# ALB target group で 2 endpoints HA。
+# helmfile が release ごとに本 values を render し、`.Release.Name` から
+# 対応する backend を選択する。新 host を追加する場合は helmfile.yaml に
+# release 追加 + 本 map に entry 追加 + ingress-monitoring-uis.yaml に
+# Ingress 追加が必要。
+{{- $upstreamMap := dict
+  "oauth2-proxy-grafana" "http://kube-prometheus-stack-grafana.monitoring.svc.cluster.local:80"
+  "oauth2-proxy-hubble" "http://hubble-ui.kube-system.svc.cluster.local:80"
+  "oauth2-proxy-alertmanager" "http://kube-prometheus-stack-alertmanager.monitoring.svc.cluster.local:9093"
+  "oauth2-proxy-prometheus" "http://kube-prometheus-stack-prometheus.monitoring.svc.cluster.local:9090"
+}}
+{{- $upstreamUrl := index $upstreamMap .Release.Name }}
+
+# =============================================================================
+# Fullname Override (= Service / Deployment / ServiceAccount 名を release name に統一)
+# =============================================================================
+# chart default の fullname は `<release>-<chart>` で `oauth2-proxy-grafana-oauth2-proxy`
+# のように冗長になる。fullnameOverride で `.Release.Name` を直接採用、Service 名を
+# Ingress backend で参照しやすくする (= 例: `oauth2-proxy-grafana`)。
+fullnameOverride: {{ .Release.Name }}
+
+# =============================================================================
+# Replicas (HA = 2 per release)
+# =============================================================================
+# 各 release ごとに 2 replicas (= ALB target group で 2 endpoints HA)、
+# 4 releases × 2 = 8 Pods。
 replicaCount: 2
 
 # =============================================================================
@@ -32,18 +57,15 @@ resources:
 # config.existingSecret で ESO 由来 K8s Secret `oauth2-proxy-google` を直接参照、
 # chart が OAUTH2_PROXY_CLIENT_ID / CLIENT_SECRET / COOKIE_SECRET を deployment 環境変数に
 # 自動注入する (= chart template/secret.yaml は existingSecret 設定時に skip)。
-# values 内に credentials を記述しないため secret 漏洩を防止。
+# 4 releases が同じ Secret を参照することで cookie_secret 共有 → cookie domain
+# `.panicboat.net` 経由で 4 hosts SSO 実現 (= 同じ cookie name `_oauth2_proxy` を
+# 4 instances が共通の cookie_secret で encrypt/decrypt)。
 config:
   existingSecret: oauth2-proxy-google
   configFile: |-
     provider = "google"
     email_domains = [ "*" ]
-    upstreams = [
-      "http://kube-prometheus-stack-grafana.monitoring.svc.cluster.local:80",
-      "http://hubble-ui.kube-system.svc.cluster.local:80",
-      "http://kube-prometheus-stack-alertmanager.monitoring.svc.cluster.local:9093",
-      "http://kube-prometheus-stack-prometheus.monitoring.svc.cluster.local:9090"
-    ]
+    upstreams = [ "{{ $upstreamUrl }}" ]
     cookie_domains = [ ".panicboat.net" ]
     whitelist_domains = [ ".panicboat.net" ]
     cookie_secure = true
@@ -60,9 +82,10 @@ config:
 # =============================================================================
 # Extra Volumes & Volume Mounts (= ConfigMap allowlist)
 # =============================================================================
-# ConfigMap `oauth2-proxy-allowed-emails` (= kustomization で deploy) を mount、
-# config.configFile の `authenticated_emails_file` で参照。ConfigMap 変更時は
-# Reloader が auto-rollout (= deploymentAnnotations 参照)。
+# ConfigMap `oauth2-proxy-allowed-emails` (= kustomization で deploy) を 4 releases が
+# 共有 mount、config.configFile の `authenticated_emails_file` で参照。
+# ConfigMap 変更時は Reloader が 4 Deployments 全部を auto-rollout
+# (= deploymentAnnotations 参照、annotation が同じ namespace 内の全 ConfigMap watch を trigger)。
 extraVolumes:
   - name: emails
     configMap:
@@ -93,6 +116,7 @@ service:
 # NOTE: chart の ServiceMonitor key path は metrics.serviceMonitor (helm show values
 # で確認済、top-level serviceMonitor ではない)。labels block は override 可能、
 # release: kube-prometheus-stack を明示指定して他 component と統一。
+# 4 release ごとに ServiceMonitor が auto-created、Mimir に各 release の metrics 流入。
 metrics:
   serviceMonitor:
     enabled: true

--- a/kubernetes/manifests/production/oauth2-proxy/manifest.yaml
+++ b/kubernetes/manifests/production/oauth2-proxy/manifest.yaml
@@ -10,15 +10,15 @@ metadata:
     app.kubernetes.io/component: authentication-proxy
     app.kubernetes.io/part-of: oauth2-proxy
     app.kubernetes.io/name: oauth2-proxy
-    app.kubernetes.io/instance: oauth2-proxy
+    app.kubernetes.io/instance: oauth2-proxy-grafana
     app.kubernetes.io/version: "7.15.2"
-  name: oauth2-proxy
+  name: oauth2-proxy-grafana
   namespace: oauth2-proxy
 spec:
   selector:
     matchLabels:      
       app.kubernetes.io/name: oauth2-proxy
-      app.kubernetes.io/instance: oauth2-proxy
+      app.kubernetes.io/instance: oauth2-proxy-grafana
   minAvailable: 1
 ---
 # Source: oauth2-proxy/templates/serviceaccount.yaml
@@ -32,9 +32,9 @@ metadata:
     app.kubernetes.io/component: authentication-proxy
     app.kubernetes.io/part-of: oauth2-proxy
     app.kubernetes.io/name: oauth2-proxy
-    app.kubernetes.io/instance: oauth2-proxy
+    app.kubernetes.io/instance: oauth2-proxy-grafana
     app.kubernetes.io/version: "7.15.2"
-  name: oauth2-proxy
+  name: oauth2-proxy-grafana
   namespace: oauth2-proxy
 automountServiceAccountToken: true
 ---
@@ -49,21 +49,16 @@ metadata:
     app.kubernetes.io/component: authentication-proxy
     app.kubernetes.io/part-of: oauth2-proxy
     app.kubernetes.io/name: oauth2-proxy
-    app.kubernetes.io/instance: oauth2-proxy
+    app.kubernetes.io/instance: oauth2-proxy-grafana
     app.kubernetes.io/version: "7.15.2"
-  name: oauth2-proxy
+  name: oauth2-proxy-grafana
   namespace: oauth2-proxy
 data:
   oauth2_proxy.cfg: |
 
     provider = "google"
     email_domains = [ "*" ]
-    upstreams = [
-      "http://kube-prometheus-stack-grafana.monitoring.svc.cluster.local:80",
-      "http://hubble-ui.kube-system.svc.cluster.local:80",
-      "http://kube-prometheus-stack-alertmanager.monitoring.svc.cluster.local:9093",
-      "http://kube-prometheus-stack-prometheus.monitoring.svc.cluster.local:9090"
-    ]
+    upstreams = [ "http://kube-prometheus-stack-grafana.monitoring.svc.cluster.local:80" ]
     cookie_domains = [ ".panicboat.net" ]
     whitelist_domains = [ ".panicboat.net" ]
     cookie_secure = true
@@ -88,9 +83,9 @@ metadata:
     app.kubernetes.io/component: authentication-proxy
     app.kubernetes.io/part-of: oauth2-proxy
     app.kubernetes.io/name: oauth2-proxy
-    app.kubernetes.io/instance: oauth2-proxy
+    app.kubernetes.io/instance: oauth2-proxy-grafana
     app.kubernetes.io/version: "7.15.2"
-  name: oauth2-proxy
+  name: oauth2-proxy-grafana
   namespace: oauth2-proxy
 spec:
   type: ClusterIP
@@ -107,7 +102,7 @@ spec:
       name: metrics
   selector:    
     app.kubernetes.io/name: oauth2-proxy
-    app.kubernetes.io/instance: oauth2-proxy
+    app.kubernetes.io/instance: oauth2-proxy-grafana
 ---
 # Source: oauth2-proxy/templates/deployment.yaml
 apiVersion: apps/v1
@@ -120,11 +115,11 @@ metadata:
     app.kubernetes.io/component: authentication-proxy
     app.kubernetes.io/part-of: oauth2-proxy
     app.kubernetes.io/name: oauth2-proxy
-    app.kubernetes.io/instance: oauth2-proxy
+    app.kubernetes.io/instance: oauth2-proxy-grafana
     app.kubernetes.io/version: "7.15.2"
   annotations:
     reloader.stakater.com/auto: "true"
-  name: oauth2-proxy
+  name: oauth2-proxy-grafana
   namespace: oauth2-proxy
 spec:
   replicas: 2
@@ -132,11 +127,11 @@ spec:
   selector:
     matchLabels:      
       app.kubernetes.io/name: oauth2-proxy
-      app.kubernetes.io/instance: oauth2-proxy
+      app.kubernetes.io/instance: oauth2-proxy-grafana
   template:
     metadata:
       annotations:
-        checksum/config: afd7b793c114f622789b99e121c305dd07ef103349d37b97325c459df0dc2153
+        checksum/config: 277914ab7cc94844e0e1245725321be02fac77a2d96267406ab521fe09ced120
         checksum/secret: 9eb46bbdefd5cf844a2c4965b1241a7177addaa7c07789e7873ccda6b0104111
         checksum/google-secret: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
         checksum/redis-secret: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
@@ -147,11 +142,11 @@ spec:
         app.kubernetes.io/component: authentication-proxy
         app.kubernetes.io/part-of: oauth2-proxy
         app.kubernetes.io/name: oauth2-proxy
-        app.kubernetes.io/instance: oauth2-proxy
+        app.kubernetes.io/instance: oauth2-proxy-grafana
         app.kubernetes.io/version: "7.15.2"
     spec:
       priorityClassName: "system-cluster-critical"
-      serviceAccountName: oauth2-proxy
+      serviceAccountName: oauth2-proxy-grafana
       enableServiceLinks: true
       automountServiceAccountToken: true
       containers:
@@ -230,7 +225,7 @@ spec:
       volumes:
       - configMap:
           defaultMode: 420
-          name: oauth2-proxy
+          name: oauth2-proxy-grafana
         name: configmain
       - configMap:
           name: oauth2-proxy-allowed-emails
@@ -240,7 +235,7 @@ spec:
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
-  name: oauth2-proxy
+  name: oauth2-proxy-grafana
   namespace: oauth2-proxy
   labels:
     prometheus: default
@@ -250,15 +245,810 @@ metadata:
     app.kubernetes.io/component: authentication-proxy
     app.kubernetes.io/part-of: oauth2-proxy
     app.kubernetes.io/name: oauth2-proxy
-    app.kubernetes.io/instance: oauth2-proxy
+    app.kubernetes.io/instance: oauth2-proxy-grafana
     app.kubernetes.io/version: "7.15.2"
     release: kube-prometheus-stack
 spec:
-  jobLabel: oauth2-proxy
+  jobLabel: oauth2-proxy-grafana
   selector:
     matchLabels:      
       app.kubernetes.io/name: oauth2-proxy
-      app.kubernetes.io/instance: oauth2-proxy
+      app.kubernetes.io/instance: oauth2-proxy-grafana
+  namespaceSelector:
+    matchNames:
+      - oauth2-proxy
+  endpoints:
+  - port: metrics
+    path: "/metrics"
+    interval: 60s
+    scrapeTimeout: 30s
+
+---
+# Source: oauth2-proxy/templates/poddisruptionbudget.yaml
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  labels:
+    app: oauth2-proxy    
+    helm.sh/chart: oauth2-proxy-10.4.3
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: authentication-proxy
+    app.kubernetes.io/part-of: oauth2-proxy
+    app.kubernetes.io/name: oauth2-proxy
+    app.kubernetes.io/instance: oauth2-proxy-hubble
+    app.kubernetes.io/version: "7.15.2"
+  name: oauth2-proxy-hubble
+  namespace: oauth2-proxy
+spec:
+  selector:
+    matchLabels:      
+      app.kubernetes.io/name: oauth2-proxy
+      app.kubernetes.io/instance: oauth2-proxy-hubble
+  minAvailable: 1
+---
+# Source: oauth2-proxy/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app: oauth2-proxy    
+    helm.sh/chart: oauth2-proxy-10.4.3
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: authentication-proxy
+    app.kubernetes.io/part-of: oauth2-proxy
+    app.kubernetes.io/name: oauth2-proxy
+    app.kubernetes.io/instance: oauth2-proxy-hubble
+    app.kubernetes.io/version: "7.15.2"
+  name: oauth2-proxy-hubble
+  namespace: oauth2-proxy
+automountServiceAccountToken: true
+---
+# Source: oauth2-proxy/templates/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    app: oauth2-proxy    
+    helm.sh/chart: oauth2-proxy-10.4.3
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: authentication-proxy
+    app.kubernetes.io/part-of: oauth2-proxy
+    app.kubernetes.io/name: oauth2-proxy
+    app.kubernetes.io/instance: oauth2-proxy-hubble
+    app.kubernetes.io/version: "7.15.2"
+  name: oauth2-proxy-hubble
+  namespace: oauth2-proxy
+data:
+  oauth2_proxy.cfg: |
+
+    provider = "google"
+    email_domains = [ "*" ]
+    upstreams = [ "http://hubble-ui.kube-system.svc.cluster.local:80" ]
+    cookie_domains = [ ".panicboat.net" ]
+    whitelist_domains = [ ".panicboat.net" ]
+    cookie_secure = true
+    cookie_httponly = true
+    cookie_samesite = "lax"
+    pass_authorization_header = true
+    pass_access_token = true
+    set_authorization_header = true
+    set_xauthrequest = true
+    skip_provider_button = true
+    reverse_proxy = true
+    authenticated_emails_file = "/etc/oauth2-proxy/emails/allowed"
+---
+# Source: oauth2-proxy/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: oauth2-proxy    
+    helm.sh/chart: oauth2-proxy-10.4.3
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: authentication-proxy
+    app.kubernetes.io/part-of: oauth2-proxy
+    app.kubernetes.io/name: oauth2-proxy
+    app.kubernetes.io/instance: oauth2-proxy-hubble
+    app.kubernetes.io/version: "7.15.2"
+  name: oauth2-proxy-hubble
+  namespace: oauth2-proxy
+spec:
+  type: ClusterIP
+  ports:
+    - port: 80
+      targetPort: http
+      protocol: TCP
+      appProtocol: http
+      name: http
+    - port: 44180
+      protocol: TCP
+      appProtocol: http
+      targetPort: metrics
+      name: metrics
+  selector:    
+    app.kubernetes.io/name: oauth2-proxy
+    app.kubernetes.io/instance: oauth2-proxy-hubble
+---
+# Source: oauth2-proxy/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: oauth2-proxy    
+    helm.sh/chart: oauth2-proxy-10.4.3
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: authentication-proxy
+    app.kubernetes.io/part-of: oauth2-proxy
+    app.kubernetes.io/name: oauth2-proxy
+    app.kubernetes.io/instance: oauth2-proxy-hubble
+    app.kubernetes.io/version: "7.15.2"
+  annotations:
+    reloader.stakater.com/auto: "true"
+  name: oauth2-proxy-hubble
+  namespace: oauth2-proxy
+spec:
+  replicas: 2
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:      
+      app.kubernetes.io/name: oauth2-proxy
+      app.kubernetes.io/instance: oauth2-proxy-hubble
+  template:
+    metadata:
+      annotations:
+        checksum/config: 1bdaf708462979504f16a9fd426c622a99d40aca0b8cd89f978cb86d1301fd6f
+        checksum/secret: 9eb46bbdefd5cf844a2c4965b1241a7177addaa7c07789e7873ccda6b0104111
+        checksum/google-secret: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+        checksum/redis-secret: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
+      labels:
+        app: oauth2-proxy        
+        helm.sh/chart: oauth2-proxy-10.4.3
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/component: authentication-proxy
+        app.kubernetes.io/part-of: oauth2-proxy
+        app.kubernetes.io/name: oauth2-proxy
+        app.kubernetes.io/instance: oauth2-proxy-hubble
+        app.kubernetes.io/version: "7.15.2"
+    spec:
+      priorityClassName: "system-cluster-critical"
+      serviceAccountName: oauth2-proxy-hubble
+      enableServiceLinks: true
+      automountServiceAccountToken: true
+      containers:
+      - name: oauth2-proxy
+        image: "quay.io/oauth2-proxy/oauth2-proxy:v7.15.2"
+        imagePullPolicy: IfNotPresent
+        args:
+          - --http-address=0.0.0.0:4180
+          - --https-address=0.0.0.0:4443
+          - --metrics-address=0.0.0.0:44180
+          - --config=/etc/oauth2_proxy/oauth2_proxy.cfg
+        env:
+        - name: OAUTH2_PROXY_CLIENT_ID
+          valueFrom:
+            secretKeyRef:
+              name:  oauth2-proxy-google
+              key: client-id
+        - name: OAUTH2_PROXY_CLIENT_SECRET
+          valueFrom:
+            secretKeyRef:
+              name:  oauth2-proxy-google
+              key: client-secret
+        - name: OAUTH2_PROXY_COOKIE_SECRET
+          valueFrom:
+            secretKeyRef:
+              name:  oauth2-proxy-google
+              key: cookie-secret
+        ports:
+          - containerPort: 4180
+            name: http
+            protocol: TCP
+          - containerPort: 44180
+            protocol: TCP
+            name: metrics
+        livenessProbe:
+          httpGet:
+            path: /ping
+            port: http
+            scheme: HTTP
+          initialDelaySeconds: 0
+          timeoutSeconds: 1
+        readinessProbe:
+          httpGet:
+            path: /ready
+            port: http
+            scheme: HTTP
+          initialDelaySeconds: 0
+          timeoutSeconds: 5
+          successThreshold: 1
+          periodSeconds: 10
+        resources:
+          limits:
+            cpu: 200m
+            memory: 256Mi
+          requests:
+            cpu: 50m
+            memory: 64Mi
+        volumeMounts:
+        - mountPath: /etc/oauth2_proxy/oauth2_proxy.cfg
+          name: configmain
+          subPath: oauth2_proxy.cfg
+        - mountPath: /etc/oauth2-proxy/emails
+          name: emails
+          readOnly: true
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 2000
+          runAsNonRoot: true
+          runAsUser: 2000
+          seccompProfile:
+            type: RuntimeDefault
+      volumes:
+      - configMap:
+          defaultMode: 420
+          name: oauth2-proxy-hubble
+        name: configmain
+      - configMap:
+          name: oauth2-proxy-allowed-emails
+        name: emails
+---
+# Source: oauth2-proxy/templates/servicemonitor.yaml
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: oauth2-proxy-hubble
+  namespace: oauth2-proxy
+  labels:
+    prometheus: default
+    app: oauth2-proxy    
+    helm.sh/chart: oauth2-proxy-10.4.3
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: authentication-proxy
+    app.kubernetes.io/part-of: oauth2-proxy
+    app.kubernetes.io/name: oauth2-proxy
+    app.kubernetes.io/instance: oauth2-proxy-hubble
+    app.kubernetes.io/version: "7.15.2"
+    release: kube-prometheus-stack
+spec:
+  jobLabel: oauth2-proxy-hubble
+  selector:
+    matchLabels:      
+      app.kubernetes.io/name: oauth2-proxy
+      app.kubernetes.io/instance: oauth2-proxy-hubble
+  namespaceSelector:
+    matchNames:
+      - oauth2-proxy
+  endpoints:
+  - port: metrics
+    path: "/metrics"
+    interval: 60s
+    scrapeTimeout: 30s
+
+---
+# Source: oauth2-proxy/templates/poddisruptionbudget.yaml
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  labels:
+    app: oauth2-proxy    
+    helm.sh/chart: oauth2-proxy-10.4.3
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: authentication-proxy
+    app.kubernetes.io/part-of: oauth2-proxy
+    app.kubernetes.io/name: oauth2-proxy
+    app.kubernetes.io/instance: oauth2-proxy-alertmanager
+    app.kubernetes.io/version: "7.15.2"
+  name: oauth2-proxy-alertmanager
+  namespace: oauth2-proxy
+spec:
+  selector:
+    matchLabels:      
+      app.kubernetes.io/name: oauth2-proxy
+      app.kubernetes.io/instance: oauth2-proxy-alertmanager
+  minAvailable: 1
+---
+# Source: oauth2-proxy/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app: oauth2-proxy    
+    helm.sh/chart: oauth2-proxy-10.4.3
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: authentication-proxy
+    app.kubernetes.io/part-of: oauth2-proxy
+    app.kubernetes.io/name: oauth2-proxy
+    app.kubernetes.io/instance: oauth2-proxy-alertmanager
+    app.kubernetes.io/version: "7.15.2"
+  name: oauth2-proxy-alertmanager
+  namespace: oauth2-proxy
+automountServiceAccountToken: true
+---
+# Source: oauth2-proxy/templates/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    app: oauth2-proxy    
+    helm.sh/chart: oauth2-proxy-10.4.3
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: authentication-proxy
+    app.kubernetes.io/part-of: oauth2-proxy
+    app.kubernetes.io/name: oauth2-proxy
+    app.kubernetes.io/instance: oauth2-proxy-alertmanager
+    app.kubernetes.io/version: "7.15.2"
+  name: oauth2-proxy-alertmanager
+  namespace: oauth2-proxy
+data:
+  oauth2_proxy.cfg: |
+
+    provider = "google"
+    email_domains = [ "*" ]
+    upstreams = [ "http://kube-prometheus-stack-alertmanager.monitoring.svc.cluster.local:9093" ]
+    cookie_domains = [ ".panicboat.net" ]
+    whitelist_domains = [ ".panicboat.net" ]
+    cookie_secure = true
+    cookie_httponly = true
+    cookie_samesite = "lax"
+    pass_authorization_header = true
+    pass_access_token = true
+    set_authorization_header = true
+    set_xauthrequest = true
+    skip_provider_button = true
+    reverse_proxy = true
+    authenticated_emails_file = "/etc/oauth2-proxy/emails/allowed"
+---
+# Source: oauth2-proxy/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: oauth2-proxy    
+    helm.sh/chart: oauth2-proxy-10.4.3
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: authentication-proxy
+    app.kubernetes.io/part-of: oauth2-proxy
+    app.kubernetes.io/name: oauth2-proxy
+    app.kubernetes.io/instance: oauth2-proxy-alertmanager
+    app.kubernetes.io/version: "7.15.2"
+  name: oauth2-proxy-alertmanager
+  namespace: oauth2-proxy
+spec:
+  type: ClusterIP
+  ports:
+    - port: 80
+      targetPort: http
+      protocol: TCP
+      appProtocol: http
+      name: http
+    - port: 44180
+      protocol: TCP
+      appProtocol: http
+      targetPort: metrics
+      name: metrics
+  selector:    
+    app.kubernetes.io/name: oauth2-proxy
+    app.kubernetes.io/instance: oauth2-proxy-alertmanager
+---
+# Source: oauth2-proxy/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: oauth2-proxy    
+    helm.sh/chart: oauth2-proxy-10.4.3
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: authentication-proxy
+    app.kubernetes.io/part-of: oauth2-proxy
+    app.kubernetes.io/name: oauth2-proxy
+    app.kubernetes.io/instance: oauth2-proxy-alertmanager
+    app.kubernetes.io/version: "7.15.2"
+  annotations:
+    reloader.stakater.com/auto: "true"
+  name: oauth2-proxy-alertmanager
+  namespace: oauth2-proxy
+spec:
+  replicas: 2
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:      
+      app.kubernetes.io/name: oauth2-proxy
+      app.kubernetes.io/instance: oauth2-proxy-alertmanager
+  template:
+    metadata:
+      annotations:
+        checksum/config: 91f5f5b6eb2688bb5c30690b987e1d025de6be729e4e3fdaea9483a91b5cdd5c
+        checksum/secret: 9eb46bbdefd5cf844a2c4965b1241a7177addaa7c07789e7873ccda6b0104111
+        checksum/google-secret: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+        checksum/redis-secret: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
+      labels:
+        app: oauth2-proxy        
+        helm.sh/chart: oauth2-proxy-10.4.3
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/component: authentication-proxy
+        app.kubernetes.io/part-of: oauth2-proxy
+        app.kubernetes.io/name: oauth2-proxy
+        app.kubernetes.io/instance: oauth2-proxy-alertmanager
+        app.kubernetes.io/version: "7.15.2"
+    spec:
+      priorityClassName: "system-cluster-critical"
+      serviceAccountName: oauth2-proxy-alertmanager
+      enableServiceLinks: true
+      automountServiceAccountToken: true
+      containers:
+      - name: oauth2-proxy
+        image: "quay.io/oauth2-proxy/oauth2-proxy:v7.15.2"
+        imagePullPolicy: IfNotPresent
+        args:
+          - --http-address=0.0.0.0:4180
+          - --https-address=0.0.0.0:4443
+          - --metrics-address=0.0.0.0:44180
+          - --config=/etc/oauth2_proxy/oauth2_proxy.cfg
+        env:
+        - name: OAUTH2_PROXY_CLIENT_ID
+          valueFrom:
+            secretKeyRef:
+              name:  oauth2-proxy-google
+              key: client-id
+        - name: OAUTH2_PROXY_CLIENT_SECRET
+          valueFrom:
+            secretKeyRef:
+              name:  oauth2-proxy-google
+              key: client-secret
+        - name: OAUTH2_PROXY_COOKIE_SECRET
+          valueFrom:
+            secretKeyRef:
+              name:  oauth2-proxy-google
+              key: cookie-secret
+        ports:
+          - containerPort: 4180
+            name: http
+            protocol: TCP
+          - containerPort: 44180
+            protocol: TCP
+            name: metrics
+        livenessProbe:
+          httpGet:
+            path: /ping
+            port: http
+            scheme: HTTP
+          initialDelaySeconds: 0
+          timeoutSeconds: 1
+        readinessProbe:
+          httpGet:
+            path: /ready
+            port: http
+            scheme: HTTP
+          initialDelaySeconds: 0
+          timeoutSeconds: 5
+          successThreshold: 1
+          periodSeconds: 10
+        resources:
+          limits:
+            cpu: 200m
+            memory: 256Mi
+          requests:
+            cpu: 50m
+            memory: 64Mi
+        volumeMounts:
+        - mountPath: /etc/oauth2_proxy/oauth2_proxy.cfg
+          name: configmain
+          subPath: oauth2_proxy.cfg
+        - mountPath: /etc/oauth2-proxy/emails
+          name: emails
+          readOnly: true
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 2000
+          runAsNonRoot: true
+          runAsUser: 2000
+          seccompProfile:
+            type: RuntimeDefault
+      volumes:
+      - configMap:
+          defaultMode: 420
+          name: oauth2-proxy-alertmanager
+        name: configmain
+      - configMap:
+          name: oauth2-proxy-allowed-emails
+        name: emails
+---
+# Source: oauth2-proxy/templates/servicemonitor.yaml
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: oauth2-proxy-alertmanager
+  namespace: oauth2-proxy
+  labels:
+    prometheus: default
+    app: oauth2-proxy    
+    helm.sh/chart: oauth2-proxy-10.4.3
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: authentication-proxy
+    app.kubernetes.io/part-of: oauth2-proxy
+    app.kubernetes.io/name: oauth2-proxy
+    app.kubernetes.io/instance: oauth2-proxy-alertmanager
+    app.kubernetes.io/version: "7.15.2"
+    release: kube-prometheus-stack
+spec:
+  jobLabel: oauth2-proxy-alertmanager
+  selector:
+    matchLabels:      
+      app.kubernetes.io/name: oauth2-proxy
+      app.kubernetes.io/instance: oauth2-proxy-alertmanager
+  namespaceSelector:
+    matchNames:
+      - oauth2-proxy
+  endpoints:
+  - port: metrics
+    path: "/metrics"
+    interval: 60s
+    scrapeTimeout: 30s
+
+---
+# Source: oauth2-proxy/templates/poddisruptionbudget.yaml
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  labels:
+    app: oauth2-proxy    
+    helm.sh/chart: oauth2-proxy-10.4.3
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: authentication-proxy
+    app.kubernetes.io/part-of: oauth2-proxy
+    app.kubernetes.io/name: oauth2-proxy
+    app.kubernetes.io/instance: oauth2-proxy-prometheus
+    app.kubernetes.io/version: "7.15.2"
+  name: oauth2-proxy-prometheus
+  namespace: oauth2-proxy
+spec:
+  selector:
+    matchLabels:      
+      app.kubernetes.io/name: oauth2-proxy
+      app.kubernetes.io/instance: oauth2-proxy-prometheus
+  minAvailable: 1
+---
+# Source: oauth2-proxy/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app: oauth2-proxy    
+    helm.sh/chart: oauth2-proxy-10.4.3
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: authentication-proxy
+    app.kubernetes.io/part-of: oauth2-proxy
+    app.kubernetes.io/name: oauth2-proxy
+    app.kubernetes.io/instance: oauth2-proxy-prometheus
+    app.kubernetes.io/version: "7.15.2"
+  name: oauth2-proxy-prometheus
+  namespace: oauth2-proxy
+automountServiceAccountToken: true
+---
+# Source: oauth2-proxy/templates/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    app: oauth2-proxy    
+    helm.sh/chart: oauth2-proxy-10.4.3
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: authentication-proxy
+    app.kubernetes.io/part-of: oauth2-proxy
+    app.kubernetes.io/name: oauth2-proxy
+    app.kubernetes.io/instance: oauth2-proxy-prometheus
+    app.kubernetes.io/version: "7.15.2"
+  name: oauth2-proxy-prometheus
+  namespace: oauth2-proxy
+data:
+  oauth2_proxy.cfg: |
+
+    provider = "google"
+    email_domains = [ "*" ]
+    upstreams = [ "http://kube-prometheus-stack-prometheus.monitoring.svc.cluster.local:9090" ]
+    cookie_domains = [ ".panicboat.net" ]
+    whitelist_domains = [ ".panicboat.net" ]
+    cookie_secure = true
+    cookie_httponly = true
+    cookie_samesite = "lax"
+    pass_authorization_header = true
+    pass_access_token = true
+    set_authorization_header = true
+    set_xauthrequest = true
+    skip_provider_button = true
+    reverse_proxy = true
+    authenticated_emails_file = "/etc/oauth2-proxy/emails/allowed"
+---
+# Source: oauth2-proxy/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: oauth2-proxy    
+    helm.sh/chart: oauth2-proxy-10.4.3
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: authentication-proxy
+    app.kubernetes.io/part-of: oauth2-proxy
+    app.kubernetes.io/name: oauth2-proxy
+    app.kubernetes.io/instance: oauth2-proxy-prometheus
+    app.kubernetes.io/version: "7.15.2"
+  name: oauth2-proxy-prometheus
+  namespace: oauth2-proxy
+spec:
+  type: ClusterIP
+  ports:
+    - port: 80
+      targetPort: http
+      protocol: TCP
+      appProtocol: http
+      name: http
+    - port: 44180
+      protocol: TCP
+      appProtocol: http
+      targetPort: metrics
+      name: metrics
+  selector:    
+    app.kubernetes.io/name: oauth2-proxy
+    app.kubernetes.io/instance: oauth2-proxy-prometheus
+---
+# Source: oauth2-proxy/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: oauth2-proxy    
+    helm.sh/chart: oauth2-proxy-10.4.3
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: authentication-proxy
+    app.kubernetes.io/part-of: oauth2-proxy
+    app.kubernetes.io/name: oauth2-proxy
+    app.kubernetes.io/instance: oauth2-proxy-prometheus
+    app.kubernetes.io/version: "7.15.2"
+  annotations:
+    reloader.stakater.com/auto: "true"
+  name: oauth2-proxy-prometheus
+  namespace: oauth2-proxy
+spec:
+  replicas: 2
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:      
+      app.kubernetes.io/name: oauth2-proxy
+      app.kubernetes.io/instance: oauth2-proxy-prometheus
+  template:
+    metadata:
+      annotations:
+        checksum/config: cce4c6c237bacd16379ce7fbd6812f51d9c533cb3cbe8611b1c08b95ffcda96c
+        checksum/secret: 9eb46bbdefd5cf844a2c4965b1241a7177addaa7c07789e7873ccda6b0104111
+        checksum/google-secret: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+        checksum/redis-secret: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
+      labels:
+        app: oauth2-proxy        
+        helm.sh/chart: oauth2-proxy-10.4.3
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/component: authentication-proxy
+        app.kubernetes.io/part-of: oauth2-proxy
+        app.kubernetes.io/name: oauth2-proxy
+        app.kubernetes.io/instance: oauth2-proxy-prometheus
+        app.kubernetes.io/version: "7.15.2"
+    spec:
+      priorityClassName: "system-cluster-critical"
+      serviceAccountName: oauth2-proxy-prometheus
+      enableServiceLinks: true
+      automountServiceAccountToken: true
+      containers:
+      - name: oauth2-proxy
+        image: "quay.io/oauth2-proxy/oauth2-proxy:v7.15.2"
+        imagePullPolicy: IfNotPresent
+        args:
+          - --http-address=0.0.0.0:4180
+          - --https-address=0.0.0.0:4443
+          - --metrics-address=0.0.0.0:44180
+          - --config=/etc/oauth2_proxy/oauth2_proxy.cfg
+        env:
+        - name: OAUTH2_PROXY_CLIENT_ID
+          valueFrom:
+            secretKeyRef:
+              name:  oauth2-proxy-google
+              key: client-id
+        - name: OAUTH2_PROXY_CLIENT_SECRET
+          valueFrom:
+            secretKeyRef:
+              name:  oauth2-proxy-google
+              key: client-secret
+        - name: OAUTH2_PROXY_COOKIE_SECRET
+          valueFrom:
+            secretKeyRef:
+              name:  oauth2-proxy-google
+              key: cookie-secret
+        ports:
+          - containerPort: 4180
+            name: http
+            protocol: TCP
+          - containerPort: 44180
+            protocol: TCP
+            name: metrics
+        livenessProbe:
+          httpGet:
+            path: /ping
+            port: http
+            scheme: HTTP
+          initialDelaySeconds: 0
+          timeoutSeconds: 1
+        readinessProbe:
+          httpGet:
+            path: /ready
+            port: http
+            scheme: HTTP
+          initialDelaySeconds: 0
+          timeoutSeconds: 5
+          successThreshold: 1
+          periodSeconds: 10
+        resources:
+          limits:
+            cpu: 200m
+            memory: 256Mi
+          requests:
+            cpu: 50m
+            memory: 64Mi
+        volumeMounts:
+        - mountPath: /etc/oauth2_proxy/oauth2_proxy.cfg
+          name: configmain
+          subPath: oauth2_proxy.cfg
+        - mountPath: /etc/oauth2-proxy/emails
+          name: emails
+          readOnly: true
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 2000
+          runAsNonRoot: true
+          runAsUser: 2000
+          seccompProfile:
+            type: RuntimeDefault
+      volumes:
+      - configMap:
+          defaultMode: 420
+          name: oauth2-proxy-prometheus
+        name: configmain
+      - configMap:
+          name: oauth2-proxy-allowed-emails
+        name: emails
+---
+# Source: oauth2-proxy/templates/servicemonitor.yaml
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: oauth2-proxy-prometheus
+  namespace: oauth2-proxy
+  labels:
+    prometheus: default
+    app: oauth2-proxy    
+    helm.sh/chart: oauth2-proxy-10.4.3
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: authentication-proxy
+    app.kubernetes.io/part-of: oauth2-proxy
+    app.kubernetes.io/name: oauth2-proxy
+    app.kubernetes.io/instance: oauth2-proxy-prometheus
+    app.kubernetes.io/version: "7.15.2"
+    release: kube-prometheus-stack
+spec:
+  jobLabel: oauth2-proxy-prometheus
+  selector:
+    matchLabels:      
+      app.kubernetes.io/name: oauth2-proxy
+      app.kubernetes.io/instance: oauth2-proxy-prometheus
   namespaceSelector:
     matchNames:
       - oauth2-proxy
@@ -328,7 +1118,7 @@ spec:
       paths:
       - backend:
           service:
-            name: oauth2-proxy
+            name: oauth2-proxy-alertmanager
             port:
               number: 80
         path: /
@@ -357,7 +1147,7 @@ spec:
       paths:
       - backend:
           service:
-            name: oauth2-proxy
+            name: oauth2-proxy-grafana
             port:
               number: 80
         path: /
@@ -386,7 +1176,7 @@ spec:
       paths:
       - backend:
           service:
-            name: oauth2-proxy
+            name: oauth2-proxy-hubble
             port:
               number: 80
         path: /
@@ -415,7 +1205,7 @@ spec:
       paths:
       - backend:
           service:
-            name: oauth2-proxy
+            name: oauth2-proxy-prometheus
             port:
               number: 80
         path: /


### PR DESCRIPTION
## Summary

Phase 4-3 PR #310 (= `feat(eks): Phase 4-3 — Grafana auth + monitoring UIs Ingress`) merge 後の post-flight check で **2 件 runtime issues** を発見、本 PR は **2 件目の oauth2-proxy CrashLoopBackOff の fix forward**。

oauth2-proxy chart 10.4.3 の単一 instance に対して 4 backends を `upstreams` config で同時設定すると、各 upstream の path が default `/` で衝突し startup error `multiple upstreams found with id "/"`。oauth2-proxy v7+ の `upstreams` は **path-based routing のみ**で host-based 不可、brainstorming Approach 1 (= 1 instance shared multi-upstream) は技術的に realisable でなく、Approach 2 (= 4 instances 1 per backend) へ migration。

## Runtime issues 整理 (= Phase 4-3 全体)

| # | Issue | Resolution | 状態 |
|---|---|---|---|
| 1 | ESO Pod が Phase 4-2 deploy 時に Pod Identity Association より先 created、webhook が injection skip した状態で 22h running、actual `GetSecretValue` で初めて発覚 | `kubectl rollout restart deployment/external-secrets -n external-secrets` で再 created → Pod Identity env 注入 → ExternalSecrets sync ✅ | 解決済 (= manual ad-hoc fix、再現防止は learnings PR で 4-2 L5 の application-level test を post-flight standard に追加) |
| 2 | oauth2-proxy CrashLoopBackOff (`multiple upstreams found with id "/"`)、4 backends 同時 routing が Approach 1 の 1 instance shared では不可 | 本 PR で 4 instances へ migration | **本 PR で対応** |

## Architecture change

### Before (= Phase 4-3 PR #310 merged state)

```
Internet → ALB → 4 Ingresses (backend → oauth2-proxy:80) → 1 oauth2-proxy
  (Deployment x 1、Service x 1、upstreams = [grafana, hubble, alertmanager, prometheus])
                                  ↑ ❌ multiple upstreams で startup fail
```

### After (= 本 PR)

```
Internet → ALB → 4 Ingresses (backend → oauth2-proxy-{grafana,hubble,alertmanager,prometheus}:80)
                                ↓
                4 oauth2-proxy releases (= 1 per backend)
                  - oauth2-proxy-grafana → grafana.monitoring:80
                  - oauth2-proxy-hubble → hubble-ui.kube-system:80
                  - oauth2-proxy-alertmanager → alertmanager.monitoring:9093
                  - oauth2-proxy-prometheus → prometheus.monitoring:9090
```

cookie_secret は ExternalSecret 由来 K8s Secret `oauth2-proxy-google` を 4 release で **共有**、cookie domain `.panicboat.net` 経由で **4 hosts SSO 維持** (= 同じ cookie name `_oauth2_proxy` を 4 instances が共通 cookie_secret で encrypt/decrypt)。

## Spec / Plan

- spec: `docs/superpowers/specs/2026-05-09-eks-production-grafana-auth-ingress-design.md` (= Decision 9 が Approach 1 と記載されているが、本 fix forward で Approach 2 へ実装変更、spec は historical record として保持、learnings PR で post-execution lesson を追加予定)
- plan: `docs/superpowers/plans/2026-05-09-eks-production-grafana-auth-ingress.md`

## Notable Decisions (= 本 fix で確定)

| Decision | 採用 |
|---|---|
| oauth2-proxy topology | **4 instances (1 per backend)** (= brainstorming Approach 2、Approach 1 は技術的 realisable でない) |
| Service naming | `fullnameOverride: {{ .Release.Name }}` で Service 名 = release 名に統一 (= `oauth2-proxy-grafana` / -hubble / -alertmanager / -prometheus) |
| Upstream selection | values.yaml.gotmpl で `.Release.Name` 経由 upstream map から選択 (= DRY な template、release 追加時に map に entry 追加するだけ) |
| Cookie 共有 | ExternalSecret 由来 cookie_secret を 4 release で共有、cookie domain `.panicboat.net` で SSO 維持 |
| Resource cost | 1 chart × 2 replicas (= 2 Pods) → 4 charts × 2 replicas (= 8 Pods、+6 Pods、~600Mi memory + 200m CPU) |

## Pre-flight check (executed pre-merge)

- [x] helmfile template render success (= 4 releases each render with different upstream + Service name)
- [x] 4 Ingress backends point to per-release Services (`oauth2-proxy-{grafana,hubble,alertmanager,prometheus}:80`)
- [x] hydrate output resource counts: 4 Deployments / 4 Services / 4 SMs / 4 Ingresses + 1 ExternalSecret + 1 ConfigMap (allowlist) + 4 chart-default ConfigMaps + 4 PDBs
- [x] ExternalSecret + ConfigMap allowlist は **shared** (= 1 件のまま、追加 AWS Secret 投入不要)
- [x] commit subject ≤ 72 chars (= 70 chars)、`-s` signoff、Co-Authored-By 不在
- [x] 比較表現 (simple / complex / easy / hard) hit なし

## Test plan (post-flight, after merge)

### 5 分以内

- [ ] Flux が main の latest commit を Applied
- [ ] 4 oauth2-proxy releases (= 8 Pods) Running、各 `/ping` health check 200
- [ ] 旧 single oauth2-proxy Deployment が cleanup される (= Flux が GitOps 管理外 resource を delete)
- [ ] 4 ALB target groups (= 4 Ingresses x IngressGroup `monitoring-uis`) で 8 endpoints HA

### 30 分以内

- [ ] `https://grafana.panicboat.net` browser access → Google OAuth → panicboat@gmail.com で login → Grafana auto-login Admin
- [ ] 同 browser session で `https://hubble.panicboat.net` / `https://alertmanager.panicboat.net` / `https://prometheus.panicboat.net` access → 再 login なし (= cookie domain 経由 SSO 動作確認)
- [ ] 別 Google account で login 試行 → ConfigMap allowlist で reject

### Sub-project 4-2 L5 適用

- [ ] AWS direct verify が AccessDenied される場合、application-level proof (= 4 oauth2-proxy Pods Running + ALB Status.LoadBalancer.Ingress[0].Hostname + browser-level SSO success) で検証

## Sub-project 4b L1 / L2 / L3 + 4-1 L1 / 4-2 L1 / L2 / L3 / L4 適用

- L1 (= chart binary verify systematic step): Phase 4-3 で確認した chart 10.4.3 を踏襲、本 fix では template render verify を再実施 (= 4 releases 全部 success)
- L4 (= 急進化 chart の design assumption gap calibration): brainstorming で「multi-upstream config が host-based routing をサポート」と仮定したが、actual chart で path-based routing only と判明、本 fix で migration

## Rollback 手順

```bash
# Pattern A: Standard rollback (= Flux suspend + revert)
flux suspend kustomization flux-system -n flux-system
gh pr create --base main --head revert-fix-oauth2-proxy --title "revert: oauth2-proxy 4 instances fix forward"
gh pr merge <pr-number>
flux resume kustomization flux-system -n flux-system
flux reconcile kustomization flux-system -n flux-system

# Pattern B: revert で Phase 4-3 PR #310 の状態に戻る (= oauth2-proxy CrashLoopBackOff 状態)
# その場合は brainstorming Approach 3 (= ALB OIDC 直接利用) 等の代替設計を再検討
```
