### PR TITLE
feat(vpc): add S3 gateway VPC endpoint to private route table

### DIFF
--- a/aws/vpc/modules/main.tf
+++ b/aws/vpc/modules/main.tf
@@ -36,3 +36,19 @@ module "vpc" {
 
   tags = var.common_tags
 }
+
+# S3 Gateway VPC Endpoint
+# Why: Mimir / Loki / Tempo の ingester / compactor および ECR image layer の S3 取得経路を
+# NAT Gateway 経由から Gateway Endpoint 経由に切替え、NAT data processing 料金 ($0.062/GB) を回避する。
+# Gateway Endpoint は時間料金もデータ処理料金も発生しない (= 完全無料)。
+# 関連付け対象は private route table のみ。public は IGW 直結、database は S3 通信源ではないため除外。
+resource "aws_vpc_endpoint" "s3" {
+  vpc_id            = module.vpc.vpc_id
+  service_name      = "com.amazonaws.${var.aws_region}.s3"
+  vpc_endpoint_type = "Gateway"
+  route_table_ids   = module.vpc.private_route_table_ids
+
+  tags = merge(var.common_tags, {
+    Name = "vpce-s3-${var.environment}"
+  })
+}


### PR DESCRIPTION
## Summary

S3 Gateway VPC Endpoint を追加し、private route table に関連付ける。

## Why

Cost Explorer 上で 2026-05-09/10 に EC2-Other (NatGateway-Bytes + DataTransfer-Regional-Bytes) が約 4x に急増した件の調査結果に基づく対策。

- 現状 VPC Endpoint が一切設定されておらず、Pod → S3 通信は全て NAT Gateway 経由
- NAT Gateway が single AZ (ap-northeast-1a) 配置で、workload は AZ-c に集中
- S3 通信が `NatGateway-Bytes` ($0.062/GB) + cross-AZ `Regional-Bytes` ($0.02/GB) の両方に課金される構造

S3 Gateway Endpoint は時間料金もデータ処理料金も発生しない完全無料サービス。

## Scope

- 関連付け対象: private route table のみ (single_nat_gateway=true のため共有 RT 1 つ: `rtb-0e923a35b18b75a84`)
- public は IGW 直結、database は S3 通信源ではないため除外

## Plan

```
Plan: 1 to add, 0 to change, 0 to destroy.
+ aws_vpc_endpoint.s3 (Gateway type, com.amazonaws.ap-northeast-1.s3)
```

## Cost impact (推定)

- $30-50/月 の削減見込み

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added S3 Gateway endpoint resource for private connectivity to S3 within the VPC.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/panicboat/platform/pull/354)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->