### PR TITLE
fix(eks): Cilium Hubble CA-based ClusterIssuer for mTLS

### DIFF
--- a/kubernetes/components/cert-manager/production/kustomization/cilium-hubble-ca.yaml
+++ b/kubernetes/components/cert-manager/production/kustomization/cilium-hubble-ca.yaml
@@ -1,0 +1,49 @@
+# =============================================================================
+# Cilium Hubble CA Certificate + Issuer (= mTLS root CA)
+# =============================================================================
+# Cilium Hubble は hubble-relay ↔ hubble-peer 間で mTLS 通信。両 cert を
+# 同一 CA で署名する必要がある。
+#
+# selfsigned-cluster-issuer (= cert-manager の SelfSigned type) は各 cert を
+# 自己署名 (= subject == issuer) で発行、共通 root CA を持たないため mTLS が
+# 成立しない (= "tls: failed to verify certificate: x509: certificate signed
+# by unknown authority" で hubble-relay CrashLoop)。
+#
+# 本ファイルで CA-based ClusterIssuer を構築:
+#   1. cilium-hubble-ca = Certificate (isCA: true)、selfsigned-cluster-issuer
+#      で発行 (= 自己署名 root CA、cert-manager が cilium-hubble-ca Secret を生成)
+#   2. cilium-hubble-ca-issuer = ClusterIssuer (kind: CA)、上記 Secret を参照
+#
+# Cilium chart の hubble.tls.auto.certManagerIssuerRef を本 ClusterIssuer に
+# 向けることで、chart が hubble-server-certs + hubble-relay-client-certs を
+# **同一 CA で署名**、mTLS 成立する。
+# =============================================================================
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: cilium-hubble-ca
+  namespace: cert-manager
+spec:
+  # Cilium Hubble TLS 用 root CA (= 1 年有効、cert-manager が auto-rotate)
+  isCA: true
+  commonName: cilium-hubble-ca
+  duration: 8760h0m0s
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+  issuerRef:
+    name: selfsigned-cluster-issuer
+    kind: ClusterIssuer
+    group: cert-manager.io
+  secretName: cilium-hubble-ca
+---
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: cilium-hubble-ca-issuer
+spec:
+  ca:
+    # 上記 Certificate `cilium-hubble-ca` が cert-manager namespace に
+    # 自動生成する Secret を CA として参照。Cilium chart 経由で
+    # hubble-server-certs + hubble-relay-client-certs が同一 CA で署名される。
+    secretName: cilium-hubble-ca

--- a/kubernetes/components/cert-manager/production/kustomization/kustomization.yaml
+++ b/kubernetes/components/cert-manager/production/kustomization/kustomization.yaml
@@ -9,3 +9,4 @@ kind: Kustomization
 
 resources:
   - cluster-issuer.yaml
+  - cilium-hubble-ca.yaml

--- a/kubernetes/components/cilium/production/values.yaml.gotmpl
+++ b/kubernetes/components/cilium/production/values.yaml.gotmpl
@@ -64,13 +64,16 @@ socketLB:
 hubble:
   enabled: true
   # TLS certs は cert-manager で管理 (= Cilium 公式 production-recommended path)。
-  # selfsigned-cluster-issuer (= cert-manager component で deploy 済) を参照、
-  # cert-manager が Certificate resource を生成して TLS cert を発行・自動 rotate する。
+  # cilium-hubble-ca-issuer (= CA-based ClusterIssuer、cert-manager component の
+  # cilium-hubble-ca Certificate 由来 root CA を参照) で hubble-server-certs と
+  # hubble-relay-client-certs を同一 CA で署名、mTLS 成立。
+  # NOTE: selfsigned-cluster-issuer (= SelfSigned type) を直接使うと各 cert が
+  # 自己署名 (= subject == issuer) で発行され mTLS 不可、CA-based issuer が必須。
   tls:
     auto:
       method: certmanager
       certManagerIssuerRef:
-        name: selfsigned-cluster-issuer
+        name: cilium-hubble-ca-issuer
         kind: ClusterIssuer
         group: cert-manager.io
   relay:

--- a/kubernetes/manifests/production/cert-manager/manifest.yaml
+++ b/kubernetes/manifests/production/cert-manager/manifest.yaml
@@ -13665,6 +13665,49 @@ webhooks:
         namespace: cert-manager
         path: /mutate
 ---
