### PR TITLE
fix(eks): disable OTel Operator metrics auth (= 6-1 fix forward)

### DIFF
--- a/kubernetes/components/opentelemetry/production/values.yaml.gotmpl
+++ b/kubernetes/components/opentelemetry/production/values.yaml.gotmpl
@@ -27,9 +27,29 @@ manager:
     repository: otel/opentelemetry-collector-contrib
     tag: 0.151.0  # 6-2 application 投入時に最新 stable に update 検討
 
+  # ---------------------------------------------------------------------------
+  # Metrics endpoint auth (= controller-runtime built-in auth) 無効化
+  # ---------------------------------------------------------------------------
+  # chart 0.112.1 default で `--metrics-secure=true` (= HTTPS + TokenReview /
+  # SubjectAccessReview による auth) が active。 ただし chart は SA
+  # `opentelemetry-operator` の ClusterRole に `tokenreviews` permission を
+  # 付与しないため、 30s 周期で `tokenreviews.authentication.k8s.io is
+  # forbidden` ERROR log が出力される (= Phase 6-1 post-flight latent issue)。
+  #
+  # panicboat は OTel Operator self-metrics を直接活用しないため (= application
+  # Instrumentation CR が deploy 目的)、 `secure: false` (= insecure HTTP
+  # metrics endpoint) に切替。 cluster 内 ServiceMonitor scrape のみ
+  # accessible で security 影響限定。 ServiceMonitor の metricsEndpoints も
+  # http scheme に合わせて override (= chart default は https + bearerToken)。
+  metrics:
+    secure: false
+
   # Prometheus integration (= 既 deploy 済 prometheus-operator 利用)
   serviceMonitor:
     enabled: true
+    metricsEndpoints:
+      - port: metrics
+        scheme: http
   prometheusRule:
     enabled: false
 

--- a/kubernetes/manifests/production/opentelemetry/manifest.yaml
+++ b/kubernetes/manifests/production/opentelemetry/manifest.yaml
@@ -18574,6 +18574,32 @@ spec:
         runAsNonRoot: true
         runAsUser: 65532
 ---
+# Source: opentelemetry-operator/templates/certmanager.yaml
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  labels:
+    helm.sh/chart: opentelemetry-operator-0.112.1
+    app.kubernetes.io/name: opentelemetry-operator
+    app.kubernetes.io/version: "0.150.0"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: opentelemetry-operator
+    app.kubernetes.io/instance: opentelemetry-operator
+    app.kubernetes.io/component: webhook
+  name: opentelemetry-operator-serving-cert
+  namespace: opentelemetry-operator-system
+spec:
+  dnsNames:
+    - opentelemetry-operator-webhook.opentelemetry-operator-system.svc
+    - opentelemetry-operator-webhook.opentelemetry-operator-system.svc.cluster.local
+  issuerRef:
+    kind: ClusterIssuer
+    name: selfsigned-cluster-issuer
+  secretName: opentelemetry-operator-controller-manager-service-cert
+  subject:
+    organizationalUnits:
+      - opentelemetry-operator
+---
 # Source: opentelemetry-operator/templates/admission-webhooks/operator-webhook-with-cert-manager.yaml
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
@@ -18658,6 +18684,32 @@ webhooks:
         scope: Namespaced
     sideEffects: None
     timeoutSeconds: 10
+---
+# Source: opentelemetry-operator/templates/servicemonitor.yaml
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: opentelemetry-operator
+  namespace: opentelemetry-operator-system
+  labels:
+    helm.sh/chart: opentelemetry-operator-0.112.1
+    app.kubernetes.io/name: opentelemetry-operator
+    app.kubernetes.io/version: "0.150.0"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: opentelemetry-operator
+    app.kubernetes.io/instance: opentelemetry-operator
+    app.kubernetes.io/component: controller-manager
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: opentelemetry-operator
+      app.kubernetes.io/component: controller-manager
+  endpoints:
+    - port: metrics
+      scheme: http
+  namespaceSelector:
+    matchNames:
+      - opentelemetry-operator-system
 ---
 # Source: opentelemetry-operator/templates/admission-webhooks/operator-webhook-with-cert-manager.yaml
 apiVersion: admissionregistration.k8s.io/v1
