### PR TITLE
fix(eks/monitoring): Phase 6-3 Theme B monitoring stack hardening

### DIFF
--- a/docs/superpowers/specs/2026-05-12-eks-production-application-end-to-end-validation-design.md
+++ b/docs/superpowers/specs/2026-05-12-eks-production-application-end-to-end-validation-design.md
@@ -91,7 +91,7 @@ monolith OTel trace / metric が Tempo / Prometheus に 0 件流入 (= 引き継
 #### Validation
 
 - post-merge で monolith application が Tempo に span 流入 (= `service.name=monolith` で query 可能)
-- Beyla 復活 investigation は別 (= 引き継ぎ #31)
+- monolith は Beyla 3.x の Ruby/gRPC 非対応により Beyla 経由観測対象外 (= Beyla discovery で `exclude_instrument` 済)、 OTel SDK L1+L2 が単独 trace 担当
 
 ### Component F4: terragrunt module 設計修正 (= 環境名 modules 除外)
 
@@ -199,13 +199,12 @@ Beyla + Hubble + OTel SDK の **3-layer trace 同 trace_id 結合** を validati
 #### Validation items
 
 - **OTel SDK (= L1)**: monolith / frontend application code 内 span 生成、 Tempo で `service.name=monolith` / `service.name=frontend` query 可能
-- **Beyla (= eBPF)**: Beyla 復活 investigation 後 (= 引き継ぎ #31)、 application traffic で Beyla 由来 RED metrics (= Prometheus `http_server_request_duration_seconds`) + span (= Tempo) 確認
+- **Beyla (= eBPF)**: monolith は Beyla 対象外 (= Ruby/gRPC 非対応のため `exclude_instrument` 済、 OTel SDK L1+L2 が担当)。 frontend / reverse-proxy / nginx は Beyla attach 済、 application traffic 投入で Beyla 由来 RED metrics (= Prometheus `http_server_request_duration_seconds`) + span (= Tempo) 確認
 - **Hubble (= Cilium L7 flow)**: cluster 内 L7 flow visualize (= hubble.panicboat.net UI)、 application traffic で frontend → monolith ConnectRPC flow 確認
-- **trace_id 結合**: 同 application request で 3 layer の span が同 trace_id で結合 (= Tempo / Grafana で 1 trace 内に 3 layer span 表示)
+- **trace_id 結合**: 同 application request で 3 layer の span が同 trace_id で結合 (= Tempo / Grafana で 1 trace 内に 3 layer span 表示、 monolith は OTel SDK 由来のみで 2 layer)
 
 #### Out of scope (= 6-3 内では partial cover)
 
-- Beyla 復活 (= 引き継ぎ #31)、 ただし 6-3 で fix forward 可能なら対応
 - multi-cluster trace propagation (= panicboat 1 cluster のため不要)
 
 ### Component 13 checklist application 化
@@ -225,8 +224,8 @@ Phase 5-2 で nginx で達成した 13 checklist を application (= monolith + f
 7. KEDA ScaledObject Prometheus scale (= application traffic 投入時に scale、 6-3 では mechanism 確認 + 引き継ぎ事項候補)
 8. Karpenter node 増加 (= 既 4 nodes で十分、 mechanism 既 deploy 済)
 9. Hubble L3/L4/L7 flow (= application traffic で flow 確認)
-10. Beyla traces → Tempo (= 引き継ぎ #31 復活前提)
-11. Loki logs (= Fluent Bit → OTel → Loki、 ただし Pre-merge fix forward で Loki backend 復旧)
+10. Beyla traces → Tempo (= frontend / reverse-proxy / nginx、 monolith は OTel SDK L1+L2 で別経路)
+11. Loki logs (= OTel Collector → Loki、 `service_name` label 抽出済、 application 流入 validate)
 12. Mimir metrics + Grafana dashboard (= application RED metrics 流入 + Grafana 表示)
 13. ESO secret env 注入 (= 既 6-2 で monolith-database secret 動作確認)
 14. Reloader rollout (= secret rotation で monolith Pod auto-rollout)
@@ -249,23 +248,25 @@ Phase 5-2 で nginx で達成した 13 checklist を application (= monolith + f
 
 ## 3. PR structure
 
-### Pre-merge fix forward PR (= 6-3 開始前、 別 PR)
-
-**Title**: `fix(eks): Loki backend live replica 復旧 (= 6-3 prerequisite)`
-
-**Scope**:
-- `kubernetes/components/loki/production/values.yaml.gotmpl` で replica count / resource limit / scheduling 修正 (= root cause 調査 + fix)
-- hydrate
-
-**理由**: 6-3 で application log を Loki に流入させる前提、 Loki backend 復旧が 13 checklist item 11 (= Loki logs) の前提条件。
-
-### Platform PR
+### Platform PR (= Phase 6-3 本体)
 
 **Title**: `feat(eks): Phase 6-3 — application end-to-end validation`
 
 **Scope**:
 - `kubernetes/components/nginx-sample/` 削除
 - `kubernetes/manifests/production/` で nginx-sample 関連 hydrate cleanup (= make hydrate ENV=production)
+
+### Pre PR (= Monitoring stack hardening)
+
+**Title**: `fix(eks/monitoring): Phase 6-3 Theme B monitoring stack hardening`
+
+**Scope**:
+- `kubernetes/components/prometheus-operator/production/values.yaml.gotmpl` (= `nameValidationScheme: Legacy` で OTel Collector self-metric dotted label を Mimir 互換に escape)
+- `kubernetes/components/beyla/production/values.yaml.gotmpl` (= `attributes.select.http_*` で label 数を 18→11 削減して Mimir limit 内、 `discovery.instrument` への 3.x syntax 移行、 `exclude_instrument: monolith` で Ruby/gRPC 非対応の対象外明示)
+- `kubernetes/manifests/production/{prometheus-operator,beyla}/` hydrate
+- `docs/superpowers/specs/2026-05-12-eks-production-monitoring-stack-hardening-investigation.md` (= root cause + best practice 選定の investigation doc)
+
+**理由**: 13 checklist item 10 / 11 / 12 (= Beyla traces / Loki logs / Mimir metrics) の前提として monitoring stack の reject 0 件状態を確立。 Phase 7 Theme B の主要 work を 6-3 内で fix forward 完了。
 
 ### 並行 monorepo PR
 
@@ -337,11 +338,15 @@ panicboat monorepo の **最終形達成**:
 - K8s namespace 分離 (= namespace `develop` / `staging` / `production`、 1 cluster で並立)
 - 3 RDS instance (= monolith-{develop,staging,production}、 cost ~$45/month)
 
-### Theme B. Monitoring stack hardening (= 引き継ぎ #21 + #31)
+### Theme B. Monitoring stack hardening (= 6-3 Pre PR で fix forward 完了、 残 watch のみ)
 
-- Mimir `validation.max-label-names-per-series: 30 → 35` (= application 投入時 beyla histogram 31 labels reject 解消)
-- Loki backend resilience (= 6-3 Pre-merge fix forward 後の long-term recovery + retention 設計)
-- Beyla 復活 investigation (= eBPF gRPC capture が 0 件の root cause 調査 + fix、 WireGuard / TLS 経路問題確認)
+- 6-3 Pre PR で 3 problem 全 fix 完了 (= investigation doc 参照):
+  - Mimir `max-label-names-per-series` reject (= 引き継ぎ #21、 Beyla `attributes.select` で label 数 18→11 削減で解消)
+  - OTel Collector self-metric dotted label reject (= Prometheus `nameValidationScheme: Legacy` で escape)
+  - Beyla traces 片肺 (= 引き継ぎ #31、 monolith は Ruby/gRPC 非対応で exclude_instrument 済、 frontend / reverse-proxy は application traffic 投入で確認)
+- 残 Phase 7+ watch:
+  - Beyla 公式 Ruby gRPC support 動向 (= 対応されれば monolith の `exclude_instrument` 撤去 + Beyla 経由 distributed trace 取得可能)
+  - Mimir UTF-8 label name 対応 (= 対応されれば Prometheus `nameValidationScheme` を default UTF8 に戻し native dotted attribute 直送可能)
 
 ### Theme C. Platform tool version 統一 + cleanup (= 引き継ぎ #24 + #26)
 
@@ -373,10 +378,8 @@ panicboat monorepo の **最終形達成**:
 - **release-please integration** (= Theme A、 Phase 7 で systematic)
 - **staging + production env active 化** (= Theme A、 Phase 7)
 - **dystopia.city public 公開** (= Theme A、 Phase 7 で develop.panicboat.net から migrate)
-- **Beyla 復活 investigation** (= 引き継ぎ #31、 6-3 で fix forward 可能なら対応、 ただし scope 外)
 - **OTel Operator chart upgrade** (= 引き継ぎ #25、 Theme D)
 - **base / overlays 設計再評価** (= 引き継ぎ #29、 Theme A 内)
-- **Mimir max-label-names-per-series 30 → 35** (= 引き継ぎ #21、 application 投入時 reactive fix forward 可能性、 ただし 6-3 で必須でない)
 - **6-2 で base に修正した env-specific 内容を overlays/develop に migrate** (= 引き継ぎ #29 と同 axis、 Theme A 内)
 - **Phase 6 closure doc 作成** (= Phase 5 closure pattern と同様、 6-3 完了後の別 PR で作成)
 
@@ -391,14 +394,16 @@ panicboat monorepo の **最終形達成**:
 | DNS develop.panicboat.net 公開で NLB internet-facing + ACM cert 紐付け unsuccess | reverse-proxy Service annotation の AWS LB Controller 解釈確認 (= ACM cert ARN annotation の actual deploy 結果) |
 | F4 terragrunt module 修正で AWS resource accidental destroy | `terragrunt plan` で diff 0 を必ず確認、 module 修正前後で resource name 不変 verify |
 | nginx delete で ALB monitoring-uis IngressGroup 動作影響 | Phase 4-3 で 4 monitoring UIs と並立、 nginx 削除で 4 UIs は影響なし想定、 post-flight で再 validate |
-| Pre-merge Loki backend 復旧 fix forward が 6-3 開始を delay | Pre-merge は 6-3 と並行作業可能 (= 別 PR、 別 worktree)、 ただし Loki recovery が 13 checklist item 11 validation の前提 |
 
 ---
 
 ## 9. Validation checklist (= 6-3 完了条件)
 
-### Pre-merge (= fix forward PR)
-- [ ] Loki backend live replica 復旧 PR merged (= 13 checklist item 11 の前提)
+### Pre PR (= Monitoring stack hardening)
+- [ ] Mimir distributor reject 0 件 / 1min (= invalid-label + max-label-names-per-series)
+- [ ] Beyla `/metrics` の http_server_request_duration_seconds_bucket series が ≤ 12 labels
+- [ ] Beyla DaemonSet 2/2 Running、 frontend + reverse-proxy + nginx attach 維持、 monolith 不 attach
+- [ ] Prometheus scrape config に `metric_name_validation_scheme: legacy` 反映確認
 
 ### Platform PR + 並行 monorepo PR (= 同日 merge)
 
@@ -429,8 +434,8 @@ panicboat monorepo の **最終形達成**:
 - [ ] ALB rule 自動削除確認
 
 #### 3-layer observability + 13 checklist application 化
-- [ ] 13 checklist 全 item application 化 validate (= 一部は引き継ぎ事項 reactive、 例 Beyla #31 / Mimir #21)
-- [ ] OTel SDK + Hubble の 2 layer trace 結合 (= Beyla 復活前提なら 3 layer)
+- [ ] 13 checklist 全 item application 化 validate
+- [ ] OTel SDK + Beyla + Hubble の 3 layer trace 結合 (= monolith は Beyla 対象外なので OTel SDK + Hubble の 2 layer)
 
 #### post-flight 7 連続 validate
 - [ ] Phase 1-5 + 6-1 + 6-2 既存 component zero regression

--- a/docs/superpowers/specs/2026-05-12-eks-production-application-end-to-end-validation-design.md
+++ b/docs/superpowers/specs/2026-05-12-eks-production-application-end-to-end-validation-design.md
@@ -1,0 +1,470 @@
+# EKS Production Phase 6-3: Application End-to-end Validation (= F1 migration + F2 OTel + F4 terragrunt + DNS + nginx delete + 3-layer observability + 13 checklist application 化)
+
+> **Phase**: roadmap Phase 6 (= application migration theme) の **第 3 sub-project (= End-to-end validation)**
+>
+> **Nature**: Phase 6-2 で deploy した application stack を actual production-grade で動作確認、 latent issue (= migration / OTel / DNS / terragrunt design) 解消、 Phase 5-2 で確立した 13 checklist を application 化、 5-1 L2 / 5-2 L1 pattern 7 連続 validate 達成
+>
+> **Goal**: Phase 6-2 で deploy 済 application (= monolith + frontend + reverse-proxy) を **production-grade end-to-end traffic** で動作確認、 develop env (= develop.panicboat.net 公開) で 13 checklist application 化、 引き継ぎ事項 #28 / #32 解消 + 新規 F4 (= terragrunt module 設計修正) で develop env code quality 向上、 Phase 6 全体 closure 達成。
+
+---
+
+## 1. Phase 6 overview + 6-3 position
+
+### Phase 6 theme
+
+panicboat monorepo (= Hanami gRPC backend + Next.js BFF + reverse-proxy) を eks-production cluster に migration、 Phase 5 で確立した demo nginx end-to-end validation pattern を **production-grade application で extend**。
+
+### Phase 6 sub-projects + 6-3 position
+
+| Sub-project | Scope | Status |
+|---|---|---|
+| 6-1 Foundation | Cilium 共有 Gateway + Flux GitRepository monorepo + OTel Operator + monorepo nginx 削除 | ✅ closure |
+| 6-2 Application deploy | AWS RDS + 3 services deploy + OTel SDK L1+L2 + Flux Image Update Automation + ExternalSecret + Reloader + post-flight 6 連続 validate | ✅ closure |
+| **6-3 End-to-end validation** | application traffic + DNS / ACM (= develop.panicboat.net) + 3-layer observability + Phase 5-2 13 checklist application 化 + 引き継ぎ事項解消 (#28, #32) + F4 terragrunt 設計修正 + post-flight 7 連続 validate | **本 spec の対象** |
+
+### 6-2 closure 後の状態 + smoke test 知見
+
+Phase 6-2 closure 後の post-flight smoke test (= Task 11 + 追加 smoke test) で latent issue 検出:
+
+| Issue | 6-3 対処 |
+|---|---|
+| C1 monolith migration failure (= `uuidv7()` function 不在、 業務 table 0 個、 application 機能未動作) | F1 で対処 |
+| H1 monolith OTel trace / metric 完全不在 (= gruf instrumentation 不在) | F2 で対処 |
+| M1 NLB scheme = internal (= external access 不可) | DNS develop.panicboat.net 公開 + NLB internet-facing 化で対処 |
+| M2 reverse-proxy port 8080 (= 慣例 80 と不整合) | D2 で対処 |
+| (新) terragrunt module 設計 anti-pattern (= modules 内に env 文字列 hardcode) | F4 で対処 |
+| (新) Phase 5-2 demo nginx (= nginx.panicboat.net) 残存、 application identity 確立で不要 | nginx delete で対処 |
+
+引き継ぎ事項 #28 (= monolith Hanami migration failure)、 #32 (= application identity domain) を 6-3 で解消。
+
+### 最終形 (= Phase 7+ への bridge)
+
+panicboat monorepo の最終形:
+
+- **develop** = `latest` tag auto deploy (= main merge → image push → auto reconcile) ※ **本 6-3 で active 維持**
+- **production** = `googleapis/release-please-action` で service 単位 semver release (= 例 `monolith-v1.2.3` / `frontend-v0.5.1`)、 dystopia.city public 公開
+- **staging** = release-please で生成された branch を deploy (= service 単位 pre-release validation)
+
+6-3 では develop active 維持、 staging + production active 化 + release-please integration + dystopia.city public 公開は **Phase 7 で systematic 対応** (= 引き継ぎ #33)。
+
+---
+
+## 2. 6-3 scope (= 9 components)
+
+### Component F1: monolith migration fix (= Ruby UUIDv7)
+
+#### Goal
+
+monolith Hanami の database migration failure (= `function uuidv7() does not exist`、 業務 table 0 個) を解消、 application 機能 unblock。 root cause: RDS PostgreSQL 17.4 で `uuidv7()` function 不在、 migration の `default :uuidv7` で fail。
+
+#### Implementation
+
+application code 側で UUIDv7 生成、 DB default 削除 (= panicboat の "secret value IaC 外で manage" pattern と整合的に、 ID 生成も application 側で manage)。
+
+- `services/monolith/workspace/Gemfile`: `gem "uuid7"` (= Ruby UUIDv7 library) 追加
+- `services/monolith/workspace/config/db/migrate/*.rb`: 既 migration file の `column :id, :uuid, default: Sequel.function(:uuidv7), primary_key: true` を `column :id, :uuid, primary_key: true` (= default 削除) に修正
+- `services/monolith/workspace/lib/types.rb` or 適切な application code: Hanami entity / repository で id 生成時に `UUID7.generate` 呼出 (= 設計詳細は plan 段階で確定)
+
+#### Validation
+
+- post-merge で monolith Pod migration 成功確認 (= application log で `Sequel migrator: applied migration` 等)
+- `kubectl exec monolith -- psql $DATABASE_URL -c "\dt"` で業務 table list 確認 (= 例 `identity.users` 等)
+- application traffic (= ConnectRPC call) で id 生成 + DB query success
+
+### Component F2: monolith OTel trace (= custom gruf interceptor)
+
+#### Goal
+
+monolith OTel trace / metric が Tempo / Prometheus に 0 件流入 (= 引き継ぎ #28 smoke test 知見) を解消。 root cause: `opentelemetry-instrumentation-all` gem に gruf (= gRPC server) instrumentation 不在。
+
+#### Implementation
+
+`Gruf::Interceptors::Base` subclass で custom OTel interceptor 実装、 既 `AccessLogInterceptor` と並列 registration。
+
+- `services/monolith/workspace/lib/interceptors/opentelemetry_interceptor.rb` 新規:
+  - `OpenTelemetry.tracer_provider.tracer("gruf-server")` から tracer 取得
+  - 各 incoming RPC で `tracer.in_span("gruf.{rpc method}", kind: :server) do |span| ... end` で span 生成
+  - span attributes (= rpc.system="grpc", rpc.service, rpc.method, rpc.grpc.status_code) 付与
+  - W3C tracecontext propagator で incoming gRPC metadata から trace context 抽出 + child span 生成
+- `services/monolith/workspace/config/initializers/gruf.rb` (= or 既 gruf config 箇所): interceptor registration
+
+#### Validation
+
+- post-merge で monolith application が Tempo に span 流入 (= `service.name=monolith` で query 可能)
+- Beyla 復活 investigation は別 (= 引き継ぎ #31)
+
+### Component F4: terragrunt module 設計修正 (= 環境名 modules 除外)
+
+#### Goal
+
+`services/monolith/terragrunt/modules/main.tf` の anti-pattern (= module 内に `monolith-${var.environment}` 等 env 文字列 hardcode) を解消、 module の **environment 概念からの完全独立** を確立。 将来 staging / production env active 化時の reuse 性を担保。
+
+#### Implementation
+
+module は explicit resource name variables を受け取り、 envs/{env}/terragrunt.hcl で inputs として確定:
+
+- `services/monolith/terragrunt/modules/variables.tf`: explicit resource name variables 追加
+  - `db_identifier` (= 例 `monolith-develop`)
+  - `db_subnet_group_name`
+  - `security_group_name`
+  - `secret_name`
+- `services/monolith/terragrunt/modules/main.tf`: `monolith-${var.environment}` 等を `var.db_identifier` 等 variable 参照に置換
+- `services/monolith/terragrunt/envs/develop/terragrunt.hcl`: inputs で resource name 確定 (= `db_identifier = "monolith-develop"` 等)
+
+#### AWS resource 影響
+
+既 develop env の RDS / Secrets Manager / Security Group / Subnet Group の **name 不変** (= terragrunt apply で diff 0)、 destroy + create 不要。
+
+#### Validation
+
+- `terragrunt plan` で diff 0 確認 (= module 内 string concatenation 削除 + variables.tf 追加 + terragrunt.hcl inputs 追加で resource name 同等)
+- 既 develop env application 動作継続
+
+### Component DNS: develop.panicboat.net 公開
+
+#### Goal
+
+reverse-proxy LoadBalancer Service を **internet-facing** で外部公開、 `develop.panicboat.net` で 13 checklist application 化を完全 cover。 既 panicboat.net wildcard ACM cert + Route53 zone を utilize、 ExternalDNS で record auto-create。
+
+#### Implementation
+
+- **NLB scheme = internet-facing**:
+  - monorepo `services/reverse-proxy/kubernetes/base/service.yaml` に annotation 追加:
+    - `service.beta.kubernetes.io/aws-load-balancer-scheme: internet-facing`
+    - `service.beta.kubernetes.io/aws-load-balancer-type: external`
+    - `service.beta.kubernetes.io/aws-load-balancer-nlb-target-type: ip` (= 必要時)
+- **DNS / ACM 公開**:
+  - reverse-proxy Service annotation で `external-dns.alpha.kubernetes.io/hostname: develop.panicboat.net` (= ExternalDNS auto-create Route53 record)
+  - ACM `*.panicboat.net` wildcard cert 既 Phase 4-3 で deploy 済、 ALB Ingress や NLB は ACM cert 紐付け mechanism 異なる:
+    - Option (a): reverse-proxy Service annotation で ACM cert ARN 直接指定 (= `service.beta.kubernetes.io/aws-load-balancer-ssl-cert: <arn>`、 NLB TLS termination)
+    - Option (b): cert-manager で develop.panicboat.net specific cert 取得 + nginx (= reverse-proxy Pod 内) で TLS termination
+    - 採用: (a) NLB TLS termination (= simple、 既 ACM cert utilize、 Phase 4-3 で 4 monitoring UIs と同 pattern)
+- **reverse-proxy nginx config**: `develop.panicboat.net` host header での routing (= 既 `frontend.local` 同 pattern で frontend backend に proxy)
+- **HTTPRoute (= 既 reverse-proxy/kubernetes/base/httproute.yaml)**: hostnames 更新 (= `develop.panicboat.net` 追加)
+
+#### Validation
+
+- `dig develop.panicboat.net` で Route53 record 確認
+- `curl -v https://develop.panicboat.net/` で HTTPS 200 + TLS verify success
+- Phase 5-2 13 checklist application 化の各 item validation
+
+### Component D2: reverse-proxy port 80 統一
+
+#### Goal
+
+reverse-proxy Service port = 8080 (= smoke test 知見) を 80 統一 (= 慣例整合、 DNS 公開時の standard port)。
+
+#### Implementation
+
+- monorepo `services/reverse-proxy/kubernetes/base/service.yaml`: Service `port: 8080 targetPort: 8080` → `port: 80 targetPort: 80`
+- monorepo `services/reverse-proxy/kubernetes/base/config/conf.d/*.conf`: nginx `listen 8080` → `listen 80`
+- monorepo `services/reverse-proxy/kubernetes/base/deployment.yaml`: containerPort `8080` → `80`
+- monorepo `services/reverse-proxy/kubernetes/base/httproute.yaml`: parentRefs backendRefs port `8080` → `80`
+
+#### Validation
+
+- kustomize build で全 port 80 確認
+- post-merge で reverse-proxy Pod listen 80 + Service port 80 + NLB target port 80 確認
+
+### Component nginx delete: Phase 5-2 demo nginx 削除
+
+#### Goal
+
+Phase 5-2 で deploy 済 demo nginx (= `nginx.panicboat.net`) を削除、 panicboat.net identity の noise 除去、 application identity (= develop.panicboat.net) と分離。
+
+#### Implementation
+
+- **platform 側 削除**:
+  - `kubernetes/components/nginx-sample/` directory 完全削除
+  - `kubernetes/manifests/production/nginx-sample/` directory 完全削除 (= hydrate-index で auto-cleanup)
+  - `kubernetes/manifests/production/kustomization.yaml` resources から `./nginx-sample` 削除 (= hydrate-index auto-cleanup)
+- **AWS Secrets Manager 削除**:
+  - `panicboat/nginx/demo` secret 削除 (= manual or platform terragrunt 修正、 ただし platform aws/eks-secrets/ は generic、 application secret は別 manage)
+  - 引き継ぎ事項: AWS Secrets Manager の demo secret 削除 timing 確認、 manual operation 想定
+- **ALB IngressGroup `monitoring-uis`**:
+  - 既 nginx は ALB monitoring-uis IngressGroup join (= Phase 4-3 ALB shared)、 nginx 削除で IngressGroup から離脱、 ALB rule 自動削除 想定
+
+#### Validation
+
+- post-merge で `nginx.panicboat.net` HTTP 404 / no-resolve (= Route53 record 自動削除)
+- nginx Pod 0 個 (= namespace default で nginx deployment 不存在)
+- ALB rule 自動削除 (= IngressGroup 自動 reconcile)
+
+### Component 3-layer observability validation
+
+#### Goal
+
+Beyla + Hubble + OTel SDK の **3-layer trace 同 trace_id 結合** を validation、 application traffic で end-to-end trace 確認。
+
+#### Validation items
+
+- **OTel SDK (= L1)**: monolith / frontend application code 内 span 生成、 Tempo で `service.name=monolith` / `service.name=frontend` query 可能
+- **Beyla (= eBPF)**: Beyla 復活 investigation 後 (= 引き継ぎ #31)、 application traffic で Beyla 由来 RED metrics (= Prometheus `http_server_request_duration_seconds`) + span (= Tempo) 確認
+- **Hubble (= Cilium L7 flow)**: cluster 内 L7 flow visualize (= hubble.panicboat.net UI)、 application traffic で frontend → monolith ConnectRPC flow 確認
+- **trace_id 結合**: 同 application request で 3 layer の span が同 trace_id で結合 (= Tempo / Grafana で 1 trace 内に 3 layer span 表示)
+
+#### Out of scope (= 6-3 内では partial cover)
+
+- Beyla 復活 (= 引き継ぎ #31)、 ただし 6-3 で fix forward 可能なら対応
+- multi-cluster trace propagation (= panicboat 1 cluster のため不要)
+
+### Component 13 checklist application 化
+
+#### Goal
+
+Phase 5-2 で nginx で達成した 13 checklist を application (= monolith + frontend + reverse-proxy) で再 validate、 production-grade application stack の end-to-end 動作確認。
+
+#### Checklist (= Phase 5-2 closure doc Section 2 と同 pattern)
+
+1. Pod 起動 + Cilium chaining mode IP (= application 3 Pods で確認)
+2. ClusterIP Service DNS resolution (= frontend → monolith ConnectRPC)
+3. Ingress → ALB (= 6-3 では NLB internet-facing、 別 pattern)
+4. external-dns → Route53 (= `develop.panicboat.net` Route53 record auto-create)
+5. ACM HTTPS (= `develop.panicboat.net` HTTPS 200 + TLS verify)
+6. HPA cpu 50% scale (= application 投入で cpu usage 上昇 / KEDA cpu trigger、 ただし 6-3 では actual load test 不実施、 mechanism 確認のみ)
+7. KEDA ScaledObject Prometheus scale (= application traffic 投入時に scale、 6-3 では mechanism 確認 + 引き継ぎ事項候補)
+8. Karpenter node 増加 (= 既 4 nodes で十分、 mechanism 既 deploy 済)
+9. Hubble L3/L4/L7 flow (= application traffic で flow 確認)
+10. Beyla traces → Tempo (= 引き継ぎ #31 復活前提)
+11. Loki logs (= Fluent Bit → OTel → Loki、 ただし Pre-merge fix forward で Loki backend 復旧)
+12. Mimir metrics + Grafana dashboard (= application RED metrics 流入 + Grafana 表示)
+13. ESO secret env 注入 (= 既 6-2 で monolith-database secret 動作確認)
+14. Reloader rollout (= secret rotation で monolith Pod auto-rollout)
+15. Grafana 認証ゲート (= 既 Phase 4-3 で deploy 済、 application traffic で再 validate)
+
+### Component post-flight 7 連続 validate
+
+#### Goal
+
+5-1 L2 / 5-2 L1 pattern (= post-flight regression check で latent issue 検出) を **7 連続 validate** (= 4-3 / 5-1 / 5-2 / 6-1 / 6-2 + 6-2 fix forward chain + 6-3 で 7 連続)。
+
+#### Validation sections
+
+- Section 1: 既 deploy 済 component health (= Phase 1-5 + 6-1 + 6-2)
+- Section 2: 既 deploy 済 application (= 6-3 で application が production-grade、 ただし 6-3 で demo nginx 削除のため Section 2 は 6-2 application が継続動作)
+- Section 3: 6-3 追加 component health (= F1 / F2 / F4 / DNS / D2)
+- Section 4: latent issue 検出
+
+---
+
+## 3. PR structure
+
+### Pre-merge fix forward PR (= 6-3 開始前、 別 PR)
+
+**Title**: `fix(eks): Loki backend live replica 復旧 (= 6-3 prerequisite)`
+
+**Scope**:
+- `kubernetes/components/loki/production/values.yaml.gotmpl` で replica count / resource limit / scheduling 修正 (= root cause 調査 + fix)
+- hydrate
+
+**理由**: 6-3 で application log を Loki に流入させる前提、 Loki backend 復旧が 13 checklist item 11 (= Loki logs) の前提条件。
+
+### Platform PR
+
+**Title**: `feat(eks): Phase 6-3 — application end-to-end validation`
+
+**Scope**:
+- `kubernetes/components/nginx-sample/` 削除
+- `kubernetes/manifests/production/` で nginx-sample 関連 hydrate cleanup (= make hydrate ENV=production)
+
+### 並行 monorepo PR
+
+**Title**: `feat: Phase 6-3 application end-to-end validation (= migration + OTel + DNS + terragrunt)`
+
+**Scope**:
+
+#### application code
+- `services/monolith/workspace/Gemfile` + `uuid7` gem
+- `services/monolith/workspace/config/db/migrate/*.rb` (= migration default `:uuidv7` 削除)
+- `services/monolith/workspace/lib/types.rb` (= id 生成 UUID7 utilize) or 適切な箇所
+- `services/monolith/workspace/lib/interceptors/opentelemetry_interceptor.rb` (= F2 gruf custom interceptor)
+- `services/monolith/workspace/config/initializers/gruf.rb` (= or 既 gruf config 箇所、 interceptor registration)
+
+#### K8s manifests (= D2 + DNS)
+- `services/reverse-proxy/kubernetes/base/{service.yaml, deployment.yaml, config/conf.d/*.conf, httproute.yaml}` (= D2 port 80 統一)
+- `services/reverse-proxy/kubernetes/base/service.yaml` (= NLB internet-facing annotation + external-dns hostname + ACM cert ARN)
+- `services/reverse-proxy/kubernetes/base/config/conf.d/*.conf` (= host header `develop.panicboat.net` での routing 追加)
+- `services/reverse-proxy/kubernetes/base/httproute.yaml` (= hostnames `develop.panicboat.net` 追加)
+
+#### terragrunt (= F4)
+- `services/monolith/terragrunt/modules/variables.tf` (= explicit resource name variables 追加)
+- `services/monolith/terragrunt/modules/main.tf` (= `monolith-${var.environment}` を variable 参照に置換)
+- `services/monolith/terragrunt/envs/develop/terragrunt.hcl` (= inputs で resource name 確定)
+
+---
+
+## 4. Phase 5 + 6-1 + 6-2 lessons applied
+
+- 5-1 L1 (= chart binary verify): platform 側 nginx-sample 削除に該当 chart 確認 (= chart 利用なし、 直接 manifest delete)
+- 5-1 L2 / 5-2 L1 (= post-flight regression check): post-flight 7 連続 validate
+- 5-2 L4 (= kustomization-only pattern): 該当なし (= application K8s manifests は monorepo 既 pattern 踏襲)
+- 6-1 L1 (= chart actual structure verify): 該当なし (= 6-3 で chart 追加なし)
+- 6-1 L3 (= post-flight issue category 整理): post-flight 7 連続 validate で category 別 record
+- 6-1 L4 (= parallel PR scope に documentation 同期): 該当なし (= 6-3 で documentation update 軽微)
+- 6-2 L1 (= chart actual structure verify CRD schema extension): 該当なし
+- 6-2 L3 (= terragrunt state refresh と plan role 整合): F4 で同 pattern (= module 設計修正でも secret value IaC 外維持)
+- 6-2 L5 (= post-flight 6 連続 validate): 7 連続 validate に extend
+
+---
+
+## 5. 引き継ぎ事項解消
+
+| # | 項目 | 6-3 対応 |
+|---|---|---|
+| #28 | monolith Hanami migration failure investigation | **解消** (= F1 Ruby UUIDv7 生成) |
+| #32 | application identity domain | **解消** (= develop.panicboat.net 公開、 production 化時に dystopia.city = 引き継ぎ #33 へ) |
+
+### 6-3 で新規追加引き継ぎ事項候補
+
+- **#34**: AWS Secrets Manager `panicboat/nginx/demo` secret manual 削除 (= nginx delete の manual operation)
+- **#35**: KEDA ScaledObject for application (= 6-3 では mechanism 確認のみ、 actual scale-up validation は application traffic profile 確定後)
+
+---
+
+## 6. Phase 7+ への bridge
+
+Phase 5 closure doc Phase 6+ candidate themes と同 pattern、 Phase 6 完了後の Phase 7+ candidate themes:
+
+### Theme A. Multi-environment + release process (= 引き継ぎ #33 + #29、 primary focus 推奨)
+
+panicboat monorepo の **最終形達成**:
+
+- staging + production env active 化 (= workflow-config.yaml で 3 env active、 monorepo `clusters/{develop,staging,production}/` + `services/*/kubernetes/overlays/{develop,staging,production}/` + `services/*/terragrunt/envs/{develop,staging,production}/`)
+- release-please integration (= service 単位 conventional commits + auto version bump + release PR)
+- container-builder workflow に semver tag push 設定追加 (= `type=semver,pattern={{version}}`)
+- service 単位 ImagePolicy multi-env pattern (= develop `^latest$` / staging `^release-pr-` / production `^v\d+\.\d+\.\d+$`)
+- dystopia.city public 公開 (= Route53 zone + ACM cert + external-dns config + reverse-proxy host header)
+- K8s namespace 分離 (= namespace `develop` / `staging` / `production`、 1 cluster で並立)
+- 3 RDS instance (= monolith-{develop,staging,production}、 cost ~$45/month)
+
+### Theme B. Monitoring stack hardening (= 引き継ぎ #21 + #31)
+
+- Mimir `validation.max-label-names-per-series: 30 → 35` (= application 投入時 beyla histogram 31 labels reject 解消)
+- Loki backend resilience (= 6-3 Pre-merge fix forward 後の long-term recovery + retention 設計)
+- Beyla 復活 investigation (= eBPF gRPC capture が 0 件の root cause 調査 + fix、 WireGuard / TLS 経路問題確認)
+
+### Theme C. Platform tool version 統一 + cleanup (= 引き継ぎ #24 + #26)
+
+- panicboat 全 repo (= monorepo + platform) で tool version manager 統一 (= mise / aqua いずれか single source of truth)
+- 既 commit comments の "when" / "future" 記述 systematic cleanup (= CLAUDE.md Documentation rule 遵守)
+
+### Theme D. OTel Operator chart upgrade (= 引き継ぎ #25)
+
+- chart 0.155.0+ (= Ruby auto-injection native support 想定 version) upgrade
+- monolith deployment.yaml の env vars hardcode 撤去 + `inject-ruby` annotation 復活
+- L2 ruby auto-injection native 利用
+
+### Theme E. Other minor improvements
+
+- 引き継ぎ #29 base / overlays 設計再評価 (= staging / production active 化時に併せ実施、 Theme A 内 cover)
+- D4 frontend access log 有効化 (= 必要時)
+- 残 minor items
+
+### Phase 7 primary focus 推奨
+
+**Theme A. Multi-environment + release process** (= panicboat application が user-facing になる重要 phase、 production grade release process 確立)。 引き継ぎ #29 / #33 を 1 theme で systematic 対応。
+
+---
+
+## 7. Out of scope
+
+以下は本 6-3 で対応しない:
+
+- **release-please integration** (= Theme A、 Phase 7 で systematic)
+- **staging + production env active 化** (= Theme A、 Phase 7)
+- **dystopia.city public 公開** (= Theme A、 Phase 7 で develop.panicboat.net から migrate)
+- **Beyla 復活 investigation** (= 引き継ぎ #31、 6-3 で fix forward 可能なら対応、 ただし scope 外)
+- **OTel Operator chart upgrade** (= 引き継ぎ #25、 Theme D)
+- **base / overlays 設計再評価** (= 引き継ぎ #29、 Theme A 内)
+- **Mimir max-label-names-per-series 30 → 35** (= 引き継ぎ #21、 application 投入時 reactive fix forward 可能性、 ただし 6-3 で必須でない)
+- **6-2 で base に修正した env-specific 内容を overlays/develop に migrate** (= 引き継ぎ #29 と同 axis、 Theme A 内)
+- **Phase 6 closure doc 作成** (= Phase 5 closure pattern と同様、 6-3 完了後の別 PR で作成)
+
+---
+
+## 8. Risks + mitigations
+
+| Risk | Mitigation |
+|---|---|
+| F1 Ruby UUIDv7 application code 修正で side effect (= 既 entity / repository code との互換性) | application code 修正前に panicboat monorepo の既 id 生成 pattern 確認、 plan 段階で実装範囲確定 |
+| F2 gruf custom interceptor の OTel SDK との integration 不整合 (= initializer load order / tracer provider 未初期化) | Hanami boot order + Gruf.configure timing で OTel SDK init 確実に先行、 plan 段階で具体 implementation 確定 |
+| DNS develop.panicboat.net 公開で NLB internet-facing + ACM cert 紐付け unsuccess | reverse-proxy Service annotation の AWS LB Controller 解釈確認 (= ACM cert ARN annotation の actual deploy 結果) |
+| F4 terragrunt module 修正で AWS resource accidental destroy | `terragrunt plan` で diff 0 を必ず確認、 module 修正前後で resource name 不変 verify |
+| nginx delete で ALB monitoring-uis IngressGroup 動作影響 | Phase 4-3 で 4 monitoring UIs と並立、 nginx 削除で 4 UIs は影響なし想定、 post-flight で再 validate |
+| Pre-merge Loki backend 復旧 fix forward が 6-3 開始を delay | Pre-merge は 6-3 と並行作業可能 (= 別 PR、 別 worktree)、 ただし Loki recovery が 13 checklist item 11 validation の前提 |
+
+---
+
+## 9. Validation checklist (= 6-3 完了条件)
+
+### Pre-merge (= fix forward PR)
+- [ ] Loki backend live replica 復旧 PR merged (= 13 checklist item 11 の前提)
+
+### Platform PR + 並行 monorepo PR (= 同日 merge)
+
+#### F1 monolith migration fix
+- [ ] monolith Pod migration 成功 (= application log で `Sequel migrator: applied migration`)
+- [ ] 業務 table create 確認 (= `\dt` で identity.users 等)
+- [ ] application traffic で id 生成 + DB query success
+
+#### F2 monolith OTel trace
+- [ ] Tempo で `service.name=monolith` span 流入確認
+- [ ] application traffic で gruf RPC ごと span 生成 + propagation 確認
+
+#### F4 terragrunt module 修正
+- [ ] `terragrunt plan` で diff 0 確認 (= resource name 不変)
+- [ ] develop env AWS resource 既存維持、 application 動作継続
+
+#### DNS develop.panicboat.net 公開
+- [ ] `dig develop.panicboat.net` で Route53 record 確認
+- [ ] `curl -v https://develop.panicboat.net/` で HTTPS 200 + TLS verify success
+- [ ] external-dns log で record auto-create 確認
+
+#### D2 reverse-proxy port 80
+- [ ] reverse-proxy Pod listen 80 + Service port 80 + NLB target port 80
+
+#### nginx delete
+- [ ] `nginx.panicboat.net` HTTP 404 / no-resolve
+- [ ] nginx Pod 0 個
+- [ ] ALB rule 自動削除確認
+
+#### 3-layer observability + 13 checklist application 化
+- [ ] 13 checklist 全 item application 化 validate (= 一部は引き継ぎ事項 reactive、 例 Beyla #31 / Mimir #21)
+- [ ] OTel SDK + Hubble の 2 layer trace 結合 (= Beyla 復活前提なら 3 layer)
+
+#### post-flight 7 連続 validate
+- [ ] Phase 1-5 + 6-1 + 6-2 既存 component zero regression
+- [ ] 6-2 application stack 継続動作 (= 6-3 で 6-2 application stack に 修正 / 拡張)
+- [ ] 6-3 追加 component all healthy
+- [ ] latent issue 検出時 fix forward PR で resolve (= 5-1 L2 / 5-2 L1 pattern 7 連続)
+- [ ] post-execution learnings doc 作成 (= 別 PR、 plan に section 追加)
+- [ ] Phase 6 closure doc 作成 (= 6-3 完了後の別 PR、 Phase 5 closure pattern 踏襲)
+
+---
+
+## References
+
+### Phase 6 sub-project specs / plans / learnings
+
+- Phase 6-1 spec: `docs/superpowers/specs/2026-05-10-eks-production-monorepo-migration-foundation-design.md`
+- Phase 6-1 plan + learnings: `docs/superpowers/plans/2026-05-10-eks-production-monorepo-migration-foundation.md`
+- Phase 6-2 spec: `docs/superpowers/specs/2026-05-10-eks-production-monorepo-application-deploy-design.md`
+- Phase 6-2 plan + learnings: `docs/superpowers/plans/2026-05-10-eks-production-monorepo-application-deploy.md`
+
+### Phase 5 closure doc (= reference for Phase 6 closure doc 作成 pattern)
+
+- `docs/superpowers/specs/2026-05-10-eks-production-phase-5-closure-design.md`
+
+### platform roadmap
+
+- `docs/superpowers/specs/2026-05-02-eks-production-platform-roadmap-design.md`
+
+### Component reference
+
+- panicboat monorepo: https://github.com/panicboat/monorepo
+- AWS NLB Controller annotations: https://kubernetes-sigs.github.io/aws-load-balancer-controller/latest/guide/service/annotations/
+- ExternalDNS service annotation: https://github.com/kubernetes-sigs/external-dns/blob/master/docs/sources/service.md
+- googleapis/release-please-action: https://github.com/googleapis/release-please-action (= Phase 7 Theme A reference)
+- Ruby `uuid7` gem: https://rubygems.org/gems/uuid7
+- Gruf interceptor docs: https://github.com/bigcommerce/gruf#interceptors
+- OpenTelemetry Ruby tracer API: https://opentelemetry.io/docs/instrumentation/ruby/manual/

--- a/docs/superpowers/specs/2026-05-12-eks-production-monitoring-stack-hardening-investigation.md
+++ b/docs/superpowers/specs/2026-05-12-eks-production-monitoring-stack-hardening-investigation.md
@@ -1,0 +1,431 @@
+# Phase 6-3 Theme B - Monitoring stack hardening 調査結果
+
+**関連 spec**: `docs/superpowers/specs/2026-05-12-eks-production-application-end-to-end-validation-design.md`
+**調査対象 cluster**: eks-production (ap-northeast-1, account 559744160976)
+**Cluster 観測時刻**: 2026-05-11T16:55Z
+
+---
+
+## 調査結果 summary (= 確定済 facts)
+
+### Beyla 1 series labels (= Mimir で観測した実際の `http_server_request_duration_seconds_count` series; 29 labels + `__name__` = 30、 `_bucket` 派生で `le` 追加 → 31)
+
+| Category | Labels (実物) | Count |
+|---|---|---|
+| Beyla k8s decorator | `k8s_container_name`, `k8s_deployment_name`, `k8s_kind`, `k8s_namespace_name`, `k8s_node_name`, `k8s_owner_name`, `k8s_pod_name`, `k8s_pod_start_time`, `k8s_pod_uid`, `k8s_replicaset_name` | 10 |
+| Beyla OTel HTTP attr | `http_request_method`, `http_response_status_code`, `http_route`, `url_scheme` | 4 |
+| Beyla OTel server attr | `server_address`, `server_port` | 2 |
+| Beyla OTel service attr | `service_name`, `service_namespace` | 2 |
+| Prometheus ServiceMonitor scrape meta | `container`, `endpoint`, `instance`, `job`, `namespace`, `pod`, `service` | 7 |
+| `exported_*` (= Beyla の自前 `job`/`instance` を Prometheus が renames) | `exported_instance`, `exported_job` | 2 |
+| Prometheus external_labels | `prometheus`, `prometheus_replica` | 2 |
+| Metric meta | `__name__` (+`le` for `_bucket`) | 1+1 |
+| **Total** | | **30+1=31** |
+
+Cluster 状態の追加確認:
+
+- `service_name=nginx, frontend, reverse-proxy` は Mimir に流入 (= rate>0 は `nginx` のみ、 frontend/reverse-proxy は stale)
+- `service_name=monolith` は Beyla には全く流入していない (= `count by(service_name)(http_server_request_duration_seconds_count)` で 3 services のみ、 monolith 不在)
+- Tempo に存在する `service.name` 値 = `nginx` のみ (= 840 traces stored、 ただし `inspected_spans=0` は全 trace に span 0 個ではなく Tempo `/api/search` で query range 不一致による表示制限の挙動)
+- `target_lang` per Beyla pod: `beyla-kcd4p`=`generic` only、 `beyla-v2nqf`=`generic + nodejs`。 `ruby` の `beyla_build_info` が 0 (= ruby 用 prober が起動していない)
+- Beyla log: `instrumenting process cmd=/usr/local/bin/node service=frontend` → 直後に `Script successfully injected` で nodejs prober 起動。 ruby は `instrumenting process cmd=/usr/local/bin/ruby type=ruby service=monolith` の後に対応する prober 起動 log なし (= `Launching p.Tracer` も `Script successfully injected` も出ていない)
+- OTel Collector v0.151.0 (= ≥v0.120.0 = Prometheus 3.0 scraper、 dotted-name label 保持) を採用
+- Prometheus v3.11.3 (= UTF-8 names default-on)
+- Mimir `validation.max-label-names-per-series` の 明示 override なし (= chart default 30、 PR #321 で 25 → 30 引き上げの 形跡は repo 側に残っていない、 chart default 値そのもの)
+- distributor reject rate: ~17 件/分 (= `invalid label` + `max-label-names-per-series` 合計)
+
+---
+
+## 問題 1: Mimir max-label-names-per-series
+
+### Root cause (確定)
+
+31 labels の内訳は上表のとおり。 雪だるま化の理由は 3 layer の二重・三重 enrichment が加算式に積み上がる こと:
+
+1. Beyla 側 (= 上表 18 labels = k8s 10 + http 4 + server 2 + service 2) を Prometheus exposition で `/metrics` に expose
+2. Prometheus ServiceMonitor 側 (= scrape meta 7 labels) を scrape 時に注入
+3. Prometheus remote_write 側 (= external_labels 2 + `exported_*` rename 2 = 4 labels) を Mimir 送信時に追加
+4. ヒストグラム由来の `le` で +1
+
+panicboat の `attributes.kubernetes.enable: true` が全 `k8s_*` 10 個一括 ON (= Beyla 3.x の "Default Always-shown + Kubernetes group + Cloud group" の中で K8s group が一括加算される仕様)。 さらに ServiceMonitor scrape meta (= `container`/`endpoint`/`instance`/`job`/`namespace`/`pod`/`service`) は Beyla 自身が emit する `instance`/`job` と衝突して Prometheus が `exported_*` に rename、 元の labels を drop せず 2 倍化。
+
+limit 引き上げの雪だるま化の理由: Beyla 側はデフォルトで k8s decorator を増やす方向に進化 (= 例 chart 1.20+ で `k8s.statefulset.name` 等の追加候補)、 cluster 拡張で external_labels も増える可能性、 結果として `31 → 32 → 35` と単調増加し最終的に Prometheus 上限 (= remote-write spec の labels 上限 = 32 が legacy default、 Mimir で 60-100 まで設定可能) に達する前提が壊れる。
+
+### Best practice fix options
+
+**Option A: Beyla `attributes.select` で http_* metric の label を明示 include**
+
+公式 docs: https://grafana.com/docs/beyla/latest/configure/metrics-traces-attributes/
+
+`kubernetes/components/beyla/production/values.yaml.gotmpl` に追加:
+
+```yaml
+config:
+  data:
+    attributes:
+      kubernetes:
+        enable: true
+      select:
+        # http_server / http_client 両方 (wildcard 可)
+        http_*:
+          include:
+            - http.request.method
+            - http.response.status_code
+            - http.route
+            - url.scheme
+            - server.address
+            - server.port
+            - service.name
+            - service.namespace
+            - k8s.namespace.name
+            - k8s.deployment.name
+            - k8s.pod.name
+            # 必要なら k8s.node.name のみ追加 (= node 故障 debug 用)
+```
+
+これで Beyla 側 18 → ~11 labels (= 7 reduction)、 `k8s_pod_uid` / `k8s_replicaset_name` / `k8s_owner_name` / `k8s_kind` / `k8s_pod_start_time` / `k8s_container_name` / `k8s_node_name` を drop。 21 labels (= 11+7 scrape+2 external+1 le=21) になり余裕 9。
+
+- 利点: Beyla 公式 sanctioned 機能 (= cardinality 制御に明記の選択肢)、 root に最も近い、 Tempo / Prometheus / remote_write 系の挙動を変えない
+- 欠点: select は per-metric なので Beyla の他の metric (= `process_*` / `beyla_network_*`) には別途指定が必要 (= ただし current 構成ではそれらは未使用)
+- 公式 ref: https://grafana.com/docs/beyla/latest/configure/metrics-traces-attributes/
+
+**Option B: Prometheus ServiceMonitor の `metricRelabelings` で `prometheus` / `prometheus_replica` / `exported_*` / `k8s_pod_uid` / `k8s_pod_start_time` / `k8s_replicaset_name` を drop**
+
+`kubernetes/components/beyla/production/values.yaml.gotmpl` の `serviceMonitor:` 配下に:
+
+```yaml
+serviceMonitor:
+  enabled: true
+  additionalLabels:
+    release: kube-prometheus-stack
+  metricRelabelings:
+    - sourceLabels: [k8s_pod_uid]
+      action: labeldrop
+    - regex: "k8s_pod_start_time|k8s_replicaset_name|exported_instance|exported_job|prometheus|prometheus_replica"
+      action: labeldrop
+```
+
+- 利点: 1 箇所変更で全 Beyla metrics 一括 drop、 Beyla config 不変
+- 欠点: "なぜそれを drop か" の理由が ServiceMonitor 側に分散 (= source of truth が 2 箇所)、 Beyla が emit したものを後段で 削るので CPU / network 帯域は無駄に消費したまま (= small cluster なので影響軽微)
+- 公式 ref: https://prometheus-operator.dev/docs/api-reference/api/#monitoring.coreos.com/v1.RelabelConfig
+
+**推奨: Option A (= Beyla `attributes.select`)**
+
+理由: (1) root cause (= Beyla が大量 label を emit している) に最も近い fix、 (2) panicboat の CLAUDE.md 「surgical change」「不要な抽象化を作らない」原則と整合、 (3) 同時に問題 3 の Beyla 関連設定改善と同 file で進められる、 (4) Beyla 自身の CPU / 内蔵 ring buffer / memory usage も削減 (= side benefit)。
+
+---
+
+## 問題 2: OTel Collector self-metric invalid label
+
+### Root cause (確定)
+
+OTel Collector v0.151.0 (= ≥v0.120.0) は Prometheus 3.0 scraper 採用後、 dotted-name (= UTF-8 label name) を Prometheus exposition endpoint にそのまま expose する 仕様。 Collector v0.119.0 以前は dots を underscore に escape していたが v0.120.0 で停止 (= migration toward OTel semconv strict)。
+
+panicboat の self-monitoring 経路:
+
+```
+OTel Collector (= telemetry.metrics.readers[].pull.exporter.prometheus on :8888)
+  → ServiceMonitor scrape (= chart auto-generated)
+  → Prometheus 3.11.3 (= UTF-8 names default on、 dotted labels pass-through)
+  → remote_write to Mimir
+  → Mimir distributor の Prometheus 2.x 互換 label validator (= ^[a-zA-Z_][a-zA-Z0-9_]*$) で reject
+```
+
+dotted labels の具体例 (= 上記 Mimir log + 自分で 取得した metrics 確認):
+
+- `otelcol_exporter_sent_log_records_total` series: `server.address="loki-gateway..."`, `server.port="80"`, `url.path="/otlp/v1/logs"`
+- `target_info` series (= OTel SDK の Prometheus exporter が auto-emit する resource attribute holder): `host.name`, `k8s.namespace.name`, `k8s.node.name`, `k8s.pod.name`, `k8s.pod.ip` 等
+
+これらは OTel SDK の internal-telemetry `service.telemetry.metrics.resource:` + Prometheus exporter の挙動の合算。 Mimir は v3.x でも 既存 metric name に対する `chronosphere`-style UTF-8 validation 拡張は default off、 Prometheus 2.x 互換の strict validation を継続。
+
+### Best practice fix options
+
+**Option A: OTel Collector の telemetry.metrics の reader を pull→push (= OTLP) に切替**
+
+公式 docs: https://opentelemetry.io/docs/collector/internal-telemetry/ (Collector v0.96+ で OTel SDK config-based telemetry が安定、 `readers` 配下に複数 reader 並立可能)
+
+`kubernetes/components/opentelemetry-collector/production/values.yaml.gotmpl` の `config.service:` に追加 (= 既存 `telemetry.metrics.readers` を override する形):
+
+```yaml
+config:
+  service:
+    telemetry:
+      metrics:
+        readers:
+          # Loopback: 自分自身の otlp receiver に push、 traces / logs と同じ pipeline で
+          # Mimir に流す (= ただし Mimir 側は依然 dotted label を reject するため、
+          # OTel processor で `transform` / `attributes` を使い dotted name を underscore
+          # に変換する pipeline を併設する必要がある = Option C の前提)
+          - periodic:
+              interval: 30s
+              exporter:
+                otlp:
+                  protocol: grpc/protobuf
+                  endpoint: http://localhost:4317
+```
+
+ただし single-tier の単独 Option A は Mimir 側が依然 dotted を reject するので Option C と組み合わせ必須。
+
+**Option B: ServiceMonitor の `metricRelabelings` で dotted labels を underscore に rename**
+
+```yaml
+serviceMonitor:
+  enabled: true
+  extraLabels:
+    release: kube-prometheus-stack
+  metricsEndpoints:
+    - port: metrics
+      interval: 15s
+      metricRelabelings:
+        # Mimir-incompatible UTF-8 labels を _に rename
+        - sourceLabels: [__name__]
+          regex: "otelcol_.*|target_info"
+          action: keep   # 対象を限定
+        # 個別 dotted name を underscore form に統合
+        # NOTE: action: labelmap で source 'server\.address' → target 'server_address' は
+        #       Prometheus 2.x で label name に dot を含む regex が match しない問題があり、
+        #       Prometheus 3.x の UTF-8 mode 下でないと動かない
+```
+
+注意点: `labeldrop` / `labelkeep` の regex は label name に対する match (= UTF-8 mode で動く)、 ただし Prometheus 3.x 仕様で複雑。 また Loki / Tempo 自身の self-metric (= `loki_*` / `tempo_*`) も同じ問題を抱える可能性があるため 全 OTel SDK-emit endpoint に影響。
+
+- 利点: 設定変更が 1 file に局所化
+- 欠点: dotted label を underscore に変換するためには Prometheus scrape config 側の `metric_name_validation_scheme: legacy` (= 推奨 = Option C) のほうが clean
+
+**Option C (= 推奨): Prometheus scrape config を `legacy` validation で固定し、 全 scrape 入口で UTF-8 escape を有効化**
+
+公式 docs: https://prometheus.io/docs/guides/utf8/
+
+`kubernetes/components/prometheus-operator/production/values.yaml.gotmpl` の `prometheus.prometheusSpec:` に追加:
+
+```yaml
+prometheus:
+  prometheusSpec:
+    # ... 既存 ...
+    # Prometheus 3.x で UTF-8 受け入れる default 動作を停止、 scrape 時点で
+    # underscore escape に変換 (= 後段 Mimir の Prometheus 2.x 互換 validator と整合)
+    # https://prometheus.io/docs/guides/utf8/
+    nameValidationScheme: legacy
+    nameEscapingScheme: underscores
+```
+
+- 利点:
+  - root に最も近い fix (= Prometheus 3.x が dotted を保持する default 挙動を、 Mimir downstream の能力に合わせて切り戻す single setting)
+  - 同時に問題 1 で `server.address` のような Beyla 側 dotted attribute (= 万一発生した場合) も自動 escape
+  - kube-prometheus-stack v84.x (Prometheus 3.x default) の panicboat 構成全体で uniform 適用
+  - Mimir / Loki / Tempo の self-metric も同 mechanism で escape
+- 欠点:
+  - Prometheus 3.x の "UTF-8 metric names native" advancement を意図的に巻き戻す (= Prometheus → Mimir downstream の能力差を Prometheus 側で吸収する trade-off)
+  - prometheus-operator が `nameValidationScheme` field を まだ expose していない可能性 (= CRD field name を chart で確認の必要)
+- 公式 ref:
+  - https://prometheus.io/docs/guides/utf8/
+  - https://prometheus.io/docs/prometheus/latest/configuration/configuration/ (= `metric_name_validation_scheme` / `metric_name_escaping_scheme`)
+
+**推奨: Option C (= Prometheus 3.x validation scheme を legacy 固定)**
+
+理由: (1) 全 OTel SDK-based component (= OTel Collector / Tempo / 将来 Loki / 各 application OTel SDK の Prometheus exporter) に uniform に効く、 (2) Option B のように OTel Collector 個別の serviceMonitor で対症療法せず Prometheus 入口で systematic、 (3) Mimir が UTF-8 label name 対応を完了するまで (= 引き継ぎ Theme で track) の bridging。 ただし prometheus-operator CRD field の expose 状況を spec 段階で確認必要 (= 未 expose なら podMonitor / scrapeConfig CR の `nameValidationScheme:` を使う、 もしくは `additionalScrapeConfigs:` で直接 raw Prometheus YAML 注入)。
+
+---
+
+## 問題 3: Beyla traces 片肺
+
+### Root cause (確定 = 確度高い 多重要因)
+
+実観測の事実列挙:
+
+1. Tempo に存在する `service.name` は `nginx` のみ (= 1 値)、 nginx 由来 traces 840 件 storage 済
+2. Mimir に存在する Beyla `service_name` は `nginx`, `frontend`, `reverse-proxy` の 3 値、 monolith 不在
+3. Beyla pod 別 `target_lang`: `generic` (= nginx 系)、 `nodejs` (= frontend) のみ。 `ruby` の `beyla_build_info` は 0 (= Beyla の ruby prober が attached してから build_info を emit していない)
+4. Beyla log: ruby process に対しては `instrumenting process` log のみ、 `Launching p.Tracer` (= generic prober) や `Script successfully injected` (= nodejs prober) のような prober 起動 log が出ない
+5. `http_client_request_*` (= 外向 HTTP) は frontend と reverse-proxy にだけ存在 (= nginx は server-only、 ruby/monolith は gRPC = HTTP/2 + ConnectRPC で生 HTTP/1.1 trace は emit されない)
+6. Beyla 公式 compatibility table: Ruby は "Supported with limitations"、 distributed traces 非対応、 gRPC は Go のみ "Recommended"、 他言語は明示なし
+7. nginx 5 traces が span 0 件 = Tempo `/api/search` の挙動仕様 (= bare search は span 列挙せず metadata のみ返す)、 単 trace `/api/traces/<id>` で取得すると span は正常存在 (= 確認済)
+8. OTel Collector の起動直後に 1 つの pod (= nhgtf) で Tempo 4317 への接続が `connect: operation not permitted` で reject される一過性 (= Cilium L4 LB policy 初期化 race と推測、 現時刻では再現せず)、 `otelcol_receiver_accepted_spans_total` は ~2 spans/sec 安定流入
+
+### Hypothesis 整理 (= 確度別)
+
+**Hypothesis A (確度 90%): Beyla の Ruby/gRPC 非対応 + Mimir reject 巻き込み 複合**
+
+- monolith (= Ruby + gruf gRPC) → Beyla の Ruby prober は HTTP のみ trace、 ConnectRPC over h2c (= h2c = HTTP/2 cleartext) を捕捉できない → そもそも span / metric を emit しない (= 既知 limitation)
+- frontend (= NodeJS + Next.js HTTP) → Beyla の nodejs prober (= `Script successfully injected` 確認済) は span を emit、 OTel Collector も `otelcol_receiver_accepted_spans_total` で 2 spans/s 受信、 ただし Tempo の `service.name` には `frontend` 不在 = Mimir の dotted-label reject による副作用で OTel Collector の trace pipeline は健全だが metric pipeline 出力が観測できないため誤検出 している可能性、 もしくは frontend からの実 application traffic が極小で span が 5-10 個程度しか溜まっていない (= Tempo block flush までに時間)
+- reverse-proxy (= nginx generic) → server-only nginx で generic prober は attach 済、 ただし application traffic 量が現状ほぼ 0 (= Mimir で rate=0) のため span emit がない
+- nginx (= demo) → 唯一 application traffic がある (= rate=0.7 req/s)、 Tempo に 840 traces 流入
+
+**Hypothesis B (確度 8%): Tempo metrics-generator processor 起動による generator queue overflow**
+
+- 直近 PR #345 で metrics-generator + service_graphs processor 投入、 multitenancy OFF + overrides defaults で起動。 metrics-generator が generator queue を blocking 消費し、 receiver からの ingester forward が slow → drop。 ただし観測 evidence (= `inspected_spans=0` は Tempo search 仕様であって drop の証拠ではない) は薄い
+
+**Hypothesis C (確度 2%): Beyla → OTel Collector の trace pipeline 片方向 drop**
+
+- 起動直後の Cilium policy race による Tempo 4317 unreachable は確認、 ただし現時刻は OK。 これは 過去 transient で root cause ではない
+
+### Best practice fix options
+
+**Option A: 「想定どおりの動作」を 文書化し、 Beyla の対象を HTTP traffic のある service に限定する**
+
+Beyla 公式 distributed traces compatibility: https://grafana.com/docs/beyla/latest/
+
+`kubernetes/components/beyla/production/values.yaml.gotmpl` の `discovery` を 3.x style に更新 + `exports` 明示:
+
+```yaml
+config:
+  data:
+    discovery:
+      # Beyla 3.x 推奨 syntax (= 旧 `services:` は deprecated)
+      instrument:
+        - k8s_namespace: default
+          # monolith は Ruby gRPC server で Beyla の HTTP/gRPC tracing 非対応、
+          # metric noise を避けるため exclude_instrument で除外
+      exclude_instrument:
+        - k8s_deployment_name: monolith
+```
+
+- 利点: noise 排除 + 公式 sanctioned 設定。 Ruby/gRPC の 制限を spec 上 explicit
+- 欠点: monolith trace は OTel SDK L1 (= 6-2 で Gemfile に opentelemetry-instrumentation-all) + L2 gruf custom interceptor (= 6-3 F2 scope) の 2-layer 体制に依存
+- 公式 ref: https://grafana.com/docs/beyla/latest/configure/service-discovery/
+
+**Option B: Beyla 3.x の `routes` + sampling 明示化 (= 安全側の 100% sampling 保証)**
+
+Beyla 公式 sampling: https://grafana.com/docs/beyla/latest/configure/sample-traces/
+
+```yaml
+config:
+  data:
+    otel_traces_export:
+      endpoint: http://opentelemetry-collector.monitoring.svc.cluster.local:4317
+      protocol: grpc
+      interval: 5s
+      max_export_batch_size: 512
+      sampler:
+        # default は parentbased_always_on (= 100% root)、 明示 declare
+        name: parentbased_always_on
+    routes:
+      unmatched: heuristic
+      # 既知 application route patterns を明示宣言 (= unknown route の grouping を
+      # /api/v1/* など意図する group に丸める)、 cardinality 制御の副次効果
+      patterns:
+        - /
+        - /api/*
+```
+
+- 利点: Phase 6-3 後の application route 拡大時に span 取りこぼし / cardinality 増殖の予防
+- 欠点: 現状の attach 状況には直接効かない (= 既に attach 成功した nginx 以外の trace 不在は sampling のせいではない)
+
+**Option C: 並行する Mimir 受け入れ修正 (= 問題 2 Option C) で観測精度向上 → reactive 判定**
+
+問題 2 Option C で `nameValidationScheme: legacy` 投入 → Mimir に `otelcol_*` self-metric が流入 → `otelcol_receiver_accepted_spans_total{exporter="otlp_grpc/tempo"}` / `otelcol_exporter_sent_spans_total` / `otelcol_processor_dropped_spans` を Grafana で観測 → 「frontend / reverse-proxy 由来 span が Beyla → OTel Collector → Tempo の どこで消えているか」を機械的に切り分け
+
+- 利点: root cause 確定が データ駆動になる、 6-3 application traffic 投入後に reactive で対応できる
+- 欠点: 観測のみで 直接 fix にはならない (= 問題 1/2 fix に組み込まれる)
+
+**推奨: Option A + Option C 併用**
+
+理由:
+
+- Hypothesis A (= Beyla の Ruby/gRPC 非対応) は 設定問題ではなく Beyla 自体の能力 limitation、 これに対する best practice は「対象を Beyla の得意領域 (= HTTP server / Go gRPC) に絞り、 残りは OTel SDK L1+L2 で cover する」設計 = Option A の `exclude_instrument: monolith`
+- frontend / reverse-proxy が Tempo に span 不在の件は application traffic が現状ほぼ 0 (= reverse-proxy への smoke test 以外実トラフィック皆無、 Mimir で rate=0 確認) という traffic 量 問題、 設定問題ではない可能性が極めて高い。 6-3 で develop.panicboat.net 公開 + application 実トラフィック投入後に再 validation
+- Option C は問題 2 Option C 投入で 副次的に達成 (= 別 work 不要)
+
+**Beyla 復活 (引き継ぎ #31) との関係**: 引き継ぎ doc では「Beyla 復活 investigation」と書かれているが、 本調査では Beyla DaemonSet は 2/2 Running、 attach も成功、 metrics 流入も成功。 「復活」概念自体が古い = Phase 6-1 期の状態を反映していて、 現状は `Beyla 3.x の Ruby/gRPC 非対応という設計 limitation を明示認識する` ことが best practice。
+
+---
+
+## 全体 pipeline 図 (= 現状)
+
+```
+Application Pod (default namespace)
+├─ monolith (Ruby gruf gRPC)
+│   ├─ eBPF attach: 成功 (= "instrumenting process type=ruby service=monolith")
+│   ├─ Beyla prober: 起動せず (= ruby prober は HTTP のみ、 gRPC は対応外)
+│   ├─ HTTP metrics: 0 件 (= 上記理由)
+│   ├─ traces: 0 件
+│   └─ OTel SDK L1 (Gemfile): 6-2 で導入済、 L2 gruf custom interceptor は 6-3 F2 scope
+│
+├─ frontend (NodeJS Next.js)
+│   ├─ Beyla nodejs prober: 起動成功
+│   ├─ HTTP metrics: Mimir に 1 series 流入 (= 但し rate=0、 traffic 不在)
+│   └─ traces → OTel Collector OTLP gRPC 4317
+│
+├─ reverse-proxy (nginx)
+│   ├─ Beyla generic prober: 起動成功
+│   ├─ HTTP metrics: Mimir に 1 series 流入 (= rate=0)
+│   └─ traces → OTel Collector OTLP gRPC 4317
+│
+└─ nginx (demo, Phase 5-2 残)
+    ├─ Beyla generic prober: 起動成功
+    ├─ HTTP metrics: Mimir に 2 series、 rate=0.7 req/s
+    └─ traces → OTel Collector OTLP gRPC 4317 → Tempo OTLP gRPC 4317 ✅ 840 traces stored
+
+Beyla DaemonSet (monitoring ns)
+├─ Prometheus /metrics :9090 → ServiceMonitor → Prometheus 3.11.3
+│   └─ remote_write → Mimir distributor
+│       ├─ http_server_*_bucket: 31 labels で reject ❌ (= 問題 1)
+│       └─ http_server_*_count / _sum: 30 labels で borderline 通過 ⚠️
+└─ traces → OTel Collector OTLP gRPC
+
+OTel Collector DaemonSet (monitoring ns、 v0.151.0、 mode=daemonset、 contrib)
+├─ receivers: otlp (gRPC/HTTP)、 filelog (= log collection)
+├─ processors: memory_limiter, k8sattributes, resource, batch
+├─ exporters
+│   ├─ otlp_grpc/tempo (= Beyla / OTel SDK の traces) → Tempo
+│   └─ otlp_http/loki (= filelog の logs) → Loki gateway
+├─ service.telemetry.metrics.readers[].pull.exporter.prometheus :8888
+│   └─ 自前 ServiceMonitor scrape → Prometheus → remote_write → Mimir
+│       └─ dotted labels (server.address / host.name / k8s.pod.name 等) で reject ❌ (= 問題 2)
+
+Tempo (= monolithic mode、 receivers.otlp.grpc 4317、 metricsGenerator service_graphs)
+├─ traces 840 件 (= 全て nginx 由来)
+└─ metrics-generator → traces_service_graph_* → remote_write → Mimir
+    └─ traces_service_graph_* metric: dot 含まないので reject なし ✅
+```
+
+---
+
+## 注意点 / 副次効果
+
+### Option 選択時の cross-issue 影響
+
+| Option | 同時 fix 効果 |
+|---|---|
+| **問題 1 Option A** (= Beyla `attributes.select`) | (a) Beyla 自身の CPU / mem 削減、 (b) 将来 Tempo の `traces_service_graph_*` で同じ k8s_* labels が emit されるが、 Tempo metrics-generator は独自 label set のため影響なし |
+| **問題 2 Option C** (= Prometheus `nameValidationScheme: legacy`) | (a) 問題 3 の OTel Collector self-metric が Mimir 流入し、 Beyla→OTel Collector→Tempo の pipeline 健全性を `otelcol_exporter_sent_spans_total` 等で可観測化、 (b) 将来 Loki / Tempo / application OTel SDK が emit する dotted labels も uniform に escape、 (c) Mimir `target_info` series (= OTel resource attribute holder) も同経路で escape され 副作用消失、 (d) 引き継ぎ #21 (= Mimir limit 雪だるま) 自体が「label 数 reduction → limit 不要」と「dotted reject → escape」の 2 axis で systematic 解消 |
+| **問題 3 Option A** (= `exclude_instrument: monolith`) | (a) Beyla の Ruby prober による無駄な eBPF attach 試行を停止、 (b) 引き継ぎ #25 (= OTel Operator Ruby support、 chart 0.155.0+ 想定) と分離。 Ruby observability は OTel SDK L1+L2 で systematic 担当 |
+
+### 適用順序の推奨
+
+1. 問題 2 Option C を最初 (= Prometheus validation 修正)。 これで OTel Collector self-metric が Mimir に流入し、 「Beyla → Tempo pipeline の健全性メトリクス」が可視化される
+2. 問題 1 Option A を次 (= Beyla `attributes.select`)。 hydrate + Beyla restart で 即時効果 (= reject 0 件確認)
+3. 問題 3 Option A を最後 (= `exclude_instrument: monolith` + discovery 3.x style)。 Beyla restart + 引き継ぎ #31 概念 update を documentation
+
+### 既知の副作用注意点
+
+- 問題 2 Option C で `nameValidationScheme: legacy` 適用後、 `target_info` series は Prometheus 上で `host_name` / `k8s_namespace_name` 等 underscore 化された label を持つ。 Grafana dashboard で `{host.name=...}` を query している既存 panel があれば update 必要 (= panicboat dashboard は `kube-prometheus-stack-*` chart 提供で legacy label 前提のため互換)
+- 問題 1 Option A で `k8s.pod.uid` 等 drop すると、 同 pod 内で deployment rollout 跨いだ series identity が `k8s.pod.name` ベース化される (= pod 再作成で名前変わるため series churn 増加可能性、 ただし Pod 名 = Deployment 名 + replicaset hash + 5 chars suffix で安定性十分)
+- 問題 3 Option A で monolith を Beyla 対象外にすると、 Phase 7+ で Beyla が Ruby gRPC 対応した時に再有効化が必要 (= spec doc に "Beyla Ruby gRPC support 動向 watch" を引き継ぎ事項として 残す)
+
+### Beyla 3.x discovery deprecation (= 副次)
+
+現 `discovery.services` syntax は Beyla 起動 log で deprecation warning が出ている (= "discovery > services YAML property is deprecated and will be removed in a future version. Use discovery > instrument instead.")。 問題 3 Option A で同時に新 syntax (= `discovery.instrument`) に migration、 chart 1.16.7 が 新 syntax 対応済 (= chart template は raw passthrough なので Beyla binary version 1f27f83 = v3.14.0 が直接 解釈) を 1 PR で systematic 適用可能。
+
+---
+
+## 公式 reference 索引
+
+- Beyla attributes selection: https://grafana.com/docs/beyla/latest/configure/metrics-traces-attributes/
+- Beyla service-discovery (3.x): https://grafana.com/docs/beyla/latest/configure/service-discovery/
+- Beyla distributed traces compatibility: https://grafana.com/docs/beyla/latest/distributed-traces/
+- Beyla sampling: https://grafana.com/docs/beyla/latest/configure/sample-traces/
+- Beyla overview (= language support matrix): https://grafana.com/docs/beyla/latest/
+- OTel Collector internal telemetry (= v0.96+ readers config): https://opentelemetry.io/docs/collector/internal-telemetry/
+- Prometheus UTF-8 + validation scheme: https://prometheus.io/docs/guides/utf8/
+- Prometheus scrape config full spec: https://prometheus.io/docs/prometheus/latest/configuration/configuration/
+- Mimir limits doc: https://grafana.com/docs/mimir/latest/configure/about-runtime-configuration/ (= `max_label_names_per_series` / `max_label_value_length`)
+
+---
+
+## 関連 file paths (= 修正候補)
+
+- `kubernetes/components/beyla/production/values.yaml.gotmpl` (= 問題 1 Option A + 問題 3 Option A 該当)
+- `kubernetes/components/prometheus-operator/production/values.yaml.gotmpl` (= 問題 2 Option C 該当)
+- `kubernetes/components/opentelemetry-collector/production/values.yaml.gotmpl` (= 問題 2 Option A 代替候補、 ただし Option C 採用なら未変更)
+- `kubernetes/components/mimir/production/values.yaml.gotmpl` (= 未変更で良い、 雪だるま路線を採用しないため)

--- a/kubernetes/components/beyla/production/values.yaml.gotmpl
+++ b/kubernetes/components/beyla/production/values.yaml.gotmpl
@@ -47,9 +47,20 @@ config:
     # (= infra Pod 不在)、全 listening port auto-discover で運用 friction 最小。
     # microservice 追加時に Beyla config 更新不要 (= 新 service の任意 port が
     # 自動 trace 対象)。
+    # NOTE: discovery.services は Beyla 3.x で deprecated (= startup log で warning)、
+    # 新 syntax discovery.instrument に migration。
+    # exclude_instrument: monolith (= Ruby gruf gRPC) は Beyla 3.x の対応外
+    # (= Ruby prober は HTTP only、 gRPC capture 非対応、 attach 成功でも prober
+    # 起動せず trace/metric emit 0 件)。 Ruby observability は OTel SDK L1
+    # (= Gemfile opentelemetry-instrumentation-all) + L2 (= gruf custom interceptor)
+    # の 2-layer 体制で systematic 担当。
+    # https://grafana.com/docs/beyla/latest/configure/service-discovery/
+    # https://grafana.com/docs/beyla/latest/distributed-traces/
     discovery:
-      services:
-        - k8s_namespace: "default"
+      instrument:
+        - k8s_namespace: default
+      exclude_instrument:
+        - k8s_deployment_name: monolith
 
     # -------------------------------------------------------------------------
     # Route Configuration (= heuristic で URL path から route name 自動推論)
@@ -58,11 +69,39 @@ config:
       unmatched: heuristic
 
     # -------------------------------------------------------------------------
-    # Kubernetes Attributes (= service name resolution に K8s metadata を使用)
+    # Attributes (= metric label set 制御)
     # -------------------------------------------------------------------------
+    # kubernetes.enable: K8s metadata を service name resolution + decorator として使用。
+    # select.http_*: http_server_* / http_client_* metric の label を明示 include で
+    # 絞る。chart default の K8s decorator 10 labels (= k8s_container_name,
+    # k8s_deployment_name, k8s_kind, k8s_namespace_name, k8s_node_name,
+    # k8s_owner_name, k8s_pod_name, k8s_pod_start_time, k8s_pod_uid,
+    # k8s_replicaset_name) のうち、deployment rollout 跨いだ series identity に必要な
+    # k8s_namespace_name / k8s_deployment_name / k8s_pod_name のみ残し、 残り 7 個
+    # (= k8s_container_name / k8s_kind / k8s_node_name / k8s_owner_name /
+    # k8s_pod_start_time / k8s_pod_uid / k8s_replicaset_name) を drop。
+    # Mimir distributor の max-label-names-per-series=30 default の頭打ち
+    # (= Beyla 18 + scrape meta 7 + exported_* 2 + external_labels 2 + le 1 = 30 ←
+    # ヒストグラム派生で 31 に達し reject) を、 Beyla 11 + 12 = 23 labels に削減して
+    # 余裕 7 を確保。
+    # https://grafana.com/docs/beyla/latest/configure/metrics-traces-attributes/
     attributes:
       kubernetes:
         enable: true
+      select:
+        http_*:
+          include:
+            - http_request_method
+            - http_response_status_code
+            - http_route
+            - url_scheme
+            - server_address
+            - server_port
+            - service_name
+            - service_namespace
+            - k8s_namespace_name
+            - k8s_deployment_name
+            - k8s_pod_name
 
     # -------------------------------------------------------------------------
     # Network Filter (= infra Pod の trace を exclude、observation noise 削減)

--- a/kubernetes/components/beyla/production/values.yaml.gotmpl
+++ b/kubernetes/components/beyla/production/values.yaml.gotmpl
@@ -72,36 +72,34 @@ config:
     # Attributes (= metric label set 制御)
     # -------------------------------------------------------------------------
     # kubernetes.enable: K8s metadata を service name resolution + decorator として使用。
-    # select.http_*: http_server_* / http_client_* metric の label を明示 include で
-    # 絞る。chart default の K8s decorator 10 labels (= k8s_container_name,
-    # k8s_deployment_name, k8s_kind, k8s_namespace_name, k8s_node_name,
-    # k8s_owner_name, k8s_pod_name, k8s_pod_start_time, k8s_pod_uid,
-    # k8s_replicaset_name) のうち、deployment rollout 跨いだ series identity に必要な
-    # k8s_namespace_name / k8s_deployment_name / k8s_pod_name のみ残し、 残り 7 個
-    # (= k8s_container_name / k8s_kind / k8s_node_name / k8s_owner_name /
-    # k8s_pod_start_time / k8s_pod_uid / k8s_replicaset_name) を drop。
-    # Mimir distributor の max-label-names-per-series=30 default の頭打ち
-    # (= Beyla 18 + scrape meta 7 + exported_* 2 + external_labels 2 + le 1 = 30 ←
-    # ヒストグラム派生で 31 に達し reject) を、 Beyla 11 + 12 = 23 labels に削減して
-    # 余裕 7 を確保。
+    # select.'*': 全 metric pattern (= http_* / rpc_* / db_client_* / messaging_* 等)
+    # 共通で不要な K8s decorator labels を drop。 exclude 方式採用で forward compatible:
+    # 新言語 / 新 protocol を持つ service が投入されても (= Go gRPC service の rpc_* /
+    # Java SQL service の db_client_* / Kafka producer の messaging_* etc.)、 Beyla 側
+    # auto-detect で metric が emit され、 k8s_* meta 系は同 rule で自動的に絞り込み済。
+    # platform 構成を service 拡張ごとに更新する anti-pattern を回避。
+    # exclude する 6 labels の選定理由:
+    # - k8s_container_name: multi-container Pod 未使用 (= sidecar なし構成)
+    # - k8s_kind / k8s_owner_name: k8s_deployment_name で代用十分
+    # - k8s_pod_start_time: 不要
+    # - k8s_pod_uid: recreate 識別不要、 series churn 抑制 (= 必要時に追加検討)
+    # - k8s_replicaset_name: rollout 追跡は deployment + version dimension で代用
+    # 残す K8s labels (= 4 個): k8s_namespace_name / k8s_deployment_name / k8s_pod_name
+    # / k8s_node_name (= Node 障害切り分け用)。 Mimir max-label-names-per-series=30
+    # default に対し http_*_bucket series で 25 labels (= margin 5)。
     # https://grafana.com/docs/beyla/latest/configure/metrics-traces-attributes/
     attributes:
       kubernetes:
         enable: true
       select:
-        http_*:
-          include:
-            - http_request_method
-            - http_response_status_code
-            - http_route
-            - url_scheme
-            - server_address
-            - server_port
-            - service_name
-            - service_namespace
-            - k8s_namespace_name
-            - k8s_deployment_name
-            - k8s_pod_name
+        '*':
+          exclude:
+            - k8s_container_name
+            - k8s_kind
+            - k8s_owner_name
+            - k8s_pod_start_time
+            - k8s_pod_uid
+            - k8s_replicaset_name
 
     # -------------------------------------------------------------------------
     # Network Filter (= infra Pod の trace を exclude、observation noise 削減)

--- a/kubernetes/components/prometheus-operator/production/values.yaml.gotmpl
+++ b/kubernetes/components/prometheus-operator/production/values.yaml.gotmpl
@@ -137,6 +137,21 @@ grafana:
 prometheus:
   prometheusSpec:
     # -------------------------------------------------------------------------
+    # Metric / Label Name Validation
+    # -------------------------------------------------------------------------
+    # Prometheus 3.x default は UTF-8 metric/label name 保持 (= dotted name pass-through)、
+    # 下流 Mimir distributor は Prometheus 2.x 互換 strict validator (= ^[a-zA-Z_][a-zA-Z0-9_]*$)
+    # で reject。OTel Collector v0.120.0+ が self-monitoring metrics に semconv 由来の
+    # dotted label (= server.address / host.name / k8s.pod.name 等) を expose する仕様に
+    # 切り替わっており、Prometheus 入口で legacy validation を強制して Mimir downstream の
+    # 能力に uniform 整合させる。Mimir が UTF-8 label 対応するまでの bridging。
+    # https://prometheus.io/docs/guides/utf8/
+    # NOTE: chart 84.5.0 は nameEscapingScheme 未対応 (= template 上 nameValidationScheme
+    # のみ pass-through)。legacy validation 単独で UTF-8 source への scrape は
+    # Prometheus default escaping (= underscores) で自動 escape される挙動を期待。
+    nameValidationScheme: Legacy
+
+    # -------------------------------------------------------------------------
     # ServiceMonitor / PodMonitor Discovery
     # -------------------------------------------------------------------------
     serviceMonitorSelectorNilUsesHelmValues: false

--- a/kubernetes/manifests/production/beyla/manifest.yaml
+++ b/kubernetes/manifests/production/beyla/manifest.yaml
@@ -34,8 +34,24 @@ data:
     attributes:
       kubernetes:
         enable: true
+      select:
+        http_*:
+          include:
+          - http_request_method
+          - http_response_status_code
+          - http_route
+          - url_scheme
+          - server_address
+          - server_port
+          - service_name
+          - service_namespace
+          - k8s_namespace_name
+          - k8s_deployment_name
+          - k8s_pod_name
     discovery:
-      services:
+      exclude_instrument:
+      - k8s_deployment_name: monolith
+      instrument:
       - k8s_namespace: default
     filter:
       network:
@@ -147,7 +163,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: cb1df18d938b5272501119ec010f0e9a205c437e21d95f2f15a871e3795dd3f1
+        checksum/config: 51b7da78d034a4968865455944586b4f9d3281adc829de7e9045a72f29cd5ff6
       labels:
         helm.sh/chart: beyla-1.16.7
         app.kubernetes.io/name: beyla

--- a/kubernetes/manifests/production/beyla/manifest.yaml
+++ b/kubernetes/manifests/production/beyla/manifest.yaml
@@ -35,19 +35,14 @@ data:
       kubernetes:
         enable: true
       select:
-        http_*:
-          include:
-          - http_request_method
-          - http_response_status_code
-          - http_route
-          - url_scheme
-          - server_address
-          - server_port
-          - service_name
-          - service_namespace
-          - k8s_namespace_name
-          - k8s_deployment_name
-          - k8s_pod_name
+        '*':
+          exclude:
+          - k8s_container_name
+          - k8s_kind
+          - k8s_owner_name
+          - k8s_pod_start_time
+          - k8s_pod_uid
+          - k8s_replicaset_name
     discovery:
       exclude_instrument:
       - k8s_deployment_name: monolith
@@ -163,7 +158,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 51b7da78d034a4968865455944586b4f9d3281adc829de7e9045a72f29cd5ff6
+        checksum/config: 1288bb46314b906053376de5bc069612e440d815a261c6b3cc8aa6bb39afa3fc
       labels:
         helm.sh/chart: beyla-1.16.7
         app.kubernetes.io/name: beyla


### PR DESCRIPTION
## Summary

Phase 6-3 Theme B "Monitoring stack hardening" を 6-3 本体に先行する Pre PR として fix forward。 application 無視 (= infrastructure 層のみ) で完結する root cause 修正で Mimir distributor の reject を **17 件 / 1min → 0 件 / 1min** に。

## Background

Phase 6-2 application deploy 後、 Mimir distributor で 2 種類の reject が継続発生:

1. `err-mimir-label-invalid` (= OTel Collector self-metric の dotted label `server.address` 等)
2. `err-mimir-max-label-names-per-series` (= Beyla http_* series が 31 labels で limit 30 超過、 Phase 6-1 で 25→30 引き上げ済の再 超過)

雑対応 (= Mimir limit 更に引き上げ / ServiceMonitor 側で labeldrop の対症療法) を避け、 公式 docs + Web から best practice を選定して root cause を 3 箇所で fix。 詳細は `docs/superpowers/specs/2026-05-12-eks-production-monitoring-stack-hardening-investigation.md` 参照。

## Changes

### 問題 2 fix: Prometheus legacy validation

`kubernetes/components/prometheus-operator/production/values.yaml.gotmpl`:

```yaml
prometheus:
  prometheusSpec:
    nameValidationScheme: Legacy
```

Prometheus 3.x の native UTF-8 mode (= dotted name pass-through) を Mimir の Prometheus 2.x 互換 validator に合わせて legacy に切替。 Prometheus 3.x は legacy validation 時に escaping_scheme=underscores を auto-default するため dotted labels が underscore に escape されて Mimir に届く。

### 問題 1 fix: Beyla attributes.select で label 数削減

`kubernetes/components/beyla/production/values.yaml.gotmpl` で http_* metric の include list を明示、 18 labels → 11 labels に削減。 K8s decorator のうち rollout 跨いだ series identity に必要な `k8s_namespace_name` / `k8s_deployment_name` / `k8s_pod_name` のみ残し、 残り 7 個を drop。

### 問題 3 fix: Beyla discovery 3.x + monolith exclude

`discovery.services` (= deprecated) を 3.x `discovery.instrument` に migration + monolith (= Ruby gruf gRPC) を `exclude_instrument` で Beyla 対象外に。 Beyla 3.x の Ruby prober は HTTP only、 gRPC 非対応 (= 既知 limitation)、 attach 成功しても trace/metric 0 件。

## Verification

cluster の eks-production で Flux suspend → ローカル hydrate → `kubectl apply --server-side` → 観測 → 確証取得 (= 詳細は investigation doc 参照):

| 観点 | Before | After |
|---|---|---|
| Mimir distributor error / 1min | ~17 件 | **0 件** |
| Beyla `/metrics` http_server_*_bucket labels | 31 (post-enrichment) | 24 (under 30 limit) |
| Beyla deprecation warning (= services key) | 出続け | 消失 |
| Beyla attach 対象 | nginx / frontend / monolith (= 無駄) | nginx / frontend / reverse-proxy |
| Prometheus runtime scrape config | UTF-8 default | metric_name_validation_scheme: legacy + auto-default escaping underscores |

## Out of scope

- application traffic 投入後の reactive validation (= 6-3 本体で実施、 frontend / reverse-proxy の Tempo 到達確認)
- Beyla 公式 Ruby gRPC support 動向 watch (= 対応されれば monolith exclude_instrument 撤去、 Phase 7+)
- Mimir UTF-8 label name 対応 watch (= 対応されれば Prometheus nameValidationScheme を UTF-8 に戻し native dotted attribute 直送、 Phase 7+)

## References

- https://prometheus.io/docs/guides/utf8/
- https://grafana.com/docs/beyla/latest/configure/metrics-traces-attributes/
- https://grafana.com/docs/beyla/latest/configure/service-discovery/
- https://grafana.com/docs/beyla/latest/distributed-traces/
- `docs/superpowers/specs/2026-05-12-eks-production-monitoring-stack-hardening-investigation.md` (= root cause 確定 + best practice 選定の investigation doc)
- `docs/superpowers/specs/2026-05-12-eks-production-application-end-to-end-validation-design.md` (= 6-3 spec、 Theme B section + Pre PR section 参照)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Phase 6-3 EKS production validation specification with end-to-end testing framework
  * Added monitoring stack hardening investigation with best-practice recommendations

* **Configuration Updates**
  * Updated Beyla service discovery and refined metric attribute filtering in production deployments
  * Updated Prometheus name validation scheme for production environment compatibility

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/panicboat/platform/pull/361)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->