### PR TITLE
chore(eks): disable audit control plane log to cut CW cost

### DIFF
--- a/aws/eks/modules/main.tf
+++ b/aws/eks/modules/main.tf
@@ -17,7 +17,16 @@ module "eks" {
   authentication_mode                      = "API"
   enable_cluster_creator_admin_permissions = false
 
-  enabled_log_types                      = ["audit", "authenticator"]
+  # `audit` is intentionally omitted: it accounted for ~99.7% of bytes in
+  # /aws/eks/<cluster>/cluster (4.32 GiB/day vs 14 MiB/day for authenticator)
+  # and grew from 2.16 GB/day → 4.70 GB/day over a week as Karpenter / ALB
+  # Controller / Flux / observability stacks were rolled out (leader-election
+  # + reconcile traffic). EKS managed control plane does not allow custom
+  # audit policies, and Vended Logs Delivery to S3/Firehose is unsupported
+  # (only `AUTO_MODE_*` log types are eligible), so on-source filtering is
+  # not possible. Re-enable only if K8s API audit is required for compliance
+  # / incident response — and budget the ~$80–100 / month CW Logs ingest.
+  enabled_log_types                      = ["authenticator"]
   cloudwatch_log_group_retention_in_days = var.log_retention_days
 
   # Disable Secrets envelope encryption (spec decision: Out of Scope).


### PR DESCRIPTION
## Summary

EKS production の CloudWatch Logs コストが想定外に高い件の調査の結果、**`/aws/eks/eks-production/cluster` の audit ログ ingest が支配的**と判明したため、`enabled_log_types` から `audit` を外す。`authenticator` は IAM 認証可視化のため残す。

## Before / After

| | 現状 | 適用後 (推定) |
|---|---|---|
| audit ingest | **4.32 GiB/日** (24h 実測, 強い増加トレンド) | 0 |
| authenticator ingest | 14 MiB/日 | 14 MiB/日 |
| CW Logs 月額 | **~$80–100/mo (増加中)** | ~$0.3/mo |

## Evidence

### Cost Explorer (2026-05-01〜05-10)
| Usage Type | Cost | Quantity |
|---|---|---|
| `APN1-VendedLog-Bytes` | **$13.33** | 22.54 GB |
| その他全部 | ~$0 | - |

→ CloudWatch のコストは **100% が Vended Logs (= EKS control plane logs)**。VPC Flow Logs / ALB access logs / Custom metrics は使用なしを確認済み。

### 日次 IncomingBytes (`/aws/eks/eks-production/cluster`, 直近 7 日)
| 日付 | GB |
|---|---|
| 2026-05-03 | 2.16 |
| 2026-05-04 | 2.59 |
| 2026-05-05 | 3.05 |
| 2026-05-06 | 3.69 |
| 2026-05-07 | 3.86 |
| 2026-05-08 | 4.37 |
| 2026-05-09 | 4.70 |

→ **1 週間で約 2 倍**。Karpenter (5/5 install)・ALB Controller (5/4 install)・Phase 3-5 で次々に追加されたコンポーネントによる leader-election & reconcile traffic 増加が原因。バグや誤設定ではなく、クラスタ成熟による自然増。

### Top userAgent (1h, audit only)
| userAgent | reqs/h |
|---|---|
| `kustomize-controller` (Flux) | 6,900 |
| Karpenter + ALB Controller の leader-election (合算) | 5,749 |
| `kubelet/v1.35.4` | 4,742 |
| `kube-apiserver/v1.35.4` (self) | 3,401 |
| `eks-k8s-metrics` | 3,163 |
| `karpenter/1.6.5` | 2,969 |
| その他 leader-election 群 (~8 controllers) | 各 ~2,800 |

→ **audit の ~28% は leader-election lease renewal**（監査価値ほぼ無し）、~33% は self-traffic / health check / 匿名 probe。EKS managed control plane は audit policy をユーザー側で書き換え不可で、ソースでの filter 不可能。

### audit / authenticator 比率 (24h 実測)
| Stream | bytes | events | 割合 |
|---|---|---|---|
| `kube-apiserver-audit-*` | **4.32 GiB** | 2,049,813 | **99.7%** |
| `authenticator-*` | 14 MiB | 57,257 | 0.3% |

## トレードオフ

- **失うもの**: K8s API audit trail（`kubectl get/create/delete` 等の監査ログ）。Compliance 要件 (SOC2 等) 発生時は再有効化を検討。
- **保持されるもの**: `authenticator` (IAM auth event), CloudTrail (AWS API レベルの監査), アプリログ (Loki), メトリクス (Mimir)。

## なぜ Loki に流す案を採用しなかったか

- EKS control plane logs は **CloudWatch Logs が必須destination**（[公式 docs](https://docs.aws.amazon.com/eks/latest/userguide/control-plane-logs.html)）
- Vended Logs Delivery API は EKS Auto Mode のログにのみ対応（control plane audit は非対応）
- → CW Subscription Filter → Firehose → Loki の経路では **CW ingest 料金 ($0.59/GB) は減らない**。むしろ Firehose 等で増える。

## Plan ノート

`terragrunt plan` 結果は `Plan: 0 to add, 6 to change, 0 to destroy`。本 PR の意図する変更は 1 件 (`enabled_cluster_log_types` から `audit` を除去) のみ。残り 5 件は本 PR と無関係の drift:

- `aws_eks_addon` (vpc-cni, coredns, eks-pod-identity-agent, aws-ebs-csi-driver) の `addon_version` 更新（`most_recent = true` 設定によるもの）
- `aws_iam_openid_connect_provider.oidc_provider` の `thumbprint_list` 再計算

→ 本 PR のレビュー時に上記 drift を一緒に apply するか、別 PR で扱うかは要判断。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated EKS control-plane logging configuration to enable only authenticator logs, reducing log volume and costs.

* **Documentation**
  * Added inline documentation explaining the audit log configuration decision.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/panicboat/platform/pull/321)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->