### PR TITLE
fix(karpenter): EC2NodeClass.spec.role to deterministic name

### DIFF
--- a/kubernetes/components/karpenter/production/kustomization/ec2nodeclass.yaml
+++ b/kubernetes/components/karpenter/production/kustomization/ec2nodeclass.yaml
@@ -24,7 +24,9 @@ spec:
   securityGroupSelectorTerms:
     - tags:
         "aws:eks:cluster-name": eks-production
-  role: Karpenter-eks-production-20260504154319852600000007
+  # STABLE: aws/karpenter/modules/main.tf で node_iam_role_use_name_prefix = false +
+  # node_iam_role_name = "Karpenter-eks-${var.environment}" に固定済、recreate でも変化しない
+  role: Karpenter-eks-production
   blockDeviceMappings:
     - deviceName: /dev/xvda
       ebs:

--- a/kubernetes/manifests/production/karpenter/manifest.yaml
+++ b/kubernetes/manifests/production/karpenter/manifest.yaml
@@ -2224,7 +2224,7 @@ spec:
     httpProtocolIPv6: disabled
     httpPutResponseHopLimit: 2
     httpTokens: required
-  role: Karpenter-eks-production-20260504154319852600000007
+  role: Karpenter-eks-production
   securityGroupSelectorTerms:
   - tags:
       aws:eks:cluster-name: eks-production


### PR DESCRIPTION
Phase 2 (PR #326) で aws/karpenter node IAM role を deterministic 化したが、`kubernetes/components/karpenter/production/kustomization/ec2nodeclass.yaml` の hardcoded role 更新が抜けていた。

これにより EC2NodeClass が削除済 OLD role を参照する状態になり、新規 NodeClaim の EC2 instance が bootstrap できず cluster degraded 状態。

## Recovery (= post-merge 手動手順)

EC2NodeClass.spec.role は immutable のため Flux の reconcile では update できない。

1. `kubectl delete ec2nodeclass system-components` (= Flux が次の reconcile で NEW role を持った EC2NodeClass を再作成)
2. `kubectl delete nodeclaim system-components-{d9s99,kdh2s,qf7lk,tqfmm,...}` (= dead claim 削除、Karpenter が NEW role で再 provision)
3. `kubectl delete node ip-10-0-{114-130,69-104,79-93,83-210}.ap-northeast-1.compute.internal --force` (= dead nodes を cluster から除去)
4. `aws ec2 terminate-instances --instance-ids ...` (= orphan EC2 instances を停止)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated production Karpenter IAM role configuration for stability. The role name is now fixed (`Karpenter-eks-production`) instead of including time-stamped suffixes, ensuring consistent and predictable infrastructure naming across deployments and resource recreation.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/panicboat/platform/pull/332)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->