### PR TITLE
docs(eks): Phase 3 design revision for Plan A operator-prompted approach

### DIFF
--- a/docs/superpowers/plans/2026-05-10-eks-production-teardown-recreate.md
+++ b/docs/superpowers/plans/2026-05-10-eks-production-teardown-recreate.md
@@ -1396,18 +1396,34 @@ Phase 3 of docs/superpowers/specs/2026-05-10-eks-production-teardown-recreate-de
 **Files:**
 - Create: `scripts/eks-lifecycle/lib/60-flux-bootstrap.sh`
 
-> **Errata (post-PR-#326)**: 当初は helmfile.yaml.gotmpl 内で `{{ exec terragrunt output ... }}` で hydrate-time に動的取得する想定だったが、CI ordering で破綻 (= spec §0 Errata 参照)。本 task は **sed-replace で in-place 更新** する形に改めた。
+> **Errata (post-PR-#326 / #330 / #332)**: 当初は helmfile.yaml.gotmpl 内で `{{ exec terragrunt output ... }}` で hydrate-time に動的取得する想定だったが、CI ordering で破綻 (= spec §0 Errata 参照)。
 >
-> - IRSA / Karpenter naming は Phase 2 で deterministic 化済 → recreate 後も同名で安定、sed 不要
-> - 動的更新が要るのは `eksApiEndpoint` (= cluster ID 変動) と `vpcId` (= VPC 変動) のみ
-> - 対象ファイル: `kubernetes/helmfile.yaml.gotmpl` と子 helmfile 2 ファイル (`cilium`, `aws-load-balancer-controller`)
+> 中間案として「lifecycle script が sed で in-place 更新」も検討したが、最終的に **Plan A: operator-prompted manual updates** を採用した (= user 選択):
+>
+> - `# RECREATE: <command>` marker (= PR #330 で導入) を grep して列挙
+> - 各 marker の command を **operator が手で実行**、出力で次行を編集
+> - operator が編集完了したら lifecycle script に y で進行を許可
+> - script は hydrate + git commit + push を担当
+>
+> ## 採用理由
+>
+> - sed-replace は **regex pattern** に依存しすぎ (= 値の format が想定外なら誤置換のリスク)
+> - PR #326 の事故で「audit pass scope が不完全だった」反省 (= kustomization/*.yaml 漏れ) を踏まえ、**operator が目で確認する** 方が confidence ↑
+> - 個人運用 panicboat 文脈で recreate cycle 数が限定的 = 自動化 amortize が小さい
+>
+> ## 動的更新が要る値 (= recreate のたびに変化)
+>
+> - `eksApiEndpoint` (= cluster ID 変動): kubernetes/helmfile.yaml.gotmpl + cilium 子 helmfile
+> - `vpcId` (= VPC 変動): kubernetes/helmfile.yaml.gotmpl + aws-load-balancer-controller 子 helmfile
+>
+> IRSA / Karpenter naming は Phase 2 で deterministic 化済 (= `# STABLE` marker 付与)、recreate 後も同名で sed 不要。
 
-- [ ] **Step 1: sed-replace + hydrate + git push + flux bootstrap**
+- [ ] **Step 1: operator-prompted update + hydrate + git push + flux bootstrap**
 
 ```bash
 #!/usr/bin/env bash
-# 60-flux-bootstrap.sh - Re-hydrate manifests with new cluster IDs, push
-# to main, then apply Flux bootstrap manifests.
+# 60-flux-bootstrap.sh - Prompt operator to update RECREATE-marked values,
+# then re-hydrate, push to main, and apply Flux bootstrap manifests.
 
 LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=lib/common.sh
@@ -1416,7 +1432,7 @@ LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 . "${LIB_DIR}/00-auth.sh"
 
 require_env
-require_cmd kubectl flux git make sed
+require_cmd kubectl flux git make grep
 
 if [ "${CLUSTER_EXISTS:-}" != "true" ]; then
   error "Cluster not reachable. Run make eks-recreate-aws ENV=${ENV} first."
@@ -1428,33 +1444,46 @@ use_admin_creds
 info "Step 60.1: Wait for system MNG nodes to be Ready"
 run kubectl wait --for=condition=Ready node --all --timeout=300s
 
-info "Step 60.2: Read new cluster_endpoint_hostname / vpc_id from terragrunt output"
-use_apply_creds  # = terragrunt output needs apply role
-NEW_ENDPOINT=$(cd "${REPO_ROOT}/aws/eks/envs/${ENV}" && TG_TF_PATH=tofu terragrunt output -raw cluster_endpoint_hostname)
-NEW_VPC_ID=$(cd "${REPO_ROOT}/aws/vpc/envs/${ENV}" && TG_TF_PATH=tofu terragrunt output -raw vpc_id)
-info "  cluster_endpoint_hostname = ${NEW_ENDPOINT}"
-info "  vpc_id = ${NEW_VPC_ID}"
+info "Step 60.2: List # RECREATE: markers in helmfile + kustomization sources"
+# RECREATE marker convention is documented in kubernetes/helmfile.yaml.gotmpl:
+#   # RECREATE: <command>
+#   <key>: <value>
+# Operator runs the command, replaces the next-line value.
+echo ""
+echo "================================================================="
+echo " The following values must be updated MANUALLY before continuing."
+echo " For each '# RECREATE: <command>' line, run the command and"
+echo " replace the next line's value with the command's stdout."
+echo "================================================================="
+echo ""
+RECREATE_FILES=$(grep -REl '# RECREATE:' \
+  "${REPO_ROOT}/kubernetes/helmfile.yaml.gotmpl" \
+  "${REPO_ROOT}/kubernetes/components" 2>/dev/null)
+for f in $RECREATE_FILES; do
+  rel="${f#${REPO_ROOT}/}"
+  echo "## $rel"
+  grep -n -B0 -A1 '# RECREATE:' "$f" | sed 's/^/  /'
+  echo ""
+done
 
-info "Step 60.3: sed-replace eksApiEndpoint / vpcId in helmfile sources"
-# Replace 全 eksApiEndpoint hostname (= 既存値の \\.gr<digits>\\.<region>\\.eks\\.amazonaws\\.com pattern)
-HELMFILE_PARENT="${REPO_ROOT}/kubernetes/helmfile.yaml.gotmpl"
-HELMFILE_CILIUM="${REPO_ROOT}/kubernetes/components/cilium/${ENV}/helmfile.yaml"
-HELMFILE_ALB="${REPO_ROOT}/kubernetes/components/aws-load-balancer-controller/${ENV}/helmfile.yaml"
+if [ "${DRY_RUN:-0}" = "1" ]; then
+  info "[DRY-RUN] Skipping operator prompt and downstream steps."
+  exit 0
+fi
 
-# eksApiEndpoint pattern: <32-hex>.gr<digits>.<region>.eks.amazonaws.com
-ENDPOINT_RE='[A-F0-9]\{32\}\.gr[0-9]\{1,\}\.[a-z0-9-]\{1,\}\.eks\.amazonaws\.com'
-if [ "${DRY_RUN:-0}" != "1" ]; then
-  sed -i.bak -E "s|${ENDPOINT_RE}|${NEW_ENDPOINT}|g" "$HELMFILE_PARENT" "$HELMFILE_CILIUM"
-  rm -f "${HELMFILE_PARENT}.bak" "${HELMFILE_CILIUM}.bak"
-  # vpcId pattern: vpc-<17-hex>
-  sed -i.bak -E "s|vpc-[a-f0-9]{17}|${NEW_VPC_ID}|g" "$HELMFILE_PARENT" "$HELMFILE_ALB"
-  rm -f "${HELMFILE_PARENT}.bak" "${HELMFILE_ALB}.bak"
-else
-  printf "${YELLOW}[DRY-RUN]${NC} sed -i -E 's|...endpoint_re...|%s|g' %s %s\n" "$NEW_ENDPOINT" "$HELMFILE_PARENT" "$HELMFILE_CILIUM"
-  printf "${YELLOW}[DRY-RUN]${NC} sed -i -E 's|vpc-[a-f0-9]{17}|%s|g' %s %s\n" "$NEW_VPC_ID" "$HELMFILE_PARENT" "$HELMFILE_ALB"
+confirm "Have you updated all RECREATE-marked values? (y to continue)"
+
+info "Step 60.3: Audit pass - any RECREATE-marked file unchanged from origin/main?"
+# Sanity check: warn if no RECREATE-marked file got modified. operator may
+# have skipped editing.
+DIFF_FILES=$(cd "$REPO_ROOT" && git diff --name-only origin/main -- kubernetes/ 2>/dev/null)
+if [ -z "$DIFF_FILES" ]; then
+  warn "No file changed under kubernetes/. Either values are already correct, or operator skipped editing."
+  confirm "Continue anyway? (y to proceed)"
 fi
 
 info "Step 60.4: Re-hydrate kubernetes/manifests/${ENV}/"
+use_apply_creds  # = hydrate may need terragrunt output (= legacy paths)
 COMPONENTS=$(ls -d "${REPO_ROOT}/kubernetes/components/"*/ 2>/dev/null | xargs -n1 basename)
 for comp in $COMPONENTS; do
   if [ -d "${REPO_ROOT}/kubernetes/components/${comp}/${ENV}" ]; then
@@ -1468,23 +1497,19 @@ info "Step 60.5: Show diff and confirm git commit"
 ( cd "$REPO_ROOT" && run git status kubernetes/ )
 ( cd "$REPO_ROOT" && run git diff --stat kubernetes/ )
 
-if [ "${DRY_RUN:-0}" = "1" ]; then
-  info "[DRY-RUN] Skipping git commit + push"
-else
-  if [ -n "$(cd "$REPO_ROOT" && git status --porcelain kubernetes/)" ]; then
-    confirm "Commit + push helmfile + hydrated manifests to main?"
-    ( cd "$REPO_ROOT" && \
-      git add kubernetes/ && \
-      git commit -s -m "chore(kubernetes): refresh helmfile + manifests after cluster recreate
+if [ -n "$(cd "$REPO_ROOT" && git status --porcelain kubernetes/)" ]; then
+  confirm "Commit + push helmfile + hydrated manifests to main?"
+  ( cd "$REPO_ROOT" && \
+    git add kubernetes/ && \
+    git commit -s -m "chore(kubernetes): refresh helmfile + manifests after cluster recreate
 
-eksApiEndpoint = ${NEW_ENDPOINT}
-vpcId = ${NEW_VPC_ID}
+Phase 3 lifecycle script (60-flux-bootstrap.sh) で operator が
+RECREATE-marked 値を手動更新後、hydrate を実行した結果。
 
 Flux が次の reconcile で pickup する。" && \
-      git push origin main )
-  else
-    info "No changes (= helmfile values already match new cluster, recreate likely no-op)."
-  fi
+    git push origin main )
+else
+  info "No changes (= helmfile values already match new cluster, recreate likely no-op)."
 fi
 
 use_admin_creds  # = back to admin for kubectl ops
@@ -1501,6 +1526,8 @@ run flux get kustomizations -A
 
 ok "Flux bootstrap complete"
 ```
+
+> **Audit pass scope expansion (= 学び from PR #326 incident)**: `RECREATE_FILES` の grep 範囲は `kubernetes/helmfile.yaml.gotmpl` (= 親) + `kubernetes/components/` 配下全体 (= 子 helmfile + kustomization/*.yaml)。PR #326 では `kubernetes/components/karpenter/production/kustomization/ec2nodeclass.yaml` の hardcoded role 更新が漏れて事故になった。grep -R で **全 source file** を対象にすることで、helmfile / kustomize の経路差異に関わらず marker を捕捉する。
 
 - [ ] **Step 2: shellcheck**
 

--- a/docs/superpowers/specs/2026-05-10-eks-production-teardown-recreate-design.md
+++ b/docs/superpowers/specs/2026-05-10-eks-production-teardown-recreate-design.md
@@ -22,18 +22,35 @@ PR #326 (Phase 2) 実装時に CI で fail し、本 spec の **hydrate-time exe
 
 | 値 | 性質 | 取り扱い |
 |---|---|---|
-| `albControllerRoleArn` / `externalDnsRoleArn` | Phase 2 で deterministic 化 (= recreate 後も同名) | `helmfile.yaml.gotmpl` に **hardcoded literal** を NEW 名で書く (= IRSA naming 変更と同一 PR で atomic) |
+| `albControllerRoleArn` / `externalDnsRoleArn` | Phase 2 で deterministic 化 (= recreate 後も同名) | `helmfile.yaml.gotmpl` に **hardcoded literal** を NEW 名で書く (= IRSA naming 変更と同一 PR で atomic)、`# STABLE` marker 付与 |
 | `nodeRoleName` (Karpenter) | 同上 | 同上 |
-| `interruptionQueueName` | 既に deterministic | 変更なし |
-| `eksApiEndpoint` | cluster 作成のたびに変化 | hardcoded、Phase 3 lifecycle script `60-flux-bootstrap.sh` で recreate 後に sed で in-place 更新 |
+| `interruptionQueueName` | 既に deterministic | 変更なし、`# STABLE` marker 付与 |
+| `eksApiEndpoint` | cluster 作成のたびに変化 | hardcoded、`# RECREATE: <command>` marker 付与 (= PR #330)、Phase 3 lifecycle script で operator が手動更新 |
 | `vpcId` | VPC 作成のたびに変化 | 同上 |
+
+### Phase 3 lifecycle script の手法選択
+
+`# RECREATE:` marker (= PR #330) の処理について、3 案を検討:
+
+1. **hydrate-time exec** (= 当初 spec): CI ordering で破綻 (= PR #326 で実証)、不採用
+2. **lifecycle script が sed で自動置換** (= 中間案、commit `d3ba15f` で plan 反映): pattern 依存度が高く誤置換リスク、PR #326 audit 漏れの反省を踏まえ不採用
+3. **Plan A: operator-prompted manual updates** (= 最終採用): script は marker を grep して列挙、operator が手で edit、y/N で進行
 
 ### 本 spec の以下の記述は読み替え
 
-- §3 Decision 7: 「hydrate-time substitution」を「deterministic naming + Phase 3 sed-replace for cluster/VPC IDs」と読み替え
-- §5 Phase 2: aqua / hydrate workflow 拡張は **撤回**。helmfile は exec ではなく hardcoded NEW 値
-- §5 Phase 3 60-flux-bootstrap.sh: **sed-replace step を追加** (= terragrunt output で新 cluster_endpoint_hostname / vpc_id を取得 → helmfile.yaml.gotmpl + 子 helmfile を sed で in-place 更新 → make hydrate)
+- §3 Decision 7: 「hydrate-time substitution」を「deterministic naming + RECREATE marker convention + Phase 3 operator-prompted manual update」と読み替え
+- §5 Phase 2: aqua / hydrate workflow 拡張は **撤回**。helmfile は exec ではなく hardcoded NEW 値、`# RECREATE:` / `# STABLE:` marker 付与
+- §5 Phase 3 60-flux-bootstrap.sh: **operator-prompted step を採用** (= grep '# RECREATE:' → 列挙して提示 → operator が手で edit → y/N → hydrate → commit + push)
 - §8 Open Q2 (CI hydrate workflow に terragrunt + AWS auth): 不要、closed
+
+### Phase 2 incident の学び (= 2026-05-10)
+
+PR #326 apply 時、`kubernetes/components/karpenter/production/kustomization/ec2nodeclass.yaml` の hardcoded `role: Karpenter-eks-production-2026...` が更新漏れで、IRSA rotation 後に EC2NodeClass が削除済 OLD role を参照する状態に。新規 NodeClaim の EC2 instance が bootstrap できず cluster 一時 degraded。PR #332 の hot-fix で復旧。
+
+**反省点と Phase 3 反映**:
+- audit pass scope を `kubernetes/components/*/production/` の helmfile.yaml だけでなく **kustomization/*.yaml も含む全 source file** に拡張
+- Phase 3 の `60-flux-bootstrap.sh` の grep は `kubernetes/helmfile.yaml.gotmpl` + `kubernetes/components/` 配下全体を対象とする (= helmfile / kustomize の経路差異に関わらず marker 捕捉)
+- IRSA rotation で running EC2 instance のクレデンシャルが失効する **構造的問題** は別 spec 化を検討 (= node IAM role 変更時は instance profile の段階的更新が必要、本 lifecycle の scope 外)
 
 詳細は `docs/superpowers/plans/2026-05-10-eks-production-teardown-recreate.md` の Errata 節を参照。
 


### PR DESCRIPTION
Phase 2 (PR #326) の apply 時に発生した cluster degradation incident と、PR #330 で導入した `# RECREATE:` / `# STABLE:` marker convention を踏まえ、Phase 3 lifecycle script の Task 3.7 (`60-flux-bootstrap.sh`) を **Plan A (operator-prompted manual update)** 方式に書き直し。

## Changes

### spec §0 Errata 拡張

- 採用した設計の表に `# RECREATE:` / `# STABLE:` marker 言及追加
- 手法選択 3 案 (hydrate-time exec / sed-replace / Plan A) の比較
- Phase 2 incident の学び (kustomization/*.yaml 漏れ、audit scope 拡張) を追加

### plan Task 3.7

- sed-replace から Plan A operator-prompted へ書き直し
- audit pass scope を helmfile.yaml + kustomization/*.yaml の全 source file に拡張
- script 内 grep で `kubernetes/components/` 配下全体を対象とすることで helmfile / kustomize の経路差異に関わらず marker 捕捉

## Phase 3 実装は別 PR で

本 PR は spec/plan の design 確定だけ。実装 (`scripts/eks-lifecycle/lib/*.sh` + Makefile + README) は別 PR で進める。コード追加のみで AWS apply 不要のため、時間と業務影響と相談して実施可能。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated EKS production infrastructure workflow and implementation documentation
  * Refined manual update process with explicit marker conventions for deployment value handling
  * Expanded audit procedures to cover additional source file types
  * Clarified lifecycle phases and operator workflow requirements based on operational learnings

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/panicboat/platform/pull/335)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->