### PR TITLE
fix(eks): Mimir cardinality limit + apiserver bucket drop

### DIFF
--- a/kubernetes/components/mimir/production/values.yaml.gotmpl
+++ b/kubernetes/components/mimir/production/values.yaml.gotmpl
@@ -60,6 +60,13 @@ mimir:
         # 1 store_gateway replica 構成のため RF=1。ingester ring と同じ理由で
         # chart default RF=3 だと query path で ring unhealthy になる。
         replication_factor: 1
+    limits:
+      # chart default `max_global_series_per_user: 150000` は small cluster で
+      # apiserver high-cardinality histogram bucket (= apiserver_request_*) で
+      # 容易に hit する。500K に拡大して buffer 確保、prometheus-operator の
+      # writeRelabelConfigs で長期 cardinality 制御 (= apiserver bucket drop)
+      # と組合せて運用する。
+      max_global_series_per_user: 500000
     # NOTE: frontend / frontend_worker は chart default に任せる
     # (query_scheduler 有効時は chart が scheduler_address を query-scheduler
     # service に向けて自動設定。Mimir 3.x で frontend_worker.frontend_address は

--- a/kubernetes/components/prometheus-operator/production/values.yaml.gotmpl
+++ b/kubernetes/components/prometheus-operator/production/values.yaml.gotmpl
@@ -155,7 +155,17 @@ prometheus:
         # Mimir の tenant header (= 本 sub-project は 1 tenant、`anonymous` で OK)
         headers:
           X-Scope-OrgID: anonymous
-        # NOTE: cardinality 抑制の writeRelabelConfigs は cluster scale up 時に追加
+        # apiserver の high-cardinality histogram bucket を Mimir 送信前に drop。
+        # small cluster で本 metrics 群が total cardinality の ~57% を占める
+        # (= 85K series of 150K limit)、観測価値が低く drop で 70K+ series 削減。
+        # `_sum` / `_count` / `_total` は維持して histogram の総量は観測可能。
+        writeRelabelConfigs:
+          - sourceLabels: [__name__]
+            regex: "apiserver_(request|response|watch_list|watch_cache_read_wait|storage_list|watch_events|request_body_size|request_sli|request_slo)_.+_bucket"
+            action: drop
+          - sourceLabels: [__name__]
+            regex: "etcd_request_duration_seconds_bucket"
+            action: drop
 
     # -------------------------------------------------------------------------
     # Resource Limits

--- a/kubernetes/manifests/production/mimir/manifest.yaml
+++ b/kubernetes/manifests/production/mimir/manifest.yaml
@@ -568,6 +568,7 @@ data:
         max_send_msg_size: 104857600
     limits:
       max_cache_freshness: 10m
+      max_global_series_per_user: 500000
       max_query_parallelism: 240
       max_total_query_length: 12000h
     memberlist:
@@ -1352,7 +1353,7 @@ spec:
         app.kubernetes.io/component: distributor
         app.kubernetes.io/part-of: memberlist
       annotations:
-        checksum/config: a9e7bed0323884705d50250a8bff7e69dd22c297ce596d96327e8a2f1831a3f4
+        checksum/config: cc4b4936dbde6327ae978a6debc8ea1d5d6d0e0b1a1ef12d05b9899fc97c6ff8
       namespace: "monitoring"
     spec:
       serviceAccountName: mimir
@@ -1596,7 +1597,7 @@ spec:
         app.kubernetes.io/component: querier
         app.kubernetes.io/part-of: memberlist
       annotations:
-        checksum/config: a9e7bed0323884705d50250a8bff7e69dd22c297ce596d96327e8a2f1831a3f4
+        checksum/config: cc4b4936dbde6327ae978a6debc8ea1d5d6d0e0b1a1ef12d05b9899fc97c6ff8
     spec:
       serviceAccountName: mimir
       securityContext:
@@ -1720,7 +1721,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/component: query-frontend
       annotations:
-        checksum/config: a9e7bed0323884705d50250a8bff7e69dd22c297ce596d96327e8a2f1831a3f4
+        checksum/config: cc4b4936dbde6327ae978a6debc8ea1d5d6d0e0b1a1ef12d05b9899fc97c6ff8
       namespace: "monitoring"
     spec:
       serviceAccountName: mimir
@@ -1842,7 +1843,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/component: query-scheduler
       annotations:
