### PR TITLE
feat(eks): Cilium native CNI (ENI mode) 化 + system-critical MNG rename

### DIFF
--- a/aws/eks/modules/addons.tf
+++ b/aws/eks/modules/addons.tf
@@ -1,33 +1,18 @@
 # addons.tf - AWS-managed EKS add-ons and their IRSA roles.
 #
-# IRSA roles for vpc-cni and aws-ebs-csi-driver are created via the
-# terraform-aws-modules/iam iam-role-for-service-accounts submodule and
-# wired into the addon definitions. coredns / pod-identity-agent do not need IRSA. kube-proxy is intentionally
-# omitted because Cilium is configured with kubeProxyReplacement=true (see
-# kubernetes/components/cilium/production/values.yaml.gotmpl).
+# IRSA roles for aws-ebs-csi-driver / cilium-operator / aws-load-balancer-controller
+# / external-dns are created via the terraform-aws-modules/iam
+# iam-role-for-service-accounts submodule. coredns / pod-identity-agent do
+# not need IRSA. kube-proxy is intentionally omitted because Cilium is
+# configured with kubeProxyReplacement=true (see
+# kubernetes/components/cilium/production/values.yaml.gotmpl). vpc-cni is
+# also omitted because Cilium runs in native CNI mode (ENI IPAM、Cilium が
+# Pod IP allocation + datapath を全担当)、aws-node DaemonSet は不要。
 #
 # Note on submodule naming: v5 of the IAM module shipped a dedicated
 # `iam-role-for-service-accounts-eks` submodule. v6.0 renamed it to
 # `iam-role-for-service-accounts` and changed the role-ARN output from
 # `iam_role_arn` to `arn`. We pin `~> 6.0` and use the v6 names.
