### PR TITLE
docs(eks): Phase 6 closure typo fix (= 24 → 25 件 + 10 → 11 件)

### DIFF
--- a/docs/superpowers/specs/2026-05-13-eks-production-phase-6-closure-design.md
+++ b/docs/superpowers/specs/2026-05-13-eks-production-phase-6-closure-design.md
@@ -494,5 +494,5 @@ panicboat の roadmap (= 2026-05-02 design doc) は Phase 1-5 のみ static defi
 - Phase 6 PRs (= deploy + fix forward + closure): 14
 - Phase 6 累計 runtime issue 数: 9 (= fix forward 9 件 で 解消)
 - Phase 6 解消 引き継ぎ事項: 13 件 (= 7 件 Phase 5 closure 由来 + 6 件 Phase 6 新規)
-- Phase 7+ 残 引き継ぎ事項: 24 件 (= 14 件 Phase 5 closure 由来 持ち越し + 10 件 Phase 6 新規)
+- Phase 7+ 残 引き継ぎ事項: 25 件 (= 14 件 Phase 5 closure 由来 持ち越し + 11 件 Phase 6 新規)
 - post-flight 連続 validate 達成: **7 連続** (= 4-3 / 5-1 / 5-2 / 6-1 / 6-2 / 6-2 fix forward chain / 6-3)


### PR DESCRIPTION
## Summary

Phase 6 closure design doc の internal consistency typo fix。 Section 6 (= Phase 6 累計 statistics) の 1 行で Phase 7+ 残 件数 が 24 件 + 10 件 のまま残存 (= 前段 sections は 既 25 件 + 11 件 で fix 済)、 #40 追加時の count 更新忘れ。

## Change

`docs/superpowers/specs/2026-05-13-eks-production-phase-6-closure-design.md` L497:

Before: `Phase 7+ 残 引き継ぎ事項: 24 件 (= 14 件 Phase 5 closure 由来 持ち越し + 10 件 Phase 6 新規)`
After: `Phase 7+ 残 引き継ぎ事項: 25 件 (= 14 件 Phase 5 closure 由来 持ち越し + 11 件 Phase 6 新規)`

## Verification

- Phase 7+ 残 25 件 (= Section 4 で全 enumerate、 #1, #2, #3, #5, #7, #8, #9, #10, #11, #12, #14, #15, #16, #19, #24, #25, #26, #29, #33, #35, #36, #37, #38, #39, #40)
- Phase 6 新規 11 件 (= #22 解消 + #23 解消 + #24 + #25 + #26 + #28 解消 + #29 + #31 解消 + #32 解消 + #33 + #34 解消 + #35 + #36 + #37 + #38 + #39 + #40 のうち未解消 11 件)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated production phase closure documentation to reflect revised handoff item counts for upcoming release phases.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/panicboat/platform/pull/381)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->