### PR TITLE
fix(eks): Mimir replication_factor 1 for single-replica ring

### DIFF
--- a/kubernetes/components/mimir/production/values.yaml.gotmpl
+++ b/kubernetes/components/mimir/production/values.yaml.gotmpl
@@ -50,6 +50,16 @@ mimir:
       enabled: false
     ingester:
       push_grpc_method_enabled: true
+      ring:
+        # 1 ingester replica 構成のため RF=1。chart default RF=3 だと distributor が
+        # quorum (= RF/2+1=2) を満たせず "at least 2 live replicas required" で
+        # write reject、querier も ring unhealthy で query 不可になる。
+        replication_factor: 1
+    store_gateway:
+      sharding_ring:
+        # 1 store_gateway replica 構成のため RF=1。ingester ring と同じ理由で
+        # chart default RF=3 だと query path で ring unhealthy になる。
+        replication_factor: 1
     # NOTE: frontend / frontend_worker は chart default に任せる
     # (query_scheduler 有効時は chart が scheduler_address を query-scheduler
     # service に向けて自動設定。Mimir 3.x で frontend_worker.frontend_address は

--- a/kubernetes/manifests/production/mimir/manifest.yaml
+++ b/kubernetes/manifests/production/mimir/manifest.yaml
@@ -559,6 +559,7 @@ data:
         heartbeat_period: 2m
         heartbeat_timeout: 10m
         num_tokens: 512
+        replication_factor: 1
         tokens_file_path: /data/tokens
         unregister_on_shutdown: false
     ingester_client:
@@ -589,6 +590,7 @@ data:
       sharding_ring:
         heartbeat_period: 1m
         heartbeat_timeout: 10m
+        replication_factor: 1
         tokens_file_path: /data/tokens
         unregister_on_shutdown: false
         wait_stability_min_duration: 1m
@@ -1350,7 +1352,7 @@ spec:
         app.kubernetes.io/component: distributor
         app.kubernetes.io/part-of: memberlist
       annotations:
-        checksum/config: 4ee4f2c1673612609d410b126c9ff57801f00e76c248bfb6317fcb67ba7bfd31
+        checksum/config: a9e7bed0323884705d50250a8bff7e69dd22c297ce596d96327e8a2f1831a3f4
       namespace: "monitoring"
     spec:
       serviceAccountName: mimir
@@ -1594,7 +1596,7 @@ spec:
         app.kubernetes.io/component: querier
         app.kubernetes.io/part-of: memberlist
       annotations:
-        checksum/config: 4ee4f2c1673612609d410b126c9ff57801f00e76c248bfb6317fcb67ba7bfd31
+        checksum/config: a9e7bed0323884705d50250a8bff7e69dd22c297ce596d96327e8a2f1831a3f4
     spec:
       serviceAccountName: mimir
       securityContext:
@@ -1718,7 +1720,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/component: query-frontend
       annotations:
-        checksum/config: 4ee4f2c1673612609d410b126c9ff57801f00e76c248bfb6317fcb67ba7bfd31
+        checksum/config: a9e7bed0323884705d50250a8bff7e69dd22c297ce596d96327e8a2f1831a3f4
       namespace: "monitoring"
     spec:
       serviceAccountName: mimir
@@ -1840,7 +1842,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/component: query-scheduler
       annotations:
-        checksum/config: 4ee4f2c1673612609d410b126c9ff57801f00e76c248bfb6317fcb67ba7bfd31
+        checksum/config: a9e7bed0323884705d50250a8bff7e69dd22c297ce596d96327e8a2f1831a3f4
     spec:
       serviceAccountName: mimir
       securityContext:
@@ -2068,7 +2070,7 @@ spec:
         app.kubernetes.io/component: compactor
         app.kubernetes.io/part-of: memberlist
       annotations:
-        checksum/config: 4ee4f2c1673612609d410b126c9ff57801f00e76c248bfb6317fcb67ba7bfd31
+        checksum/config: a9e7bed0323884705d50250a8bff7e69dd22c297ce596d96327e8a2f1831a3f4
       namespace: "monitoring"
     spec:
       serviceAccountName: mimir
@@ -2201,7 +2203,7 @@ spec:
         app.kubernetes.io/component: ingester
         app.kubernetes.io/part-of: memberlist
       annotations:
-        checksum/config: 4ee4f2c1673612609d410b126c9ff57801f00e76c248bfb6317fcb67ba7bfd31
+        checksum/config: a9e7bed0323884705d50250a8bff7e69dd22c297ce596d96327e8a2f1831a3f4
       namespace: "monitoring"
     spec:
       serviceAccountName: mimir
@@ -2338,7 +2340,7 @@ spec:
         app.kubernetes.io/component: store-gateway
         app.kubernetes.io/part-of: memberlist
       annotations:
