### PR TITLE
docs(eks): Phase 7-0 LB hardening design spec (= #37 + Cilium upgrade + #39)

### DIFF
--- a/aws/eks/modules/main.tf
+++ b/aws/eks/modules/main.tf
@@ -41,3 +41,34 @@ module "eks" {
 
   tags = var.common_tags
 }
+
+# Read the node SG state after module apply to detect the cluster tag.
+# depends_on = [module.eks] ensures this runs after the module applies the tag,
+# so triggers_replace captures the "owned" value and triggers local-exec cleanup.
+data "aws_security_group" "node_sg" {
+  id = module.eks.node_security_group_id
+
+  depends_on = [module.eks]
+}
+
+# Remove the cluster tag from the node SG after every apply.
+# terraform-aws-modules/eks/aws hardcodes kubernetes.io/cluster/<name>=owned on
+# the node SG (node_groups.tf merge block), and node_security_group_tags only
+# supports map(string) so null-value key removal is not possible via variable.
+# AWS LB Controller identifies the target endpoint SG by checking if the tag key
+# exists (value-independent check, pkg/networking/networking_manager.go line 561),
+# so both the EKS cluster SG (eks-cluster-sg-*) and the node SG would match,
+# causing "expected exactly one securityGroup" panic.
+# The data source re-reads the SG after module.eks applies "owned", changing the
+# trigger and causing local-exec to delete the tag on the same apply run.
+resource "terraform_data" "node_sg_cluster_tag_removal" {
+  triggers_replace = [
+    try(data.aws_security_group.node_sg.tags["kubernetes.io/cluster/eks-${var.environment}"], "")
+  ]
+
+  depends_on = [data.aws_security_group.node_sg]
+
+  provisioner "local-exec" {
+    command = "aws ec2 delete-tags --region ${var.aws_region} --resources ${module.eks.node_security_group_id} --tags Key=kubernetes.io/cluster/eks-${var.environment} 2>/dev/null || true"
+  }
+}

--- a/docs/superpowers/plans/2026-05-14-eks-phase-7-0-lb-hardening.md
+++ b/docs/superpowers/plans/2026-05-14-eks-phase-7-0-lb-hardening.md
@@ -1,0 +1,1315 @@
+# Phase 7-0 LB Hardening Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Phase 6 closure で identify した 引き継ぎ事項 #37 / #39 を 1 sub-project で systematic 解消、 cluster LB architecture を panicboat 設計 spec ("north-south は ALB Controller、 east-west は cilium-gateway") に re-align、 monthly cost ~$79 削減 + Gateway 層 JWT validation 採用余地確保。
+
+**Architecture:** 3 components sequential (= #37 → Cilium upgrade → #39) + fallback (= #39 fail 時 #40 bridge revival)。 4 PRs (= platform 3 + monorepo 1) for strict completion、 fallback path で +1 PR。 panicboat の "Flux suspend + ローカル apply + 試行錯誤" pattern 採用、 user 許容 cluster downtime で trial-and-error 進む。
+
+**Tech Stack:** AWS EKS + terraform-aws-modules/eks/aws v21.20.0 + terragrunt + OpenTofu + Cilium 1.18.6 → 1.x.y + helmfile + kustomize + AWS Load Balancer Controller + ExternalDNS + AWS ACM + Route53 + Flux CD
+
+---
+
+## Phase 7-0 deploy 順序
+
+```
+PR 1: #37 fix (= terragrunt eks module node SG tag 除去)
+  ↓ apply + verify AWS LB Controller panic loop 停止
+PR 2: Cilium upgrade (= 1.18.6 → 1.x.y)
+  ↓ apply + verify 既 fix forward regression なし
+PR 3: #39 platform side (= cilium hostNetwork + Gateway port 8080 + ALB Ingress)
+  ↓ apply + verify ALB provision + 旧 NLB auto-delete
+PR 4: #39 monorepo side (= reverse-proxy 削除 + frontend HTTPRoute)
+  ↓ apply + verify develop.panicboat.net 200 OK
+[Fallback PR F1 (= #39 fail 時): cilium revert + #40 bridge]
+```
+
+各 PR は **前 PR の cluster apply + verify 完了後** に着手。 panicboat の "Flux suspend + ローカル apply で試行確認 → 確証後 PR 作成 → merge → Flux resume" pattern 適用。
+
+---
+
+## Task 1: #37 fix (= terragrunt eks module node SG cluster tag 除去)
+
+**Files:**
+- Modify: `aws/eks/modules/main.tf`
+- 必要時 Modify: `aws/eks/modules/variables.tf`
+- 必要時 Modify: `aws/eks/envs/production/terragrunt.hcl`
+
+**Test:** `terragrunt plan` で diff = node SG の cluster tag 1 個除去のみ (= no resource recreation、 in-place tag update)。 apply 後 AWS LB Controller log で panic loop 停止。
+
+- [ ] **Step 1: 現状確認 (= node SG の cluster tag 確認)**
+
+```bash
+cd /Users/takanokenichi/GitHub/panicboat/platform/.claude/worktrees/eks-phase-7-0-lb-hardening
+source /tmp/awsenv.sh  # = eks-admin-production role credentials (= expire 時は assume-role 再取得)
+
+# AWS LB Controller log で panic loop 確認 (= 現状再現)
+kubectl logs -n kube-system deploy/aws-load-balancer-controller --tail=20 | grep "expected exactly one securityGroup" | head -3
+```
+
+Expected: 直近で panic message が repeat 出力。
+
+```bash
+# IAM user で switch (= EC2 describe-security-groups 必要)
+unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_SESSION_TOKEN
+
+# 2 SG の cluster tag 確認
+for sg in sg-06a911469ce77dc76 sg-0c5888ca990469b88; do
+  echo "--- $sg ---"
+  aws ec2 describe-security-groups --region ap-northeast-1 --group-ids $sg --output text \
+    --query 'SecurityGroups[*].[GroupName,Tags[?Key==`kubernetes.io/cluster/eks-production`].Value|[0]]'
+done
+```
+
+Expected: 両 SG で cluster tag `owned` 確認。
+
+- [ ] **Step 2: terragrunt module の actual structure 確認**
+
+```bash
+cat aws/eks/modules/main.tf | head -80
+cat aws/eks/modules/variables.tf
+```
+
+確認 point:
+- `module "eks"` block の `node_security_group_tags` variable 設定有無
+- terraform-aws-modules/eks/aws v21.20.0 で `node_security_group_tags` variable が cluster tag を上書きできる仕様か
+
+terraform-aws-modules/eks/aws docs (= v21.20.0): https://github.com/terraform-aws-modules/terraform-aws-eks/tree/v21.20.0
+- `node_security_group_tags` = node SG に attach する additional tag、 default `{}`
+- ただし module-internal で `kubernetes.io/cluster/<cluster-name>` tag が auto-attach される実装の可能性
+
+→ Step 3 で実 module source code 確認 (= go to https://github.com/terraform-aws-modules/terraform-aws-eks/blob/v21.20.0/main.tf で `kubernetes.io/cluster` grep)
+
+- [ ] **Step 3: module の cluster tag attach 箇所 特定 + override path 決定**
+
+terraform-aws-modules/eks/aws v21.20.0 source 確認:
+
+```bash
+# WebFetch で module source の relevant section 取得
+# https://github.com/terraform-aws-modules/terraform-aws-eks/blob/v21.20.0/main.tf
+# `kubernetes.io/cluster` grep
+```
+
+判定:
+- (a) cluster tag が `node_security_group_tags` で override 可能なら panicboat 側 main.tf で `tags = {}` or 同 key で null 設定で除去
+- (b) module-internal hardcoded で override 不可なら module fork 必要 (= panicboat 側で copy + 修正、 もしくは `aws_ec2_tag` resource で delete tag、 ただし terraform-driven cleanup は不確実)
+
+panicboat の preferred path: (a)、 ただし module で対応していない場合 (b) で workaround。
+
+- [ ] **Step 4: aws/eks/modules/main.tf で cluster tag override 設定追加**
+
+option (a) の場合 (= module variable 経由):
+
+```terraform
+module "eks" {
+  source  = "terraform-aws-modules/eks/aws"
+  version = "~> 21.20"
+  # ... 既存 settings ...
+
+  # node SG から cluster tag 除去 (= AWS LB Controller "1 SG expectation" 確保、
+  # cluster SG (= eks-cluster-sg-*) のみが cluster tag を保持する状態にする)
+  node_security_group_tags = {
+    "kubernetes.io/cluster/${var.cluster_name}" = null
+  }
+}
+```
+
+option (b) の場合 (= module fork OR aws_ec2_tag resource):
+
+```terraform
+# 既 module から auto-attached の cluster tag を override で removal
+resource "aws_ec2_tag" "node_sg_remove_cluster_tag" {
+  resource_id = module.eks.node_security_group_id
+  key         = "kubernetes.io/cluster/${var.cluster_name}"
+
+  # null value は AWS API で tag 削除に変換される (= delete tag mechanism)
+  # ただし terraform behavior は version 依存、 Step 5 で plan で確認
+  value = null
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+```
+
+注意: actual module variable structure / behavior は Step 3 で確定、 ここでは proposed code。
+
+- [ ] **Step 5: terragrunt plan で diff 確認**
+
+```bash
+source /tmp/awsenv.sh  # = eks-admin-production role 必要
+# あるいは IAM user default profile で実行 (= eks-admin role に terraform state S3 access ない場合):
+# unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_SESSION_TOKEN
+
+cd aws/eks/envs/production
+terragrunt plan 2>&1 | tee /tmp/eks-plan.txt
+```
+
+Expected output keywords:
+- `Plan: 0 to add, 1 to change, 0 to destroy` (= in-place tag update のみ)
+- `~ tags = {`
+- `~ "kubernetes.io/cluster/eks-production" = "owned" -> null` (or removed)
+
+NOT expected:
+- `resource recreation` (= -/+ symbol)
+- 他 resource への変更
+
+万一 resource recreation が出る場合: Step 4 の implementation を見直し、 別 approach (= aws_ec2_tag for delete) で再試行。
+
+- [ ] **Step 6: terragrunt apply (= ローカル試行、 panicboat の試行錯誤 pattern)**
+
+```bash
+cd aws/eks/envs/production
+terragrunt apply -auto-approve 2>&1 | tee /tmp/eks-apply.txt
+```
+
+Expected: `Apply complete! Resources: 0 added, 1 changed, 0 destroyed.`
+
+- [ ] **Step 7: AWS LB Controller panic loop 停止確認**
+
+```bash
+source /tmp/awsenv.sh
+sleep 60  # = AWS LB Controller の reconcile interval 待ち
+kubectl logs -n kube-system deploy/aws-load-balancer-controller --since=2m 2>&1 | grep -c "expected exactly one securityGroup"
+```
+
+Expected: `0` (= panic loop 停止)
+
+- [ ] **Step 8: 新規 LB provision テスト (= 既 fail していた pattern が解消されているか)**
+
+```bash
+# AWS LB Controller の TargetGroupBinding reconcile が success するか確認
+kubectl get targetgroupbinding -A -o jsonpath='{range .items[*]}{.metadata.namespace}/{.metadata.name}: {.status.conditions[?(@.type=="Synced")].status}{"\n"}{end}'
+```
+
+Expected: 全 TargetGroupBinding が `Status: True` (= Synced 成立)
+
+- [ ] **Step 9: commit + push + PR 作成**
+
+```bash
+cd /Users/takanokenichi/GitHub/panicboat/platform/.claude/worktrees/eks-phase-7-0-lb-hardening
+git add aws/eks/modules/main.tf
+# 必要時: git add aws/eks/modules/variables.tf aws/eks/envs/production/terragrunt.hcl
+
+git commit -s -m "fix(aws/eks): remove kubernetes.io/cluster/X tag from node SG
+
+Phase 6-3 で発覚した AWS LB Controller の SG 重複 panic loop 解消。
+直近 terraform-aws-modules/eks/aws v21.20.0 + aws v6.44.0 update (= PR
+#355-#358) で node SG に kubernetes.io/cluster/eks-production: owned tag
+が追加され、 EKS cluster SG (= eks-cluster-sg-*) と 2 重に同 tag を持つ状態
+になっていた。 AWS LB Controller は ENI に attach される SG のうち cluster
+tag を持つ SG を 1 つ pick up する仕様で、 2 SG ある場合 reconcile fail
+(= 'expected exactly one securityGroup, got: [sg-A, sg-B]' panic loop)、
+新規 LoadBalancer / Ingress provision が blocking。
+
+node_security_group_tags で cluster tag override 除去、 cluster SG のみが
+cluster tag を保持する状態に。 node identification は module の他 tag
+(= aws:eks:cluster-name 等) で代替、 EBS CSI / VPC CNI / Karpenter は別経路
+(= IRSA / Pod Identity) で IAM、 cluster tag に依存しない。
+
+Validation: terragrunt plan で in-place tag update のみ (= no resource
+recreation)、 apply 後 AWS LB Controller log で panic loop 停止、 全
+TargetGroupBinding Synced=True 確認。"
+
+git push -u origin HEAD
+
+gh pr create --draft --base main --head claude/eks-phase-7-0-lb-hardening \
+  --title "fix(aws/eks): remove kubernetes.io/cluster/X tag from node SG (= AWS LB Controller SG 重複解消)" \
+  --body "## Summary
+
+Phase 6-3 で発覚した AWS LB Controller SG 重複 reconcile error (= 引き継ぎ #37) を解消。 multi-env active 化 (= Phase 7 #29 / #33) の LB provision blocking 解消 + Phase 7-0 LB hardening の prerequisite。
+
+## Root cause
+
+terraform-aws-modules/eks/aws v21.20.0 + aws v6.44.0 update (= PR #355-#358) で node SG に \`kubernetes.io/cluster/eks-production: owned\` tag が追加、 EKS cluster SG と 2 重 tag、 AWS LB Controller の '1 SG expectation' で panic loop。
+
+## Fix
+
+\`aws/eks/modules/main.tf\` で \`node_security_group_tags\` 経由で cluster tag override 除去。 cluster SG (= eks-cluster-sg-*) のみが cluster tag を保持。
+
+## Validation
+
+- terragrunt plan で in-place tag update のみ (= no resource recreation)
+- apply 後 AWS LB Controller log で panic loop 停止
+- 全 TargetGroupBinding Synced=True 確認
+
+## Related
+
+- Phase 6 closure 引き継ぎ #37 (= 解消対象)
+- Phase 7-0 LB hardening spec: \`docs/superpowers/specs/2026-05-14-eks-phase-7-0-lb-hardening-design.md\`"
+```
+
+Expected: PR URL 表示
+
+---
+
+## Task 2: Cilium upgrade (= 1.18.6 → 1.x.y)
+
+**Files:**
+- Modify: `kubernetes/components/cilium/production/helmfile.yaml`
+- 必要時 Modify: `kubernetes/components/cilium/production/values.yaml.gotmpl`
+- Hydrate: `kubernetes/manifests/production/cilium/manifest.yaml`
+
+**Test:** `cilium-cli` で upgrade status 確認 + 既 fix forward (= Beyla / Prometheus / Theme B 全般) regression なし。 Mimir reject 0 件維持、 application traffic continue。
+
+**Dependency:** Task 1 完了 + PR 1 merge + Flux reconcile (= AWS LB Controller panic loop 停止状態が前提)。
+
+- [ ] **Step 1: Cilium 公式 release notes 確認 + upgrade target version 確定**
+
+WebFetch で 公式 docs から hostNetwork mode に関する CHANGELOG / known issues fix を確認:
+
+```
+https://docs.cilium.io/en/v1.19/operations/upgrade/
+https://docs.cilium.io/en/v1.20/operations/upgrade/
+https://github.com/cilium/cilium/releases (= release notes 全)
+```
+
+確認 point:
+- "Gateway API host network mode" の改善が含まれた earliest version
+- CiliumEnvoyConfig CR の listener port migration logic 改善
+
+判定:
+- (a) 1.19.x で hostNetwork mode 完全動作 → target = 最新 1.19.x patch
+- (b) 1.20.x で必要 → target = 最新 1.20.x patch
+- (c) どちらも未対応 → target = 最新 stable (= 1.21+ 等)、 ただし Component C fail 確実視
+
+panicboat の "minimal change" 原則: 1.19.x → 1.20.x の順で試行、 1.19.x で hostNetwork OK なら 1.19.x で fix。 plan では暫定 **1.20.x** (= 最新 stable で safer)、 Step 2 で actual version 確定。
+
+- [ ] **Step 2: actual upgrade target version 確定 (= 例 1.20.5 等の specific patch)**
+
+```bash
+# helm repo update + 最新 patch version 確認
+helm repo add cilium https://helm.cilium.io/
+helm repo update
+helm search repo cilium/cilium --versions 2>&1 | head -10
+```
+
+Expected: 1.20.x の specific patch version (= 例 1.20.5)
+
+→ TARGET_VERSION 変数として 以降 Step で参照 (= 例: `TARGET_VERSION=1.20.5`)
+
+- [ ] **Step 3: cluster state pre-flight snapshot**
+
+```bash
+source /tmp/awsenv.sh
+mkdir -p /tmp/cilium-upgrade-snapshot
+kubectl get pod -A -o yaml > /tmp/cilium-upgrade-snapshot/pods-pre.yaml
+kubectl get svc -A -o yaml > /tmp/cilium-upgrade-snapshot/services-pre.yaml
+kubectl get gateway,httproute,gatewayclass -A -o yaml > /tmp/cilium-upgrade-snapshot/gateway-api-pre.yaml
+kubectl get ciliumenvoyconfig -A -o yaml > /tmp/cilium-upgrade-snapshot/cec-pre.yaml
+kubectl get cm -n kube-system cilium-config -o yaml > /tmp/cilium-upgrade-snapshot/cilium-config-pre.yaml
+
+# Theme B fix forward state confirm (= Mimir reject 0 件、 Beyla labels 等)
+kubectl logs -n monitoring deploy/mimir-distributed-distributor --since=1m 2>&1 | grep -c "level=error"
+```
+
+Expected: error count 0 (= Theme B fix forward 動作中)
+
+- [ ] **Step 4: helmfile.yaml で chart version bump**
+
+`kubernetes/components/cilium/production/helmfile.yaml` を edit:
+
+```yaml
+# Before:
+releases:
+  - name: cilium
+    namespace: kube-system
+    chart: cilium/cilium
+    version: "1.18.6"
+
+# After (= actual target version):
+releases:
+  - name: cilium
+    namespace: kube-system
+    chart: cilium/cilium
+    version: "1.20.5"  # = TARGET_VERSION 確定値
+```
+
+- [ ] **Step 5: values.yaml.gotmpl で deprecated values 確認 + migration**
+
+公式 upgrade guide (= 1.18 → 1.20 の path) で deprecated values を確認:
+
+```bash
+# 公式 upgrade guide WebFetch:
+# https://docs.cilium.io/en/v1.20/operations/upgrade/#step-by-step-upgrade-procedure
+# https://docs.cilium.io/en/v1.20/operations/upgrade/#deprecated-options
+```
+
+確認すべき panicboat current values の関連 fields:
+- `gatewayAPI.enabled: true`
+- `gatewayAPI.hostNetwork.enabled` (= 1.20 で structure 変更可能性)
+- `socketLB.enabled: true`
+- `envoy.enabled: true` (= L7 Proxy 独立 DaemonSet)
+- `hubble.tls.auto.method: certmanager`
+
+migration 必要なら `kubernetes/components/cilium/production/values.yaml.gotmpl` を edit (= 1.20 syntax に変更)。
+
+- [ ] **Step 6: hydrate + diff 確認**
+
+```bash
+cd /Users/takanokenichi/GitHub/panicboat/platform/.claude/worktrees/eks-phase-7-0-lb-hardening
+bash scripts/kubernetes-hydrate/hydrate-component.sh cilium production 2>&1 | tail -5
+git diff --stat kubernetes/manifests/production/cilium/
+git diff kubernetes/manifests/production/cilium/manifest.yaml | head -40
+```
+
+Expected: chart version 反映 + CRD update + 関連 manifest 変更 (= 内容は version 依存)
+
+- [ ] **Step 7: Flux suspend + ローカル apply 試行**
+
+```bash
+source /tmp/awsenv.sh
+flux suspend kustomization flux-system -n flux-system
+kubectl apply -k kubernetes/manifests/production/cilium/ --server-side --force-conflicts 2>&1 | tail -10
+```
+
+Expected: 全 resource serverside-applied (= CRD / Cilium / cilium-envoy / cilium-operator / Hubble 等)
+
+- [ ] **Step 8: cilium DaemonSet rollout + status 確認**
+
+```bash
+kubectl rollout status -n kube-system ds/cilium --timeout=300s
+kubectl rollout status -n kube-system ds/cilium-envoy --timeout=300s
+kubectl rollout status -n kube-system deploy/cilium-operator --timeout=180s
+```
+
+Expected: 全 rollout success
+
+```bash
+# cilium-cli で post-upgrade status 確認
+cilium status --wait 2>&1 | head -20
+```
+
+Expected: `Cilium: 1.20.5` (= TARGET_VERSION 反映)、 全 component OK
+
+- [ ] **Step 9: 既 fix forward regression 確認 (= Theme B 全般)**
+
+```bash
+# Mimir reject 直近 2min
+sleep 60
+kubectl logs -n monitoring deploy/mimir-distributed-distributor --since=2m 2>&1 | grep -E "max-label-names|label-invalid" | wc -l
+```
+
+Expected: `0` (= reject 持続的 0、 Theme B 維持)
+
+```bash
+# Beyla labels 確認 (= attributes.select exclude 動作中?)
+beyla_pod_ip=$(kubectl get po -n monitoring -l app.kubernetes.io/name=beyla -o jsonpath='{.items[0].status.podIP}')
+kubectl exec -n monitoring prometheus-kube-prometheus-stack-prometheus-0 -c prometheus -- wget -qO- "http://${beyla_pod_ip}:9090/metrics" 2>&1 | grep "^http_server_request_duration_seconds_bucket{" | head -1 | grep -oE '[a-z_]+=' | wc -l
+```
+
+Expected: ~20 labels (= Phase 6-3 Theme B 設定済)
+
+```bash
+# Prometheus name validation 確認
+kubectl exec -n monitoring prometheus-kube-prometheus-stack-prometheus-0 -c prometheus -- wget -qO- http://localhost:9090/api/v1/status/config 2>&1 | jq -r .data.yaml | grep "name_validation_scheme" | head -1
+```
+
+Expected: `metric_name_validation_scheme: legacy`
+
+- [ ] **Step 10: application traffic continue 確認 (= regression なし)**
+
+```bash
+curl -sI --max-time 10 --resolve develop.panicboat.net:443:$(dig +short k8s-default-reversep-4c0b605be5-41367d3702a18720.elb.ap-northeast-1.amazonaws.com @1.1.1.1 | head -1) https://develop.panicboat.net/ 2>&1 | head -3
+```
+
+Expected: `HTTP/1.1 200 OK`
+
+万一 regression / fail 発見: helmfile revert + Step 6-8 で 1.18.6 に downgrade、 cluster state recovery 確認後 issue 別 PR で fix forward。
+
+- [ ] **Step 11: Flux resume + commit + push + PR 作成**
+
+```bash
+source /tmp/awsenv.sh
+flux resume kustomization flux-system -n flux-system
+flux reconcile kustomization flux-system -n flux-system
+
+cd /Users/takanokenichi/GitHub/panicboat/platform/.claude/worktrees/eks-phase-7-0-lb-hardening
+git add kubernetes/components/cilium/production/helmfile.yaml \
+        kubernetes/components/cilium/production/values.yaml.gotmpl \
+        kubernetes/manifests/production/cilium/
+
+git commit -s -m "chore(eks/cilium): upgrade Cilium 1.18.6 → 1.20.5
+
+Phase 7-0 Component B。 Cilium upgrade で hostNetwork mode の CEC CR migration
+logic 改善 (= Phase 6-3 (γ-a) failed の root cause、 chart 1.18.6 で listener
+port migration 不完全) + chaining mode / socketLB / Hubble / dnsProxy / L7
+Proxy 独立 DaemonSet stable 維持。
+
+deprecated values migration: (= 必要時 specify)
+- (なし、 1.18 → 1.20 で panicboat values 互換性確認済)
+
+Validation:
+- cilium-cli status で 1.20.5 確認 + 全 component OK
+- 既 Theme B fix forward regression なし (= Mimir reject 0 件、 Beyla
+  attributes.select 動作、 Prometheus name_validation_scheme: legacy)
+- application traffic (= develop.panicboat.net) HTTP 200 継続"
+
+git push origin HEAD
+
+gh pr create --draft --base main --head claude/eks-phase-7-0-lb-hardening \
+  --title "chore(eks/cilium): upgrade Cilium 1.18.6 → 1.20.5 (= hostNetwork mode 改善)" \
+  --body "## Summary
+
+Phase 7-0 Component B = Cilium upgrade 1.18.6 → 1.20.5。 hostNetwork mode の CEC CR migration logic 改善 + Phase 6-3 (γ-a) failed の root cause 解消、 Component C (= #39) migration の前提。
+
+## Validation
+
+- cilium-cli \`cilium status\` で 1.20.5 確認 + 全 component OK
+- Theme B fix forward 全 regression なし (= Mimir reject 0 件 + Beyla attributes.select + Prometheus name_validation_scheme: legacy)
+- application traffic 継続 (= develop.panicboat.net 200 OK)
+
+## Pre-flight snapshot
+
+\`/tmp/cilium-upgrade-snapshot/\` に cluster state full backup (= pods / services / gateway-api / CEC / cilium-config)
+
+## Related
+
+- Phase 7-0 spec Component B
+- Phase 6-3 Theme B fix forward への regression test 含む"
+```
+
+---
+
+## Task 3: #39 platform side (= cilium hostNetwork + Gateway port 8080 + ALB Ingress)
+
+**Files:**
+- Modify: `kubernetes/components/cilium/production/values.yaml.gotmpl` (= `gatewayAPI.hostNetwork.enabled: true`)
+- Modify: `kubernetes/components/cilium/production/kustomization/cilium-gateway.yaml` (= listener port 80 → 8080)
+- Create: `kubernetes/components/cilium/production/kustomization/application-ingress.yaml`
+- Modify: `kubernetes/components/cilium/production/kustomization/kustomization.yaml` (= application-ingress.yaml 追加)
+- Hydrate: `kubernetes/manifests/production/cilium/manifest.yaml`
+
+**Test:** Cilium DaemonSet rollout + cilium-gateway-cilium-gateway Service が ClusterIP に変化 (= LoadBalancer auto-create disable) + 旧 NLB auto-delete + ALB provision active + cilium-envoy が host port 8080 で listen。
+
+**Dependency:** Task 2 完了 + PR 2 merge + Cilium 1.20.5 動作確認。
+
+- [ ] **Step 1: values.yaml.gotmpl で hostNetwork.enabled: true 追加**
+
+`kubernetes/components/cilium/production/values.yaml.gotmpl` の `gatewayAPI:` block を edit:
+
+```yaml
+# Before:
+gatewayAPI:
+  enabled: true
+
+# After:
+# =============================================================================
+# Gateway API（北南: ALB Controller 経由で hostNetwork mode の Cilium Gateway を expose、
+# 東西: 同 Cilium Gateway で internal routing。 北南統一で reverse-proxy 不要、
+# Cilium Gateway + CiliumEnvoyConfig で JWT validation 余地確保）
+# =============================================================================
+# hostNetwork.enabled: true は LoadBalancer Service auto-create を disable
+# (= 公式 mutual exclusive)、 cilium-gateway-cilium-gateway Service が ClusterIP に。
+# eks-pod-identity-agent が hostNetwork で port 80 占有のため Gateway listener は
+# port 8080 (= cilium-gateway.yaml)、 1024 未満特権 port 回避で NET_BIND_SERVICE
+# capability 不要。
+# https://docs.cilium.io/en/v1.20/network/servicemesh/gateway-api/host-network-mode/
+gatewayAPI:
+  enabled: true
+  hostNetwork:
+    enabled: true
+```
+
+- [ ] **Step 2: cilium-gateway.yaml で listener port 80 → 8080**
+
+`kubernetes/components/cilium/production/kustomization/cilium-gateway.yaml` を edit:
+
+```yaml
+# Before:
+spec:
+  gatewayClassName: cilium
+  listeners:
+    - name: http
+      port: 80
+      protocol: HTTP
+
+# After:
+spec:
+  gatewayClassName: cilium
+  listeners:
+    - name: http
+      port: 8080  # = hostNetwork mode、 eks-pod-identity-agent の port 80 と collision 回避
+      protocol: HTTP
+```
+
+- [ ] **Step 3: application-ingress.yaml 新規作成**
+
+Create `kubernetes/components/cilium/production/kustomization/application-ingress.yaml`:
+
+```yaml
+# =============================================================================
+# Ingress: application IngressGroup (= cilium-gateway hostNetwork backend)
+# =============================================================================
+# Cilium Gateway hostNetwork mode (= values.yaml.gotmpl gatewayAPI.hostNetwork.enabled)
+# で 全 node の host port 8080 に cilium-envoy が listen、 ALB がそれを backend
+# として target-type=ip で Pod IP (= node IP) に register。
+#
+# ACM cert auto-discovery: ALB Controller が wildcard cert *.panicboat.net を
+# 自動 attach (= Ingress.host が SAN match)。explicit certificate-arn annotation
+# 不要。
+#
+# external-dns annotation: hostname を Route53 record として auto-create
+# (= aws-load-balancer-controller / external-dns 連携)。
+# =============================================================================
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: application
+  namespace: default
+  annotations:
+    alb.ingress.kubernetes.io/scheme: internet-facing
+    alb.ingress.kubernetes.io/listen-ports: '[{"HTTPS":443}]'
+    alb.ingress.kubernetes.io/group.name: application
+    alb.ingress.kubernetes.io/target-type: ip
+    alb.ingress.kubernetes.io/healthcheck-path: /
+    alb.ingress.kubernetes.io/healthcheck-port: traffic-port
+    alb.ingress.kubernetes.io/ssl-policy: ELBSecurityPolicy-TLS13-1-2-2021-06
+    alb.ingress.kubernetes.io/ssl-redirect: "443"
+    external-dns.alpha.kubernetes.io/hostname: develop.panicboat.net
+spec:
+  ingressClassName: alb
+  rules:
+    - host: develop.panicboat.net
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: cilium-gateway-cilium-gateway
+                port:
+                  number: 8080
+```
+
+- [ ] **Step 4: kustomization.yaml に application-ingress.yaml 追加**
+
+`kubernetes/components/cilium/production/kustomization/kustomization.yaml` を edit:
+
+```yaml
+# Before:
+resources:
+  - gateway-class.yaml
+  - cilium-gateway.yaml
+
+# After:
+resources:
+  - gateway-class.yaml
+  - cilium-gateway.yaml
+  - application-ingress.yaml
+```
+
+- [ ] **Step 5: hydrate + diff 確認**
+
+```bash
+cd /Users/takanokenichi/GitHub/panicboat/platform/.claude/worktrees/eks-phase-7-0-lb-hardening
+bash scripts/kubernetes-hydrate/hydrate-component.sh cilium production 2>&1 | tail -3
+git diff kubernetes/manifests/production/cilium/manifest.yaml 2>&1 | grep -B1 -A3 -E "hostNetwork|port:|application" | head -30
+```
+
+Expected:
+- `gateway-api-hostnetwork-enabled: "true"` 反映
+- Gateway CR の listener port 8080
+- 新 Ingress application 追加
+
+- [ ] **Step 6: Flux suspend + ローカル apply**
+
+```bash
+source /tmp/awsenv.sh
+flux suspend kustomization flux-system -n flux-system
+kubectl apply -k kubernetes/manifests/production/cilium/ --server-side --force-conflicts 2>&1 | tail -10
+```
+
+- [ ] **Step 7: Cilium operator restart + cilium-gateway Service ClusterIP 化観測**
+
+```bash
+kubectl rollout restart -n kube-system deploy/cilium-operator ds/cilium ds/cilium-envoy
+kubectl rollout status -n kube-system deploy/cilium-operator --timeout=180s
+kubectl rollout status -n kube-system ds/cilium-envoy --timeout=300s
+kubectl rollout status -n kube-system ds/cilium --timeout=300s
+
+sleep 60
+
+# cilium-gateway-cilium-gateway Service の type 確認 (= LoadBalancer → ClusterIP に変化期待)
+kubectl get svc -n default cilium-gateway-cilium-gateway
+```
+
+Expected: `TYPE: ClusterIP` (= hostNetwork mode で LoadBalancer auto-create disable、 Cilium 1.20 で正常動作期待)
+
+万一 LoadBalancer 維持 + EXTERNAL-IP <pending> なら #39 fail trigger → Step 14 fallback path:
+
+```bash
+# 失敗 detect、 fallback path に進む (= Task 5 へ skip)
+echo "Component C fail detected, switching to fallback (Task 5)"
+```
+
+- [ ] **Step 8: cilium-envoy host port 8080 listen 確認**
+
+```bash
+NODE=$(kubectl get po -n kube-system -l k8s-app=cilium-envoy -o jsonpath='{.items[0].spec.nodeName}')
+kubectl debug node/$NODE -it --image=nicolaka/netshoot --profile=netadmin -- ss -tlnp 2>&1 | grep -E ":8080" | head -5
+```
+
+Expected: `LISTEN 0 ... 0.0.0.0:8080 ... users:(("cilium-envoy",...))`
+
+- [ ] **Step 9: 旧 cilium-gateway NLB auto-delete 観測**
+
+```bash
+unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_SESSION_TOKEN
+sleep 60
+aws elbv2 describe-load-balancers --region ap-northeast-1 --output text \
+  --query 'LoadBalancers[?contains(LoadBalancerName, `ciliumga`)].[LoadBalancerName,State.Code]'
+```
+
+Expected: empty (= 旧 NLB auto-delete 完了)
+
+- [ ] **Step 10: ALB application 新規 provision 観測**
+
+```bash
+sleep 120  # = ALB provision 通常 ~5-10 min
+source /tmp/awsenv.sh
+kubectl get ingress -n default application 2>&1
+
+unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_SESSION_TOKEN
+aws elbv2 describe-load-balancers --region ap-northeast-1 --output text \
+  --query 'LoadBalancers[?contains(LoadBalancerName, `application`) || contains(LoadBalancerName, `applicat`)].[LoadBalancerName,Type,State.Code,DNSName]'
+```
+
+Expected:
+- Ingress `application` で ADDRESS field に ALB hostname 表示
+- ALB type=application、 State=active
+
+- [ ] **Step 11: ALB target group health 確認**
+
+```bash
+LB_ARN=$(aws elbv2 describe-load-balancers --region ap-northeast-1 --output text \
+  --query 'LoadBalancers[?contains(LoadBalancerName, `application`)].LoadBalancerArn' | head -1)
+TG_ARNS=$(aws elbv2 describe-target-groups --load-balancer-arn "$LB_ARN" --region ap-northeast-1 --output text --query 'TargetGroups[*].TargetGroupArn')
+for tg in $TG_ARNS; do
+  echo "--- $(echo $tg | awk -F/ '{print $(NF-1)}') ---"
+  aws elbv2 describe-target-health --target-group-arn "$tg" --region ap-northeast-1 --output text \
+    --query 'TargetHealthDescriptions[*].[Target.Id,Target.Port,TargetHealth.State]'
+done
+```
+
+Expected: 全 target が `healthy` (= cilium-envoy hostNetwork :8080 が responding)
+
+- [ ] **Step 12: ExternalDNS が新 ALB hostname を Route53 に register 観測**
+
+```bash
+source /tmp/awsenv.sh
+kubectl logs -n external-dns deploy/external-dns --tail=30 2>&1 | grep -i "develop.panicboat" | tail -10
+
+# DNS resolve 確認 (= cloudflare resolver 経由)
+sleep 60
+dig +short develop.panicboat.net @1.1.1.1 | head -3
+```
+
+Expected:
+- ExternalDNS log で `CREATE develop.panicboat.net A` 等の record action
+- DNS resolve で ALB IPs 取得 (= 旧 reverse-proxy NLB IPs から switch)
+
+- [ ] **Step 13: curl https で 200 OK 確認 (= 旧経路依然 active、 新経路は monorepo PR merge 後)**
+
+```bash
+# 旧経路 (= reverse-proxy NLB) で 動作確認 (= Component C platform side では旧経路 依然 active)
+curl -sI --max-time 10 --resolve develop.panicboat.net:443:54.95.222.148 https://develop.panicboat.net/ 2>&1 | head -3
+```
+
+Expected: `HTTP/1.1 200 OK` (= 旧経路 reverse-proxy NLB 経由 functional、 ALB 経路は monorepo PR merge 後 verify)
+
+注意: ExternalDNS が新 ALB hostname に Route53 record 切替で **default DNS resolve は ALB 経由になる**、 ただし旧 reverse-proxy NLB target 経由 traffic は monorepo PR (= Task 4) merge まで functional 維持。
+
+- [ ] **Step 14: success or fallback judgment**
+
+判定:
+- Step 7 で Service が ClusterIP + Step 8 で port 8080 listen + Step 11 で target healthy → **success** → Step 15 (commit + push + PR) へ
+- いずれか fail → **fallback** → Task 5 (#40 bridge) へ skip + Task 4 monorepo 着手なし
+
+- [ ] **Step 15: Flux resume + commit + push + PR 作成**
+
+```bash
+source /tmp/awsenv.sh
+flux resume kustomization flux-system -n flux-system
+flux reconcile kustomization flux-system -n flux-system
+
+cd /Users/takanokenichi/GitHub/panicboat/platform/.claude/worktrees/eks-phase-7-0-lb-hardening
+git add kubernetes/components/cilium/production/values.yaml.gotmpl \
+        kubernetes/components/cilium/production/kustomization/cilium-gateway.yaml \
+        kubernetes/components/cilium/production/kustomization/application-ingress.yaml \
+        kubernetes/components/cilium/production/kustomization/kustomization.yaml \
+        kubernetes/manifests/production/cilium/
+
+git commit -s -m "feat(eks): Cilium Gateway hostNetwork mode + application ALB IngressGroup
+
+Phase 7-0 Component C platform side。 panicboat architecture spec ('north-south
+は ALB Controller、 east-west は cilium-gateway') への re-align、 internet
+公開経路を ALB IngressGroup 経由 cilium-gateway hostNetwork に統一。
+
+Changes:
+- gatewayAPI.hostNetwork.enabled: true で LoadBalancer Service auto-create
+  disable (= cilium-gateway-cilium-gateway が ClusterIP 化)
+- Gateway listener port 80 → 8080 (= eks-pod-identity-agent の port 80 と
+  collision 回避、 1024 未満特権 port 回避で NET_BIND_SERVICE capability 不要)
+- 新 ALB Ingress application (= IngressGroup application、 ACM cert
+  auto-discovery、 TLS 1.3、 HTTP → HTTPS redirect、 ExternalDNS で
+  develop.panicboat.net Route53 record auto-create、 backend は
+  cilium-gateway-cilium-gateway Service:8080)
+
+Validation:
+- cilium-gateway-cilium-gateway Service type=ClusterIP 確認
+- cilium-envoy host port 8080 listen 確認 (= ss output)
+- 旧 cilium-gateway NLB auto-delete 確認 (= ELB list で消失)
+- 新 ALB provision active + target healthy 確認
+- ExternalDNS で Route53 record auto-create 確認 + DNS resolve 切替
+- 旧 reverse-proxy 経路継続 functional (= curl HTTPS 200、 monorepo PR
+  merge 前は旧経路維持)
+
+Architecture impact:
+- monthly cost ~\$48 削減 (= cilium-gateway NLB 削除)
+- ingress L7 visibility 復活 (= Hubble flow observe で cilium-gateway 経由
+  HTTP method / path / status 観測可能化)
+- Gateway 層 JWT validation 採用余地確保 (= Phase 8+ で
+  CiliumEnvoyConfig 経由)"
+
+git push origin HEAD
+
+gh pr create --draft --base main --head claude/eks-phase-7-0-lb-hardening \
+  --title "feat(eks): Cilium Gateway hostNetwork mode + application ALB IngressGroup (= #39 platform 側)" \
+  --body "## Summary
+
+Phase 7-0 Component C platform side = Cilium Gateway hostNetwork mode + 新 ALB IngressGroup 'application'。 panicboat architecture spec への re-align、 cilium-gateway NLB 削除 + ALB IngressGroup 経由 internet 公開。
+
+## Changes
+
+- \`kubernetes/components/cilium/production/values.yaml.gotmpl\`: \`gatewayAPI.hostNetwork.enabled: true\`
+- \`kubernetes/components/cilium/production/kustomization/cilium-gateway.yaml\`: listener port 80 → 8080
+- 新 \`kubernetes/components/cilium/production/kustomization/application-ingress.yaml\`: ALB Ingress、 IngressGroup application、 backend cilium-gateway:8080
+- \`kubernetes/components/cilium/production/kustomization/kustomization.yaml\`: application-ingress.yaml 追加
+
+## Validation
+
+- cilium-gateway-cilium-gateway Service ClusterIP 化
+- cilium-envoy host port 8080 listen
+- 旧 cilium-gateway NLB auto-delete
+- 新 ALB provision active + target healthy
+- ExternalDNS で develop.panicboat.net Route53 record auto-create
+- application traffic 継続 (= curl HTTPS 200、 旧 reverse-proxy 経路は monorepo PR merge 後に廃止)
+
+## Post-merge
+
+monorepo PR (= reverse-proxy 廃止 + frontend HTTPRoute) と並行 merge で旧経路廃止 + 新経路 (= ALB → Cilium Gateway → frontend) 確立。
+
+## Related
+
+- Phase 7-0 spec Component C
+- 引き継ぎ #39 / #40 解消"
+```
+
+---
+
+## Task 4: #39 monorepo side (= reverse-proxy 削除 + frontend HTTPRoute)
+
+**Files:**
+- Delete: `services/reverse-proxy/` (= 全 directory recursive)
+- Create: `services/frontend/kubernetes/base/httproute.yaml`
+- Modify: `services/frontend/kubernetes/base/kustomization.yaml` (= httproute.yaml 追加)
+
+**Test:** Flux reconcile で reverse-proxy Pod / Service / NLB auto-delete + frontend HTTPRoute provision + Cilium Gateway → frontend routing 確立 + curl https で 200 OK。
+
+**Dependency:** Task 3 完了 + PR 3 merge + cluster で ALB IngressGroup + Cilium Gateway hostNetwork 動作確認済。
+
+- [ ] **Step 1: monorepo worktree setup (= 別 repo)**
+
+```bash
+cd /Users/takanokenichi/GitHub/panicboat/monorepo
+git fetch origin main
+git checkout main
+git pull origin main
+git checkout -b claude/eks-phase-7-0-reverse-proxy-removal
+```
+
+- [ ] **Step 2: reverse-proxy directory 削除**
+
+```bash
+cd /Users/takanokenichi/GitHub/panicboat/monorepo
+rm -rf services/reverse-proxy/
+```
+
+- [ ] **Step 3: frontend HTTPRoute 新規作成**
+
+Create `services/frontend/kubernetes/base/httproute.yaml`:
+
+```yaml
+# =============================================================================
+# Frontend HTTPRoute (= Cilium Gateway 経由 develop.panicboat.net routing)
+# =============================================================================
+# Cilium Gateway (= namespace default、 listener http:8080) を parentRef、
+# host develop.panicboat.net への traffic を frontend Service:80 に backend
+# する。 ingress 経路: client → ALB (= application IngressGroup、 platform 側
+# kubernetes/components/cilium/) → cilium-gateway hostNetwork :8080 → 本
+# HTTPRoute → frontend。
+# =============================================================================
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: frontend
+  namespace: default
+spec:
+  parentRefs:
+    - name: cilium-gateway
+      namespace: default
+  hostnames:
+    - develop.panicboat.net
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: frontend
+          port: 80
+```
+
+- [ ] **Step 4: frontend kustomization.yaml に httproute.yaml 追加**
+
+`services/frontend/kubernetes/base/kustomization.yaml` を edit:
+
+```yaml
+# Before (例):
+resources:
+  - service.yaml
+  - deployment.yaml
+  # ... 他 frontend resources ...
+
+# After (= httproute.yaml 追加):
+resources:
+  - service.yaml
+  - deployment.yaml
+  - httproute.yaml  # 追加
+  # ... 他 frontend resources ...
+```
+
+- [ ] **Step 5: local kustomize build で確認**
+
+```bash
+cd /Users/takanokenichi/GitHub/panicboat/monorepo
+kustomize build services/frontend/kubernetes/overlays/develop 2>&1 | grep -B2 -A20 "kind: HTTPRoute" | head -30
+```
+
+Expected: HTTPRoute frontend が render される (= hostname develop.panicboat.net、 backend frontend:80)
+
+```bash
+# reverse-proxy 関連 reference が monorepo に残存していないか確認
+grep -rn "reverse-proxy" services/ 2>&1 | grep -v "\.kustomization-cache" | head -10
+```
+
+Expected: 0 hits (= 全 reference 削除済)
+
+- [ ] **Step 6: commit + push + PR 作成**
+
+```bash
+cd /Users/takanokenichi/GitHub/panicboat/monorepo
+git add -A services/reverse-proxy/ services/frontend/kubernetes/base/
+
+git commit -s -m "feat: reverse-proxy 廃止 + frontend HTTPRoute (= Cilium Gateway 経由 direct routing)
+
+Phase 7-0 Component C monorepo side。 platform 側 PR (= Cilium Gateway
+hostNetwork mode + ALB IngressGroup) と並行で reverse-proxy nginx を廃止、
+frontend を Cilium Gateway HTTPRoute backend に直接 register。
+
+Architecture (= after this PR + platform PR):
+  client (internet)
+    → ALB (= application IngressGroup、 ACM TLS termination 443)
+    → cilium-gateway hostNetwork :8080
+    → Cilium Gateway (= Envoy)
+    → HTTPRoute frontend (= 本 PR)
+    → frontend Service:80
+
+Changes:
+- services/reverse-proxy/ 全 directory 削除 (= service / deployment /
+  configmap / httproute / kustomization)
+- services/frontend/kubernetes/base/httproute.yaml 新規作成 (= parentRef
+  cilium-gateway、 hostname develop.panicboat.net、 backend frontend:80)
+
+Architecture impact:
+- monthly cost ~\$31 削減 (= reverse-proxy NLB 削除)
+- nginx custom config maintenance 不要
+- ingress L7 visibility 復活 (= Hubble flow observe で Gateway 経由
+  HTTP traffic 観測可能化)
+
+Validation (= post-merge):
+- reverse-proxy Pod / Service auto-delete (= Flux prune)
+- 旧 reverse-proxy NLB auto-delete
+- ExternalDNS で 旧 NLB hostname の Route53 record cleanup
+- curl https://develop.panicboat.net/ HTTP 200 (= ALB 経由 routing)"
+
+git push -u origin HEAD
+
+gh pr create --draft --base main --head claude/eks-phase-7-0-reverse-proxy-removal \
+  --title "feat: reverse-proxy 廃止 + frontend HTTPRoute (= Phase 7-0 #39 monorepo 側)" \
+  --body "## Summary
+
+Phase 7-0 Component C monorepo side = reverse-proxy nginx 廃止 + frontend HTTPRoute 新規追加 (= Cilium Gateway 経由 direct routing)。
+
+## Changes
+
+- \`services/reverse-proxy/\` 全 directory 削除
+- \`services/frontend/kubernetes/base/httproute.yaml\` 新規 (= parentRef cilium-gateway、 hostname develop.panicboat.net、 backend frontend:80)
+- \`services/frontend/kubernetes/base/kustomization.yaml\`: httproute.yaml 追加
+
+## Architecture (= after merge)
+
+\`\`\`
+client (= internet)
+  → ALB (= application IngressGroup、 ACM TLS termination 443、 platform PR で deploy)
+  → cilium-gateway hostNetwork :8080
+  → Cilium Gateway (= Envoy)
+  → HTTPRoute frontend (= 本 PR)
+  → frontend Service:80
+\`\`\`
+
+## Cost / impact
+
+- monthly cost ~\$31 削減 (= reverse-proxy NLB 削除)
+- nginx custom config maintenance 不要
+- ingress L7 hubble visibility 復活
+
+## Post-merge validation
+
+- reverse-proxy resources auto-delete (= Flux prune)
+- 旧 reverse-proxy NLB auto-delete
+- ExternalDNS で旧 NLB hostname Route53 record cleanup
+- curl https://develop.panicboat.net/ 200 OK (= ALB 経由 routing)
+
+## Related
+
+- Phase 7-0 spec Component C
+- companion PR: panicboat/platform Phase 7-0 platform 側 (= ALB IngressGroup + Cilium Gateway hostNetwork)"
+```
+
+- [ ] **Step 7: post-merge cluster validate (= user merge 後)**
+
+```bash
+source /tmp/awsenv.sh
+# Flux reconcile (= 必要時 trigger)
+flux reconcile source git monorepo -n flux-system
+flux reconcile kustomization frontend -n flux-system
+
+sleep 60
+
+# reverse-proxy 削除確認
+kubectl get all -n default -l app=reverse-proxy
+# Expected: No resources found
+
+# frontend HTTPRoute provision 確認
+kubectl get httproute -n default frontend -o jsonpath='{.status.parents[0].conditions[?(@.type=="Accepted")].status}'
+# Expected: True
+
+# DNS 切替確認
+dig +short develop.panicboat.net @1.1.1.1 | head -3
+# Expected: ALB IPs (= 旧 reverse-proxy NLB IPs から switch)
+
+# HTTPS access 確認
+curl -sI --max-time 15 https://develop.panicboat.net/ 2>&1 | head -3
+# Expected: HTTP/1.1 200 OK (= ALB → Cilium Gateway → frontend で routing 成功)
+```
+
+- [ ] **Step 8: 旧 reverse-proxy NLB auto-delete 確認**
+
+```bash
+unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_SESSION_TOKEN
+sleep 120  # = AWS LB Controller の finalizer cleanup 待ち
+aws elbv2 describe-load-balancers --region ap-northeast-1 --output text \
+  --query 'LoadBalancers[?contains(LoadBalancerName, `reversep`) || contains(LoadBalancerName, `reverse`)].[LoadBalancerName,State.Code]'
+```
+
+Expected: empty (= 旧 reverse-proxy NLB auto-delete 完了)
+
+```bash
+# cost ~$79 削減 verify (= cilium-gateway NLB + reverse-proxy NLB 両方削除)
+aws elbv2 describe-load-balancers --region ap-northeast-1 --output text \
+  --query 'LoadBalancers[*].[LoadBalancerName,Type,Scheme]'
+```
+
+Expected output: monitoring-uis ALB + application ALB のみ (= 2 LB)、 NLB は 0 件 (= classic ELB / cilium-gateway NLB / reverse-proxy NLB すべて削除済)
+
+---
+
+## Task 5 (= fallback、 #39 fail 時のみ): cilium revert + #40 bridge revival
+
+**Trigger:** Task 3 Step 7 / 8 / 10 / 11 のいずれかで fail (= Service が LoadBalancer 維持 / cilium-envoy port 8080 未 listen / 旧 NLB delete 失敗 / ALB target unhealthy)。
+
+**Files:**
+- Revert: `kubernetes/components/cilium/production/values.yaml.gotmpl` (= hostNetwork.enabled false)
+- Revert: `kubernetes/components/cilium/production/kustomization/cilium-gateway.yaml` (= port 80)
+- Delete: `kubernetes/components/cilium/production/kustomization/application-ingress.yaml`
+- Modify: `kubernetes/components/cilium/production/kustomization/kustomization.yaml` (= application-ingress.yaml 削除)
+- Modify: `kubernetes/components/aws-load-balancer-controller/production/values.yaml.gotmpl` (= `loadBalancerClass: service.k8s.aws/nlb` default 設定)
+- Hydrate: `kubernetes/manifests/production/cilium/` + `kubernetes/manifests/production/aws-load-balancer-controller/`
+
+**Test:** cluster recover (= cilium-gateway-cilium-gateway Service が type=LoadBalancer に復活 + NLB provision + 旧 reverse-proxy 経路 functional) + classic ELB recreate cycle 防止 (= #40 effect)。
+
+- [ ] **Step 1: cilium revert (= Component C platform side 取り消し)**
+
+```bash
+cd /Users/takanokenichi/GitHub/panicboat/platform/.claude/worktrees/eks-phase-7-0-lb-hardening
+git checkout kubernetes/components/cilium/production/values.yaml.gotmpl
+git checkout kubernetes/components/cilium/production/kustomization/cilium-gateway.yaml
+rm kubernetes/components/cilium/production/kustomization/application-ingress.yaml
+git checkout kubernetes/components/cilium/production/kustomization/kustomization.yaml
+```
+
+- [ ] **Step 2: AWS LB Controller values で `loadBalancerClass` default 設定**
+
+`kubernetes/components/aws-load-balancer-controller/production/values.yaml.gotmpl` を edit:
+
+```yaml
+# 追加 (= 既 values に append):
+# =============================================================================
+# Default loadBalancerClass for type=LoadBalancer Services without annotation
+# =============================================================================
+# loadBalancerClass annotation 不在の Service (= Cilium operator auto-create
+# 等) を in-tree Cloud Provider が pick up + classic ELB recreate する drift
+# を防止。 全 type=LoadBalancer Service が AWS LB Controller 経由 NLB 化、
+# Cloud Provider 経路を closed。
+# https://kubernetes-sigs.github.io/aws-load-balancer-controller/v2.8/deploy/configurations/#loadbalancerclass
+loadBalancerClass: service.k8s.aws/nlb
+```
+
+- [ ] **Step 3: hydrate**
+
+```bash
+bash scripts/kubernetes-hydrate/hydrate-component.sh cilium production 2>&1 | tail -3
+bash scripts/kubernetes-hydrate/hydrate-component.sh aws-load-balancer-controller production 2>&1 | tail -3
+```
+
+- [ ] **Step 4: Flux suspend + ローカル apply (= cilium revert + AWS LB Controller config update)**
+
+```bash
+source /tmp/awsenv.sh
+flux suspend kustomization flux-system -n flux-system
+
+# cilium revert apply
+kubectl apply -k kubernetes/manifests/production/cilium/ --server-side --force-conflicts 2>&1 | tail -10
+
+# AWS LB Controller values 反映 (= helm chart 経由)
+kubectl apply -k kubernetes/manifests/production/aws-load-balancer-controller/ --server-side --force-conflicts 2>&1 | tail -10
+
+# cilium / cilium-envoy / cilium-operator restart (= hostNetwork OFF + LoadBalancer mode 復活 trigger)
+kubectl rollout restart -n kube-system deploy/cilium-operator ds/cilium ds/cilium-envoy
+kubectl rollout status -n kube-system ds/cilium-envoy --timeout=180s
+kubectl rollout status -n kube-system ds/cilium --timeout=180s
+kubectl rollout status -n kube-system deploy/cilium-operator --timeout=120s
+
+# AWS LB Controller restart (= default loadBalancerClass 設定反映)
+kubectl rollout restart -n kube-system deploy/aws-load-balancer-controller
+kubectl rollout status -n kube-system deploy/aws-load-balancer-controller --timeout=180s
+```
+
+- [ ] **Step 5: 既 orphan classic ELB delete**
+
+```bash
+unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_SESSION_TOKEN
+
+# classic ELB list 確認
+aws elb describe-load-balancers --region ap-northeast-1 --output text \
+  --query 'LoadBalancerDescriptions[*].[LoadBalancerName,CreatedTime]'
+
+# 該当 classic ELB delete (= cluster prefix 含むもの)
+CLASSIC_ELB=$(aws elb describe-load-balancers --region ap-northeast-1 --output text --query 'LoadBalancerDescriptions[*].LoadBalancerName' | head -1)
+if [ -n "$CLASSIC_ELB" ]; then
+  aws elb delete-load-balancer --region ap-northeast-1 --load-balancer-name "$CLASSIC_ELB"
+  sleep 60
+  echo "verify after delete:"
+  aws elb describe-load-balancers --region ap-northeast-1 --output text --query 'LoadBalancerDescriptions[*].[LoadBalancerName]'
+fi
+```
+
+Expected (= verify after delete): empty (= classic ELB 削除完了 + default loadBalancerClass で 再 provision 防止)
+
+- [ ] **Step 6: cilium-gateway-cilium-gateway Service が type=LoadBalancer に復活 + 新 NLB provision 観測**
+
+```bash
+source /tmp/awsenv.sh
+sleep 120  # = AWS LB Controller の NLB provision 通常 ~5-10 min
+kubectl get svc -n default cilium-gateway-cilium-gateway
+```
+
+Expected: `TYPE: LoadBalancer`、 `EXTERNAL-IP: <NLB hostname>`、 `PORT(S): 80:XXXX/TCP`
+
+- [ ] **Step 7: 旧 reverse-proxy 経路 functional 維持確認**
+
+```bash
+curl -sI --max-time 10 --resolve develop.panicboat.net:443:$(dig +short k8s-default-reversep-4c0b605be5-41367d3702a18720.elb.ap-northeast-1.amazonaws.com @1.1.1.1 | head -1) https://develop.panicboat.net/ 2>&1 | head -3
+```
+
+Expected: `HTTP/1.1 200 OK` (= 旧 reverse-proxy NLB 経由 internet 公開維持)
+
+- [ ] **Step 8: Flux resume + commit + push + PR 作成 (= fallback PR)**
+
+```bash
+source /tmp/awsenv.sh
+flux resume kustomization flux-system -n flux-system
+flux reconcile kustomization flux-system -n flux-system
+
+cd /Users/takanokenichi/GitHub/panicboat/platform/.claude/worktrees/eks-phase-7-0-lb-hardening
+git add kubernetes/components/aws-load-balancer-controller/production/values.yaml.gotmpl \
+        kubernetes/manifests/production/aws-load-balancer-controller/
+# 注: cilium revert は git restore で working tree が clean (= commit 対象外)
+
+git commit -s -m "fix(eks/aws-load-balancer-controller): default loadBalancerClass to service.k8s.aws/nlb (= classic ELB recreate 防止、 #40 bridge)
+
+Phase 7-0 Component C (= #39 Cilium Gateway hostNetwork mode + ALB IngressGroup
+migration) で Cilium 1.20 でも hostNetwork mode の CEC CR migration logic /
+LoadBalancer Service disable 動作が完遂しなかった、 cilium revert で 1.18.6
+LoadBalancer mode 復活。 #39 を Phase 8+ 引き継ぎ persist + partial completion
+として #40 bridge (= AWS LB Controller default loadBalancerClass 設定) を採用。
+
+Changes:
+- aws-load-balancer-controller values.yaml.gotmpl: loadBalancerClass:
+  service.k8s.aws/nlb default 設定追加
+- 効果: loadBalancerClass annotation 不在の Service (= Cilium operator
+  auto-create cilium-gateway-cilium-gateway 等) が AWS LB Controller 経由
+  NLB 化、 in-tree Cloud Provider が skip、 classic ELB recreate cycle 防止
+
+Architecture impact:
+- monthly cost ~\$10-20 削減 (= classic ELB のみ防止、 cilium-gateway NLB +
+  reverse-proxy NLB ~\$79 削減は Phase 8+ 再試行で持ち越し)
+- panicboat architecture spec ('north-south は ALB Controller、 east-west は
+  cilium-gateway') の partial 達成、 classic ELB drift のみ解消
+
+Validation:
+- 既 orphan classic ELB delete + 再 provision 防止確認
+- cilium-gateway-cilium-gateway Service LoadBalancer mode 復活確認
+- 旧 reverse-proxy 経路 functional 維持 (= curl HTTPS 200)"
+
+git push origin HEAD
+
+gh pr create --draft --base main --head claude/eks-phase-7-0-lb-hardening \
+  --title "fix(eks): AWS LB Controller default loadBalancerClass (= Phase 7-0 #40 bridge fallback)" \
+  --body "## Summary
+
+Phase 7-0 Component C (= #39 migration) が Cilium 1.20 upgrade 後も hostNetwork mode で fail、 cilium revert + partial completion path として #40 bridge (= AWS LB Controller default loadBalancerClass 設定) を採用。
+
+## Changes
+
+\`kubernetes/components/aws-load-balancer-controller/production/values.yaml.gotmpl\` に \`loadBalancerClass: service.k8s.aws/nlb\` default 追加。
+
+## Effect
+
+- loadBalancerClass annotation 不在 Service (= cilium-gateway 等) が AWS LB Controller 経由 NLB 化、 in-tree Cloud Provider skip → classic ELB recreate cycle 防止
+- cost ~\$10-20 削減 (= classic ELB のみ防止)
+- cilium-gateway NLB + reverse-proxy NLB ~\$79 削減は Phase 8+ 引き継ぎ持ち越し (= 別 Cilium version or 別 approach で #39 再試行)
+
+## Validation
+
+- 既 orphan classic ELB delete 完了 + 再 provision されない確認
+- cilium-gateway-cilium-gateway Service LoadBalancer mode 復活
+- application traffic 維持 (= 旧 reverse-proxy NLB 経由 curl HTTPS 200)
+
+## Phase 7-0 partial completion
+
+#37 fix + Cilium upgrade + #40 bridge で 7-0 closure。 #39 は Phase 8+ 引き継ぎ。"
+```
+
+---
+
+## Task 6: cluster validate + closure
+
+**Files:** (= none、 documentation + observation のみ)
+
+**Test:** spec Section 9 Validation checklist の全 item pass。
+
+- [ ] **Step 1: spec validation checklist 全 verify (= success / fallback いずれの path も)**
+
+success path (= #39 success、 Task 4 まで完了):
+
+```bash
+source /tmp/awsenv.sh
+
+# #37 fix verify
+kubectl logs -n kube-system deploy/aws-load-balancer-controller --since=2m 2>&1 | grep -c "expected exactly one securityGroup"
+# Expected: 0
+
+# Cilium upgrade verify
+cilium status 2>&1 | grep -i version
+# Expected: 1.20.5
+
+# #39 migration verify
+dig +short develop.panicboat.net @1.1.1.1 | head -3
+curl -sI --max-time 10 https://develop.panicboat.net/ 2>&1 | head -3
+# Expected: ALB IPs + HTTP 200 OK
+
+# 旧 NLB auto-delete verify
+unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_SESSION_TOKEN
+aws elbv2 describe-load-balancers --region ap-northeast-1 --output text \
+  --query 'LoadBalancers[?Type==`network`].[LoadBalancerName,State.Code]'
+# Expected: empty (= NLB 0 件)
+
+# Hubble L7 ingress flow visualize (= 新規 functionality)
+source /tmp/awsenv.sh
+CILIUM_POD=$(kubectl get po -n kube-system -l k8s-app=cilium -o name | head -1 | sed 's|pod/||')
+kubectl exec -n kube-system $CILIUM_POD -- hubble observe --to-port 8080 --since 5m --output compact 2>&1 | head -5
+# Expected: HTTP flow observation (= cilium-gateway 経由 traffic 可視化)
+```
+
+fallback path (= #39 fail、 Task 5 まで):
+
+```bash
+# classic ELB recreate 防止 verify
+unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_SESSION_TOKEN
+aws elb describe-load-balancers --region ap-northeast-1 --output text \
+  --query 'LoadBalancerDescriptions[*].[LoadBalancerName]'
+# Expected: empty (= classic ELB 0 件、 default loadBalancerClass で再 provision 防止)
+
+# 旧 reverse-proxy 経路 functional 維持
+source /tmp/awsenv.sh
+curl -sI --max-time 10 https://develop.panicboat.net/ 2>&1 | head -3
+# Expected: HTTP 200 OK
+```
+
+- [ ] **Step 2: 引き継ぎ事項 update (= 別 PR で Phase 6 closure doc に反映)**
+
+success path: #37 / #39 / #40 全 解消 (= Phase 7-0 で完了)
+fallback path: #37 解消 / #40 解消 / **#39 を Phase 8+ 引き継ぎ persist** (= 別 Cilium version or 別 approach で再試行)
+
+Phase 6 closure doc の Section 4 を update する別 PR (= docs only PR):
+```bash
+# 別 worktree で進める (= 別 PR scope)
+# 内容:
+# - #37 解消 (= Phase 7-0 PR 1)
+# - #39 解消 (= Phase 7-0 PR 3+4) OR Phase 8+ 持ち越し (= fallback path)
+# - #40 内包解消 OR 独立解消 (= fallback path で別 PR 採用)
+# - 7-0 で確立した patterns + lessons aggregate
+```
+
+注: docs update は Phase 7-0 closure 一環、 ただし plan の scope を 4 PR + fallback に絞るため Task 6 では別 PR 化を指示のみ。
+
+- [ ] **Step 3: Phase 7-1 OTel Operator upgrade brainstorming に進む**
+
+7-0 closure 後、 Phase 7-1 (= OTel Operator chart 0.155+ upgrade + monolith env vars hardcode 撤去 + inject-ruby annotation 復活) brainstorming session 起動。
+
+---
+
+## Plan summary
+
+| Task | PR | Cluster impact | Estimated time |
+|---|---|---|---|
+| 1. #37 fix (= terragrunt eks node SG tag) | platform PR 1 | 0 (= in-place tag update) | 30-60 min |
+| 2. Cilium upgrade (= 1.18.6 → 1.20.5) | platform PR 2 | ~5-10 min DaemonSet rollout | 1-2 h (= 公式 docs 確認含む) |
+| 3. #39 platform side (= hostNetwork + Gateway port 8080 + ALB Ingress) | platform PR 3 | ~5-10 min (= Cilium rollout + 旧 NLB delete + ALB provision) | 1-2 h |
+| 4. #39 monorepo side (= reverse-proxy 削除 + frontend HTTPRoute) | monorepo PR 4 | ~2-5 min (= Flux prune + Route53 切替) | 30 min |
+| 5. fallback (= #39 fail 時) | platform PR F1 | ~5 min (= cilium revert + AWS LB Controller restart) | 1 h |
+| 6. cluster validate + closure | - (= docs only 別 PR) | 0 | 30 min |
+
+**Total**: 3-5 h (= strict completion 成功 case)、 fallback 含む と 4-6 h
+
+**Critical path**: Task 1 → Task 2 → Task 3 sequential、 Task 4 は Task 3 cluster validate 後。 fallback (= Task 5) は Task 3 fail 時のみ trigger。
+
+**PR merge 順序**:
+1. PR 1 merge (= #37 fix) → cluster で AWS LB Controller panic loop 停止確認
+2. PR 2 merge (= Cilium upgrade) → Theme B fix forward regression なし確認
+3. PR 3 merge (= #39 platform) → ALB provision active + 旧 cilium-gateway NLB auto-delete 確認
+4. PR 4 merge (= #39 monorepo) → reverse-proxy 削除 + 旧 reverse-proxy NLB auto-delete + curl HTTPS 200 確認
+5. (= 必要時) PR F1 merge (= fallback path)

--- a/docs/superpowers/specs/2026-05-14-eks-phase-7-0-lb-hardening-design.md
+++ b/docs/superpowers/specs/2026-05-14-eks-phase-7-0-lb-hardening-design.md
@@ -1,0 +1,394 @@
+# EKS Production Phase 7-0: LB Hardening (= AWS LB Controller SG 重複 fix + Cilium upgrade + Cilium Gateway hostNetwork mode + ALB IngressGroup migration)
+
+> **Phase**: roadmap Phase 7 (= Multi-environment + release process foundation) の **第 0 sub-project (= LB hardening prerequisite)**
+>
+> **Nature**: cluster LB architecture re-org、 panicboat の architecture spec (= "north-south は ALB Controller、 east-west は cilium-gateway") に LB layer を整合、 multi-env active 化 (= 引き継ぎ #29 / #33) の LB provision blocking 解消
+>
+> **Goal**: Phase 6 closure で identify した 引き継ぎ事項 **#37 / #39** を 1 sub-project で systematic 解消。 #37 (= AWS LB Controller SG 重複 panic loop) で multi-env LB provision blocking 解消、 #39 (= Cilium Gateway hostNetwork mode + ALB IngressGroup migration) で reverse-proxy 廃止 + monthly ~$79 cost 削減 + architectural drift 解消 + Gateway 層 JWT validation 採用余地確保。
+
+---
+
+## 1. Phase 7-0 overview
+
+### Phase 7-0 goal
+
+panicboat current の LB architecture は 3 NLB 並立 (= reverse-proxy NLB + cilium-gateway NLB + monitoring-uis ALB) + classic ELB recreate cycle = architectural drift。 これを panicboat 設計 spec (= "north-south は ALB Controller、 east-west は cilium-gateway") に re-align、 1 ALB (= application IngressGroup) + Cilium Gateway hostNetwork mode で完結。
+
+### Sub-project scope + 順序
+
+1. **#37 fix** (= AWS LB Controller SG 重複 reconcile error 解消、 multi-env LB provision の prerequisite)
+2. **Cilium upgrade** (= 1.18.6 → 1.19+ / 1.20+、 hostNetwork mode 改善期待)
+3. **#39 migration** (= Cilium Gateway hostNetwork mode + ALB IngressGroup + reverse-proxy 廃止)
+4. **Fallback** (= #39 fail 時 #40 bridge revival + 7-0 partial completion)
+
+### 完了条件 (= "(c) panicboat の PR 手戻り最小化 + best effort + partial fallback")
+
+- **strict completion**: #37 fix + #39 success
+  - reverse-proxy 廃止 + cilium-gateway NLB 削除 + ALB IngressGroup 経由 develop.panicboat.net 公開 + Cilium Gateway 経由 全 ingress traffic + Gateway 層 JWT validation 余地確保
+  - monthly cost ~$79 削減
+- **partial completion** (= #39 fail 時): #37 fix + Cilium upgrade + #40 bridge revival
+  - classic ELB recreate cycle 防止 + monthly cost ~$10-20 削減
+  - reverse-proxy 構成維持、 #39 を Phase 8+ 引き継ぎに persist
+
+### 作業中の cluster impact 許容
+
+- cluster traffic 一時停止 OK (= maintenance window 設定不要、 user 許容)
+- AWS resource cost 増は **NG** (= 試行錯誤で LB / RDS / etc を作りっぱなしにしない)
+- 試行錯誤 / revert / retry を許容
+
+---
+
+## 2. 7-0 scope (= 3 components + 1 fallback)
+
+### Component A: #37 AWS LB Controller SG 重複 fix
+
+#### 現状
+
+`aws/eks/modules/main.tf` (= terraform-aws-modules/eks/aws v21.20.0 経由) で **node SG** が `kubernetes.io/cluster/eks-production: owned` tag を持つ (= 直近 PR #355-#358 の module update で追加)。 EKS cluster SG (= `eks-cluster-sg-...`) と 2 重 tag、 AWS LB Controller の "1 SG expectation" で panic loop。
+
+panic log:
+```
+"expected exactly one securityGroup tagged with kubernetes.io/cluster/eks-production for eni eni-..., got: [sg-06a911469ce77dc76 sg-0c5888ca990469b88]"
+```
+
+影響: 既 register 済 LB target は healthy 維持、 ただし **新規 LoadBalancer / Ingress 作成で reconcile fail** (= 例: #39 で新規 ALB Ingress 作成必要、 そこで blocking)。
+
+#### 修正方針
+
+terragrunt eks module の `node_security_group_tags` variable (= module spec 次第、 implementation で actual variable structure 確認) で cluster tag override / 除去。 EKS cluster SG のみが cluster tag を維持 → AWS LB Controller の SG identification が 1 SG に確定。
+
+option (= module variable 仕様による、 implementation で確定):
+- (a) `node_security_group_tags = {}` (= 全 default tag 除去、 影響範囲広い、 risk あり)
+- (b) cluster tag のみ override 削除 (= 最小変更、 推奨)
+
+#### 影響評価
+
+| 利用 system | cluster tag 利用? | 影響 |
+|---|---|---|
+| AWS LB Controller | ✓ (= panic 原因) | tag 除去で 正常化 |
+| EBS CSI driver | ✗ (= IRSA 経由 IAM) | 影響なし |
+| VPC CNI | ✗ (= ENI tag 別 axis) | 影響なし |
+| Karpenter | ✗ (= cluster identification は別 tag + annotation) | 影響なし |
+
+#### Validation
+
+- `terragrunt plan` で **diff = node SG の tag 1 個除去のみ** 確認 (= no resource recreation、 in-place tag update)
+- apply 後 AWS LB Controller log で panic loop 停止確認
+- 新規 test LoadBalancer Service / Ingress 作成で TargetGroupBinding reconcile success 確認
+
+#### Risk + mitigation
+
+- **risk**: `node_security_group_tags` variable で cluster tag を override できない module 仕様の可能性 (= module-internal hardcoded tag)
+- **mitigation**: 確認後 override 不可なら module を fork / inline copy で対処、 もしくは AWS CLI で manual tag 削除 + terragrunt state 整合性確保
+
+### Component B: Cilium upgrade (= 1.18.6 → 1.19+ / 1.20+)
+
+#### 現状
+
+Cilium 1.18.6 (= Phase 4-1 deploy)。 panicboat 設定:
+- chaining mode (= aws-cni 経由 IPAM / datapath、 Cilium は L7 / policy / observability 担当)
+- Gateway API enabled
+- L7 Proxy 独立 DaemonSet (= cilium-envoy)
+- socketLB + Hubble + dnsProxy + Prometheus + ServiceMonitor
+
+#### Upgrade target
+
+**1.19.x or 1.20.x** (= 公式 release notes で hostNetwork mode の CEC CR migration logic 改善が含まれた earliest version を implementation 段階で確定)。 panicboat の "minimal change" 原則で earliest version 優先。
+
+#### Upgrade 戦略
+
+1. **helmfile.yaml で chart version bump** (= 1.18.6 → 1.19.x / 1.20.x)
+2. **values.yaml.gotmpl で compatibility 確認**: deprecated values 確認 + migration (= 例: `attributes.kubernetes.enable` の syntax 変更可能性、 helm values の rename / removal)
+3. **CRD update**: `cilium-cli` or `kubectl apply` で新 version の CRDs (= CiliumEnvoyConfig / Gateway API extension / etc) install
+4. **pre-flight check**: cluster health snapshot (= Pod / Service / CRD 全 list + 既 fix forward state 記録、 fail 時 reapply 用)
+5. **DaemonSet rollout**: cilium-operator → cilium-envoy → cilium の順序 (= ordered)、 panicboat 4 nodes で sequential ~2-3 min cluster traffic 一時停止
+6. **post-upgrade smoke test**: 既 fix forward (= Beyla attributes.select / Prometheus nameValidationScheme / Theme B 全般) regression 確認
+
+#### Breaking change 想定 risk
+
+| 影響範囲 | risk | mitigation |
+|---|---|---|
+| helm values rename / removal | medium (= 例: `attributes.*` の syntax 変更) | implementation で公式 upgrade guide 精読、 deprecated values list を check |
+| CRD structure 変更 | medium (= 例: CiliumEnvoyConfig listener field 変更で 既 deploy CEC への影響) | pre-flight で 既 CEC CR state snapshot、 必要なら delete → recreate |
+| Phase 6-3 Theme B fix forward への regression | low-medium (= Beyla / Prometheus 設定は cilium core と独立、 ただし cilium-envoy 経由 OTLP export 経路で間接影響) | post-upgrade で Mimir reject rate / Tempo trace 流入 / Beyla `/metrics` content を Theme B fix forward と同 method で再 verify |
+| chaining mode + socketLB | low (= 1.18 → 1.19 / 1.20 で chaining + socketLB 互換性 stable 想定) | post-upgrade で application pod-to-pod traffic 確認 (= frontend ↔ coredns 等 hubble observe) |
+
+#### Rollout 戦略 (= user 許容 cluster downtime 前提)
+
+- maintenance window 設定不要 (= 作業中 traffic 停止 OK)
+- pre-upgrade snapshot: cluster state full backup (= `kubectl get all -A -o yaml` 等)
+- chart upgrade `helmfile sync` で apply
+- DaemonSet rollout sequential、 各 node ~30s 一時停止
+- post-flight regression check (= Theme B fix forward + 13 checklist 再 validate)
+
+#### Fallback
+
+- chart upgrade で deploy error / cluster recover 不能 (= 例: CRD migration logic で stuck) なら **helmfile revert (= 1.18.6)** で復旧
+- CRD downgrade は backward compat 不確実 (= 1.20 で deploy した CRD resource を 1.18 で 解釈不可可能性)、 必要なら CRD resource 手動 delete + 1.18 で recreate
+- user 許容 cluster downtime で trial-and-error 進められる
+
+### Component C: #39 Cilium Gateway hostNetwork mode + ALB IngressGroup migration
+
+#### Architecture target
+
+```
+client (= internet)
+  → ALB (= application IngressGroup、 443 ACM TLS termination)
+  → cilium-gateway-cilium-gateway Service:8080 (= ClusterIP、 target-type=ip で hostNetwork Pod IPs = node IPs)
+  → Cilium Gateway (= Envoy on host port 8080)
+  → HTTPRoute (= frontend HTTPRoute、 parentRef cilium-gateway、 hostname develop.panicboat.net)
+  → frontend Service:80 (= ClusterIP、 直接 backend)
+```
+
+#### Platform side changes (= panicboat/platform)
+
+**1. `kubernetes/components/cilium/production/values.yaml.gotmpl`**:
+```yaml
+gatewayAPI:
+  enabled: true
+  hostNetwork:
+    enabled: true
+```
+
+**2. `kubernetes/components/cilium/production/kustomization/cilium-gateway.yaml`** (= listener port 80 → 8080):
+```yaml
+listeners:
+  - name: http
+    port: 8080
+    protocol: HTTP
+```
+
+理由:
+- eks-pod-identity-agent が hostNetwork で port 80 を占有 (= cluster validate で確認済)
+- 1024 未満特権 port 回避で NET_BIND_SERVICE capability 不要
+
+**3. 新 ALB Ingress** (= 場所: `kubernetes/components/cilium/production/kustomization/` 配下、 もしくは 新 `kubernetes/components/application-ingress/` component、 implementation で確定):
+
+```yaml
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: application
+  namespace: default
+  annotations:
+    alb.ingress.kubernetes.io/scheme: internet-facing
+    alb.ingress.kubernetes.io/listen-ports: '[{"HTTPS":443}]'
+    alb.ingress.kubernetes.io/group.name: application
+    alb.ingress.kubernetes.io/target-type: ip
+    alb.ingress.kubernetes.io/healthcheck-path: /
+    alb.ingress.kubernetes.io/healthcheck-port: traffic-port
+    alb.ingress.kubernetes.io/ssl-policy: ELBSecurityPolicy-TLS13-1-2-2021-06
+    alb.ingress.kubernetes.io/ssl-redirect: "443"
+    external-dns.alpha.kubernetes.io/hostname: develop.panicboat.net
+spec:
+  ingressClassName: alb
+  rules:
+    - host: develop.panicboat.net
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: cilium-gateway-cilium-gateway
+                port:
+                  number: 8080
+```
+
+panicboat の `monitoring-uis` IngressGroup pattern を踏襲 (= ACM cert auto-discovery で `*.panicboat.net` wildcard 自動 attach、 TLS 1.3 policy、 HTTP → HTTPS redirect)。
+
+#### Monorepo side changes (= panicboat/monorepo)
+
+**1. `services/reverse-proxy/` 全 directory 削除** (= service.yaml / deployment.yaml / httproute.yaml / config/conf.d/*.conf / kustomization.yaml)
+
+**2. `services/frontend/kubernetes/base/httproute.yaml` 新規**:
+```yaml
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: frontend
+  namespace: default
+spec:
+  parentRefs:
+    - name: cilium-gateway
+      namespace: default
+  hostnames:
+    - develop.panicboat.net
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: frontend
+          port: 80
+```
+
+#### Deploy 順序
+
+1. **platform PR merge** 先 (= cilium values + Gateway port 8080 + ALB Ingress)
+2. **ExternalDNS が新 ALB Ingress を pick up** → Route53 record を ALB hostname に切替 (= 旧 reverse-proxy NLB hostname と一時並立、 ExternalDNS TXT owner record で source 識別、 latest update が winner)
+3. **monorepo PR merge** (= reverse-proxy 削除 + frontend HTTPRoute 追加)
+4. **旧 reverse-proxy NLB + cilium-gateway NLB が auto-delete** (= Service / Pod 不在で AWS LB Controller cleanup)
+5. **ExternalDNS が旧 source TXT record cleanup**
+
+#### Validation
+
+- ALB provision active 確認
+- `dig develop.panicboat.net` で 新 ALB hostname resolve 確認
+- `curl https://develop.panicboat.net/` で 200 OK + TLS verify pass
+- 旧 NLB 2 個 auto-delete 確認 (= cost ~$79/month 削減 verify)
+- Hubble L7 flow visualize for ingress traffic (= 新規 functionality、 cilium-gateway 経由 traffic を hubble observe で 観測可、 architecture diagram 上の ingress L7 visibility 復活)
+
+### Fallback (= #39 fail 時 #40 bridge revival)
+
+#### Trigger 条件
+
+Cilium 1.19 / 1.20 upgrade 後でも:
+- hostNetwork mode の CEC CR migration logic 動作不能
+- ALB → cilium-envoy backend 不健全 (= target health check fail 持続)
+- 他 unexpected issue で migration 完遂不可
+
+#### Fallback path
+
+1. **platform side revert** (= cilium values の hostNetwork.enabled false に戻す、 cilium-gateway.yaml port 80 に戻す、 ALB Ingress 削除)
+2. **Cilium 1.18 へ downgrade** (= upgrade で発生した issue が原因なら) **or upgrade version 維持で hostNetwork 不採用継続**
+3. **#40 bridge revival** (= `kubernetes/components/aws-load-balancer-controller/production/values.yaml.gotmpl` に `loadBalancerClass: service.k8s.aws/nlb` default 設定追加)
+4. **reverse-proxy 構成維持** (= monorepo PR は 7-0 fail で merge せず、 reverse-proxy NLB 経由 internet 公開 持続)
+
+#### Fallback completion
+
+- cost 削減: ~$10-20/month (= classic ELB のみ防止、 ~$79 削減は未達)
+- #39 を **Phase 8+ 引き継ぎ** に persist (= 別 Cilium version で再試行 or 別 approach)
+- Phase 7-0 を partial completion で closure (= panic loop 解消 + Cilium upgrade + classic ELB cycle 防止)
+
+---
+
+## 3. PR structure
+
+### Platform PRs
+
+**PR 1: #37 fix (= terragrunt eks module node SG tag 除去)**
+
+Title: `fix(aws/eks): remove kubernetes.io/cluster/X tag from node SG (= AWS LB Controller SG 重複解消)`
+
+Scope:
+- `aws/eks/modules/main.tf` (= `node_security_group_tags` variable で cluster tag override 除去)
+- 必要なら `aws/eks/modules/variables.tf` (= variable 追加 / 修正)
+- `aws/eks/envs/production/terragrunt.hcl` (= inputs で値確定、 必要時)
+
+**PR 2: Cilium upgrade (= 1.18.6 → 1.19.x / 1.20.x)**
+
+Title: `chore(eks/cilium): upgrade Cilium 1.18.6 → 1.x.y (= hostNetwork mode 改善期待)`
+
+Scope:
+- `kubernetes/components/cilium/production/helmfile.yaml` (= chart version bump)
+- `kubernetes/components/cilium/production/values.yaml.gotmpl` (= deprecated values migration、 必要時)
+- hydrate
+
+**PR 3: #39 Cilium Gateway hostNetwork mode + ALB IngressGroup (= platform 側)**
+
+Title: `feat(eks): Cilium Gateway hostNetwork mode + ALB IngressGroup (= reverse-proxy 廃止経路確立)`
+
+Scope:
+- `kubernetes/components/cilium/production/values.yaml.gotmpl` (= `gatewayAPI.hostNetwork.enabled: true`)
+- `kubernetes/components/cilium/production/kustomization/cilium-gateway.yaml` (= listener port 80 → 8080)
+- 新 ALB Ingress yaml (= application IngressGroup、 場所は implementation で確定)
+- hydrate
+
+### Monorepo PR
+
+**PR 4: reverse-proxy 廃止 + frontend HTTPRoute**
+
+Title: `feat: reverse-proxy 廃止 + frontend HTTPRoute (= Cilium Gateway 経由 direct routing)`
+
+Scope:
+- `services/reverse-proxy/` 全 directory 削除
+- `services/frontend/kubernetes/base/httproute.yaml` 新規
+- `services/frontend/kubernetes/base/kustomization.yaml` (= httproute.yaml 追加)
+
+### Fallback PR (= #39 fail 時)
+
+**PR F1: cilium revert + #40 bridge (= 7-0 partial completion)**
+
+Title: `fix(eks): revert Cilium Gateway hostNetwork + AWS LB Controller default loadBalancerClass`
+
+Scope:
+- platform PR 3 の revert (= cilium values + cilium-gateway.yaml + ALB Ingress)
+- `kubernetes/components/aws-load-balancer-controller/production/values.yaml.gotmpl` で `loadBalancerClass: service.k8s.aws/nlb` default 設定
+- AWS Console / CLI で 既 orphan classic ELB delete
+
+---
+
+## 4. Phase 6 lessons applied
+
+- **5-1 L2 / 5-2 L1 (= post-flight regression check pattern)**: Cilium upgrade 後の既 fix forward (= Theme B Beyla / Prometheus 設定) regression check を post-flight で systematic 実施、 detection panicboat の 7 連続 validate pattern を 8 連続に extend
+- **6-3 (= Flux suspend + ローカル apply + 試行錯誤)**: #39 試行は cluster impact 大 (= cilium DaemonSet rollout)、 ただし user 許容 cluster downtime で trial-and-error 進められる、 panic 発生時 immediate revert path 確保
+- **6-3 Theme B (= root cause fix + best practice 採用)**: 雑対応 (= AWS LB Controller annotation で SG specify 等) を避け、 root cause (= node SG cluster tag 除去) で fix forward
+- **6-3 (= panicboat の "PR 手戻り最小化" 哲学)**: 7-0 完了条件を (c) (= partial fallback 許容) で確定、 panic 発生時 即 revert + 引き継ぎ持ち越しで 7-0 closure 可
+
+---
+
+## 5. 引き継ぎ事項解消
+
+| # | 項目 | 7-0 対応 |
+|---|---|---|
+| #37 | AWS LB Controller SG 重複 reconcile error | **解消** (= Component A) |
+| #39 | Cilium Gateway hostNetwork mode + ALB IngressGroup migration | **解消** (= Component C、 ただし fail 時 partial に persist) |
+| #40 | panicboat AWS LB Controller helm values で loadBalancerClass default 設定 | **内包解消** (= Component C success で副次解消)、 fail 時 fallback で必要部分のみ実施 |
+
+### 7-0 で新規追加引き継ぎ事項候補 (= 想定)
+
+- #39 fail 時、 別 Cilium version or 別 approach での再試行を **Phase 8+ 引き継ぎ** に persist
+- Cilium upgrade で発覚した想定外 regression が あれば fix forward PR + 引き継ぎ事項追加
+
+---
+
+## 6. Phase 8+ への bridge
+
+7-0 完了後、 Phase 7 の他 sub-projects (= 7-1 OTel Operator upgrade、 7-2 base / overlays re-org、 7-3 Pod Identity injection detection、 7-4 Platform consolidation) に進む。 加えて 7-0 で persist された #39 fail 残作業 (= 別 Cilium version 等での再試行) を Phase 8+ で systematic 検討。
+
+---
+
+## 7. Out of scope
+
+以下は対応しない (= 7-0 scope 外):
+
+- **#33 multi-env active 化** (= Phase 7-2 base / overlays re-org 完了後 + 別 sub-project)
+- **#5 post-flight check 自動化** (= "やりたいけど今じゃない")
+- **#10 OTel Collector exporter alias check 自動化** (= 同上)
+- **Cilium upgrade に伴う Theme B fix forward regression が発生した場合** (= 7-0 内 fix forward で対応、 ただし新規 framework 化は scope 外)
+- **dystopia.city 公開** (= #33 と統合、 Phase 7+)
+
+---
+
+## 8. Risks + mitigations
+
+| Risk | Mitigation |
+|---|---|
+| #37 fix で terraform-aws-modules/eks/aws v21.20.0 の `node_security_group_tags` variable が cluster tag override 不可な仕様 | implementation 段階で variable structure 確認、 override 不可なら module fork / AWS CLI manual + state 整合性確保 |
+| Cilium upgrade で既 fix forward への regression (= Beyla / Prometheus / Theme B 全般) | pre-flight で fix forward state snapshot、 post-upgrade で regression check + 即 fix forward PR |
+| Cilium upgrade で CRD downgrade 不能 (= 1.20 で deploy CRD を 1.18 で解釈不可) で chart revert 不能 | pre-upgrade で CRD resource snapshot、 必要なら CRD resource 手動 delete + 旧 version で recreate |
+| #39 試行で cilium-gateway-cilium-gateway Service が hostNetwork mode で ClusterIP 化されず LoadBalancer 維持 | classic ELB recreate cycle 発生、 即 revert + #40 bridge fallback |
+| ALB → cilium-envoy hostNetwork backend で target health check fail (= /  endpoint が cilium-envoy で responding しない) | healthcheck-path を `/` から `/healthz` 等の cilium-envoy 標準 endpoint に変更、 もしくは TCP health check に切替 |
+| Phase 7-0 全体完了に時間かかる場合 (= 試行錯誤 / fail / revert / retry chain) | (c) 完了条件で partial closure 可、 #39 fail 部分を Phase 8+ 引き継ぎに persist |
+
+---
+
+## 9. Validation checklist (= 7-0 完了条件)
+
+### strict completion (= #39 success 時)
+
+- [ ] #37 fix: AWS LB Controller log で panic loop 停止確認 + 新規 LB provision 復活確認
+- [ ] Cilium upgrade: cilium-cli `cilium status` で 1.19+ / 1.20+ 確認、 全 DaemonSet rollout success
+- [ ] 既 fix forward regression なし (= Mimir reject 0 件 / Beyla `/metrics` Theme B 設定 active / Prometheus nameValidationScheme legacy)
+- [ ] #39 migration: dig develop.panicboat.net で 新 ALB hostname resolve、 curl HTTPS 200 OK、 旧 NLB 2 個 auto-delete、 cost ~$79/month 削減 verify
+- [ ] Hubble L7 flow ingress visibility 確認 (= 新規 functionality、 cilium-gateway 経由 traffic を hubble observe で 観測可)
+
+### partial completion (= #39 fail 時)
+
+- [ ] #37 fix: panic loop 停止確認 + 新規 LB provision 復活
+- [ ] Cilium upgrade: success or skip (= 必要なら downgrade)
+- [ ] #40 bridge revival: AWS LB Controller default loadBalancerClass 設定 + 既 orphan classic ELB delete + cost ~$10-20/month 削減 verify
+- [ ] reverse-proxy 構成維持、 develop.panicboat.net 経由 internet 公開 functional
+- [ ] #39 を Phase 8+ 引き継ぎ事項として記録

--- a/kubernetes/components/cilium/production/helmfile.yaml
+++ b/kubernetes/components/cilium/production/helmfile.yaml
@@ -1,7 +1,7 @@
 # =============================================================================
 # Cilium Helmfile for production
 # =============================================================================
-# Cilium 1.18.x を chaining mode (VPC CNI 共存) で deploy する。
+# Cilium 1.19.x を chaining mode (VPC CNI 共存) で deploy する。
 # KPR / Gateway Controller / 独立 Envoy DaemonSet / Hubble を有効化。
 # k8sServiceHost は .Values.cluster.eksApiEndpoint で動的に差し込む。
 # =============================================================================
@@ -23,6 +23,6 @@ releases:
   - name: cilium
     namespace: kube-system
     chart: cilium/cilium
-    version: "1.18.6"
+    version: "1.19.4"
     values:
       - values.yaml.gotmpl

--- a/kubernetes/components/cilium/production/kustomization/application-gateway-service.yaml
+++ b/kubernetes/components/cilium/production/kustomization/application-gateway-service.yaml
@@ -1,0 +1,28 @@
+# =============================================================================
+# Service: application-gateway (= cilium-envoy hostNetwork backend pointer)
+# =============================================================================
+# Cilium 1.19.4 hostNetwork mode で cilium operator が auto-create する
+# cilium-gateway-cilium-gateway Service の EndpointSlice には dummy endpoint
+# (= 192.192.192.192:9999) が設定される (= LoadBalancer Service auto-create
+# 防止が cilium operator の intentional design)、 これは AWS LB Controller の
+# target-type=ip と incompatible。
+#
+# 本 Service は selector で cilium-envoy DaemonSet pod (= hostNetwork=true、
+# pod IP = node IP) を直接 target、 K8s controller-manager auto-generate の
+# EndpointSlice が node IP:8080 を populate、 ALB Ingress backend として
+# target-type=ip で healthy targets 確保。
+# =============================================================================
+apiVersion: v1
+kind: Service
+metadata:
+  name: application-gateway
+  namespace: kube-system
+spec:
+  type: ClusterIP
+  selector:
+    k8s-app: cilium-envoy
+  ports:
+    - name: http
+      port: 8080
+      targetPort: 8080
+      protocol: TCP

--- a/kubernetes/components/cilium/production/kustomization/application-gateway-service.yaml
+++ b/kubernetes/components/cilium/production/kustomization/application-gateway-service.yaml
@@ -19,6 +19,10 @@ metadata:
   namespace: kube-system
 spec:
   type: ClusterIP
+  # FALLBACK: k8s-app: cilium-envoy は Cilium chart 内部 label (= cilium-envoy
+  # DaemonSet の matchLabels)。 Cilium chart upgrade で label rename された場合、
+  # 本 Service の EndpointSlice が targets=0 で silent fail する risk。 Cilium
+  # upgrade 時は manifest の DaemonSet labels を verify、 必要時 selector 更新。
   selector:
     k8s-app: cilium-envoy
   ports:

--- a/kubernetes/components/cilium/production/kustomization/application-ingress.yaml
+++ b/kubernetes/components/cilium/production/kustomization/application-ingress.yaml
@@ -16,6 +16,9 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: application
+  # namespace は backend Service (= application-gateway) と同一が必須 (= K8s
+  # Ingress backend 仕様制約、 cross-namespace 不可)。 cilium-envoy DaemonSet
+  # が kube-system 配下のため Service 経由で本 Ingress も kube-system。
   namespace: kube-system
   annotations:
     alb.ingress.kubernetes.io/scheme: internet-facing

--- a/kubernetes/components/cilium/production/kustomization/application-ingress.yaml
+++ b/kubernetes/components/cilium/production/kustomization/application-ingress.yaml
@@ -1,0 +1,42 @@
+# =============================================================================
+# Ingress: application IngressGroup (= cilium-gateway hostNetwork backend)
+# =============================================================================
+# Cilium Gateway hostNetwork mode (= values.yaml.gotmpl gatewayAPI.hostNetwork.enabled)
+# で 全 node の host port 8080 に cilium-envoy が listen、 ALB がそれを backend
+# として target-type=ip で Pod IP (= node IP) に register。
+#
+# ACM cert auto-discovery: ALB Controller が wildcard cert *.panicboat.net を
+# 自動 attach (= Ingress.host が SAN match)。explicit certificate-arn annotation
+# 不要。
+#
+# external-dns annotation: hostname を Route53 record として auto-create
+# (= aws-load-balancer-controller / external-dns 連携)。
+# =============================================================================
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: application
+  namespace: default
+  annotations:
+    alb.ingress.kubernetes.io/scheme: internet-facing
+    alb.ingress.kubernetes.io/listen-ports: '[{"HTTPS":443}]'
+    alb.ingress.kubernetes.io/group.name: application
+    alb.ingress.kubernetes.io/target-type: ip
+    alb.ingress.kubernetes.io/healthcheck-path: /
+    alb.ingress.kubernetes.io/healthcheck-port: traffic-port
+    alb.ingress.kubernetes.io/ssl-policy: ELBSecurityPolicy-TLS13-1-2-2021-06
+    alb.ingress.kubernetes.io/ssl-redirect: "443"
+    external-dns.alpha.kubernetes.io/hostname: develop.panicboat.net
+spec:
+  ingressClassName: alb
+  rules:
+    - host: develop.panicboat.net
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: cilium-gateway-cilium-gateway
+                port:
+                  number: 8080

--- a/kubernetes/components/cilium/production/kustomization/application-ingress.yaml
+++ b/kubernetes/components/cilium/production/kustomization/application-ingress.yaml
@@ -16,13 +16,20 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: application
-  namespace: default
+  namespace: kube-system
   annotations:
     alb.ingress.kubernetes.io/scheme: internet-facing
     alb.ingress.kubernetes.io/listen-ports: '[{"HTTPS":443}]'
     alb.ingress.kubernetes.io/group.name: application
     alb.ingress.kubernetes.io/target-type: ip
     alb.ingress.kubernetes.io/healthcheck-path: /
+    # success-codes workaround: HTTPRoute install 前 + cilium-envoy が routing
+    # 不在で 404 / 503 返す状態でも ALB target healthy 扱い (= ALB Controller
+    # v3 の正式 annotation key は success-codes、 healthcheck-matcher は無効)。
+    # actual service error (= cilium-envoy internal 5xx) も healthy 扱いになる
+    # silent fail risk あり、 将来 healthcheck-path を frontend HTTPRoute install
+    # 後の 200 OK 返す endpoint に変更検討。
+    alb.ingress.kubernetes.io/success-codes: "200-499"
     alb.ingress.kubernetes.io/healthcheck-port: traffic-port
     alb.ingress.kubernetes.io/ssl-policy: ELBSecurityPolicy-TLS13-1-2-2021-06
     alb.ingress.kubernetes.io/ssl-redirect: "443"
@@ -37,6 +44,6 @@ spec:
             pathType: Prefix
             backend:
               service:
-                name: cilium-gateway-cilium-gateway
+                name: application-gateway
                 port:
                   number: 8080

--- a/kubernetes/components/cilium/production/kustomization/cilium-gateway.yaml
+++ b/kubernetes/components/cilium/production/kustomization/cilium-gateway.yaml
@@ -1,15 +1,17 @@
 # =============================================================================
-# Cilium shared Gateway (namespace default, listener HTTP port 80)
+# Cilium shared Gateway (namespace default, listener HTTP port 8080)
 # =============================================================================
-# Application-shared Gateway. The monorepo's reverse-proxy HTTPRoute targets
-# this Gateway via `parentRefs.name: cilium-gateway` / `namespace: default`.
+# Application-shared Gateway. The monorepo's HTTPRoute targets this Gateway
+# via `parentRefs.name: cilium-gateway` / `namespace: default`.
 #
 # The current single-application footprint does not justify per-service
 # Gateways (YAGNI), so a single shared Gateway is used.
 #
-# Listener: HTTP port 80 only (internal east-west routing; reverse-proxy
-# Pods call cilium-gateway as their upstream). HTTPS / TLS listeners can be
-# added if external traffic via this Gateway becomes required.
+# Listener: HTTP port 8080。 hostNetwork mode (= values.yaml.gotmpl
+# gatewayAPI.hostNetwork.enabled: true) で cilium-envoy が全 node の host port
+# で listen、 ALB が target-type=ip でその port を backend に register。
+# port 8080: eks-pod-identity-agent が hostNetwork で port 80 を占有するため
+# collision 回避、かつ 1024 未満特権 port 回避で NET_BIND_SERVICE capability 不要。
 # =============================================================================
 apiVersion: gateway.networking.k8s.io/v1
 kind: Gateway
@@ -20,7 +22,7 @@ spec:
   gatewayClassName: cilium
   listeners:
     - name: http
-      port: 80
+      port: 8080  # = hostNetwork mode、 eks-pod-identity-agent の port 80 と collision 回避
       protocol: HTTP
       allowedRoutes:
         namespaces:

--- a/kubernetes/components/cilium/production/kustomization/kustomization.yaml
+++ b/kubernetes/components/cilium/production/kustomization/kustomization.yaml
@@ -18,3 +18,4 @@ resources:
   - gateway-class.yaml
   - cilium-gateway.yaml
   - application-ingress.yaml
+  - application-gateway-service.yaml

--- a/kubernetes/components/cilium/production/kustomization/kustomization.yaml
+++ b/kubernetes/components/cilium/production/kustomization/kustomization.yaml
@@ -17,3 +17,4 @@ kind: Kustomization
 resources:
   - gateway-class.yaml
   - cilium-gateway.yaml
+  - application-ingress.yaml

--- a/kubernetes/components/cilium/production/values.yaml.gotmpl
+++ b/kubernetes/components/cilium/production/values.yaml.gotmpl
@@ -1,5 +1,10 @@
 # Cilium CNI Configuration for production (eks-production)
 
+# TODO: Remove after upgrade to 1.19.x is confirmed stable.
+# upgradeCompatibility instructs the new chart to preserve the 1.18 datapath
+# encoding during rolling replacement, preventing in-flight connection drops.
+upgradeCompatibility: "1.18"
+
 # =============================================================================
 # CNI Chaining Mode（VPC CNI が IPAM/datapath、Cilium は L7/policy/observability）
 # =============================================================================

--- a/kubernetes/components/cilium/production/values.yaml.gotmpl
+++ b/kubernetes/components/cilium/production/values.yaml.gotmpl
@@ -56,10 +56,20 @@ envoy:
   enabled: true
 
 # =============================================================================
-# Gateway API（東西用、北南は ALB Controller）
+# Gateway API（北南: ALB Controller 経由で hostNetwork mode の Cilium Gateway を expose、
+# 東西: 同 Cilium Gateway で internal routing。 北南統一で reverse-proxy 不要、
+# Cilium Gateway + CiliumEnvoyConfig で JWT validation 余地確保）
 # =============================================================================
+# hostNetwork.enabled: true は LoadBalancer Service auto-create を disable
+# (= 公式 mutual exclusive)、 cilium-gateway-cilium-gateway Service が ClusterIP に。
+# eks-pod-identity-agent が hostNetwork で port 80 占有のため Gateway listener は
+# port 8080 (= cilium-gateway.yaml)、 1024 未満特権 port 回避で NET_BIND_SERVICE
+# capability 不要。
+# https://docs.cilium.io/en/v1.19/network/servicemesh/gateway-api/host-network-mode/
 gatewayAPI:
   enabled: true
+  hostNetwork:
+    enabled: true
 
 # =============================================================================
 # Socket-level LB（Beyla / hostNetwork Pod が ClusterIP に到達するため）

--- a/kubernetes/components/cilium/production/values.yaml.gotmpl
+++ b/kubernetes/components/cilium/production/values.yaml.gotmpl
@@ -1,6 +1,8 @@
 # Cilium CNI Configuration for production (eks-production)
 
-# TODO: Remove after upgrade to 1.19.x is confirmed stable.
+# TODO: Remove once the 1.19.4 upgrade is fully rolled out across all nodes
+# and cluster stability is confirmed (= no pre-upgrade nodes remain、 in-flight
+# connection 保護不要 state)。
 # upgradeCompatibility instructs the new chart to preserve the 1.18 datapath
 # encoding during rolling replacement, preventing in-flight connection drops.
 upgradeCompatibility: "1.18"

--- a/kubernetes/components/cilium/production/values.yaml.gotmpl
+++ b/kubernetes/components/cilium/production/values.yaml.gotmpl
@@ -58,7 +58,8 @@ envoy:
 # =============================================================================
 # Gateway API（北南: ALB Controller 経由で hostNetwork mode の Cilium Gateway を expose、
 # 東西: 同 Cilium Gateway で internal routing。 北南統一で reverse-proxy 不要、
-# Cilium Gateway + CiliumEnvoyConfig で JWT validation 余地確保）
+# 全 ingress traffic が Cilium Gateway (= Envoy) を経由するため CiliumEnvoyConfig
+# CR + Envoy jwt_authn filter で Gateway 層 JWT 検証を実装可能な architecture）
 # =============================================================================
 # hostNetwork.enabled: true は LoadBalancer Service auto-create を disable
 # (= 公式 mutual exclusive)、 cilium-gateway-cilium-gateway Service が ClusterIP に。

--- a/kubernetes/manifests/production/cilium/manifest.yaml
+++ b/kubernetes/manifests/production/cilium/manifest.yaml
@@ -2484,6 +2484,21 @@ spec:
       targetLabel: node
 
 ---
+apiVersion: v1
+kind: Service
+metadata:
+  name: application-gateway
+  namespace: kube-system
+spec:
+  ports:
+  - name: http
+    port: 8080
+    protocol: TCP
+    targetPort: 8080
+  selector:
+    k8s-app: cilium-envoy
+  type: ClusterIP
+---
 apiVersion: gateway.networking.k8s.io/v1
 kind: Gateway
 metadata:
@@ -2518,10 +2533,11 @@ metadata:
     alb.ingress.kubernetes.io/scheme: internet-facing
     alb.ingress.kubernetes.io/ssl-policy: ELBSecurityPolicy-TLS13-1-2-2021-06
     alb.ingress.kubernetes.io/ssl-redirect: "443"
+    alb.ingress.kubernetes.io/success-codes: 200-499
     alb.ingress.kubernetes.io/target-type: ip
     external-dns.alpha.kubernetes.io/hostname: develop.panicboat.net
   name: application
-  namespace: default
+  namespace: kube-system
 spec:
   ingressClassName: alb
   rules:
@@ -2530,7 +2546,7 @@ spec:
       paths:
       - backend:
           service:
-            name: cilium-gateway-cilium-gateway
+            name: application-gateway
             port:
               number: 8080
         path: /

--- a/kubernetes/manifests/production/cilium/manifest.yaml
+++ b/kubernetes/manifests/production/cilium/manifest.yaml
@@ -111,7 +111,7 @@ data:
   gateway-api-xff-num-trusted-hops: "0"
   gateway-api-service-externaltrafficpolicy: "Cluster"
   gateway-api-secrets-namespace: "cilium-secrets"
-  gateway-api-hostnetwork-enabled: "false"
+  gateway-api-hostnetwork-enabled: "true"
   gateway-api-hostnetwork-nodelabelselector: ""
   enable-policy-secrets-sync: "true"
   policy-secrets-only-from-secrets-namespace: "true"
@@ -2020,7 +2020,7 @@ spec:
     metadata:
       annotations:
         # ensure pods roll when configmap updates
-        cilium.io/cilium-configmap-checksum: "aa643b445aefe330cb03f8dd87f61b66a9491cbeac246c52e52611413ec6e4bb"
+        cilium.io/cilium-configmap-checksum: "497c443ea02a8e4e50d7030e3c55a70c5099882701152929625b02c047fa005d"
       labels:
         io.cilium/app: operator
         name: cilium-operator
@@ -2496,7 +2496,7 @@ spec:
       namespaces:
         from: Same
     name: http
-    port: 80
+    port: 8080
     protocol: HTTP
 ---
 apiVersion: gateway.networking.k8s.io/v1
@@ -2506,3 +2506,32 @@ metadata:
 spec:
   controllerName: io.cilium/gateway-controller
   description: Cilium Gateway Controller
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  annotations:
+    alb.ingress.kubernetes.io/group.name: application
+    alb.ingress.kubernetes.io/healthcheck-path: /
+    alb.ingress.kubernetes.io/healthcheck-port: traffic-port
+    alb.ingress.kubernetes.io/listen-ports: '[{"HTTPS":443}]'
+    alb.ingress.kubernetes.io/scheme: internet-facing
+    alb.ingress.kubernetes.io/ssl-policy: ELBSecurityPolicy-TLS13-1-2-2021-06
+    alb.ingress.kubernetes.io/ssl-redirect: "443"
+    alb.ingress.kubernetes.io/target-type: ip
+    external-dns.alpha.kubernetes.io/hostname: develop.panicboat.net
+  name: application
+  namespace: default
+spec:
+  ingressClassName: alb
+  rules:
+  - host: develop.panicboat.net
+    http:
+      paths:
+      - backend:
+          service:
+            name: cilium-gateway-cilium-gateway
+            port:
+              number: 8080
+        path: /
+        pathType: Prefix

--- a/kubernetes/manifests/production/cilium/manifest.yaml
+++ b/kubernetes/manifests/production/cilium/manifest.yaml
@@ -188,7 +188,7 @@ data:
 
   # Name of the cluster. Only relevant when building a mesh of clusters.
   cluster-name: "default"
-  # Unique ID of the cluster. Must be unique across all conneted clusters and
+  # Unique ID of the cluster. Must be unique across all connected clusters and
   # in the range of 1 and 255. Only relevant when building a mesh of clusters.
   cluster-id: "0"
 
@@ -202,6 +202,7 @@ data:
   tunnel-protocol: "vxlan"
   tunnel-source-port-range: "0-0"
   service-no-backend-response: "reject"
+  policy-deny-response: "none"
 
 
   # Enables L7 proxy for L7 policy enforcement and visibility
@@ -238,6 +239,7 @@ data:
 
   kube-proxy-replacement: "true"
   kube-proxy-replacement-healthz-bind-address: ""
+  enable-no-service-endpoints-routable: "true"
   bpf-lb-sock: "true"
   nodeport-addresses: ""
   enable-health-check-nodeport: "true"
@@ -245,7 +247,7 @@ data:
   node-port-bind-protection: "true"
   enable-auto-protect-node-port-range: "true"
   bpf-lb-acceleration: "disabled"
-  enable-svc-source-range-check: "true"
+  enable-service-topology: "false"
   enable-l2-neigh-discovery: "false"
   k8s-require-ipv4-pod-cidr: "false"
   k8s-require-ipv6-pod-cidr: "false"
@@ -302,6 +304,8 @@ data:
   vtep-cidr: ""
   vtep-mask: ""
   vtep-mac: ""
+
+  packetization-layer-pmtud-mode: "blackhole"
   procfs: "/host/proc"
   bpf-root: "/sys/fs/bpf"
   cgroup-root: "/run/cilium/cgroupv2"
@@ -311,7 +315,7 @@ data:
   remove-cilium-node-taints: "true"
   set-cilium-node-taints: "true"
   set-cilium-is-up-condition: "true"
-  unmanaged-pod-watcher-interval: "15"
+  unmanaged-pod-watcher-interval: "15s"
   dnsproxy-socket-linger-timeout: "10"
   tofqdns-dns-reject-response-code: "refused"
   tofqdns-enable-dns-compression: "true"
@@ -322,7 +326,7 @@ data:
   tofqdns-preallocate-identities:  "true"
   agent-not-ready-taint-key: "node.cilium.io/agent-not-ready"
 
-  mesh-auth-enabled: "true"
+  mesh-auth-enabled: "false"
   mesh-auth-queue-size: "1024"
   mesh-auth-rotated-identities-queue-size: "1024"
   mesh-auth-gc-interval: "5m0s"
@@ -331,10 +335,14 @@ data:
   proxy-xff-num-trusted-hops-egress: "0"
   proxy-connect-timeout: "2"
   proxy-initial-fetch-timeout: "30"
+  proxy-max-active-downstream-connections: "50000"
   proxy-max-requests-per-connection: "0"
   proxy-max-connection-duration-seconds: "0"
   proxy-idle-timeout-seconds: "60"
   proxy-max-concurrent-retries: "128"
+  proxy-use-original-source-address: "true"
+  proxy-cluster-max-connections: "1024"
+  proxy-cluster-max-requests: "1024"
   http-retry-count: "3"
   http-stream-idle-timeout: "300"
 
@@ -343,16 +351,19 @@ data:
   envoy-access-log-buffer-size: "4096"
   envoy-keep-cap-netbindservice: "false"
   max-connected-clusters: "255"
+  clustermesh-cache-ttl: "0s"
   clustermesh-enable-endpoint-sync: "false"
   clustermesh-enable-mcs-api: "false"
-  policy-default-local-cluster: "false"
+  clustermesh-mcs-api-install-crds: "true"
+  policy-default-local-cluster: "true"
 
   nat-map-stats-entries: "32"
   nat-map-stats-interval: "30s"
-  enable-internal-traffic-policy: "true"
   enable-lb-ipam: "true"
   enable-non-default-deny-policies: "true"
   enable-source-ip-verification: "true"
+  enable-dynamic-config: "true"
+  enable-drift-checker: "true"
 
 # Extra config allows adding arbitrary properties to the cilium config.
 # By putting it at the end of the ConfigMap, it's also possible to override existing properties.
@@ -366,7 +377,7 @@ metadata:
 data:
   # Keep the key name as bootstrap-config.json to avoid breaking changes
   bootstrap-config.json: |
-    {"admin":{"address":{"pipe":{"path":"/var/run/cilium/envoy/sockets/admin.sock"}}},"applicationLogConfig":{"logFormat":{"textFormat":"[%Y-%m-%d %T.%e][%t][%l][%n] [%g:%#] %v"}},"bootstrapExtensions":[{"name":"envoy.bootstrap.internal_listener","typedConfig":{"@type":"type.googleapis.com/envoy.extensions.bootstrap.internal_listener.v3.InternalListener"}}],"dynamicResources":{"cdsConfig":{"apiConfigSource":{"apiType":"GRPC","grpcServices":[{"envoyGrpc":{"clusterName":"xds-grpc-cilium"}}],"setNodeOnFirstMessageOnly":true,"transportApiVersion":"V3"},"initialFetchTimeout":"30s","resourceApiVersion":"V3"},"ldsConfig":{"apiConfigSource":{"apiType":"GRPC","grpcServices":[{"envoyGrpc":{"clusterName":"xds-grpc-cilium"}}],"setNodeOnFirstMessageOnly":true,"transportApiVersion":"V3"},"initialFetchTimeout":"30s","resourceApiVersion":"V3"}},"node":{"cluster":"ingress-cluster","id":"host~127.0.0.1~no-id~localdomain"},"overloadManager":{"resourceMonitors":[{"name":"envoy.resource_monitors.global_downstream_max_connections","typedConfig":{"@type":"type.googleapis.com/envoy.extensions.resource_monitors.downstream_connections.v3.DownstreamConnectionsConfig","max_active_downstream_connections":"50000"}}]},"staticResources":{"clusters":[{"circuitBreakers":{"thresholds":[{"maxRetries":128}]},"cleanupInterval":"2.500s","connectTimeout":"2s","lbPolicy":"CLUSTER_PROVIDED","name":"ingress-cluster","type":"ORIGINAL_DST","typedExtensionProtocolOptions":{"envoy.extensions.upstreams.http.v3.HttpProtocolOptions":{"@type":"type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions","commonHttpProtocolOptions":{"idleTimeout":"60s","maxConnectionDuration":"0s","maxRequestsPerConnection":0},"useDownstreamProtocolConfig":{}}}},{"circuitBreakers":{"thresholds":[{"maxRetries":128}]},"cleanupInterval":"2.500s","connectTimeout":"2s","lbPolicy":"CLUSTER_PROVIDED","name":"egress-cluster-tls","transportSocket":{"name":"cilium.tls_wrapper","typedConfig":{"@type":"type.googleapis.com/cilium.UpstreamTlsWrapperContext"}},"type":"ORIGINAL_DST","typedExtensionProtocolOptions":{"envoy.extensions.upstreams.http.v3.HttpProtocolOptions":{"@type":"type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions","commonHttpProtocolOptions":{"idleTimeout":"60s","maxConnectionDuration":"0s","maxRequestsPerConnection":0},"upstreamHttpProtocolOptions":{},"useDownstreamProtocolConfig":{}}}},{"circuitBreakers":{"thresholds":[{"maxRetries":128}]},"cleanupInterval":"2.500s","connectTimeout":"2s","lbPolicy":"CLUSTER_PROVIDED","name":"egress-cluster","type":"ORIGINAL_DST","typedExtensionProtocolOptions":{"envoy.extensions.upstreams.http.v3.HttpProtocolOptions":{"@type":"type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions","commonHttpProtocolOptions":{"idleTimeout":"60s","maxConnectionDuration":"0s","maxRequestsPerConnection":0},"useDownstreamProtocolConfig":{}}}},{"circuitBreakers":{"thresholds":[{"maxRetries":128}]},"cleanupInterval":"2.500s","connectTimeout":"2s","lbPolicy":"CLUSTER_PROVIDED","name":"ingress-cluster-tls","transportSocket":{"name":"cilium.tls_wrapper","typedConfig":{"@type":"type.googleapis.com/cilium.UpstreamTlsWrapperContext"}},"type":"ORIGINAL_DST","typedExtensionProtocolOptions":{"envoy.extensions.upstreams.http.v3.HttpProtocolOptions":{"@type":"type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions","commonHttpProtocolOptions":{"idleTimeout":"60s","maxConnectionDuration":"0s","maxRequestsPerConnection":0},"upstreamHttpProtocolOptions":{},"useDownstreamProtocolConfig":{}}}},{"connectTimeout":"2s","loadAssignment":{"clusterName":"xds-grpc-cilium","endpoints":[{"lbEndpoints":[{"endpoint":{"address":{"pipe":{"path":"/var/run/cilium/envoy/sockets/xds.sock"}}}}]}]},"name":"xds-grpc-cilium","type":"STATIC","typedExtensionProtocolOptions":{"envoy.extensions.upstreams.http.v3.HttpProtocolOptions":{"@type":"type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions","explicitHttpConfig":{"http2ProtocolOptions":{}}}}},{"connectTimeout":"2s","loadAssignment":{"clusterName":"/envoy-admin","endpoints":[{"lbEndpoints":[{"endpoint":{"address":{"pipe":{"path":"/var/run/cilium/envoy/sockets/admin.sock"}}}}]}]},"name":"/envoy-admin","type":"STATIC"}],"listeners":[{"address":{"socketAddress":{"address":"0.0.0.0","portValue":9964}},"filterChains":[{"filters":[{"name":"envoy.filters.network.http_connection_manager","typedConfig":{"@type":"type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager","httpFilters":[{"name":"envoy.filters.http.router","typedConfig":{"@type":"type.googleapis.com/envoy.extensions.filters.http.router.v3.Router"}}],"internalAddressConfig":{"cidrRanges":[{"addressPrefix":"10.0.0.0","prefixLen":8},{"addressPrefix":"172.16.0.0","prefixLen":12},{"addressPrefix":"192.168.0.0","prefixLen":16},{"addressPrefix":"127.0.0.1","prefixLen":32}]},"routeConfig":{"virtualHosts":[{"domains":["*"],"name":"prometheus_metrics_route","routes":[{"match":{"prefix":"/metrics"},"name":"prometheus_metrics_route","route":{"cluster":"/envoy-admin","prefixRewrite":"/stats/prometheus"}}]}]},"statPrefix":"envoy-prometheus-metrics-listener","streamIdleTimeout":"300s"}}]}],"name":"envoy-prometheus-metrics-listener"},{"address":{"socketAddress":{"address":"127.0.0.1","portValue":9878}},"filterChains":[{"filters":[{"name":"envoy.filters.network.http_connection_manager","typedConfig":{"@type":"type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager","httpFilters":[{"name":"envoy.filters.http.router","typedConfig":{"@type":"type.googleapis.com/envoy.extensions.filters.http.router.v3.Router"}}],"internalAddressConfig":{"cidrRanges":[{"addressPrefix":"10.0.0.0","prefixLen":8},{"addressPrefix":"172.16.0.0","prefixLen":12},{"addressPrefix":"192.168.0.0","prefixLen":16},{"addressPrefix":"127.0.0.1","prefixLen":32}]},"routeConfig":{"virtual_hosts":[{"domains":["*"],"name":"health","routes":[{"match":{"prefix":"/healthz"},"name":"health","route":{"cluster":"/envoy-admin","prefixRewrite":"/ready"}}]}]},"statPrefix":"envoy-health-listener","streamIdleTimeout":"300s"}}]}],"name":"envoy-health-listener"}]}}
+    {"admin":{"address":{"pipe":{"mode":432,"path":"/var/run/cilium/envoy/sockets/admin.sock"}}},"applicationLogConfig":{"logFormat":{"textFormat":"[%Y-%m-%d %T.%e][%t][%l][%n] [%g:%#] %v"}},"bootstrapExtensions":[{"name":"envoy.bootstrap.internal_listener","typedConfig":{"@type":"type.googleapis.com/envoy.extensions.bootstrap.internal_listener.v3.InternalListener"}}],"dynamicResources":{"cdsConfig":{"apiConfigSource":{"apiType":"GRPC","grpcServices":[{"envoyGrpc":{"clusterName":"xds-grpc-cilium"}}],"setNodeOnFirstMessageOnly":true,"transportApiVersion":"V3"},"initialFetchTimeout":"30s","resourceApiVersion":"V3"},"ldsConfig":{"apiConfigSource":{"apiType":"GRPC","grpcServices":[{"envoyGrpc":{"clusterName":"xds-grpc-cilium"}}],"setNodeOnFirstMessageOnly":true,"transportApiVersion":"V3"},"initialFetchTimeout":"30s","resourceApiVersion":"V3"}},"node":{"cluster":"ingress-cluster","id":"host~127.0.0.1~no-id~localdomain"},"overloadManager":{"resourceMonitors":[{"name":"envoy.resource_monitors.global_downstream_max_connections","typedConfig":{"@type":"type.googleapis.com/envoy.extensions.resource_monitors.downstream_connections.v3.DownstreamConnectionsConfig","max_active_downstream_connections":"50000"}}]},"staticResources":{"clusters":[{"circuitBreakers":{"thresholds":[{"maxConnections":1024,"maxRequests":1024,"maxRetries":128}]},"cleanupInterval":"2.500s","connectTimeout":"2s","lbPolicy":"CLUSTER_PROVIDED","name":"ingress-cluster","type":"ORIGINAL_DST","typedExtensionProtocolOptions":{"envoy.extensions.upstreams.http.v3.HttpProtocolOptions":{"@type":"type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions","commonHttpProtocolOptions":{"idleTimeout":"60s","maxConnectionDuration":"0s","maxRequestsPerConnection":0},"useDownstreamProtocolConfig":{}}}},{"circuitBreakers":{"thresholds":[{"maxConnections":1024,"maxRequests":1024,"maxRetries":128}]},"cleanupInterval":"2.500s","connectTimeout":"2s","lbPolicy":"CLUSTER_PROVIDED","name":"egress-cluster-tls","transportSocket":{"name":"cilium.tls_wrapper","typedConfig":{"@type":"type.googleapis.com/cilium.UpstreamTlsWrapperContext"}},"type":"ORIGINAL_DST","typedExtensionProtocolOptions":{"envoy.extensions.upstreams.http.v3.HttpProtocolOptions":{"@type":"type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions","commonHttpProtocolOptions":{"idleTimeout":"60s","maxConnectionDuration":"0s","maxRequestsPerConnection":0},"upstreamHttpProtocolOptions":{},"useDownstreamProtocolConfig":{}}}},{"circuitBreakers":{"thresholds":[{"maxConnections":1024,"maxRequests":1024,"maxRetries":128}]},"cleanupInterval":"2.500s","connectTimeout":"2s","lbPolicy":"CLUSTER_PROVIDED","name":"egress-cluster","type":"ORIGINAL_DST","typedExtensionProtocolOptions":{"envoy.extensions.upstreams.http.v3.HttpProtocolOptions":{"@type":"type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions","commonHttpProtocolOptions":{"idleTimeout":"60s","maxConnectionDuration":"0s","maxRequestsPerConnection":0},"useDownstreamProtocolConfig":{}}}},{"circuitBreakers":{"thresholds":[{"maxConnections":1024,"maxRequests":1024,"maxRetries":128}]},"cleanupInterval":"2.500s","connectTimeout":"2s","lbPolicy":"CLUSTER_PROVIDED","name":"ingress-cluster-tls","transportSocket":{"name":"cilium.tls_wrapper","typedConfig":{"@type":"type.googleapis.com/cilium.UpstreamTlsWrapperContext"}},"type":"ORIGINAL_DST","typedExtensionProtocolOptions":{"envoy.extensions.upstreams.http.v3.HttpProtocolOptions":{"@type":"type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions","commonHttpProtocolOptions":{"idleTimeout":"60s","maxConnectionDuration":"0s","maxRequestsPerConnection":0},"upstreamHttpProtocolOptions":{},"useDownstreamProtocolConfig":{}}}},{"connectTimeout":"2s","loadAssignment":{"clusterName":"xds-grpc-cilium","endpoints":[{"lbEndpoints":[{"endpoint":{"address":{"pipe":{"path":"/var/run/cilium/envoy/sockets/xds.sock"}}}}]}]},"name":"xds-grpc-cilium","type":"STATIC","typedExtensionProtocolOptions":{"envoy.extensions.upstreams.http.v3.HttpProtocolOptions":{"@type":"type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions","explicitHttpConfig":{"http2ProtocolOptions":{}}}}},{"connectTimeout":"2s","loadAssignment":{"clusterName":"/envoy-admin","endpoints":[{"lbEndpoints":[{"endpoint":{"address":{"pipe":{"path":"/var/run/cilium/envoy/sockets/admin.sock"}}}}]}]},"name":"/envoy-admin","type":"STATIC"}],"listeners":[{"address":{"socketAddress":{"address":"0.0.0.0","portValue":9964}},"filterChains":[{"filters":[{"name":"envoy.filters.network.http_connection_manager","typedConfig":{"@type":"type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager","httpFilters":[{"name":"envoy.filters.http.router","typedConfig":{"@type":"type.googleapis.com/envoy.extensions.filters.http.router.v3.Router"}}],"internalAddressConfig":{"cidrRanges":[{"addressPrefix":"10.0.0.0","prefixLen":8},{"addressPrefix":"172.16.0.0","prefixLen":12},{"addressPrefix":"192.168.0.0","prefixLen":16},{"addressPrefix":"127.0.0.1","prefixLen":32}]},"routeConfig":{"virtualHosts":[{"domains":["*"],"name":"prometheus_metrics_route","routes":[{"match":{"prefix":"/metrics"},"name":"prometheus_metrics_route","route":{"cluster":"/envoy-admin","prefixRewrite":"/stats/prometheus"}}]}]},"statPrefix":"envoy-prometheus-metrics-listener","streamIdleTimeout":"300s"}}]}],"name":"envoy-prometheus-metrics-listener"},{"address":{"socketAddress":{"address":"127.0.0.1","portValue":9878}},"filterChains":[{"filters":[{"name":"envoy.filters.network.http_connection_manager","typedConfig":{"@type":"type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager","httpFilters":[{"name":"envoy.filters.http.router","typedConfig":{"@type":"type.googleapis.com/envoy.extensions.filters.http.router.v3.Router"}}],"internalAddressConfig":{"cidrRanges":[{"addressPrefix":"10.0.0.0","prefixLen":8},{"addressPrefix":"172.16.0.0","prefixLen":12},{"addressPrefix":"192.168.0.0","prefixLen":16},{"addressPrefix":"127.0.0.1","prefixLen":32}]},"routeConfig":{"virtual_hosts":[{"domains":["*"],"name":"health","routes":[{"match":{"prefix":"/healthz"},"name":"health","route":{"cluster":"/envoy-admin","prefixRewrite":"/ready"}}]}]},"statPrefix":"envoy-health-listener","streamIdleTimeout":"300s"}}]}],"name":"envoy-health-listener"}]}}
 ---
 # Source: cilium/templates/hubble-relay/configmap.yaml
 apiVersion: v1
@@ -596,6 +607,18 @@ rules:
   - delete
   - patch
 - apiGroups:
+  - "discovery.k8s.io"
+  resources:
+  - endpointslices
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - delete
+  - patch
+- apiGroups:
   - cilium.io
   resources:
   - ciliumnetworkpolicies
@@ -694,7 +717,6 @@ rules:
   - update
   resourceNames:
   - ciliumloadbalancerippools.cilium.io
-  - ciliumbgppeeringpolicies.cilium.io
   - ciliumbgpclusterconfigs.cilium.io
   - ciliumbgppeerconfigs.cilium.io
   - ciliumbgpadvertisements.cilium.io
@@ -808,6 +830,12 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - cilium.io
+  resources:
+  - ciliumendpointslices
+  verbs:
+  - deletecollection
 ---
 # Source: cilium/templates/hubble-ui/clusterrole.yaml
 kind: ClusterRole
@@ -818,14 +846,6 @@ metadata:
     app.kubernetes.io/part-of: cilium
 
 rules:
-- apiGroups:
-  - networking.k8s.io
-  resources:
-  - networkpolicies
-  verbs:
-  - get
-  - list
-  - watch
 - apiGroups:
   - ""
   resources:
@@ -843,14 +863,6 @@ rules:
   - apiextensions.k8s.io
   resources:
   - customresourcedefinitions
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - cilium.io
-  resources:
-  - "*"
   verbs:
   - get
   - list
@@ -997,6 +1009,29 @@ rules:
   - update
   - patch
 ---
+# Source: cilium/templates/cilium-operator/role.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: cilium-operator-ztunnel
+  namespace: kube-system
+  labels:
+    app.kubernetes.io/part-of: cilium
+rules:
+# ZTunnel DaemonSet management permissions
+# Note: These permissions must always be granted (not conditional on encryption.type)
+# because the controller needs to clean up stale DaemonSets when ztunnel is disabled.
+- apiGroups:
+  - apps
+  resources:
+  - daemonsets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - watch
+---
 # Source: cilium/templates/cilium-agent/rolebinding.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -1082,6 +1117,23 @@ subjects:
   name: "cilium-operator"
   namespace: kube-system
 ---
+# Source: cilium/templates/cilium-operator/rolebinding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: cilium-operator-ztunnel
+  namespace: kube-system
+  labels:
+    app.kubernetes.io/part-of: cilium
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: cilium-operator-ztunnel
+subjects:
+- kind: ServiceAccount
+  name: "cilium-operator"
+  namespace: kube-system
+---
 # Source: cilium/templates/cilium-agent/service.yaml
 apiVersion: v1
 kind: Service
@@ -1126,7 +1178,7 @@ spec:
   - name: envoy-metrics
     port: 9964
     protocol: TCP
-    targetPort: envoy-metrics
+    targetPort: 9964
 ---
 # Source: cilium/templates/cilium-operator/service.yaml
 kind: Service
@@ -1270,7 +1322,7 @@ spec:
           type: Unconfined
       containers:
       - name: cilium-agent
-        image: "quay.io/cilium/cilium:v1.18.6@sha256:42ec562a5ff6c8a860c0639f5a7611685e253fd9eb2d2fcdade693724c9166a4"
+        image: "quay.io/cilium/cilium:v1.19.4@sha256:2eb67991eaa9368ba199c2fac2c573cb0ffdeb79184533344f42fc9a7ff6af3c"
         imagePullPolicy: IfNotPresent
         command:
         - cilium-agent
@@ -1280,7 +1332,7 @@ spec:
           httpGet:
             host: "127.0.0.1"
             path: /healthz
-            port: 9879
+            port: health
             scheme: HTTP
             httpHeaders:
             - name: "brief"
@@ -1293,7 +1345,7 @@ spec:
           httpGet:
             host: "127.0.0.1"
             path: /healthz
-            port: 9879
+            port: health
             scheme: HTTP
             httpHeaders:
             - name: "brief"
@@ -1308,7 +1360,7 @@ spec:
           httpGet:
             host: "127.0.0.1"
             path: /healthz
-            port: 9879
+            port: health
             scheme: HTTP
             httpHeaders:
             - name: "brief"
@@ -1349,6 +1401,10 @@ spec:
               command:
               - /cni-uninstall.sh
         ports:
+        - name: health
+          containerPort: 9879
+          hostPort: 9879
+          protocol: TCP
         - name: peer-service
           containerPort: 4244
           hostPort: 4244
@@ -1379,6 +1435,7 @@ spec:
               - FOWNER
               - SETGID
               - SETUID
+              - SYSLOG
             drop:
               - ALL
         terminationMessagePolicy: FallbackToLogsOnError
@@ -1425,7 +1482,7 @@ spec:
         
       initContainers:
       - name: config
-        image: "quay.io/cilium/cilium:v1.18.6@sha256:42ec562a5ff6c8a860c0639f5a7611685e253fd9eb2d2fcdade693724c9166a4"
+        image: "quay.io/cilium/cilium:v1.19.4@sha256:2eb67991eaa9368ba199c2fac2c573cb0ffdeb79184533344f42fc9a7ff6af3c"
         imagePullPolicy: IfNotPresent
         command:
         - cilium-dbg
@@ -1449,10 +1506,16 @@ spec:
         - name: tmp
           mountPath: /tmp
         terminationMessagePolicy: FallbackToLogsOnError
+        securityContext:
+          capabilities:
+            add:
+              - NET_ADMIN
+            drop:
+              - ALL
       # Required to mount cgroup2 filesystem on the underlying Kubernetes node.
       # We use nsenter command with host's cgroup and mount namespaces enabled.
       - name: mount-cgroup
-        image: "quay.io/cilium/cilium:v1.18.6@sha256:42ec562a5ff6c8a860c0639f5a7611685e253fd9eb2d2fcdade693724c9166a4"
+        image: "quay.io/cilium/cilium:v1.19.4@sha256:2eb67991eaa9368ba199c2fac2c573cb0ffdeb79184533344f42fc9a7ff6af3c"
         imagePullPolicy: IfNotPresent
         env:
         - name: CGROUP_ROOT
@@ -1460,7 +1523,7 @@ spec:
         - name: BIN_PATH
           value: /opt/cni/bin
         command:
-        - sh
+        - bash
         - -ec
         # The statically linked Go program binary is invoked to avoid any
         # dependency on utilities like sh and mount that can be missing on certain
@@ -1489,13 +1552,13 @@ spec:
             drop:
               - ALL
       - name: apply-sysctl-overwrites
-        image: "quay.io/cilium/cilium:v1.18.6@sha256:42ec562a5ff6c8a860c0639f5a7611685e253fd9eb2d2fcdade693724c9166a4"
+        image: "quay.io/cilium/cilium:v1.19.4@sha256:2eb67991eaa9368ba199c2fac2c573cb0ffdeb79184533344f42fc9a7ff6af3c"
         imagePullPolicy: IfNotPresent
         env:
         - name: BIN_PATH
           value: /opt/cni/bin
         command:
-        - sh
+        - bash
         - -ec
         # The statically linked Go program binary is invoked to avoid any
         # dependency on utilities like sh that can be missing on certain
@@ -1527,7 +1590,7 @@ spec:
       # from a privileged container because the mount propagation bidirectional
       # only works from privileged containers.
       - name: mount-bpf-fs
-        image: "quay.io/cilium/cilium:v1.18.6@sha256:42ec562a5ff6c8a860c0639f5a7611685e253fd9eb2d2fcdade693724c9166a4"
+        image: "quay.io/cilium/cilium:v1.19.4@sha256:2eb67991eaa9368ba199c2fac2c573cb0ffdeb79184533344f42fc9a7ff6af3c"
         imagePullPolicy: IfNotPresent
         args:
         - 'mount | grep "/sys/fs/bpf type bpf" || mount -t bpf bpf /sys/fs/bpf'
@@ -1543,7 +1606,7 @@ spec:
           mountPath: /sys/fs/bpf
           mountPropagation: Bidirectional
       - name: clean-cilium-state
-        image: "quay.io/cilium/cilium:v1.18.6@sha256:42ec562a5ff6c8a860c0639f5a7611685e253fd9eb2d2fcdade693724c9166a4"
+        image: "quay.io/cilium/cilium:v1.19.4@sha256:2eb67991eaa9368ba199c2fac2c573cb0ffdeb79184533344f42fc9a7ff6af3c"
         imagePullPolicy: IfNotPresent
         command:
         - /init-container.sh
@@ -1594,11 +1657,14 @@ spec:
           mountPath: /var/run/cilium # wait-for-kube-proxy
       # Install the CNI binaries in an InitContainer so we don't have a writable host mount in the agent
       - name: install-cni-binaries
-        image: "quay.io/cilium/cilium:v1.18.6@sha256:42ec562a5ff6c8a860c0639f5a7611685e253fd9eb2d2fcdade693724c9166a4"
+        image: "quay.io/cilium/cilium:v1.19.4@sha256:2eb67991eaa9368ba199c2fac2c573cb0ffdeb79184533344f42fc9a7ff6af3c"
         imagePullPolicy: IfNotPresent
         command:
           - "/install-plugin.sh"
         resources:
+          limits:
+            cpu: 1
+            memory: 1Gi
           requests:
             cpu: 100m
             memory: 10Mi
@@ -1632,7 +1698,7 @@ spec:
       tolerations:
         - operator: Exists
       volumes:
-        # For sharing configuration between the "config" initContainer and the agent
+      # For sharing configuration between the "config" initContainer and the agent
       - name: tmp
         emptyDir: {}
         # To keep state between restarts / upgrades
@@ -1760,6 +1826,7 @@ spec:
   selector:
     matchLabels:
       k8s-app: cilium-envoy
+  
   updateStrategy:
     rollingUpdate:
       maxUnavailable: 2
@@ -1776,9 +1843,10 @@ spec:
       securityContext:
         appArmorProfile:
           type: Unconfined
+      
       containers:
       - name: cilium-envoy
-        image: "quay.io/cilium/cilium-envoy:v1.35.9-1767794330-db497dd19e346b39d81d7b5c0dedf6c812bcc5c9@sha256:81398e449f2d3d0a6a70527e4f641aaa685d3156bea0bb30712fae3fd8822b86"
+        image: "quay.io/cilium/cilium-envoy:v1.36.6-1778235340-b87d1e32f522b33bd51701c6476d199326f01496@sha256:71d4fa0ec45e8d546dbd5604e169dc77fe92be63b799313bff031d00d89762e3"
         imagePullPolicy: IfNotPresent
         command:
         - /usr/bin/cilium-envoy-starter
@@ -1787,6 +1855,7 @@ spec:
         - '-c /var/run/cilium/envoy/bootstrap-config.json'
         - '--base-id 0'
         - '--log-level info'
+        
         startupProbe:
           httpGet:
             host: "127.0.0.1"
@@ -1832,6 +1901,7 @@ spec:
           value: "BD10E7689A05E46191305DDC7BE6CA67.gr7.ap-northeast-1.eks.amazonaws.com"
         - name: KUBERNETES_SERVICE_PORT
           value: "443"
+        
         ports:
         - name: envoy-metrics
           containerPort: 9964
@@ -1861,12 +1931,14 @@ spec:
         - name: bpf-maps
           mountPath: /sys/fs/bpf
           mountPropagation: HostToContainer
+        
       restartPolicy: Always
       priorityClassName: system-node-critical
       serviceAccountName: "cilium-envoy"
       automountServiceAccountToken: true
       terminationGracePeriodSeconds: 1
       hostNetwork: true
+      
       affinity:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
@@ -1948,7 +2020,7 @@ spec:
     metadata:
       annotations:
         # ensure pods roll when configmap updates
-        cilium.io/cilium-configmap-checksum: "d598ac5d96db4d2cb414fe1073ea1a036adec9a6aa82984e1d51df9237c46570"
+        cilium.io/cilium-configmap-checksum: "aa643b445aefe330cb03f8dd87f61b66a9491cbeac246c52e52611413ec6e4bb"
       labels:
         io.cilium/app: operator
         name: cilium-operator
@@ -1960,7 +2032,7 @@ spec:
           type: RuntimeDefault
       containers:
       - name: cilium-operator
-        image: "quay.io/cilium/operator-generic:v1.18.6@sha256:34a827ce9ed021c8adf8f0feca131f53b3c54a3ef529053d871d0347ec4d69af"
+        image: "quay.io/cilium/operator-generic:v1.19.4@sha256:1aa2b62735e7d8ab49ee840ae59c346932024c88901579121395c1271b435f71"
         imagePullPolicy: IfNotPresent
         command:
         - cilium-operator-generic
@@ -1989,6 +2061,9 @@ spec:
         - name: KUBERNETES_SERVICE_PORT
           value: "443"
         ports:
+        - name: health
+          containerPort: 9234
+          hostPort: 9234
         - name: prometheus
           containerPort: 9963
           hostPort: 9963
@@ -1997,7 +2072,7 @@ spec:
           httpGet:
             host: "127.0.0.1"
             path: /healthz
-            port: 9234
+            port: health
             scheme: HTTP
           initialDelaySeconds: 60
           periodSeconds: 10
@@ -2006,7 +2081,7 @@ spec:
           httpGet:
             host: "127.0.0.1"
             path: /healthz
-            port: 9234
+            port: health
             scheme: HTTP
           initialDelaySeconds: 0
           periodSeconds: 5
@@ -2016,6 +2091,7 @@ spec:
         - name: cilium-config-path
           mountPath: /tmp/cilium/config-map
           readOnly: true
+        
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:
@@ -2100,7 +2176,7 @@ spec:
             runAsUser: 65532
             seccompProfile:
               type: RuntimeDefault
-          image: "quay.io/cilium/hubble-relay:v1.18.6@sha256:fb6135e34c31e5f175cb5e75f86cea52ef2ff12b49bcefb7088ed93f5009eb8e"
+          image: "quay.io/cilium/hubble-relay:v1.19.4@sha256:59af8c0d561e560c2a042e7600a3496bc0367df8fbf868aa68d5834c8ec1a431"
           imagePullPolicy: IfNotPresent
           command:
             - hubble-relay
@@ -2222,7 +2298,7 @@ spec:
       automountServiceAccountToken: true
       containers:
       - name: frontend
-        image: "quay.io/cilium/hubble-ui:v0.13.3@sha256:661d5de7050182d495c6497ff0b007a7a1e379648e60830dd68c4d78ae21761d"
+        image: "quay.io/cilium/hubble-ui:v0.13.5@sha256:f7d514fc54d784ed6df9d58cf0e97648b143f92b766dd1780ed3fc845bd4c516"
         imagePullPolicy: IfNotPresent
         ports:
         - name: http
@@ -2230,11 +2306,11 @@ spec:
         livenessProbe:
           httpGet:
             path: /healthz
-            port: 8081
+            port: http
         readinessProbe:
           httpGet:
             path: /
-            port: 8081
+            port: http
         volumeMounts:
         - name: hubble-ui-nginx-conf
           mountPath: /etc/nginx/conf.d/default.conf
@@ -2245,7 +2321,7 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
       - name: backend
-        image: "quay.io/cilium/hubble-ui-backend:v0.13.3@sha256:db1454e45dc39ca41fbf7cad31eec95d99e5b9949c39daaad0fa81ef29d56953"
+        image: "quay.io/cilium/hubble-ui-backend:v0.13.5@sha256:fac0c300ae119274edca11fd89b1ad23c788792d8bc4ea2ba631c709e8d3c688"
         imagePullPolicy: IfNotPresent
         env:
         - name: EVENTS_SERVER_PORT
@@ -2266,8 +2342,8 @@ spec:
           defaultMode: 420
           name: hubble-ui-nginx
         name: hubble-ui-nginx-conf
-      - emptyDir: {}
-        name: tmp-dir
+      - name: tmp-dir
+        emptyDir: {}
 ---
 # Source: cilium/templates/hubble/tls-certmanager/relay-client-secret.yaml
 apiVersion: cert-manager.io/v1


### PR DESCRIPTION
## Summary

Phase 7 の第 0 sub-project = **LB hardening**。 Phase 6 closure で identify した 引き継ぎ事項 **#37 / #39** を 1 sub-project で systematic 解消、 Phase 7 multi-env active 化 (= #29 / #33) の LB provision blocking 解消 + cluster LB architecture を panicboat 設計 spec ("north-south は ALB Controller、 east-west は cilium-gateway") に re-align。

## Scope

3 components + 1 fallback:

- **Component A: #37 fix** = terragrunt eks module の node SG cluster tag 除去 (= AWS LB Controller panic loop 解消、 multi-env LB provision の prerequisite)
- **Component B: Cilium upgrade** = 1.18.6 → 1.19+ / 1.20+ (= hostNetwork mode 改善期待)
- **Component C: #39 migration** = Cilium Gateway hostNetwork mode + ALB IngressGroup + reverse-proxy 廃止 + frontend HTTPRoute (= monthly ~$79 cost 削減 + Gateway 層 JWT validation 余地確保 + architectural drift 解消)
- **Fallback (= #39 fail 時)**: cilium revert + #40 bridge revival (= classic ELB cycle 防止のみ partial closure、 #39 を Phase 8+ 引き継ぎ persist)

## 完了条件 ((c) panicboat の "PR 手戻り最小化" + best effort + partial fallback)

- **strict completion** (= #37 fix + Cilium upgrade + #39 success): reverse-proxy 廃止 + cilium-gateway NLB 削除 + ALB IngressGroup 経由 develop.panicboat.net 公開 + monthly cost ~$79 削減
- **partial completion** (= #39 fail 時): #37 fix + Cilium upgrade + #40 bridge revival + cost ~$10-20 削減 + reverse-proxy 構成維持

## 作業中の cluster impact 許容

- cluster traffic 一時停止 OK (= maintenance window 設定不要)
- AWS resource cost 増は禁止 (= 試行錯誤で LB / RDS / etc 作りっぱなしにしない)
- 試行錯誤 / revert / retry 許容

## PR Structure

- **PR 1**: #37 fix (= terragrunt eks module node SG tag 除去)
- **PR 2**: Cilium upgrade (= 1.18.6 → 1.x.y)
- **PR 3**: #39 Cilium Gateway hostNetwork mode + ALB IngressGroup (= platform 側)
- **PR 4**: reverse-proxy 廃止 + frontend HTTPRoute (= monorepo 側)
- **PR F1** (= fallback、 #39 fail 時): cilium revert + #40 bridge

## Related

- Phase 6 closure: `docs/superpowers/specs/2026-05-13-eks-production-phase-6-closure-design.md`
- 引き継ぎ事項 #37 / #39 / #40 (= Phase 6 closure Section 4 Category I)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Updates**
  * Upgraded Cilium from 1.18.6 to 1.19.4 with new hostNetwork mode enabled.
  * Changed Cilium Gateway listener port to 8080 for ALB compatibility.

* **New Features**
  * Added ALB Ingress resource for application traffic routing to develop.panicboat.net.
  * Introduced application gateway service for improved traffic management.

* **Bug Fixes**
  * Fixed Kubernetes cluster tag duplication on AWS security groups preventing load balancer controller issues.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/panicboat/platform/pull/382)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->