### PR TITLE
chore: remove redundant empty stack declarations from workflow-config

### DIFF
--- a/workflow-config.yaml
+++ b/workflow-config.yaml
@@ -1,8 +1,5 @@
 environments:
   - environment: local
-    # local environment is kubernetes-only
-    stacks:
-      kubernetes: {}
 
   - environment: develop
     stacks:
@@ -10,7 +7,6 @@ environments:
         aws_region: us-east-1
         iam_role_plan: arn:aws:iam::559744160976:role/github-oidc-auth-develop-github-actions-plan-role
         iam_role_apply: arn:aws:iam::559744160976:role/github-oidc-auth-develop-github-actions-apply-role
-      kubernetes: {}
 
   - environment: production
     stacks:
@@ -18,7 +14,6 @@ environments:
         aws_region: ap-northeast-1
         iam_role_plan: arn:aws:iam::559744160976:role/github-oidc-auth-production-github-actions-plan-role
         iam_role_apply: arn:aws:iam::559744160976:role/github-oidc-auth-production-github-actions-apply-role
-      kubernetes: {}
 
 stack_conventions:
   - root: "aws/{service}"


### PR DESCRIPTION
## What

Remove `kubernetes: {}` from `environments[].stacks` in `workflow-config.yaml` for all three environments (local / develop / production). The `local` env's now-empty `stacks:` block is dropped together.

## Why

These empty declarations are equivalent to omitting the key entirely:

- `WorkflowConfig#stack_attributes_for` (in deploy-actions) returns `{}` whether the stack key exists with an empty hash or is absent.
- `validate_config.rb` enforces `required_attributes` only on stacks that declare them; `kubernetes` declares none, so the empty hash is a no-op.
- Matrix generation iterates `stack_conventions`, not `environments[].stacks`, and gates targets on directory existence.

For the `local` environment, the comment claimed "kubernetes-only" but the actual mechanism is directory existence under `kubernetes/components/{service}/local` — the same after this change.

## Verification

- YAML parses cleanly.
- Logical equivalent of `validate_config.rb` passes (terragrunt `required_attributes` still declared on develop / production).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated workflow environment configurations with enhanced cloud infrastructure provisioning settings for development and production deployments.
  * Simplified configuration structure by consolidating environment setup blocks.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/panicboat/platform/pull/368)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->