@@ -18765,56 +18817,4 @@ webhooks:
         scope: Namespaced
     sideEffects: None
     timeoutSeconds: 10
----
-# Source: opentelemetry-operator/templates/certmanager.yaml
-apiVersion: cert-manager.io/v1
-kind: Certificate
-metadata:
-  labels:
-    helm.sh/chart: opentelemetry-operator-0.112.1
-    app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.150.0"
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/part-of: opentelemetry-operator
-    app.kubernetes.io/instance: opentelemetry-operator
-    app.kubernetes.io/component: webhook
-  name: opentelemetry-operator-serving-cert
-  namespace: opentelemetry-operator-system
-spec:
-  dnsNames:
-    - opentelemetry-operator-webhook.opentelemetry-operator-system.svc
-    - opentelemetry-operator-webhook.opentelemetry-operator-system.svc.cluster.local
-  issuerRef:
-    kind: ClusterIssuer
-    name: selfsigned-cluster-issuer
-  secretName: opentelemetry-operator-controller-manager-service-cert
-  subject:
-    organizationalUnits:
-      - opentelemetry-operator
----
-# Source: opentelemetry-operator/templates/servicemonitor.yaml
-apiVersion: monitoring.coreos.com/v1
-kind: ServiceMonitor
-metadata:
-  name: opentelemetry-operator
-  namespace: opentelemetry-operator-system
-  labels:
-    helm.sh/chart: opentelemetry-operator-0.112.1
-    app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.150.0"
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/part-of: opentelemetry-operator
-    app.kubernetes.io/instance: opentelemetry-operator
-    app.kubernetes.io/component: controller-manager
-spec:
-  selector:
-    matchLabels:
-      app.kubernetes.io/name: opentelemetry-operator
-      app.kubernetes.io/component: controller-manager
-  endpoints:
-    - port: metrics
-      scheme: http
-  namespaceSelector:
-    matchNames:
-      - opentelemetry-operator-system
 

--- a/kubernetes/manifests/production/opentelemetry/manifest.yaml
+++ b/kubernetes/manifests/production/opentelemetry/manifest.yaml
@@ -18174,25 +18174,6 @@ rules:
     verbs:
       - create
 ---
-# Source: opentelemetry-operator/templates/clusterrole.yaml
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  labels:
-    helm.sh/chart: opentelemetry-operator-0.112.1
-    app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.150.0"
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/part-of: opentelemetry-operator
-    app.kubernetes.io/instance: opentelemetry-operator
-    app.kubernetes.io/component: controller-manager
-  name: opentelemetry-operator-metrics
-rules:
-  - nonResourceURLs:
-      - /metrics
-    verbs:
-      - get
----
 # Source: opentelemetry-operator/templates/clusterrolebinding.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -18523,7 +18504,7 @@ spec:
       containers:
         - args:
             - --metrics-addr=0.0.0.0:8443
-            - --metrics-secure=true
+            - --metrics-secure=false
             - --enable-leader-election
             - --health-probe-addr=:8081
             - --webhook-port=9443
@@ -18592,32 +18573,6 @@ spec:
         runAsGroup: 65532
         runAsNonRoot: true
         runAsUser: 65532