-        checksum/config: 4ee4f2c1673612609d410b126c9ff57801f00e76c248bfb6317fcb67ba7bfd31
+        checksum/config: a9e7bed0323884705d50250a8bff7e69dd22c297ce596d96327e8a2f1831a3f4
       namespace: "monitoring"
     spec:
       serviceAccountName: mimir


### PR DESCRIPTION
## Summary

Phase 4-3 PR #310 + #311 merge 後の post-flight check で Grafana の Mimir datasource query が `Validation failed: too many unhealthy instances in the ring` で fail することを確認。Mimir distributor logs で **Phase 3 Sub-project 2 (= Mimir deploy) 以来 23 時間継続で発生していた latent runtime issue** が判明:

```
err="send data to ingesters: at least 2 live replicas required, could only find 1"
```

= Prometheus remote-write が 23 時間 500 で reject 状態、Grafana で datasource query が ring unhealthy で fail。Mimir auth gate (= Phase 4-3) は正常、observability stack の **internal config issue**。

## Root cause

Mimir values で `ingester.replicas: 1` + `store_gateway.replicas: 1` を **明示設定** (= small cluster 用、Phase 3 Sub-project 2 deploy 時)、ただし `replication_factor` の override が missing で chart default 3 のまま。

```
distributor が quorum (= RF/2+1=2) を要求 → 1 ingester では quorum 不成立
                ↓
       全 write 500 reject + 全 query ring unhealthy
```

## Fix

`kubernetes/components/mimir/production/values.yaml.gotmpl` の `mimir.structuredConfig` に **2 箇所追加**:

```yaml
mimir:
  structuredConfig:
    ingester:
      ring:
        replication_factor: 1   # 1 ingester replica 構成のため
    store_gateway:
      sharding_ring:
        replication_factor: 1   # 1 store_gateway replica 構成のため
```

## Loki / Tempo の同種 issue 確認

verify 結果: **修正不要**:

| Component | mode | ring 必要性 |
|---|---|---|
| Loki | monolithic mode (`loki-0` 1 pod に全 component) | ring 内部使用、replication_factor=1 default |
| Tempo | monolithic mode (`tempo-0` 1 pod に全 component) | ring 概念不在 |

distributor logs / pod logs で ring エラーなし、両方正常動作。

## Spec / Plan

- 修正対象 spec: `docs/superpowers/specs/2026-05-05-eks-production-observability-metrics-stack-design.md` (= Phase 3 Sub-project 2)
- 関連 spec: `docs/superpowers/specs/2026-05-09-eks-production-grafana-auth-ingress-design.md` (= Phase 4-3、本 issue を post-flight で発覚)

## Notable points

- **23 時間 latent**: Phase 3 Sub-project 2 deploy 以来発生、Phase 4-3 で Grafana を browser から actually 使い始めて初めて発覚
- **Phase 4-3 自体は正常**: oauth2-proxy / 4 ALB Ingress / Google OAuth / Grafana auth.proxy mode 全部動作、本 issue は Mimir 内部 config
- **Sub-project 4-2 L5 + 本 issue の共通教訓**: deploy 時の "Pod Running" + "Capabilities=ReadWrite" 等の static health check では捕捉できない、application-level の actual data flow を post-flight で test する必要

## Pre-flight check (executed pre-merge)

- [x] helmfile template render success
- [x] render output で `replication_factor: 1` が ingester ring + store_gateway sharding_ring の 2 箇所に反映
- [x] `kustomize build` error なし
- [x] commit subject ≤ 72 chars (= 60 chars)、`-s` signoff、Co-Authored-By 不在
- [x] 比較表現 (simple / complex / easy / hard) hit なし

## Test plan (post-flight, after merge)

### 5 分以内

- [ ] Flux が main の latest commit を Applied
- [ ] mimir-distributed-distributor / ingester / querier / store_gateway Pods Running
- [ ] mimir-distributed-distributor logs で `at least 2 live replicas required` エラーが停止
- [ ] mimir-distributed-distributor logs で write success (= 200 response) が観測される

### 10 分以内

- [ ] Prometheus remote-write が 200 で success、Mimir に書き込み再開
- [ ] Grafana の Mimir datasource query が success (= browser で `https://grafana.panicboat.net` を開いて任意の dashboard で metrics 表示確認)
- [ ] Loki / Tempo datasource query も success (= 既存正常状態の継続確認)

## Rollback 手順

```bash
# Pattern A: Standard rollback (= Flux suspend + revert)
flux suspend kustomization flux-system -n flux-system
gh pr create --base main --head revert-fix-mimir-rf --title "revert: Mimir replication_factor fix"
gh pr merge <pr-number>
flux resume kustomization flux-system -n flux-system
flux reconcile kustomization flux-system -n flux-system

# Pattern B: ingester replicas を 2 に増やす (= alternative fix)
# values.yaml.gotmpl で ingester.replicas: 2 + store_gateway.replicas: 2 に変更、
# replication_factor: 1 を removed。production cluster size 増加が trade-off。
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Kubernetes deployment configuration for Mimir to support single-replica deployments while ensuring system stability and query health.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->