+# Source: cert-manager/templates/servicemonitor.yaml
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: cert-manager
+  namespace: cert-manager
+  labels:
+    app: cert-manager
+    app.kubernetes.io/name: cert-manager
+    app.kubernetes.io/instance: cert-manager
+    app.kubernetes.io/component: "controller"
+    app.kubernetes.io/version: "v1.20.2"
+    app.kubernetes.io/managed-by: Helm
+    helm.sh/chart: cert-manager-v1.20.2
+    prometheus: default
+    release: kube-prometheus-stack
+spec:
+  jobLabel: app.kubernetes.io/name
+  selector:
+    matchExpressions:
+      - key: app.kubernetes.io/name
+        operator: In
+        values:
+        - cainjector
+        - cert-manager
+        - webhook
+      - key: app.kubernetes.io/instance
+        operator: In
+        values:
+        - cert-manager
+      - key: app.kubernetes.io/component
+        operator: In
+        values:
+        - cainjector
+        - controller
+        - webhook
+  endpoints:
+  - targetPort: http-metrics
+    path: /metrics
+    interval: 60s
+    scrapeTimeout: 30s
+    honorLabels: false
+---
 # Source: cert-manager/templates/webhook-validating-webhook.yaml
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
@@ -13712,49 +13755,6 @@ webhooks:
         name: cert-manager-webhook
         namespace: cert-manager
         path: /validate
----
-# Source: cert-manager/templates/servicemonitor.yaml
-apiVersion: monitoring.coreos.com/v1
-kind: ServiceMonitor
-metadata:
-  name: cert-manager
-  namespace: cert-manager
-  labels:
-    app: cert-manager
-    app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/instance: cert-manager
-    app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.20.2"
-    app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.20.2
-    prometheus: default
-    release: kube-prometheus-stack
-spec:
-  jobLabel: app.kubernetes.io/name
-  selector:
-    matchExpressions:
-      - key: app.kubernetes.io/name
-        operator: In
-        values:
-        - cainjector
-        - cert-manager
-        - webhook
-      - key: app.kubernetes.io/instance
-        operator: In
-        values:
-        - cert-manager
-      - key: app.kubernetes.io/component
-        operator: In
-        values:
-        - cainjector
-        - controller
-        - webhook
-  endpoints:
-  - targetPort: http-metrics
-    path: /metrics
-    interval: 60s
-    scrapeTimeout: 30s
-    honorLabels: false
 ---
 # Source: cert-manager/templates/startupapicheck-serviceaccount.yaml
 apiVersion: v1

--- a/kubernetes/manifests/production/cert-manager/manifest.yaml
+++ b/kubernetes/manifests/production/cert-manager/manifest.yaml
@@ -13665,49 +13665,6 @@ webhooks:
         namespace: cert-manager
         path: /mutate
 ---
-# Source: cert-manager/templates/servicemonitor.yaml
-apiVersion: monitoring.coreos.com/v1
-kind: ServiceMonitor
-metadata:
-  name: cert-manager
-  namespace: cert-manager
-  labels:
-    app: cert-manager
-    app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/instance: cert-manager
-    app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.20.2"
-    app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.20.2
-    prometheus: default
-    release: kube-prometheus-stack
-spec:
-  jobLabel: app.kubernetes.io/name
-  selector:
-    matchExpressions:
-      - key: app.kubernetes.io/name
-        operator: In
-        values:
-        - cainjector
-        - cert-manager
-        - webhook
-      - key: app.kubernetes.io/instance
-        operator: In
-        values:
-        - cert-manager
-      - key: app.kubernetes.io/component
-        operator: In
-        values:
-        - cainjector
-        - controller
-        - webhook
-  endpoints:
-  - targetPort: http-metrics
-    path: /metrics
-    interval: 60s
-    scrapeTimeout: 30s
-    honorLabels: false
----
 # Source: cert-manager/templates/webhook-validating-webhook.yaml
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
@@ -13755,6 +13712,49 @@ webhooks:
         name: cert-manager-webhook
         namespace: cert-manager
         path: /validate
+---
+# Source: cert-manager/templates/servicemonitor.yaml
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: cert-manager
+  namespace: cert-manager
+  labels:
+    app: cert-manager
+    app.kubernetes.io/name: cert-manager
+    app.kubernetes.io/instance: cert-manager
+    app.kubernetes.io/component: "controller"
+    app.kubernetes.io/version: "v1.20.2"
+    app.kubernetes.io/managed-by: Helm
+    helm.sh/chart: cert-manager-v1.20.2
+    prometheus: default
+    release: kube-prometheus-stack
+spec:
+  jobLabel: app.kubernetes.io/name
+  selector:
+    matchExpressions:
+      - key: app.kubernetes.io/name
+        operator: In
+        values:
+        - cainjector
+        - cert-manager
+        - webhook
+      - key: app.kubernetes.io/instance
+        operator: In
+        values:
+        - cert-manager
+      - key: app.kubernetes.io/component
+        operator: In
+        values:
+        - cainjector
+        - controller
+        - webhook
+  endpoints:
+  - targetPort: http-metrics
+    path: /metrics
+    interval: 60s
+    scrapeTimeout: 30s
+    honorLabels: false
 ---
 # Source: cert-manager/templates/startupapicheck-serviceaccount.yaml
 apiVersion: v1
