### PR TITLE
revert(ci): restore push:main deploy-trigger (revert #322 + #325)

### DIFF
--- a/.github/workflows/auto-label--deploy-trigger.yaml
+++ b/.github/workflows/auto-label--deploy-trigger.yaml
@@ -77,7 +77,6 @@ jobs:
       environment: ${{ matrix.env.environment }}
       services: ${{ toJson(matrix.env.services) }}
       app-id: ${{ vars.APP_ID }}
-      pr-number: ${{ github.event.pull_request.number }}
     secrets:
       private-key: ${{ secrets.APP_PRIVATE_KEY }}
 
@@ -100,7 +99,6 @@ jobs:
       aws-region: ${{ matrix.target.aws_region }}
       working-directory: ${{ matrix.target.working_directory }}
       app-id: ${{ vars.APP_ID }}
-      pr-number: ${{ github.event.pull_request.number }}
     secrets:
       private-key: ${{ secrets.APP_PRIVATE_KEY }}
 
@@ -123,7 +121,6 @@ jobs:
       service-name: ${{ matrix.target.service }}
       environment: ${{ matrix.target.environment }}
       app-id: ${{ vars.APP_ID }}
-      pr-number: ${{ github.event.pull_request.number }}
     secrets:
       private-key: ${{ secrets.APP_PRIVATE_KEY }}
 

--- a/.github/workflows/auto-label--deploy-trigger.yaml
+++ b/.github/workflows/auto-label--deploy-trigger.yaml
@@ -2,9 +2,12 @@ name: 'Auto Label - Label Resolver'
 
 on:
   pull_request:
-    types: [labeled, closed]
+    types: [labeled]
     branches:
       - '**'
+  push:
+    branches:
+      - main
 
 permissions:
   id-token: write
@@ -12,13 +15,12 @@ permissions:
   pull-requests: write
 
 concurrency:
-  group: deploy-trigger-${{ github.event.pull_request.number }}-${{ github.event.action }}
-  cancel-in-progress: ${{ github.event.action == 'labeled' }}
+  group: deploy-trigger-${{ github.event_name }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   deploy-trigger:
     name: 'Deployment Trigger'
-    if: github.event.action == 'labeled' || (github.event.action == 'closed' && github.event.pull_request.merged == true)
     runs-on: ubuntu-latest
     outputs:
       targets: ${{ steps.resolver.outputs.targets }}
@@ -32,12 +34,20 @@ jobs:
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
 
+      - name: Get PR information
+        id: pr-info
+        uses: jwalton/gh-find-current-pr@f3d61b485d2801773f7a07b2aaa3306bd8f8e653 # v1.3.5
+        with:
+          github-token: ${{ steps.app-token.outputs.token }}
+          state: all
+        continue-on-error: true
+
       - name: Label Resolver
         id: resolver
         uses: panicboat/deploy-actions/label-resolver@3399490d98d6e4d4ff1a06badfd63d9f9a0c8699 # v1.1.0
         with:
           repository: ${{ github.repository }}
-          pr-number: ${{ github.event.pull_request.number }}
+          pr-number: ${{ steps.pr-info.outputs.number }}
           github-token: ${{ steps.app-token.outputs.token }}
           config-path: 'workflow-config.yaml'
 
@@ -45,7 +55,6 @@ jobs:
     name: 'Group Kubernetes Targets by Environment'
     needs: deploy-trigger
     if: |
-      github.event.action == 'labeled' &&
       needs.deploy-trigger.outputs.has-targets == 'true' &&
       contains(needs.deploy-trigger.outputs.targets, '"stack":"kubernetes"')
     runs-on: ubuntu-latest
@@ -94,8 +103,8 @@ jobs:
     with:
       service-name: ${{ matrix.target.service }}
       environment: ${{ matrix.target.environment }}
-      action-type: ${{ matrix.target.stack == 'terragrunt' && (github.event.pull_request.merged && 'apply' || 'plan') || '' }}
-      iam-role: ${{ github.event.pull_request.merged && matrix.target.iam_role_apply || matrix.target.iam_role_plan }}
+      action-type: ${{ matrix.target.stack == 'terragrunt' && (github.event_name == 'pull_request' && 'plan' || 'apply') || '' }}
+      iam-role: ${{ github.event_name == 'pull_request' && matrix.target.iam_role_plan || matrix.target.iam_role_apply }}
       aws-region: ${{ matrix.target.aws_region }}
       working-directory: ${{ matrix.target.working_directory }}
       app-id: ${{ vars.APP_ID }}
@@ -106,7 +115,6 @@ jobs:
     name: 'Deploy Kubernetes (${{ matrix.target.service }}:${{ matrix.target.environment }})'
     needs: [deploy-trigger, deploy-kubernetes-hydrate]
     if: |
-      github.event.action == 'labeled' &&
       needs.deploy-trigger.outputs.has-targets == 'true' &&
       contains(needs.deploy-trigger.outputs.targets, '"stack":"kubernetes"')
     strategy:

--- a/.github/workflows/reusable--kubernetes-builder.yaml
+++ b/.github/workflows/reusable--kubernetes-builder.yaml
@@ -15,10 +15,6 @@ on:
         required: true
         type: string
         description: 'GitHub App ID for authentication'
-      pr-number:
-        required: true
-        type: string
-        description: 'Pull request number for posting kustomize diff comment'
     secrets:
       private-key:
         required: true
@@ -41,6 +37,14 @@ jobs:
           private-key: ${{ secrets.private-key }}
           owner: ${{ github.repository_owner }}
 
+      - name: Get PR information
+        id: pr-info
+        uses: jwalton/gh-find-current-pr@f3d61b485d2801773f7a07b2aaa3306bd8f8e653 # v1.3.5
+        with:
+          github-token: ${{ steps.app-token.outputs.token }}
+          state: all
+        continue-on-error: true
+
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -55,4 +59,4 @@ jobs:
           service-name: ${{ inputs.service-name }}
           environment: ${{ inputs.environment }}
           path: kubernetes/manifests/${{ inputs.environment }}/${{ inputs.service-name }}
-          pr-number: ${{ inputs.pr-number }}
+          pr-number: ${{ steps.pr-info.outputs.number }}

--- a/.github/workflows/reusable--kubernetes-hydrator.yaml
+++ b/.github/workflows/reusable--kubernetes-hydrator.yaml
@@ -15,10 +15,6 @@ on:
         required: true
         type: string
         description: 'GitHub App ID for authentication'
-      pr-number:
-        required: true
-        type: string
-        description: 'Pull request number for posting kubernetes index diff comment'
     secrets:
       private-key:
         required: true
@@ -44,6 +40,14 @@ jobs:
           app-id: ${{ inputs.app-id }}
           private-key: ${{ secrets.private-key }}
           owner: ${{ github.repository_owner }}
+
+      - name: Get PR information
+        id: pr-info
+        uses: jwalton/gh-find-current-pr@f3d61b485d2801773f7a07b2aaa3306bd8f8e653 # v1.3.5
+        with:
+          github-token: ${{ steps.app-token.outputs.token }}
+          state: all
+        continue-on-error: true
 
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -86,7 +90,7 @@ jobs:
 
       - name: Compute index diff
         id: index-diff
-        if: inputs.pr-number != ''
+        if: steps.pr-info.outputs.number != ''
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
           ENV: ${{ inputs.environment }}
@@ -107,7 +111,7 @@ jobs:
           fi
 
       - name: Comment index diff
-        if: steps.index-diff.outputs.has-diff == 'true' && inputs.pr-number != ''
+        if: steps.index-diff.outputs.has-diff == 'true' && steps.pr-info.outputs.number != ''
         uses: thollander/actions-comment-pull-request@24bffb9b452ba05a4f3f77933840a6a841d1b32b # v3.0.1
         with:
           message: |
@@ -120,6 +124,6 @@ jobs:
             ```
           comment-tag: 'kubernetes-index-${{ inputs.environment }}'
           mode: upsert
-          pr-number: ${{ inputs.pr-number }}
+          pr-number: ${{ steps.pr-info.outputs.number }}
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
         continue-on-error: true

--- a/.github/workflows/reusable--terragrunt-executor.yaml
+++ b/.github/workflows/reusable--terragrunt-executor.yaml
@@ -31,10 +31,6 @@ on:
         required: true
         type: string
         description: 'GitHub App ID for authentication'
-      pr-number:
-        required: true
-        type: string
-        description: 'Pull request number for posting plan/apply result comment'
     secrets:
       private-key:
         required: true
@@ -54,6 +50,14 @@ jobs:
           private-key: ${{ secrets.private-key }}
           owner: ${{ github.repository_owner }}
 
+      - name: Get PR information
+        id: pr-info
+        uses: jwalton/gh-find-current-pr@f3d61b485d2801773f7a07b2aaa3306bd8f8e653 # v1.3.5
+        with:
+          github-token: ${{ steps.app-token.outputs.token }}
+          state: all
+        continue-on-error: true
+
       - name: Execute Terragrunt
         uses: panicboat/panicboat-actions/terragrunt-run@f917fa0921e06ec7b08941df04958361c43253fb # main
         with:
@@ -64,4 +68,4 @@ jobs:
           iam-role: ${{ inputs.iam-role }}
           aws-region: ${{ inputs.aws-region }}
           working-directory: ${{ inputs.working-directory }}
-          pr-number: ${{ inputs.pr-number }}
+          pr-number: ${{ steps.pr-info.outputs.number }}


### PR DESCRIPTION
## Why

PR #322 で deploy-trigger を `push:main` から `pull_request:closed` に変更した結果、apply 時の OIDC `sub` claim が `repo:panicboat/platform:ref:refs/heads/main` から `repo:panicboat/platform:pull_request` に変わり、`aws/github-oidc-auth` の apply role trust policy にマッチしなくなった。

`aws/github-oidc-auth/modules/main.tf` の `apply_conditions` は `refs/heads/main` か `environment:<env>` のみ許可しているため、PR merge 時の `pull_request:closed` イベントからは AssumeRoleWithWebIdentity が拒否される。

実害: https://github.com/panicboat/platform/actions/runs/25629374777/job/75230187362 で `Could not assume role with OIDC: Not authorized to perform sts:AssumeRoleWithWebIdentity`

## What

- Revert #325 (`refactor(ci): pass pr-number from caller to deploy reusables`) — #322 と一体の修正のため
- Revert #322 (`fix(ci): drive deploy-trigger from pull_request:closed instead of push:main`)

トリガーが `push:main` + `pull_request:[labeled]` に戻り、apply 時の OIDC sub も `refs/heads/main` に戻る。

## Followup

`pull_request:closed` 駆動 + 多層防御 (GitHub Environment + deployment branch policy + `job_workflow_ref` claim) で再設計するなら別 PR で。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved CI/CD automation by implementing automatic pull request detection across deployment workflows, eliminating the need for manual PR number inputs and enhancing reliability.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/panicboat/platform/pull/334)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->