-        checksum/config: a9e7bed0323884705d50250a8bff7e69dd22c297ce596d96327e8a2f1831a3f4
+        checksum/config: cc4b4936dbde6327ae978a6debc8ea1d5d6d0e0b1a1ef12d05b9899fc97c6ff8
     spec:
       serviceAccountName: mimir
       securityContext:
@@ -2070,7 +2071,7 @@ spec:
         app.kubernetes.io/component: compactor
         app.kubernetes.io/part-of: memberlist
       annotations:
-        checksum/config: a9e7bed0323884705d50250a8bff7e69dd22c297ce596d96327e8a2f1831a3f4
+        checksum/config: cc4b4936dbde6327ae978a6debc8ea1d5d6d0e0b1a1ef12d05b9899fc97c6ff8
       namespace: "monitoring"
     spec:
       serviceAccountName: mimir
@@ -2203,7 +2204,7 @@ spec:
         app.kubernetes.io/component: ingester
         app.kubernetes.io/part-of: memberlist
       annotations:
-        checksum/config: a9e7bed0323884705d50250a8bff7e69dd22c297ce596d96327e8a2f1831a3f4
+        checksum/config: cc4b4936dbde6327ae978a6debc8ea1d5d6d0e0b1a1ef12d05b9899fc97c6ff8
       namespace: "monitoring"
     spec:
       serviceAccountName: mimir
@@ -2340,7 +2341,7 @@ spec:
         app.kubernetes.io/component: store-gateway
         app.kubernetes.io/part-of: memberlist
       annotations:
-        checksum/config: a9e7bed0323884705d50250a8bff7e69dd22c297ce596d96327e8a2f1831a3f4
+        checksum/config: cc4b4936dbde6327ae978a6debc8ea1d5d6d0e0b1a1ef12d05b9899fc97c6ff8
       namespace: "monitoring"
     spec:
       serviceAccountName: mimir


### PR DESCRIPTION
## Summary

Phase 5-1 brainstorming pause 中の Loki / Grafana ログ調査で **Mimir cardinality limit hit** が判明。Mimir distributor で 1 分あたり 100+ 件の `err-mimir-max-series-per-user` reject、Phase 4-3 で fix した RF=1 後の 23h buffered metrics flush + 累積で chart default `max_global_series_per_user: 150000` に到達。

```
err="send data to ingesters: failed pushing to ingester mimir-distributed-ingester-0:
     user=anonymous: per-user series limit of 150000 exceeded
     (err-mimir-max-series-per-user)"
```

= Phase 3 Sub-project 2 (Mimir) の **latent issue が Phase 4-3 で fix した RF と同 pattern**、Phase 5-1 brainstorming 中に発覚 + fix forward PR で解消。

## Cardinality 調査結果

| Source | Sample 数 | 影響 |
|---|---|---|
| **`job=apiserver`** | **85,871** 🔴 | **57% を占める dominant source** (= K8s API server の高 cardinality histogram metrics) |
| `job=kubelet` | 30,990 | 21% |
| `job=cilium-agent` | 9,129 | 6% |
| `job=kube-state-metrics` | 8,879 | 6% |
| `job=node-exporter` | 7,171 | 5% |
| その他 | ~9,000 | 5% |

### Top series-count metric names

| Metric | Series 数 |
|---|---|
| `apiserver_request_duration_seconds_bucket` | 11,760 |
| `apiserver_request_body_size_bytes_bucket` | 11,488 |
| `etcd_request_duration_seconds_bucket` | 7,820 |
| `apiserver_request_sli_duration_seconds_bucket` | 6,592 |
| `apiserver_watch_list_duration_seconds_bucket` | 4,644 |

= small cluster (= panicboat ~5-7 nodes) で 25-30K series が typical、apiserver bucket drop で ~70K+ series 削減見込み。

## Fix 内容

### Immediate fix (= Mimir limit 拡大)

`kubernetes/components/mimir/production/values.yaml.gotmpl` に追加:

```yaml
mimir:
  structuredConfig:
    limits:
      max_global_series_per_user: 500000   # 150K (chart default) → 500K で buffer 確保
```

### Long-term fix (= Prometheus writeRelabelConfigs で root cause 対策)

`kubernetes/components/prometheus-operator/production/values.yaml.gotmpl` に追加:

```yaml
prometheus:
  prometheusSpec:
    remoteWrite:
      - url: http://mimir-distributed-gateway.monitoring.svc.cluster.local/api/v1/push
        headers:
          X-Scope-OrgID: anonymous
        writeRelabelConfigs:
          - sourceLabels: [__name__]
            regex: "apiserver_(request|response|watch_list|watch_cache_read_wait|storage_list|watch_events|request_body_size|request_sli|request_slo)_.+_bucket"
            action: drop
          - sourceLabels: [__name__]
            regex: "etcd_request_duration_seconds_bucket"
            action: drop
```

