### PR TITLE
fix(eks): remove ruby from Instrumentation CR (= 6-2 fix forward)

### DIFF
--- a/kubernetes/components/opentelemetry/production/kustomization/instrumentation.yaml
+++ b/kubernetes/components/opentelemetry/production/kustomization/instrumentation.yaml
@@ -11,7 +11,8 @@
 # NodeSDK) がそれらを detect + use する pattern。
 #
 # auto-instrumentation image version は 5-1 L1 chart binary verify 適用、
-# specific version (= ruby 0.59.0 / nodejs 0.62.0) を pin (= :latest 不採用)。
+# specific version (= nodejs 0.62.0) を pin (= :latest 不採用)。
+# ruby は chart 0.112.1 で未 support、 後続 chart upgrade で追加予定 (= 引き継ぎ事項 #25)。
 # =============================================================================
 apiVersion: opentelemetry.io/v1alpha1
 kind: Instrumentation
@@ -27,7 +28,5 @@ spec:
   sampler:
     type: parentbased_traceidratio
     argument: "1.0"
-  ruby:
-    image: ghcr.io/open-telemetry/opentelemetry-ruby-instrumentation:0.59.0
   nodejs:
     image: ghcr.io/open-telemetry/opentelemetry-operator/autoinstrumentation-nodejs:0.62.0

--- a/kubernetes/manifests/production/opentelemetry/manifest.yaml
+++ b/kubernetes/manifests/production/opentelemetry/manifest.yaml
@@ -18832,8 +18832,6 @@ spec:
   propagators:
   - tracecontext
   - baggage
-  ruby:
-    image: ghcr.io/open-telemetry/opentelemetry-ruby-instrumentation:0.59.0
   sampler:
     argument: "1.0"
     type: parentbased_traceidratio


### PR DESCRIPTION
## Summary

Phase 6-2 Task 11 post-flight で検出した重大 issue (= 6-2 stack 全体 deploy block) の fix forward PR。

## Issue

OTel Operator chart 0.112.1 (= 6-1 で deploy 済) の Instrumentation CRD schema は \`java / nodejs / python / apacheHttpd / dotnet / go / nginx\` field のみで **\`ruby\` field 不在**。 chart 0.112.1 + image 0.150.0 の組合せでは Ruby auto-injection (= \`spec.ruby\`) を未 support、 \`spec.ruby\` block 含む Instrumentation manifest を apply すると schema validation で fail。

### Impact

- flux-system Kustomization 全体 reconcile failed (= \`context deadline exceeded\`)
- monorepo-cluster Kustomization の \`suspend: false\` 反映されず
- 6-2 application stack (= monolith / frontend / reverse-proxy + RDS + ExternalSecret + Image Update Automation) **100% 未 deploy**

## Fix (= short-term unblock)

\`kubernetes/components/opentelemetry/production/kustomization/instrumentation.yaml\` から \`spec.ruby\` block (= 2 lines) 削除。 frontend (= nodejs) L2 auto-injection は維持、 monolith は L1 (= application code SDK init) のみで運用 (= env vars 不在で SDK 動作は no-op default、 後続 monorepo fix forward で env vars hardcode)。

## Pattern

**5-1 L2 / 5-2 L1 pattern**: post-flight regression check で 6-2 deploy 起因 latent issue 検出 → fix forward。 6 連続 validate (= 4-3 / 5-1 / 5-2 / 6-1 / 6-2 / 本 fix forward) extend。

## 引き継ぎ事項 #25 (= 新規)

- **Title**: OTel Operator chart upgrade for Ruby auto-injection support
- **Detail**: chart 0.112.1 で Ruby auto-injection (= \`spec.ruby\`) 未 support、 chart 0.155.0+ (= 想定) upgrade で ruby field support 取得、 monolith deployment.yaml の env vars hardcode 撤去 + \`inject-ruby\` annotation 復活
- **Timing**: Phase 6-2 closure 後、 別 phase で systematic 対応

## 後続 fix forward (= 別 PR、 monorepo 側)

monolith \`base/deployment.yaml\` の env section に OTel env vars hardcode (= \`OTEL_EXPORTER_OTLP_ENDPOINT\` 等、 L2 injection 代替) + \`instrumentation.opentelemetry.io/inject-ruby\` annotation 撤去。

## Validation (= merge 後)

- [ ] flux-system Kustomization reconcile 復活
- [ ] monorepo-cluster Kustomization Suspended=false
- [ ] 6-2 application stack deploy 開始 (= application Pod / RDS / ExternalSecret 等)
- [ ] frontend Pod auto-injection (= L2、 init container `opentelemetry-auto-instrumentation-nodejs` 存在)
- [ ] monolith Pod は init container なし、 L1 のみ動作 (= env vars 不在で telemetry no-op)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated OpenTelemetry instrumentation configuration for production environments.
  * Node.js auto-instrumentation updated to version 0.62.0.
  * Ruby auto-instrumentation temporarily disabled pending future support.
  * Trace propagation enhanced with improved context propagation standards.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/panicboat/platform/pull/344)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->