@@ -13889,6 +13889,32 @@ spec:
       nodeSelector:
         kubernetes.io/os: "linux"
 
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: cilium-hubble-ca
+  namespace: cert-manager
+spec:
+  commonName: cilium-hubble-ca
+  duration: 8760h0m0s
+  isCA: true
+  issuerRef:
+    group: cert-manager.io
+    kind: ClusterIssuer
+    name: selfsigned-cluster-issuer
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+  secretName: cilium-hubble-ca
+---
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: cilium-hubble-ca-issuer
+spec:
+  ca:
+    secretName: cilium-hubble-ca
 ---
 apiVersion: cert-manager.io/v1
 kind: ClusterIssuer

--- a/kubernetes/manifests/production/cilium/manifest.yaml
+++ b/kubernetes/manifests/production/cilium/manifest.yaml
@@ -2279,7 +2279,7 @@ spec:
   issuerRef:
     group: cert-manager.io
     kind: ClusterIssuer
-    name: selfsigned-cluster-issuer
+    name: cilium-hubble-ca-issuer
   secretName: hubble-relay-client-certs
   commonName: "*.hubble-relay.cilium.io"
   dnsNames:
@@ -2303,7 +2303,7 @@ spec:
   issuerRef:
     group: cert-manager.io
     kind: ClusterIssuer
-    name: selfsigned-cluster-issuer
+    name: cilium-hubble-ca-issuer
   secretName: hubble-server-certs
   commonName: "*.default.hubble-grpc.cilium.io"
   dnsNames:


### PR DESCRIPTION
## Summary