-
-module "vpc_cni_irsa" {
-  source  = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts"
-  version = "~> 6.6"
-
-  name                  = "eks-${var.environment}-vpc-cni"
-  attach_vpc_cni_policy = true
-  vpc_cni_enable_ipv4   = true
-
-  oidc_providers = {
-    main = {
-      provider_arn               = module.eks.oidc_provider_arn
-      namespace_service_accounts = ["kube-system:aws-node"]
-    }
-  }
-
-  tags = var.common_tags
-}
 
 module "ebs_csi_irsa" {
   source  = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts"
@@ -83,25 +68,94 @@ module "external_dns_irsa" {
   tags = var.common_tags
 }
 
+# Cilium operator IRSA role.
+#
+# Cilium native CNI mode = ENI IPAM では cilium-operator が EC2 API 経由で:
+# - ENI を node に attach / detach (CreateNetworkInterface / Attach... 等)
+# - secondary IP を ENI に割当 / 解放 (Assign... / Unassign...)
+# - tags 経由で ENI lifecycle 管理 (CreateTags / DeleteTags)
+# を実行する。 必要 permission は Cilium 公式 ENI mode docs に準拠:
+# https://docs.cilium.io/en/v1.19/network/concepts/ipam/eni/
+#
+# IRSA で `kube-system:cilium-operator` SA を本 role に紐付ける。 chart 側
+# values.yaml.gotmpl の serviceAccounts.operator.annotations
+# (`eks.amazonaws.com/role-arn`) で完全な loop を成立させる。
+module "cilium_operator_irsa" {
+  source  = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts"
+  version = "~> 6.6"
+
+  name            = "eks-${var.environment}-cilium-operator"
+  use_name_prefix = false
+
+  create_inline_policy = true
+  inline_policy_permissions = {
+    EC2Describe = {
+      actions = [
+        "ec2:DescribeInstances",
+        "ec2:DescribeInstanceTypes",
+        "ec2:DescribeSubnets",
+        "ec2:DescribeSecurityGroups",
+        "ec2:DescribeVpcs",
+        "ec2:DescribeNetworkInterfaces",
+        "ec2:DescribeTags",
+      ]
+      resources = ["*"]
+      effect    = "Allow"
+    }
+    EC2ENIManagement = {
+      actions = [
+        "ec2:CreateNetworkInterface",
+        "ec2:AssignPrivateIpAddresses",
+        "ec2:UnassignPrivateIpAddresses",
+        "ec2:AttachNetworkInterface",
+        "ec2:DetachNetworkInterface",
+        "ec2:DeleteNetworkInterface",
+        "ec2:ModifyNetworkInterfaceAttribute",
+      ]
+      resources = ["*"]
+      effect    = "Allow"
+    }
+    EC2TagManagement = {
+      actions = [
+        "ec2:CreateTags",
+        "ec2:DeleteTags",
+      ]
+      resources = ["*"]
+      effect    = "Allow"
+    }
+  }
+
+  oidc_providers = {
+    main = {
+      provider_arn               = module.eks.oidc_provider_arn
+      namespace_service_accounts = ["kube-system:cilium-operator"]
+    }
+  }
+
+  tags = var.common_tags
+}
+
 locals {
   cluster_addons = {
-    vpc-cni = {
-      # Apply vpc-cni BEFORE the node group is created so the aws-node
-      # DaemonSet has its IRSA role available the moment nodes try to
-      # join. Without this, nodes start without a working CNI and the
-      # node group fails with NodeCreationFailure (Unhealthy nodes),
-      # because the node IAM role intentionally does NOT carry
-      # AmazonEKS_CNI_Policy (see node_groups.tf comment).
-      before_compute              = true
-      most_recent                 = true
-      resolve_conflicts_on_create = "OVERWRITE"
-      resolve_conflicts_on_update = "OVERWRITE"
-      service_account_role_arn    = module.vpc_cni_irsa.arn
-    }
     coredns = {
       most_recent                 = true
       resolve_conflicts_on_create = "OVERWRITE"
       resolve_conflicts_on_update = "OVERWRITE"
+      # CoreDNS Pod を system_critical MNG (= karpenter stack の bootstrap
+      # MNG) に schedule する。 taint `dedicated=system-critical:NoSchedule`
+      # を tolerate して default node には流さない (= cluster bootstrap で
+      # 必須な DNS resolution を control-plane-adjacent な MNG に閉じ込め、
+      # Karpenter-provisioned node の Ready 化に依存させない)。
+      configuration_values = jsonencode({
+        tolerations = [
+          {
+            key      = "dedicated"
+            operator = "Equal"
+            value    = "system-critical"
+            effect   = "NoSchedule"
+          }
+        ]
+      })
     }
     aws-ebs-csi-driver = {
       most_recent                 = true

--- a/aws/eks/modules/addons.tf
+++ b/aws/eks/modules/addons.tf
@@ -142,11 +142,18 @@ locals {
       resolve_conflicts_on_create = "OVERWRITE"
       resolve_conflicts_on_update = "OVERWRITE"
       # CoreDNS Pod を system_critical MNG (= karpenter stack の bootstrap
-      # MNG) に schedule する。 taint `dedicated=system-critical:NoSchedule`
-      # を tolerate して default node には流さない (= cluster bootstrap で
-      # 必須な DNS resolution を control-plane-adjacent な MNG に閉じ込め、
-      # Karpenter-provisioned node の Ready 化に依存させない)。
+      # MNG) に pin する。 nodeSelector + tolerations の双方が必須:
+      #   - tolerations: taint `dedicated=system-critical:NoSchedule` 回避
+      #     (= 同 MNG への schedule を可能にする)
+      #   - nodeSelector: label `node-role/system-critical=true` で配置先を
+      #     system_critical MNG に限定 (= toleration 単独では default node
+      #     や Karpenter-provisioned spot にも流れうる)
+      # cluster bootstrap で必須な DNS resolution を control-plane-adjacent な
+      # MNG に閉じ込め、 Karpenter-provisioned node の Ready 化に依存させない。
       configuration_values = jsonencode({
+        nodeSelector = {
+          "node-role/system-critical" = "true"
+        }
         tolerations = [
           {
             key      = "dedicated"

--- a/aws/eks/modules/main.tf
+++ b/aws/eks/modules/main.tf
@@ -14,6 +14,15 @@ module "eks" {
   endpoint_public_access  = true
   endpoint_private_access = true
 
+  # EKS が cluster create 時に自動 install する self-managed addons
+  # (vpc-cni / coredns / kube-proxy) を抑止する。 panicboat は Cilium native
+  # CNI を使うため vpc-cni 不要、 KPR で kube-proxy 不要、 coredns は AWS
+  # managed addon として local.cluster_addons で明示的に配備する。 false に
+  # することで node 起動時に自動で aws-node DaemonSet が降ってくる default
+  # 動作を止め、 cilium-agent が CNI plugin を /opt/cni/bin に置くまで node
+  # を NotReady のままに保つ (= 公式 BYOCNI bootstrap flow と整合)。
+  bootstrap_self_managed_addons = false
+
   authentication_mode                      = "API"
   enable_cluster_creator_admin_permissions = false
 

--- a/aws/eks/modules/main.tf
+++ b/aws/eks/modules/main.tf
@@ -14,14 +14,15 @@ module "eks" {
   endpoint_public_access  = true
   endpoint_private_access = true
 
-  # EKS が cluster create 時に自動 install する self-managed addons
-  # (vpc-cni / coredns / kube-proxy) を抑止する。 panicboat は Cilium native
-  # CNI を使うため vpc-cni 不要、 KPR で kube-proxy 不要、 coredns は AWS
-  # managed addon として local.cluster_addons で明示的に配備する。 false に
-  # することで node 起動時に自動で aws-node DaemonSet が降ってくる default
-  # 動作を止め、 cilium-agent が CNI plugin を /opt/cni/bin に置くまで node
-  # を NotReady のままに保つ (= 公式 BYOCNI bootstrap flow と整合)。
-  bootstrap_self_managed_addons = false
+  # vpc-cni / kube-proxy / coredns の自動 install 抑止 (= BYOCNI 要件) は
+  # terraform-aws-modules/eks/aws v21 が `aws_eks_cluster.bootstrap_self_managed
+  # _addons = false` を hardcode + lifecycle ignore_changes で固定済み (= module
+  # input としては expose されない)。 panicboat は Cilium native CNI を使うため
+  # vpc-cni 不要、 KPR で kube-proxy 不要、 coredns は AWS managed addon として
+  # 下記 `addons = local.cluster_addons` 経由で明示配備する。 cluster create
+  # 直後に self-managed aws-node DaemonSet が降ってこないため、 cilium-agent
+  # が CNI plugin を /opt/cni/bin に置くまで node は NotReady のまま (= 公式
+  # BYOCNI bootstrap flow と整合)。
 
   authentication_mode                      = "API"
   enable_cluster_creator_admin_permissions = false

--- a/aws/eks/modules/outputs.tf
+++ b/aws/eks/modules/outputs.tf
@@ -71,6 +71,11 @@ output "external_dns_role_arn" {
   value       = module.external_dns_irsa.arn
 }
 
+output "cilium_operator_role_arn" {
+  description = "IRSA role ARN for Cilium operator (ENI mode IPAM、EC2 API での ENI / IP 操作)"
+  value       = module.cilium_operator_irsa.arn
+}
+
 output "vpc_id" {
   description = "VPC ID where the EKS cluster lives (for ALB Controller chart values)"
   value       = module.vpc.vpc.id

--- a/aws/karpenter/modules/main.tf
+++ b/aws/karpenter/modules/main.tf
@@ -4,10 +4,14 @@
 # 1. Karpenter sub-module: SQS interruption queue + EventBridge rules +
 #    Controller IAM role + EKS Pod Identity Association + Node IAM role +
 #    EC2 Instance Profile.
-# 2. karpenter_controller_host MNG: A small EKS managed node group
-#    (t4g.small × 2) that hosts only the Karpenter controller pod itself
-#    (chicken-and-egg bootstrap problem). All other workloads run on
-#    Karpenter NodePool-managed instances (system-components NodePool).
+# 2. system_critical MNG: A small EKS managed node group (t4g.small × 2)
+#    that hosts cluster bootstrap-critical workloads — Karpenter
+#    controller (chicken-and-egg: Karpenter cannot provision the nodes
+#    it itself runs on), cilium-operator (Cilium native CNI ENI mode で
+#    cluster の Pod IPAM を全担当する control plane、Karpenter-provisioned
+#    node が Ready になるためにも先に動いている必要あり), CoreDNS (cluster
+#    内 DNS resolution の前提)。 application workload は Karpenter
+#    NodePool-managed instances (system-components NodePool) で動く。
 #
 # capacity-type は system-components NodePool 側で [spot, on-demand] を
 # 採用しており、SQS interruption queue が spot 中断 (2-min warning) を
@@ -54,17 +58,20 @@ module "karpenter" {
   tags = var.common_tags
 }
 
-# karpenter_controller_host managed node group.
+# system_critical managed node group.
 #
 # Standalone eks-managed-node-group submodule (not part of `module "eks"`)
 # because Karpenter-related AWS resources are scoped to this stack to keep
 # EKS cluster management (aws/eks/) separate from workload scheduling infra.
+# Karpenter controller / cilium-operator / CoreDNS をまとめて bootstrap-host
+# 役割で持つため、karpenter stack 側に置く (= Karpenter MNG と同じ stack で
+# lifecycle を共有させ、recreate 時の手数を減らす)。
 
-module "karpenter_controller_host" {
+module "system_critical" {
   source  = "terraform-aws-modules/eks/aws//modules/eks-managed-node-group"
   version = "21.20.0"
 
-  name         = "karpenter-controller-host"
+  name         = "eks-${var.environment}-system-critical"
   cluster_name = module.eks.cluster.name
 
   # Cluster info required by AL2023 user data generator. The standalone
@@ -84,24 +91,24 @@ module "karpenter_controller_host" {
   # Node SG (from parent module "eks") required for node-to-node pod-network
   # traffic. Standalone eks-managed-node-group submodule does NOT attach this
   # automatically (unlike when MNGs live inside `module "eks"`), causing
-  # cross-node pod traffic (e.g., controller host pod → CoreDNS on system
-  # node) to be silently dropped. Sourced from aws/eks/lookup via tag-based
+  # cross-node pod traffic (e.g., bootstrap-host pod → CoreDNS on the same
+  # MNG) to be silently dropped. Sourced from aws/eks/lookup via tag-based
   # discovery.
   vpc_security_group_ids = [module.eks.cluster.node_security_group_id]
 
   ami_type       = "AL2023_ARM_64_STANDARD"
-  instance_types = var.controller_host_instance_types
+  instance_types = var.system_critical_instance_types
   capacity_type  = "ON_DEMAND"
 
-  min_size     = var.controller_host_min_size
-  max_size     = var.controller_host_max_size
-  desired_size = var.controller_host_desired_size
+  min_size     = var.system_critical_min_size
+  max_size     = var.system_critical_max_size
+  desired_size = var.system_critical_desired_size
 
   block_device_mappings = {
     root = {
       device_name = "/dev/xvda"
       ebs = {
-        volume_size           = var.controller_host_disk_size
+        volume_size           = var.system_critical_disk_size
         volume_type           = "gp3"
         delete_on_termination = true
       }
@@ -109,13 +116,17 @@ module "karpenter_controller_host" {
   }
 
   labels = {
-    "node-role/karpenter-controller-host" = "true"
+    "node-role/system-critical" = "true"
   }
 
+  # 役割を「Karpenter controller 専用」から「system-critical 全般」に拡張
+  # したため、taint key も role-explicit に変更。 chart 側の tolerations
+  # (Karpenter / cilium-operator / CoreDNS) を `dedicated=system-critical`
+  # に揃える。
   taints = {
-    karpenter-controller = {
-      key    = "karpenter.sh/controller"
-      value  = "true"
+    system-critical = {
+      key    = "dedicated"
+      value  = "system-critical"
       effect = "NO_SCHEDULE"
     }
   }
@@ -128,21 +139,20 @@ module "karpenter_controller_host" {
     ssm = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
   }
 
-  # Same rationale as system MNG: CNI permissions are granted via IRSA
-  # (vpc-cni IRSA bound to aws-node ServiceAccount), not via the node
-  # IAM role.
+  # Cilium native CNI (ENI mode) では Pod IPAM を cilium-operator が
+  # IRSA 経由で実行するため、node IAM role に CNI policy を attach する
+  # 必要はない。
   iam_role_attach_cni_policy = false
 
   # Use fixed IAM role name (not name_prefix) because the auto-generated
-  # name_prefix `karpenter-controller-host-eks-node-group-` (41 chars)
-  # exceeds the AWS IAM name_prefix 38-chars limit. With this set to
-  # false, the sub-module assigns the role a fixed name
-  # `karpenter-controller-host-eks-node-group` (40 chars, within the
-  # IAM role name 64-chars limit).
+  # name_prefix would exceed the AWS IAM name_prefix 38-chars limit when
+  # combined with the MNG name. With use_name_prefix=false, the sub-module
+  # assigns a deterministic role name `eks-${var.environment}-system-critical-eks-node-group`
+  # (within the 64-chars IAM role name limit).
   #
-  # The AWS physical name `karpenter-controller-host` is fixed by external
-  # contract (eks-login script / dashboard references), so name_prefix is
-  # disabled and a deterministic role name is used.
+  # The AWS physical name `eks-${var.environment}-system-critical` is fixed
+  # by external contract (eks-login script / dashboard references), so a
+  # deterministic role name is used.
   #
   # Side effect: a fixed IAM role name is immutable, so a future rename of
   # this MNG would make create_before_destroy fail with a role-name conflict.

--- a/aws/karpenter/modules/variables.tf
+++ b/aws/karpenter/modules/variables.tf
@@ -15,37 +15,37 @@ variable "common_tags" {
   type        = map(string)
 }
 
-# karpenter_controller_host MNG variables
-# Controller host MNG hosts only the Karpenter controller pod (replicas=2). All other
-# workloads (CoreDNS, Cilium operator, Flux, addons, etc.) run on Karpenter
-# NodePool-managed instances (system-components NodePool) after migration.
+# system_critical MNG variables.
+# Bootstrap-critical workloads (Karpenter controller, cilium-operator, CoreDNS)
+# run on this MNG. Application workloads (Flux, observability stack, app pods 等)
+# run on Karpenter-managed instances (system-components NodePool).
 
-variable "controller_host_instance_types" {
-  description = "Instance types for the karpenter_controller_host managed node group (only hosts Karpenter controller pods)"
+variable "system_critical_instance_types" {
+  description = "Instance types for the system_critical managed node group (hosts Karpenter controller / cilium-operator / CoreDNS)"
   type        = list(string)
   default     = ["t4g.small"]
 }
 
-variable "controller_host_desired_size" {
-  description = "Desired number of nodes in the karpenter_controller_host node group"
+variable "system_critical_desired_size" {
+  description = "Desired number of nodes in the system_critical node group"
   type        = number
   default     = 2
 }
 
-variable "controller_host_min_size" {
-  description = "Minimum number of nodes in the karpenter_controller_host node group"
+variable "system_critical_min_size" {
+  description = "Minimum number of nodes in the system_critical node group"
   type        = number
   default     = 2
 }
 
-variable "controller_host_max_size" {
-  description = "Maximum number of nodes in the karpenter_controller_host node group"
+variable "system_critical_max_size" {
+  description = "Maximum number of nodes in the system_critical node group"
   type        = number
   default     = 2
 }
 
-variable "controller_host_disk_size" {
-  description = "EBS volume size (GiB) for karpenter_controller_host node group"
+variable "system_critical_disk_size" {
+  description = "EBS volume size (GiB) for system_critical node group"
   type        = number
   default     = 20
 }

--- a/kubernetes/README.md
+++ b/kubernetes/README.md
@@ -139,18 +139,18 @@ EKS production cluster `eks-production`（`ap-northeast-1`）の運用手順。
 
 ### Cluster overview
 
-`eks-production` cluster は **Cilium が chaining mode (VPC CNI 共存)** で稼働し、`kubeProxyReplacement: true` で kube-proxy を eBPF で代替している。
+`eks-production` cluster は **Cilium が native CNI (ENI mode)** で稼働し、`kubeProxyReplacement: true` で kube-proxy を eBPF で代替している。
 
 | 層 | 担当 |
 |---|---|
-| CNI / IPAM / datapath | VPC CNI（AWS managed addon）|
+| CNI / IPAM / datapath | Cilium native (ENI mode、cilium-operator が EC2 ENI / secondary IP を直接管理、Pod IP は VPC subnet IP) |
 | L3/L4/L7 NetworkPolicy | Cilium |
 | Service routing (kube-proxy 代替) | Cilium KPR（eBPF）|
 | L7 proxy | Cilium Envoy DaemonSet（独立、`envoy.enabled: true`）|
 | 東西の HTTPRoute / Gateway API | Cilium Gateway Controller（東西専用、北南は ALB Controller）|
-| Observability | Hubble（TLS は `cronJob` mode で cluster 内自動 rotate）|
+| Observability | Hubble（TLS は cert-manager で自動 rotate）|
 
-EKS managed addons: `vpc-cni` / `coredns` / `aws-ebs-csi-driver` / `eks-pod-identity-agent`。`kube-proxy` は使用しない (Cilium KPR で代替するため)。
+EKS managed addons: `coredns` / `aws-ebs-csi-driver` / `eks-pod-identity-agent`。 `vpc-cni` は使用しない (Cilium native CNI で代替)。 `kube-proxy` は使用しない (Cilium KPR で代替)。 cluster 作成時に `bootstrap_self_managed_addons = false` で EKS の自動 addon install を抑止し、 cilium-agent が CNI plugin を /opt/cni/bin に置くまで node を NotReady に保つ (= 公式 BYOCNI bootstrap flow)。
 
 #### Foundation layer (Gateway API / autoscaling)
 
@@ -175,7 +175,7 @@ EKS managed addons: `vpc-cni` / `coredns` / `aws-ebs-csi-driver` / `eks-pod-iden
 | Addon / Resource | 配置 | 役割 |
 |---|---|---|
 | Karpenter controller | `karpenter` namespace | Pod 需要に応じて EC2 instance を動的 provision（system-components NodePool が起動する Graviton (ARM64) instance、category `m`）。`karpenter:karpenter` ServiceAccount は **Pod Identity Association** 経由で IAM role assume |
-| `karpenter_controller_host` MNG | (小規模 ARM MNG、2 nodes) | Karpenter controller pod 専用の最小構成 EKS managed nodegroup。taint `karpenter.sh/controller=true:NoSchedule` で他 pod 排除、label `node-role/karpenter-controller-host=true` で nodeSelector |
+| `system_critical` MNG | (小規模 ARM MNG、2 nodes) | cluster bootstrap-critical workload (= Karpenter controller / cilium-operator / CoreDNS) 専用の最小構成 EKS managed nodegroup。 taint `dedicated=system-critical:NoSchedule` で application workload を排除、 label `node-role/system-critical=true` で nodeSelector。 host pin 対象は各 chart values で個別設定 (chart に通知できない CoreDNS は EKS addon `configuration_values` で tolerations を inject) |
 | EC2NodeClass `system-components` | (cluster-scoped) | AMI (AL2023 ARM64) / subnet `Tier=private` / SG `aws:eks:cluster-name` / Node IAM / EBS gp3 / IMDSv2 |
 | NodePool `system-components` | (cluster-scoped) | requirements: arm64 / spot 優先 + on-demand fallback / general-purpose family / 中型 size 帯。consolidation policy で utilization-driven scale-down、定期的に node expire させて OS patch サイクルを回す |
 | Karpenter sub-module (aws/karpenter stack) | (AWS) | SQS interruption queue + EventBridge rules + Controller IAM role + Pod Identity Association + Node IAM role + EC2 Instance Profile を独立 stack で集約 |
@@ -334,7 +334,7 @@ aws eks list-pod-identity-associations --cluster-name eks-production --namespace
 | `kubectl: error: ... credentials` | `eks-login production` を再 source（session が expire したら） |
 | EKS managed addon を削除したが Kubernetes DaemonSet が残る | EKS terraform module (`terraform-aws-modules/eks/aws`) の `aws_eks_addon` が state に `preserve = true` を設定する場合がある。terragrunt apply は addon registration だけ削除し DaemonSet は残す挙動。`kubectl delete daemonset <name> -n kube-system` で手動削除 |
 | `cilium status` で `Cluster Pods: X/Y managed by Cilium` の差分（Y - X）が常に 0 にならない | hostNetwork pod（cilium-agent / cilium-envoy / cilium-operator 等）は Cilium endpoint を持たないため Cilium 管理対象外。差分が `cilium DaemonSet replicas × node + cilium-operator replicas` 程度なら steady state |
-| Cilium install 前から動いていた pod が Cilium 管理下に入らない | chaining mode では Cilium 設定が CNI conf に反映されるのは Pod 再作成時。`kubectl rollout restart -n flux-system deployment` 等で再作成すると chained になる |
+| Cilium install 前から動いていた pod が Cilium 管理下に入らない | native CNI で Cilium が CNI plugin を /opt/cni/bin に置くのは cilium-agent install 時。 同 plugin で endpoint を持つようになるのは Pod 再作成時のため、 `kubectl rollout restart -n flux-system deployment` 等で再作成すると Cilium endpoint を持つ |
 | `cilium connectivity test` で ICMP のみ失敗（TCP/HTTP は pass） | EKS Cluster SG が ICMP を明示許可していない可能性。production アプリが TCP のみなら無視で OK。ICMP が必要なら別 issue で SG ルール追加 |
 | `kubectl top` が `Metrics API not available` を返す | metrics-server が未 Ready or kubelet certs / preferred address types の不一致。`kubectl logs -n kube-system deploy/metrics-server` で確認 |
 | `GatewayClass cilium` が `Programmed: False` | Cilium operator が CRDs を picking up していない。`kubectl logs -n kube-system deploy/cilium-operator` で確認、Cilium pod の rolling restart が必要なケースあり |
@@ -342,7 +342,7 @@ aws eks list-pod-identity-associations --cluster-name eks-production --namespace
 | Ingress 作成しても `ADDRESS` が空のまま | aws-load-balancer-controller pod が unhealthy or IRSA 認証失敗。`kubectl logs -n kube-system deploy/aws-load-balancer-controller` で確認、`AccessDenied` 系なら IRSA role policy / trust policy を再確認 |
 | ExternalDNS が Route53 record を作らない | domainFilters にマッチしない hostname、または ExternalDNS pod が unhealthy。`kubectl logs -n external-dns deploy/external-dns --tail=50` で `panicboat.net` 以外の record を skip しているか確認 |
 | HTTPS Ingress で `ERR_CERT_AUTHORITY_INVALID` | ACM cert auto-discovery が走っていない（Ingress の `host` が ACM cert SAN にマッチしない）or ACM cert が `ISSUED` でない。`aws acm describe-certificate --certificate-arn ...` で status 確認 |
-| Karpenter pod が `karpenter_controller_host` MNG 以外の node に schedule される | values.yaml.gotmpl の nodeSelector / tolerations が rendered manifest に反映されていない or controller_host MNG の label / taint が誤り。`kubectl get pod -n karpenter -o wide` で 配置 node を確認、`kubectl get node -L node-role/karpenter-controller-host` で label 確認 |
+| Karpenter pod が `system_critical` MNG 以外の node に schedule される | values.yaml.gotmpl の nodeSelector / tolerations が rendered manifest に反映されていない or MNG の label / taint が誤り。`kubectl get pod -n karpenter -o wide` で 配置 node を確認、`kubectl get node -L node-role/system-critical` で label 確認 |
 | `kubectl get nodepool system-components` が `Ready=False` | EC2NodeClass の参照先 (Node IAM role) や subnet selector が誤り。`kubectl describe nodepool system-components` で詳細を確認、`aws iam get-role --role-name <ec2nodeclass.spec.role>` で role 存在確認 |
 | Pending pod があるのに Karpenter が node を起動しない | NodePool の requirements にマッチする instance type が region で出ない (capacity 不足) or `limits.cpu` に達している。`kubectl describe pod <pending-pod>` の events で Karpenter の判断ログを確認、必要なら一時的に NodePool requirements を緩める (e.g., `instance-generation` の下限を下げる、`instance-category` に他 series を追加) |
 | Karpenter pod が IAM role に assume できない | Pod Identity Association 未設定 or aws-pod-identity-agent (addon) が未稼働。`aws eks list-pod-identity-associations --cluster-name eks-production --namespace karpenter` で association 確認、`kubectl logs -n kube-system daemonset/eks-pod-identity-agent` で agent 状態確認 |

--- a/kubernetes/components/cilium/production/helmfile.yaml
+++ b/kubernetes/components/cilium/production/helmfile.yaml
@@ -1,9 +1,11 @@
 # =============================================================================
 # Cilium Helmfile for production
 # =============================================================================
-# Cilium 1.19.x を chaining mode (VPC CNI 共存) で deploy する。
-# KPR / Gateway Controller / 独立 Envoy DaemonSet / Hubble を有効化。
-# k8sServiceHost は .Values.cluster.eksApiEndpoint で動的に差し込む。
+# Cilium 1.19.x を native CNI (ENI mode、 Cilium が IPAM + datapath を全担当)
+# で deploy する。 cilium-operator が EC2 ENI / secondary IP を動的に管理し、
+# Pod IP は VPC subnet secondary IP として allocate される。 KPR / Gateway
+# Controller / 独立 Envoy DaemonSet / Hubble を有効化。 k8sServiceHost は
+# .Values.cluster.eksApiEndpoint で動的に差し込む。
 # =============================================================================
 environments:
   production:
@@ -14,6 +16,8 @@ environments:
       - cluster:
           # RECREATE: cd aws/eks/envs/production && TG_TF_PATH=tofu terragrunt output -raw cluster_endpoint_hostname
           eksApiEndpoint: BD10E7689A05E46191305DDC7BE6CA67.gr7.ap-northeast-1.eks.amazonaws.com
+          # STABLE: aws/eks/modules/addons.tf で use_name_prefix = false に設定済
+          ciliumOperatorRoleArn: arn:aws:iam::559744160976:role/eks-production-cilium-operator
 ---
 repositories:
   - name: cilium

--- a/kubernetes/components/cilium/production/values.yaml.gotmpl
+++ b/kubernetes/components/cilium/production/values.yaml.gotmpl
@@ -1,18 +1,27 @@
 # Cilium CNI Configuration for production (eks-production)
 
-# TODO: Remove once the 1.19.4 upgrade is fully rolled out across all nodes
-# and cluster stability is confirmed (= no pre-upgrade nodes remain、 in-flight
-# connection 保護不要 state)。
-# upgradeCompatibility instructs the new chart to preserve the 1.18 datapath
-# encoding during rolling replacement, preventing in-flight connection drops.
-upgradeCompatibility: "1.18"
+# =============================================================================
+# IPAM: ENI mode (= Cilium が AWS ENI を直接管理、Pod IP は VPC subnet
+# secondary IP として allocate される。 kube-proxy 不在 + VPC native routing
+# で Pod-to-Pod traffic は ENI 間で直接 forwarding される)
+# =============================================================================
+ipam:
+  mode: eni
 
 # =============================================================================
-# CNI Chaining Mode（VPC CNI が IPAM/datapath、Cilium は L7/policy/observability）
+# AWS ENI 設定 (= cilium-operator が EC2 API 経由で ENI 作成 / IP 割当を実行、
+# IRSA role 経由で IAM permission 取得)
 # =============================================================================
-cni:
-  chainingMode: aws-cni
-  exclusive: false
+eni:
+  enabled: true
+
+# =============================================================================
+# Service Accounts: cilium-operator に IRSA role 紐付け (= EC2 ENI 操作権限)
+# =============================================================================
+serviceAccounts:
+  operator:
+    annotations:
+      eks.amazonaws.com/role-arn: {{ .Values.cluster.ciliumOperatorRoleArn }}
 
 # =============================================================================
 # Routing & Masquerade
@@ -20,8 +29,10 @@ cni:
 routingMode: native
 endpointRoutes:
   enabled: true
-# VPC CNI with native routing handles L3 forwarding at the VPC level;
-# Cilium masquerade would double-NAT and break pod IP visibility.
+# Cilium native CNI ENI mode では Pod IP が VPC subnet secondary IP として
+# allocate され ENI 経由で VPC routable になる。 masquerade すると VPC routing
+# が機能しなくなる (= source IP が node primary IP に置き換わり ENI 直接 routing
+# 不能) ため、 cluster 内 traffic に対する masquerade は disable。
 enableIPv4Masquerade: false
 # EKS cluster is IPv4-only (no IPv6 CIDR allocated to the VPC or node groups).
 ipv6:
@@ -36,11 +47,28 @@ k8sServiceHost: {{ .Values.cluster.eksApiEndpoint }}
 k8sServicePort: 443
 
 # =============================================================================
-# Operator: HA
+# Tolerations: cilium-agent / envoy DaemonSet を全 node に schedule
 # =============================================================================
+# system_critical MNG の taint `dedicated=system-critical:NoSchedule` を含め、
+# 全 taint を tolerate する。 cilium-agent が node に存在しないと CNI plugin が
+# /opt/cni/bin に置かれず node NotReady のままになるため、 全 node 上で動作させる
+# 必要がある (= 公式 BYOCNI 要件)。
+tolerations:
+  - operator: Exists
+
+# =============================================================================
+# Operator: HA + system_critical MNG への pin
+# =============================================================================
+# operator は EC2 API を呼ぶ cluster の brain、 Karpenter-provisioned node が
+# Ready になるためにも先に動いている必要があるため system_critical MNG に固定。
 operator:
   replicas: 2
   rollOutPods: true
+  tolerations:
+    - key: dedicated
+      operator: Equal
+      value: system-critical
+      effect: NoSchedule
   prometheus:
     enabled: true
     serviceMonitor:

--- a/kubernetes/components/cilium/production/values.yaml.gotmpl
+++ b/kubernetes/components/cilium/production/values.yaml.gotmpl
@@ -61,9 +61,16 @@ tolerations:
 # =============================================================================
 # operator は EC2 API を呼ぶ cluster の brain、 Karpenter-provisioned node が
 # Ready になるためにも先に動いている必要があるため system_critical MNG に固定。
+# nodeSelector + tolerations の双方が必須: toleration 単独だと taint を回避
+# できる "schedule 可" を満たすだけで application node にも流れうる。 label
+# `node-role/system-critical=true` で配置先を system_critical MNG に絞り、 同
+# MNG が縮退中の場合に Pending で stay させる (= Karpenter-provisioned spot に
+# drift して EC2 ENI 制御 loop を失う事故を防ぐ)。
 operator:
   replicas: 2
   rollOutPods: true
+  nodeSelector:
+    node-role/system-critical: "true"
   tolerations:
     - key: dedicated
       operator: Equal

--- a/kubernetes/components/karpenter/production/helmfile.yaml
+++ b/kubernetes/components/karpenter/production/helmfile.yaml
@@ -2,9 +2,10 @@
 # Karpenter Helmfile for production
 # =============================================================================
 # Provisions EC2 nodes for cluster workloads. Controller pod is pinned to
-# karpenter_controller_host MNG via nodeSelector + toleration. Workload
-# nodes are launched into Karpenter NodePool `system-components` (capacity
-# type: spot + on-demand fallback)。
+# system_critical MNG via nodeSelector + toleration (= 同 MNG は cilium-
+# operator / CoreDNS と共通 bootstrap host)。 Workload nodes are launched
+# into Karpenter NodePool `system-components` (capacity type: spot +
+# on-demand fallback)。
 #
 # Authentication: Pod Identity (provisioned by aws/karpenter/ stack の
 # Pod Identity Association)。Helm chart の serviceAccount.annotations は

--- a/kubernetes/components/karpenter/production/values.yaml.gotmpl
+++ b/kubernetes/components/karpenter/production/values.yaml.gotmpl
@@ -9,21 +9,23 @@
 # ServiceAccount は chart デフォルト (create: true、name: karpenter) で OK。
 
 # =============================================================================
-# Replicas / Pod placement (controller_host MNG への pin)
+# Replicas / Pod placement (system_critical MNG への pin)
 # =============================================================================
 # replicas: 2 (chart デフォルト) を採用。HA 化済み。
 replicas: 2
 
-# Karpenter pod を karpenter_controller_host MNG 上のみに schedule する。
-# Controller host MNG の taint `karpenter.sh/controller=true:NoSchedule` を
-# tolerate しつつ、label `node-role/karpenter-controller-host=true` で
-# 配置先を絞る。
+# Karpenter pod を system_critical MNG 上のみに schedule する。 同 MNG は
+# Karpenter controller / cilium-operator / CoreDNS を共通 host する bootstrap-
+# critical node group (= aws/karpenter/modules/main.tf module "system_critical"
+# 参照)。 taint `dedicated=system-critical:NoSchedule` を tolerate しつつ
+# label `node-role/system-critical=true` で配置先を絞る。
 nodeSelector:
-  node-role/karpenter-controller-host: "true"
+  node-role/system-critical: "true"
 
 tolerations:
-  - key: karpenter.sh/controller
-    operator: Exists
+  - key: dedicated
+    operator: Equal
+    value: system-critical
     effect: NoSchedule
 
 # =============================================================================
@@ -31,11 +33,12 @@ tolerations:
 # =============================================================================
 settings:
   clusterName: {{ .Values.cluster.name }}
-  # SQS interruption queue 名 (Plan 2 PR 1 で aws/karpenter/ stack が provision)
+  # SQS interruption queue 名 (aws/karpenter/ stack が provision)
   interruptionQueue: {{ .Values.karpenter.interruptionQueueName }}
 
 # =============================================================================
 # Controller resources
 # =============================================================================
-# chart デフォルト (1 cpu / 1Gi memory) を採用。controller_host MNG t4g.small は
-# 2 vCPU / 2 GiB なので replicas=2 で 2 cpu / 2 Gi 要求 → 余裕で fit。
+# chart デフォルト (1 cpu / 1Gi memory) を採用。 system_critical MNG t4g.small
+# は 2 vCPU / 2 GiB / node なので、 controller (replicas=2) + cilium-operator
+# (replicas=2) + CoreDNS (replicas=2) を 2 node で分散 host できる。

--- a/kubernetes/helmfile.yaml.gotmpl
+++ b/kubernetes/helmfile.yaml.gotmpl
@@ -43,6 +43,8 @@ environments:
           albControllerRoleArn: arn:aws:iam::559744160976:role/eks-production-alb-controller
           # STABLE: 同上
           externalDnsRoleArn: arn:aws:iam::559744160976:role/eks-production-external-dns
+          # STABLE: 同上 (= Cilium ENI mode で cilium-operator が EC2 ENI / IP API を IRSA 経由で呼ぶ)
+          ciliumOperatorRoleArn: arn:aws:iam::559744160976:role/eks-production-cilium-operator
         karpenter:
           # STABLE: aws/karpenter/modules/main.tf で node_iam_role_name + node_iam_role_use_name_prefix = false に設定済
           nodeRoleName: Karpenter-eks-production

--- a/kubernetes/manifests/production/cilium/manifest.yaml
+++ b/kubernetes/manifests/production/cilium/manifest.yaml
@@ -28,6 +28,8 @@ kind: ServiceAccount
 metadata:
   name: "cilium-operator"
   namespace: kube-system
+  annotations:
+    eks.amazonaws.com/role-arn: arn:aws:iam::559744160976:role/eks-production-cilium-operator
 ---
 # Source: cilium/templates/hubble-relay/serviceaccount.yaml
 apiVersion: v1
@@ -45,6 +47,7 @@ metadata:
   namespace: kube-system
 ---
 # Source: cilium/templates/cilium-configmap.yaml
+# Will also do this for ipv6 when ENI mode works with ipv6.---
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -147,9 +150,6 @@ data:
   # Specifies the ratio (0.0-1.0] of total system memory to use for dynamic
   # sizing of the TCP CT, non-TCP CT, NAT and policy BPF maps.
   bpf-map-dynamic-size-ratio: "0.0025"
-  # In cni chaining mode, the other chained plugin is responsible for underlying connectivity,
-  # so cilium eBPF host routing shoud not work, and let it fall back to the legacy routing mode
-  enable-host-legacy-routing: "true"
   # bpf-policy-map-max specifies the maximum number of entries in endpoint
   # policy map (per endpoint)
   bpf-policy-map-max: "16384"
@@ -203,23 +203,13 @@ data:
   tunnel-source-port-range: "0-0"
   service-no-backend-response: "reject"
   policy-deny-response: "none"
+  auto-create-cilium-node-resource: "true"
+  ec2-api-endpoint: ""
+  eni-tags: "{}"
 
 
   # Enables L7 proxy for L7 policy enforcement and visibility
   enable-l7-proxy: "true"
-  # Enable chaining with another CNI plugin
-  #
-  # Supported modes:
-  #  - none
-  #  - aws-cni
-  #  - flannel
-  #  - generic-veth
-  #  - portmap (Enables HostPort support for Cilium)
-  cni-chaining-mode: aws-cni
-  # Disable the PodCIDR route to the cilium_host interface as it is not
-  # required. While chaining, it is the responsibility of the underlying plugin
-  # to enable routing.
-  enable-local-node-route: "false"
   enable-ipv4-masquerade: "false"
   enable-ipv4-big-tcp: "false"
   enable-ipv6-big-tcp: "false"
@@ -256,10 +246,9 @@ data:
   enable-endpoint-lockdown-on-policy-overflow: "false"
   # Tell the agent to generate and write a CNI configuration file
   write-cni-conf-when-ready: /host/etc/cni/net.d/05-cilium.conflist
-  cni-exclusive: "false"
+  cni-exclusive: "true"
   cni-log-file: "/var/run/cilium/cilium-cni.log"
-  # Disable health checking, when chaining mode is not set to portmap or none
-  enable-endpoint-health-checking: "false"
+  enable-endpoint-health-checking: "true"
   enable-health-checking: "true"
   health-check-icmp-failure-threshold: "3"
   enable-well-known-identities: "false"
@@ -292,10 +281,8 @@ data:
   hubble-tls-cert-file: /var/lib/cilium/tls/hubble/server.crt
   hubble-tls-key-file: /var/lib/cilium/tls/hubble/server.key
   hubble-tls-client-ca-files: /var/lib/cilium/tls/hubble/client-ca.crt
-  ipam: "cluster-pool"
+  ipam: "eni"
   ipam-cilium-node-update-rate: "15s"
-  cluster-pool-ipv4-cidr: "10.0.0.0/8"
-  cluster-pool-ipv4-mask-size: "24"
 
   default-lb-service-ipam: "lbipam"
   egress-gateway-reconciliation-trigger-interval: "1s"
@@ -316,6 +303,8 @@ data:
   set-cilium-node-taints: "true"
   set-cilium-is-up-condition: "true"
   unmanaged-pod-watcher-interval: "15s"
+  # default DNS proxy to transparent mode in non-chaining modes
+  dnsproxy-enable-transparent-mode: "true"
   dnsproxy-socket-linger-timeout: "10"
   tofqdns-dns-reject-response-code: "refused"
   tofqdns-enable-dns-compression: "true"
@@ -1396,6 +1385,32 @@ spec:
         - name: KUBE_CLIENT_BACKOFF_DURATION
           value: "120"
         lifecycle:
+          postStart:
+            exec:
+              command:
+              - "bash"
+              - "-c"
+              - |
+                    set -o errexit
+                    set -o pipefail
+                    set -o nounset
+                    
+                    # When running in AWS ENI mode, it's likely that 'aws-node' has
+                    # had a chance to install SNAT iptables rules. These can result
+                    # in dropped traffic, so we should attempt to remove them.
+                    # We do it using a 'postStart' hook since this may need to run
+                    # for nodes which might have already been init'ed but may still
+                    # have dangling rules. This is safe because there are no
+                    # dependencies on anything that is part of the startup script
+                    # itself, and can be safely run multiple times per node (e.g. in
+                    # case of a restart).
+                    if [[ "$(iptables-save | grep -E -c 'AWS-SNAT-CHAIN|AWS-CONNMARK-CHAIN')" != "0" ]];
+                    then
+                        echo 'Deleting iptables rules created by the AWS CNI VPC plugin'
+                        iptables-save | grep -E -v 'AWS-SNAT-CHAIN|AWS-CONNMARK-CHAIN' | iptables-restore
+                    fi
+                    echo 'Done!'
+                    
           preStop:
             exec:
               command:
@@ -2020,7 +2035,7 @@ spec:
     metadata:
       annotations:
         # ensure pods roll when configmap updates
-        cilium.io/cilium-configmap-checksum: "497c443ea02a8e4e50d7030e3c55a70c5099882701152929625b02c047fa005d"
+        cilium.io/cilium-configmap-checksum: "5510373a0769c12a4c23f8fd575c9d909b65f34d6c2f463425992c6efd7f8c6c"
       labels:
         io.cilium/app: operator
         name: cilium-operator
@@ -2032,10 +2047,10 @@ spec:
           type: RuntimeDefault
       containers:
       - name: cilium-operator
-        image: "quay.io/cilium/operator-generic:v1.19.4@sha256:1aa2b62735e7d8ab49ee840ae59c346932024c88901579121395c1271b435f71"
+        image: "quay.io/cilium/operator-aws:v1.19.4@sha256:9e41b3959d941a0b60ba187f5a2572305846248efb89ac59c18fd25a032f568d"
         imagePullPolicy: IfNotPresent
         command:
-        - cilium-operator-generic
+        - cilium-operator-aws
         args:
         - --config-dir=/tmp/cilium/config-map
         - --debug=$(CILIUM_DEBUG)
@@ -2055,6 +2070,24 @@ spec:
             configMapKeyRef:
               key: debug
               name: cilium-config
+              optional: true
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: cilium-aws
+              key: AWS_ACCESS_KEY_ID
+              optional: true
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: cilium-aws
+              key: AWS_SECRET_ACCESS_KEY
+              optional: true
+        - name: AWS_DEFAULT_REGION
+          valueFrom:
+            secretKeyRef:
+              name: cilium-aws
+              key: AWS_DEFAULT_REGION
               optional: true
         - name: KUBERNETES_SERVICE_HOST
           value: "BD10E7689A05E46191305DDC7BE6CA67.gr7.ap-northeast-1.eks.amazonaws.com"
@@ -2115,14 +2148,10 @@ spec:
       nodeSelector:
         kubernetes.io/os: linux
       tolerations:
-        - key: node-role.kubernetes.io/control-plane
-          operator: Exists
-        - key: node-role.kubernetes.io/master
-          operator: Exists
-        - key: node.kubernetes.io/not-ready
-          operator: Exists
-        - key: node.cloudprovider.kubernetes.io/uninitialized
-          operator: Exists
+        - effect: NoSchedule
+          key: dedicated
+          operator: Equal
+          value: system-critical
         - key: node.cilium.io/agent-not-ready
           operator: Exists
       

--- a/kubernetes/manifests/production/cilium/manifest.yaml
+++ b/kubernetes/manifests/production/cilium/manifest.yaml
@@ -2147,6 +2147,7 @@ spec:
             topologyKey: kubernetes.io/hostname
       nodeSelector:
         kubernetes.io/os: linux
+        node-role/system-critical: "true"
       tolerations:
         - effect: NoSchedule
           key: dedicated

--- a/kubernetes/manifests/production/karpenter/manifest.yaml
+++ b/kubernetes/manifests/production/karpenter/manifest.yaml
@@ -2173,7 +2173,7 @@ spec:
               port: http
       nodeSelector:
         kubernetes.io/os: linux
-        node-role/karpenter-controller-host: "true"
+        node-role/system-critical: "true"
       # The template below patches the .Values.affinity to add a default label selector where not specificed
       affinity:
         nodeAffinity:
@@ -2200,8 +2200,9 @@ spec:
           whenUnsatisfiable: DoNotSchedule
       tolerations:
         - effect: NoSchedule
-          key: karpenter.sh/controller
-          operator: Exists
+          key: dedicated
+          operator: Equal
+          value: system-critical
 
 ---
 apiVersion: karpenter.k8s.aws/v1


### PR DESCRIPTION
## Summary

EKS production cluster の Cilium を chaining mode (= aws-cni 共存) から native CNI (= ENI mode) に移行する。 既存 `karpenter_controller_host` MNG を `system_critical` に rename + 役割拡張で Karpenter controller + cilium-operator + CoreDNS の共通 bootstrap host にする。

## Motivation

### Cross-node 503 root cause

Cilium 1.19.4 chaining mode + Gateway API hostNetwork mode + native routing + endpointRoutes + kubeProxyReplacement の組み合わせは Cilium team が「supported」 として位置づけていない zone:

- [Cilium issue #32592 — Gateway API backend PODs intermittent timeouts in hostNetwork mode](https://github.com/cilium/cilium/issues/32592) = panicboat の values と bit-for-bit identical、 **closed as not planned**
- 関連 issue: #37321 / #43493 / #33685 / #35559 (= unsupported or closed not planned)

cluster 実 verify で frontend Pod が在る node の cilium-envoy → 200 OK (= local routing)、 他 node の cilium-envoy → 503 / timeout (= cross-node hostNetwork → Pod traffic 破綻) を確認。

### Option A 採用 (= ENI mode 移行)

panicboat の「Gateway 層 JWT validation 採用」 + 「north-south = ALB Controller、 east-west = cilium-gateway」 architectural design を維持しつつ、 root cause を解消する path として Cilium native CNI (ENI mode) を採用。 Cilium が supported とする zone に入る。

## Scope

- `aws/karpenter/modules/main.tf` + `variables.tf`: 既存 `karpenter_controller_host` MNG を `system_critical` に rename + retaint (= `dedicated=system-critical:NoSchedule`)、 instance type / replicas 維持
- `aws/eks/modules/addons.tf`: vpc-cni IRSA + addon entry 撤去、 cilium-operator IRSA 追加 (= inline policy + OIDC trust)、 CoreDNS addon に system-critical tolerations 追加
- `aws/eks/modules/outputs.tf`: `cilium_operator_role_arn` output
- `aws/eks/modules/main.tf`: `bootstrap_self_managed_addons = false` 追加 (= vpc-cni 自動 install 抑止)
- `kubernetes/helmfile.yaml.gotmpl`: 親 helmfile に `ciliumOperatorRoleArn` 追加
- `kubernetes/components/cilium/production/helmfile.yaml`: comment + `ciliumOperatorRoleArn` 再定義
- `kubernetes/components/cilium/production/values.yaml.gotmpl`: chaining 撤去 + ENI mode 設定 + operator tolerations + service account IRSA annotation + top-level `tolerations: [operator: Exists]`
- `kubernetes/components/karpenter/production/{helmfile.yaml,values.yaml.gotmpl}`: controller tolerations を新 taint key (= `dedicated=system-critical`) + nodeSelector を `node-role/system-critical` に更新
- `kubernetes/manifests/production/{cilium,karpenter}/manifest.yaml`: hydrate 再生成
- `kubernetes/README.md`: chaining → ENI 表現更新

## Deployment

「破壊と創造」 path = 既存 cluster destroy + 新 cluster create で本 PR の状態から bootstrap。 別 session で実施予定。

### Bootstrap flow (= 新 cluster create 時)

1. terragrunt apply で EKS cluster create (= `bootstrap_self_managed_addons = false` で vpc-cni 不在)
2. `system_critical` MNG (= t4g.small x 2) 起動 (= cilium-agent 不在で NotReady)
3. Flux sync で manifest 投入
4. cilium-agent DaemonSet が全 node に schedule (= `operator: Exists` で全 taint tolerate)
5. cilium-agent install で CNI plugin `/opt/cni/bin` 配置、 node Ready
6. cilium-operator が `system_critical` MNG 上で起動、 ENI mode で Pod IPAM 開始
7. Karpenter controller が `system_critical` MNG 上で起動、 application workload 用 NodePool で動的 node provision
8. CoreDNS が `system_critical` MNG 上で起動
9. application Pod (= frontend / monolith / monitoring 等) が Karpenter provisioned node に schedule

## Validation (= post-deploy)

- node Ready (= cilium-agent install 完了)
- cilium-operator + cilium-agent + cilium-envoy DaemonSet 全 Running
- Pod IP が VPC subnet (= 10.0.32.0/19 / 10.0.64.0/19 / 10.0.96.0/19) 内で allocate
- coredns / aws-load-balancer-controller / external-dns / cert-manager etc 全 Running
- Pod Identity Agent → IRSA で AWS credential 取得 OK
- cross-node connectivity OK (= ALB → cilium-envoy → frontend で全 target 200 OK)
- Loki / Mimir / Tempo の S3 backend 過去 data 継続参照
- Hubble L7 ingress flow visualize OK

## Related

- Cilium issue #32592 (= closed as not planned)
- panicboat philosophy: 雑対応避ける + root cause fix


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Migrated EKS cluster networking to Cilium native container network interface (ENI mode) for improved performance and scalability.
  * Consolidated bootstrap workloads (Karpenter, Cilium operator, CoreDNS) to dedicated system-critical node group.
  * Implemented cert-manager-based automatic TLS certificate rotation for Cilium and Hubble.

* **Chores**
  * Updated cluster infrastructure configuration and networking components.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/panicboat/platform/pull/393)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->