### PR TITLE
fix(ci): drive deploy-trigger from pull_request:closed instead of push:main

### DIFF
--- a/.github/workflows/auto-label--deploy-trigger.yaml
+++ b/.github/workflows/auto-label--deploy-trigger.yaml
@@ -2,12 +2,9 @@ name: 'Auto Label - Label Resolver'
 
 on:
   pull_request:
-    types: [labeled]
+    types: [labeled, closed]
     branches:
       - '**'
-  push:
-    branches:
-      - main
 
 permissions:
   id-token: write
@@ -15,12 +12,13 @@ permissions:
   pull-requests: write
 
 concurrency:
-  group: deploy-trigger-${{ github.event_name }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  group: deploy-trigger-${{ github.event.pull_request.number }}-${{ github.event.action }}
+  cancel-in-progress: ${{ github.event.action == 'labeled' }}
 
 jobs:
   deploy-trigger:
     name: 'Deployment Trigger'
+    if: github.event.action == 'labeled' || (github.event.action == 'closed' && github.event.pull_request.merged == true)
     runs-on: ubuntu-latest
     outputs:
       targets: ${{ steps.resolver.outputs.targets }}
@@ -34,20 +32,12 @@ jobs:
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
 
-      - name: Get PR information
-        id: pr-info
-        uses: jwalton/gh-find-current-pr@f3d61b485d2801773f7a07b2aaa3306bd8f8e653 # v1.3.5
-        with:
-          github-token: ${{ steps.app-token.outputs.token }}
-          state: all
-        continue-on-error: true
-
       - name: Label Resolver
         id: resolver
         uses: panicboat/deploy-actions/label-resolver@3399490d98d6e4d4ff1a06badfd63d9f9a0c8699 # v1.1.0
         with:
           repository: ${{ github.repository }}
-          pr-number: ${{ steps.pr-info.outputs.number }}
+          pr-number: ${{ github.event.pull_request.number }}
           github-token: ${{ steps.app-token.outputs.token }}
           config-path: 'workflow-config.yaml'
 
@@ -55,6 +45,7 @@ jobs:
     name: 'Group Kubernetes Targets by Environment'
     needs: deploy-trigger
     if: |
+      github.event.action == 'labeled' &&
       needs.deploy-trigger.outputs.has-targets == 'true' &&
       contains(needs.deploy-trigger.outputs.targets, '"stack":"kubernetes"')
     runs-on: ubuntu-latest
@@ -103,8 +94,8 @@ jobs:
     with:
       service-name: ${{ matrix.target.service }}
       environment: ${{ matrix.target.environment }}
-      action-type: ${{ matrix.target.stack == 'terragrunt' && (github.event_name == 'pull_request' && 'plan' || 'apply') || '' }}
-      iam-role: ${{ github.event_name == 'pull_request' && matrix.target.iam_role_plan || matrix.target.iam_role_apply }}
+      action-type: ${{ matrix.target.stack == 'terragrunt' && (github.event.pull_request.merged && 'apply' || 'plan') || '' }}
+      iam-role: ${{ github.event.pull_request.merged && matrix.target.iam_role_apply || matrix.target.iam_role_plan }}
       aws-region: ${{ matrix.target.aws_region }}
       working-directory: ${{ matrix.target.working_directory }}
       app-id: ${{ vars.APP_ID }}
@@ -115,6 +106,7 @@ jobs:
     name: 'Deploy Kubernetes (${{ matrix.target.service }}:${{ matrix.target.environment }})'
     needs: [deploy-trigger, deploy-kubernetes-hydrate]
     if: |
+      github.event.action == 'labeled' &&
       needs.deploy-trigger.outputs.has-targets == 'true' &&
       contains(needs.deploy-trigger.outputs.targets, '"stack":"kubernetes"')
     strategy:


### PR DESCRIPTION
## Why

`Auto Label - Label Resolver` の post-merge run で `Deploy Terragrunt` 等が断続的に skip される race condition を修正します。

### Root cause

`jwalton/gh-find-current-pr@v1.3.5` は `push: main` event で PR を解決するために `GET /repos/{owner}/{repo}/commits/{sha}/pulls` を呼びます。GitHub は squash merge 直後の commit↔PR association を**非同期で書き込む**ため、この endpoint は数秒〜数十秒の間 **空配列を返すことがあります**。post-merge workflow がその window で発火すると、`pr-number` が空 → label resolver が `targets: []` → 全 deploy job が skip。

### 直近の発生事例（main で `Deploy Terragrunt` が skip）

| PR | 内容 | 影響 |
|---|---|---|
| #311 | oauth2-proxy 4 instances | apply 抜け |
| #315 | Beyla foundation | apply 抜け |
| #321 | disable EKS audit log | apply 抜け（本 PR の発端） |

### Discovery

`jwalton/gh-find-current-pr` の v1.3.5 ソース確認で、内部実装が `octokit.rest.repos.listPullRequestsAssociatedWithCommit`（= 上記 endpoint）であることを確認。同じ endpoint を直接叩く案 (`actions/github-script` 等) も同じ race を踏むため不採用。

## What

`push: main` を廃し、`pull_request: types: [labeled, closed]` 1 本にまとめます。`closed` event payload は `pull_request.number` / `.labels` / `.merged` を merge 同期で持つため、API lookup 不要 → race 消滅。

### Diff のポイント

- \`on:\` から \`push: main\` を削除、\`pull_request.types\` に \`closed\` を追加
- \`deploy-trigger\` job に \`if: action == 'labeled' || (action == 'closed' && merged == true)\` を追加（merged=false の close は no-op）
- \`Get PR information\` step を削除し、\`pr-number\` を \`github.event.pull_request.number\` 直参照に
- terragrunt の \`action-type\` / \`iam-role\` を \`event_name\` 比較から \`merged\` フラグに切替
- \`concurrency\` を \`(pr-number, action)\` ベースに、\`cancel-in-progress\` は \`labeled\` 時のみ
- \`kubernetes-targets-group\` / \`deploy-kubernetes\` に \`action == 'labeled'\` gate を追加（kubernetes は plan/diff のみで apply 不要、gitops 側で picking up する設計を維持）

## Side effects

- **main への直接 push では apply されなくなります**（PR 経由のみ）。main は protected で直 push 不可の前提なので実害なしと判断
- 移行は段階的：\`pull_request\` event は **PR head SHA の workflow file** で動くため、本 PR マージ前に open 済みの PR は merge 時も旧 \`push: main\` path を使います。新規 PR から自動で新 path

## Out of scope

- \`reusable--terragrunt-executor.yaml\` 内部の \`gh-find-current-pr\` race：apply 結果コメントの post に影響するだけで apply 実行自体は止まらないため、別 PR で対応
- 同じ root cause を持つ \`panicboat/monorepo\` 側の修正：別 PR で並行対応予定

## Test plan

マージ後、最初に merge される deploy 系 PR が新 path で apply 走ることを確認。

> 🤖 Generated with [Claude Code](https://claude.com/claude-code)