Phase 5-1 (= PR #315) post-flight regression check で **hubble-relay Pod の CrashLoop** (= 163 restarts、9h) を確認、調査の結果 **Phase 4-1 cert-manager + Cilium Hubble TLS migration (= PR #306) の latent architectural issue** と判明。

```
"transport: authentication handshake failed: tls: failed to verify certificate:
 x509: certificate signed by unknown authority"
```

## Root cause

`selfsigned-cluster-issuer` は cert-manager の **`SelfSigned` type ClusterIssuer** (= `spec.selfSigned: {}`)、各 Certificate を **自己署名** (= subject == issuer) で発行する仕組み。共通 root CA を持たないため、hubble-relay ↔ hubble-peer 間の mTLS が成立しない:

| Cert | Subject | sha256 |
|---|---|---|
| `hubble-server-certs` ca.crt | `*.default.hubble-grpc.cilium.io` (= self-signed) | `1E:F1:EA:...` |
| `hubble-relay-client-certs` ca.crt | `*.hubble-relay.cilium.io` (= self-signed) | `52:A3:55:...` |
| Cilium agent mounted `/var/lib/cilium/tls/hubble/server.crt` | `*.default.hubble-grpc.cilium.io` (= sha256 一致) | `1E:F1:EA:...` |

= Server cert と Relay Client cert が **異なる self-signed Issuer** で発行され、trust chain 分離。

## 性質

- **Phase 4-1 PR #306 で deploy 時から broken**、selfsigned ClusterIssuer の本質的限界 (= mTLS 不可能) を design 時に見落とし
- **6 days dormant**: hubble-relay は connection retry を続けており、初期 deploy 時から失敗していた可能性あるが Pod restart 頻度が低く visible でなかった
- **9h 前 (= Phase 4-3 / 5-1 周辺の Karpenter rollout) で Pod recreation** → 連続 CrashLoop で visible 化
- **Phase 4-3 L5 (= post-flight end-to-end browser test) の重要性を再 validate**: deploy 時 static health check (= Pod Ready / Certificate Ready) では捕捉できず、actual mTLS connection で初発覚

## Fix

### 1. cert-manager component に CA-based Issuer 構築

新規 file `kubernetes/components/cert-manager/production/kustomization/cilium-hubble-ca.yaml`:

```yaml
apiVersion: cert-manager.io/v1
kind: Certificate
metadata:
  name: cilium-hubble-ca
  namespace: cert-manager
spec:
  isCA: true
  commonName: cilium-hubble-ca
  duration: 8760h0m0s
  privateKey:
    algorithm: ECDSA
    size: 256
  issuerRef:
    name: selfsigned-cluster-issuer
    kind: ClusterIssuer
    group: cert-manager.io
  secretName: cilium-hubble-ca
---
apiVersion: cert-manager.io/v1
kind: ClusterIssuer
metadata:
  name: cilium-hubble-ca-issuer
spec:
  ca:
    secretName: cilium-hubble-ca
```

- `cilium-hubble-ca` Certificate (= `isCA: true`) を `selfsigned-cluster-issuer` で発行 → root CA Secret 生成
- `cilium-hubble-ca-issuer` ClusterIssuer (= `kind: CA`) が上記 Secret を参照 → CA-based issuer として機能

### 2. Cilium values の `certManagerIssuerRef.name` を変更

`kubernetes/components/cilium/production/values.yaml.gotmpl`:

```diff
 hubble:
   tls:
     auto:
       method: certmanager
       certManagerIssuerRef:
-        name: selfsigned-cluster-issuer
+        name: cilium-hubble-ca-issuer
         kind: ClusterIssuer
         group: cert-manager.io
```

= Cilium chart が `cilium-hubble-ca-issuer` で hubble-server-certs + hubble-relay-client-certs を **同一 CA で署名**、mTLS 成立。

## Pre-flight check (executed pre-merge)

- [x] hydrate output で cert-manager manifest に `cilium-hubble-ca` Certificate + `cilium-hubble-ca-issuer` ClusterIssuer 反映
- [x] cilium manifest の hubble-server-certs + hubble-relay-client-certs 両 Certificate が `cilium-hubble-ca-issuer` を参照
- [x] commit subject ≤ 72 chars (= 55 chars)、`-s` signoff、Co-Authored-By 不在
- [x] 比較表現 (simple / complex / easy / hard) hit なし

## Test plan (post-flight, after merge)

### 5 分以内

- [ ] Flux が main の latest commit を Applied
- [ ] cert-manager で `cilium-hubble-ca` Certificate Ready=True、`cilium-hubble-ca` Secret created
- [ ] `cilium-hubble-ca-issuer` ClusterIssuer Ready=True
- [ ] Cilium chart の `hubble-server-certs` + `hubble-relay-client-certs` Certificate が **新 issuer 由来** で reissue (= Ready=True 維持、ただし Secret 内容更新)

### 10 分以内

- [ ] hubble-relay Pod が CrashLoop 解消、`Running` 状態維持 (= restarts 増加停止)
- [ ] hubble-relay logs で `Stream established with hubble-peer` 等の正常 connection log
- [ ] Cilium agent が新 server cert を pick up (= 必要なら Cilium DaemonSet rollout が auto-trigger される)
- [ ] hubble-relay logs に `tls: failed to verify certificate` エラー停止

### 30 分以内 (= Hubble UI end-to-end test)

- [ ] `https://hubble.panicboat.net` browser access で Hubble UI の flow 表示が機能 (= relay が flow を peer から fetch + UI に提供)
- [ ] Hubble L7 metrics が引き続き Mimir に流入 (= Phase 4-3 で deploy 済 Hubble metrics ServiceMonitor 経由)

### Verify TLS chain (= 構造的 verify)

```bash
# 両 cert が同一 CA で署名されているか verify
kubectl get secret -n kube-system hubble-server-certs -o jsonpath='{.data.ca\.crt}' | base64 -d | openssl x509 -noout -fingerprint -sha256
kubectl get secret -n kube-system hubble-relay-client-certs -o jsonpath='{.data.ca\.crt}' | base64 -d | openssl x509 -noout -fingerprint -sha256
# Expected: 両者の sha256 fingerprint 一致 (= cilium-hubble-ca 由来)
```

## Sub-project 4-3 L5 lesson 再 validate

本 issue 発覚で **Phase 4-3 L5 (= AWS direct verify AccessDenied → application-level indirect proof) を mTLS protocol-level に extension**:

- Phase 4-3 L5: AWS direct verify が AccessDenied → application-level (= ExternalSecret Ready=True 等) で proof
- 本 issue: cert-manager Certificate Ready=True / Secret created → architectural correctness は **end-to-end mTLS 動作** で proof
- = "Cert Resource healthy != mTLS works" を learnings に追加候補

## Rollback 手順

```bash
# Pattern A: Standard rollback (= Flux suspend + revert)
flux suspend kustomization flux-system -n flux-system
gh pr create --base main --head revert-hubble-ca --title "revert: Cilium Hubble CA-based ClusterIssuer"
gh pr merge <pr-number>
flux resume kustomization flux-system -n flux-system

# Pattern B: Hubble TLS 完全 disable (= 緊急対応、security regression)
# values.yaml.gotmpl で hubble.tls.enabled: false に変更、revert で戻す
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Established Kubernetes cert-manager infrastructure to enable mutual TLS for Cilium Hubble. Added a dedicated Certificate Authority and ClusterIssuer resource to secure inter-component communication, with updated Hubble relay and server certificate configurations now referencing the new issuer instead of the previous self-signed issuer approach.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/panicboat/platform/pull/316)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->