----
-# Source: opentelemetry-operator/templates/certmanager.yaml
-apiVersion: cert-manager.io/v1
-kind: Certificate
-metadata:
-  labels:
-    helm.sh/chart: opentelemetry-operator-0.112.1
-    app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.150.0"
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/part-of: opentelemetry-operator
-    app.kubernetes.io/instance: opentelemetry-operator
-    app.kubernetes.io/component: webhook
-  name: opentelemetry-operator-serving-cert
-  namespace: opentelemetry-operator-system
-spec:
-  dnsNames:
-    - opentelemetry-operator-webhook.opentelemetry-operator-system.svc
-    - opentelemetry-operator-webhook.opentelemetry-operator-system.svc.cluster.local
-  issuerRef:
-    kind: ClusterIssuer
-    name: selfsigned-cluster-issuer
-  secretName: opentelemetry-operator-controller-manager-service-cert
-  subject:
-    organizationalUnits:
-      - opentelemetry-operator
 ---
 # Source: opentelemetry-operator/templates/admission-webhooks/operator-webhook-with-cert-manager.yaml
 apiVersion: admissionregistration.k8s.io/v1
@@ -18703,35 +18658,6 @@ webhooks:
         scope: Namespaced
     sideEffects: None
     timeoutSeconds: 10
----
-# Source: opentelemetry-operator/templates/servicemonitor.yaml
-apiVersion: monitoring.coreos.com/v1
-kind: ServiceMonitor
-metadata:
-  name: opentelemetry-operator
-  namespace: opentelemetry-operator-system
-  labels:
-    helm.sh/chart: opentelemetry-operator-0.112.1
-    app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.150.0"
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/part-of: opentelemetry-operator
-    app.kubernetes.io/instance: opentelemetry-operator
-    app.kubernetes.io/component: controller-manager
-spec:
-  selector:
-    matchLabels:
-      app.kubernetes.io/name: opentelemetry-operator
-      app.kubernetes.io/component: controller-manager
-  endpoints:
-    - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
-      port: metrics
-      scheme: https
-      tlsConfig:
-        insecureSkipVerify: true
-  namespaceSelector:
-    matchNames:
-      - opentelemetry-operator-system
 ---
 # Source: opentelemetry-operator/templates/admission-webhooks/operator-webhook-with-cert-manager.yaml
 apiVersion: admissionregistration.k8s.io/v1
@@ -18839,4 +18765,56 @@ webhooks:
         scope: Namespaced
     sideEffects: None
     timeoutSeconds: 10
+---
+# Source: opentelemetry-operator/templates/certmanager.yaml
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  labels:
+    helm.sh/chart: opentelemetry-operator-0.112.1
+    app.kubernetes.io/name: opentelemetry-operator
+    app.kubernetes.io/version: "0.150.0"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: opentelemetry-operator
+    app.kubernetes.io/instance: opentelemetry-operator
+    app.kubernetes.io/component: webhook
+  name: opentelemetry-operator-serving-cert
+  namespace: opentelemetry-operator-system
+spec:
+  dnsNames:
+    - opentelemetry-operator-webhook.opentelemetry-operator-system.svc
+    - opentelemetry-operator-webhook.opentelemetry-operator-system.svc.cluster.local
+  issuerRef:
+    kind: ClusterIssuer
+    name: selfsigned-cluster-issuer
+  secretName: opentelemetry-operator-controller-manager-service-cert
+  subject:
+    organizationalUnits:
+      - opentelemetry-operator
+---
+# Source: opentelemetry-operator/templates/servicemonitor.yaml
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: opentelemetry-operator
+  namespace: opentelemetry-operator-system
+  labels:
+    helm.sh/chart: opentelemetry-operator-0.112.1
+    app.kubernetes.io/name: opentelemetry-operator
+    app.kubernetes.io/version: "0.150.0"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: opentelemetry-operator
+    app.kubernetes.io/instance: opentelemetry-operator
+    app.kubernetes.io/component: controller-manager
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: opentelemetry-operator
+      app.kubernetes.io/component: controller-manager
+  endpoints:
+    - port: metrics
+      scheme: http
+  namespaceSelector:
+    matchNames:
+      - opentelemetry-operator-system
 


### PR DESCRIPTION
## Summary

Phase 6-1 (= monorepo migration foundation) post-flight で発覚した latent issue の fix forward PR。