= apiserver / etcd の high-cardinality histogram bucket を Mimir 送信前に drop。`_sum` / `_count` / `_total` は維持 (= histogram の総量 + percentile は引き続き観測可能)。

## 性質

- **Phase 3 Sub-project 2 (Mimir) latent issue**、Phase 4-3 で fix した RF=1 と同 pattern
- 直接的 trigger は Phase 4-3 後の Pod rollout (= ESO restart / Mimir RF fix / oauth2-proxy 4 instances 等) で series 増、150K hit
- Phase 5-1 (= Beyla deploy) と直接無関係、ただし **Phase 5 完了条件 "Mimir で nginx metrics が見える" の前提条件**

## Pre-flight check (executed pre-merge)

- [x] helmfile template render success (= Mimir + prometheus-operator 両方)
- [x] hydrate output で `max_global_series_per_user: 500000` が Mimir limits に反映
- [x] hydrate output で writeRelabelConfigs が Prometheus CR の `remoteWrite[0]` に反映 (= 2 drop rules)
- [x] commit subject ≤ 72 chars (= 57 chars)、`-s` signoff、Co-Authored-By 不在
- [x] 比較表現 (simple / complex / easy / hard) hit なし

## Test plan (post-flight, after merge)

### 5 分以内

- [ ] Flux が main の latest commit を Applied
- [ ] Mimir Pods 再起動 + 新 limits 反映 (= mimir-distributed-config ConfigMap update + StatefulSet rollout)
- [ ] Prometheus Pod 再起動 + writeRelabelConfigs 反映 (= prometheus-kube-prometheus-stack-prometheus StatefulSet rollout)

### 10 分以内

- [ ] Mimir distributor logs で `err-mimir-max-series-per-user` の停止 (= `kubectl logs --since=2m | grep "max-series" | wc -l` が 0)
- [ ] Prometheus が apiserver scrape を継続、ただし高 cardinality bucket は remote_write 前に drop (= scrape は維持)
- [ ] Mimir ingester active series が 150K → ~30-50K に縮小 (= `cortex_ingester_active_series{user="anonymous"}`)
- [ ] Grafana datasource query (= Mimir) で apiserver `_sum` / `_count` 等の `_bucket` 以外は引き続き query 可、`_bucket` は不在

### 30 分以内 (= long-term verify)

- [ ] cardinality 安定 (= ingester active series が ~30-50K で安定、再増加なし)
- [ ] Phase 4-3 で発覚した別 issue (= 400 err-mimir-label-invalid for OTLP labels) は本 PR で対応せず、Phase 6+ 引き継ぎ事項 (= L6 Loki label promotion 関連) で別途扱う

## Sub-project 4-3 L4 (= distributed system replica / RF 整合) 再 validate

Phase 4-3 L4 で発見した "distributed system chart の replica count vs replication_factor 整合" を **更に拡張**:
- 4-3: `replicas: 1` + `replication_factor: 1` 整合 (= RF を replica に合わせる)
- 本 PR: `max_global_series_per_user` の small cluster 適合 (= 150K default → 500K + cardinality 制御)
- 共通 lesson: **chart default は production-grade を仮定**、small / dev cluster では複数 limits を明示 override 必要

## Rollback 手順

```bash
# Pattern A: Standard rollback (= Flux suspend + revert)
flux suspend kustomization flux-system -n flux-system
gh pr create --base main --head revert-fix-mimir-cardinality --title "revert: Mimir cardinality limit fix"
gh pr merge <pr-number>
flux resume kustomization flux-system -n flux-system
flux reconcile kustomization flux-system -n flux-system

# Pattern B: writeRelabelConfigs のみ revert (= limits 拡大は維持)
# prometheus-operator/production/values.yaml.gotmpl の writeRelabelConfigs を削除、
# Mimir limits は維持で 500K buffer のまま運用、apiserver bucket は再 ingest される
# (= cardinality 増加に逆戻り、ただし limit 500K で reject 回避)
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Increased production metrics ingestion capacity limits to support more series per user
  * Implemented metric filtering rules to drop high-cardinality histogram metrics, reducing data volume transmitted to the metrics system
  * Optimized production infrastructure configuration for improved system performance and stability

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/panicboat/platform/pull/314)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->