## Issue

Phase 6-1 で deploy された OTel Operator (= chart 0.112.1) の Pod が 30s 周期で ERROR log 出力:

```
tokenreviews.authentication.k8s.io is forbidden:
User "system:serviceaccount:opentelemetry-operator-system:opentelemetry-operator"
cannot create resource "tokenreviews" in API group "authentication.k8s.io"
at the cluster scope
```

### Root cause

chart 0.112.1 default で controller-runtime built-in auth (= `--metrics-secure=true` flag による HTTPS + TokenReview / SubjectAccessReview auth) が active。 chart 0.112.1 は kubeRBACProxy sidecar 構造ではなく、 manager 本体に `--metrics-secure` flag を渡す設計 (= `manager.metrics.secure` values で control)。

chart は SA `opentelemetry-operator` の ClusterRole に `tokenreviews` permission を付与しないため、 controller-runtime が tokenreview create を試みて 401 で失敗。

### 影響範囲

- **影響なし**: OTel Operator 本体機能 (= reconcile / admission webhook / Instrumentation CR 処理) 動作中、 admission webhook serving cert Ready=True
- **影響あり**: ServiceMonitor 経由の `/metrics` scrape が 401 で失敗 (= OTel Operator self-metrics が Prometheus に流入しない)

## Fix

chart values で 2 箇所を追加:

1. `manager.metrics.secure: false` → controller-runtime の auth check 無効化 (= insecure HTTP metrics endpoint)
2. `manager.serviceMonitor.metricsEndpoints` を http scheme で override (= chart default は https + bearerToken / tlsConfig)

### Rationale

- panicboat は OTel Operator self-metrics を直接活用しない (= application Instrumentation CR が deploy 目的)
- security 影響限定 (= cluster 内 ServiceMonitor scrape のみ accessible)
- surgical change (= values 数行追加)
- chart upgrade 時の RBAC patch conflict 回避

## Pattern

**5-1 L2 / 5-2 L1 (= post-flight regression check) pattern continuation**:
- 過去 3 連続 validate established (= 4-3 / 5-1 / 5-2)
- 6-1 で 4 連続 validate 機会、 検出された latent issue は **6-1 自身の chart default 起因** (= 4-3 oauth2-proxy 4 instances PR #311 と類似 pattern)
- Phase 1-5 既 deploy 済 component の dormant issue は 0 件 (= zero regression 部分 established)

## Changes

- `kubernetes/components/opentelemetry/production/values.yaml.gotmpl`: `manager.metrics.secure: false` + `serviceMonitor.metricsEndpoints` (http scheme) 追加
- `kubernetes/manifests/production/opentelemetry/manifest.yaml`: hydrate 結果。 diff は 3 点:
  - Deployment args: `--metrics-secure=true` → `--metrics-secure=false`
  - ClusterRole `opentelemetry-operator-metrics` (= `/metrics` non-resource get、 `secure: true` 条件分岐) 削除
  - ServiceMonitor `metricsEndpoints`: `scheme: https` + `bearerTokenFile` + `tlsConfig.insecureSkipVerify` → `port: metrics` + `scheme: http`

## Hydrate note

`--kube-version v1.32.0` で render (= CI baseline と一致、 EKS cluster version 1.32 想定)。 chart 0.112.1 の clusterrole.yaml は `semverCompare ">=1.33-0"` 条件で `nodes/proxy` ↔ `nodes/pods` を切替えるため、 kube-version 指定なしだと local helm の default kube-version 起因の noise diff が発生する。 本 PR では Phase 6-1 baseline (= `nodes/proxy`) を維持するため明示指定。

## Validation (= post-merge)

- [ ] OTel Operator Pod restart で error log 消失
- [ ] ServiceMonitor scrape 200 (= insecure http endpoint で metrics 流入)
- [ ] admission webhook 動作継続 (= cert Ready 維持)
