### PR TITLE
docs(eks-lifecycle): README 補強 — operator-prompted RECREATE marker update flow

### DIFF
--- a/scripts/eks-lifecycle/README.md
+++ b/scripts/eks-lifecycle/README.md
@@ -6,11 +6,32 @@ Temporary teardown / idempotent recreate of `eks-production` cluster + 周辺 AW
 
 ## Prerequisites
 
-- 操作者の IAM principal が `sts:AssumeRole` で以下を assume できること:
-  - `arn:aws:iam::<acct>:role/github-oidc-auth-production-github-actions-apply-role`
-  - `arn:aws:iam::<acct>:role/eks-admin-production`
+- **操作者の IAM principal** が以下を満たすこと:
+  - terragrunt apply / destroy に必要な AWS 操作権限を default credential chain で利用可能 (= 例: panicboat IAM user は `AdministratorAccess` 保持)。GitHub OIDC apply role (= `github-oidc-auth-${ENV}-github-actions-apply-role`) は `sts:AssumeRoleWithWebIdentity` のみ trust で IAM user からは assume 不可、operator 自身の credentials で直接 terragrunt を実行する
+  - `eks-admin-${ENV}` role を `sts:AssumeRole` で assume 可能 (= 同 role の trust policy は IAM root を許可、AWS 上で account 内任意の IAM principal が `sts:AssumeRole` 権限保持していれば成立)
 - 手元に installed: `tofu`, `terragrunt`, `kubectl`, `flux`, `jq`, `aws`, `make`, `bash`
 - repo root から `make` を実行する (= `Makefile` がある場所)
+- **対話型 terminal で実行**: `confirm` プロンプトが stdin から `y` を読むため、CI / pipe / nohup 経由などの非対話実行ではプロンプトで EOF となり `set -e` で即終了する
+
+## Pre-flight checks
+
+teardown / recreate 開始前に以下を確認:
+
+```bash
+# 1. operator identity (= 期待する IAM user / role か)
+aws sts get-caller-identity
+
+# 2. cluster 接続性 (= recreate 後の検証にも使う)
+kubectl config current-context
+kubectl get nodes
+
+# 3. 70-reconcile-watch.sh が wait する HelmRelease の audit
+#    (= 出力が lib/70-reconcile-watch.sh の wait_helmreleases 引数と一致するか確認)
+kubectl get helmreleases -A -o json | \
+  jq -r '.items[] | "\(.metadata.namespace)/\(.metadata.name)"' | sort
+```
+
+3 番目で差分 (= 新規 chart 追加 / removal) があれば `lib/70-reconcile-watch.sh` 側を先に更新してから recreate を回す。
 
 ## Usage
 
@@ -27,7 +48,7 @@ make eks-teardown ENV=production
 実行内容:
 
 1. `10-k8s-cleanup.sh`: kubectl delete ingress / LB svc / Karpenter NodePool、ノード drain 待機
-2. `30-destroy-stacks.sh`: 8 stacks を固定順で `terragrunt destroy` (= karpenter → eks-secrets → eks-logs/metrics/traces → eks → alb → vpc)
+2. `30-destroy-stacks.sh`: 「8 stack を destroy するか」y/N 確認 → 8 stacks を固定順で `terragrunt destroy` (= karpenter → eks-secrets → eks-logs/metrics/traces → eks → alb → vpc)
 3. `40-orphan-verify.sh`: ENI / EBS / target group / SG / Route53 record / CloudWatch log group の orphan 検出 (= 削除はしない、人間に diagnostic 提示)
 
 部分実行:
@@ -44,22 +65,67 @@ make eks-teardown-verify ENV=production    # orphan verify only
 # Dry-run
 DRY_RUN=1 make eks-recreate ENV=production
 
-# Live run
+# Live run (= 途中で operator の手作業が入る、後述)
 make eks-recreate ENV=production
 ```
 
 実行内容:
 
-1. `50-apply-stacks.sh`: 8 stacks を固定順で `terragrunt apply` (= vpc → alb → eks → karpenter → eks-secrets → eks-logs/metrics/traces)
-2. `60-flux-bootstrap.sh`: hydrate-component で manifests を新 cluster ID で再生成 → git commit + push → `kubectl apply -k kubernetes/clusters/production/`
+1. `50-apply-stacks.sh`: 「8 stack を apply するか」y/N 確認 → 8 stacks を固定順で `terragrunt apply` (= vpc → alb → eks → karpenter → eks-secrets → eks-logs/metrics/traces)
+2. `60-flux-bootstrap.sh`: **operator-prompted RECREATE marker update** (後述) → re-hydrate kubernetes manifests → git commit + push to main → `kubectl apply -k kubernetes/clusters/production/`
 3. `70-reconcile-watch.sh`: 全 HelmRelease が Ready になるまで Phase 単位で wait
+
+部分実行:
+
+```bash
+make eks-recreate-aws ENV=production       # terragrunt apply only
+make eks-recreate-flux ENV=production      # flux bootstrap only (= operator-prompted)
+make eks-recreate-watch ENV=production     # reconcile watch only
+```
+
+### Operator-prompted RECREATE marker update (= `60-flux-bootstrap.sh` Step 60.2)
+
+recreate のたびに変化する 2 種類の値 (= 新 cluster ID + 新 VPC ID) を hardcode した 4 箇所を、operator が手で更新する。 `60-flux-bootstrap.sh` が以下のように marker を grep + 列挙して `confirm` で待機する:
+
+```
+=================================================================
+ The following values must be updated MANUALLY before continuing.
+ For each '# RECREATE: <command>' line, run the command and
+ replace the next line's value with the command's stdout.
+=================================================================
+
+## kubernetes/helmfile.yaml.gotmpl
+  38:  # RECREATE: cd aws/eks/envs/production && TG_TF_PATH=tofu terragrunt output -raw cluster_endpoint_hostname
+  39-  eksApiEndpoint: <old value>
+  40:  # RECREATE: cd aws/vpc/envs/production && TG_TF_PATH=tofu terragrunt output -raw vpc_id
+  41-  vpcId: <old value>
+
+## kubernetes/components/aws-load-balancer-controller/production/helmfile.yaml
+  16:  # RECREATE: cd aws/vpc/envs/production && TG_TF_PATH=tofu terragrunt output -raw vpc_id
+  17-  vpcId: <old value>
+
+## kubernetes/components/cilium/production/helmfile.yaml
+  15:  # RECREATE: cd aws/eks/envs/production && TG_TF_PATH=tofu terragrunt output -raw cluster_endpoint_hostname
+  16-  eksApiEndpoint: <old value>
+
+Have you updated all RECREATE-marked values? (y to continue) [y/N]
+```
+
+operator の手順:
+
+1. 別 terminal で 2 つの `terragrunt output` コマンドを実行し、新 cluster_endpoint_hostname と vpc_id を取得
+2. editor で **4 箇所** を新値に書き換え (= eksApiEndpoint × 2 + vpcId × 2)
+3. script に戻って `y` を入力 → script が `kubernetes/components/*/${ENV}/` を hydrate → `git diff kubernetes/` を表示 → `confirm` で push 承認 → main に commit + push → `kubectl apply -k kubernetes/clusters/production/`
+
+marker convention の design rationale は `kubernetes/helmfile.yaml.gotmpl` 冒頭コメント参照 (= sed 自動置換ではなく operator-prompted を選んだ理由: PR #326 incident で audit pass 漏れがあり、目視で 1 件ずつ確認する方が confidence 高い)。
 
 ## Failure handling
 
 - 各 step は **fail fast** (= 即 exit 1)、診断メッセージで「次に何を打つべきか」を提示
 - partial state からの再 run は idempotent: `make eks-teardown` / `make eks-recreate` は何度叩いても安全
 - ロールバックは前進復旧のみ (= teardown 中断は再 teardown、recreate 中断は再 recreate)
-- credentials 期限 1h は `00-auth.sh` が自動再 assume
+- admin role 一時 credentials の expire (= 1h STS session) は `30-destroy-stacks.sh` / `50-apply-stacks.sh` の各 stack 開始時に `creds_expiring_soon` (< 5min) で検出して `00-auth.sh` を re-source、admin role を assume し直す
+- `40-orphan-verify.sh` は read-only verify で auto-delete しない (= false-positive 含み得る出力を operator が目視精査し、必要なら提示された AWS CLI コマンドで個別削除)
 
 ## What is preserved through teardown
 


### PR DESCRIPTION
PR #390 (= Phase 3 lifecycle scripts) merge 後の follow-up。実運用フローのうち以下が `scripts/eks-lifecycle/README.md` に不足していたため追記。

## 追記内容

### Prerequisites の正確化

旧記述では「GitHub OIDC apply role を assume できること」を要求していたが、当該 role の trust policy は `sts:AssumeRoleWithWebIdentity` only で IAM user からは assume 不可。実際の design は「operator の default credential chain (= 例: panicboat IAM user の `AdministratorAccess`) で terragrunt を直接実行」「`eks-admin-${ENV}` role は IAM root trust で assume 可、kubectl ops 用」というモデル (= PR #390 commit `80bf1ce` で確立済) に修正。

### Pre-flight checks 節新設

- `aws sts get-caller-identity` で operator identity 確認
- `kubectl config current-context` + `kubectl get nodes` で cluster 接続性確認
- `kubectl get helmreleases -A` で `lib/70-reconcile-watch.sh` の `wait_helmreleases` 引数が live cluster の HelmRelease 一覧と一致するか audit (= chart 追加 / removal で差分があれば script を先に更新)

### Recreate 節の operator-prompted flow 詳細化

`60-flux-bootstrap.sh` Step 60.2 の prompt 出力サンプルと、operator が手で行う 4 箇所 edit (= `eksApiEndpoint` × 2 + `vpcId` × 2 across `kubernetes/helmfile.yaml.gotmpl` + `cilium 子 helmfile` + `aws-load-balancer-controller 子 helmfile`) を詳細記述。design rationale (= sed 自動置換ではなく operator-prompted を選んだ理由は PR #326 incident の audit pass 漏れの反省) は `kubernetes/helmfile.yaml.gotmpl` 冒頭コメントに既存のため reference のみ。

### Failure handling

`00-auth.sh` の credential refresh 動作を正確化 — apply creds は operator IAM user の static creds で expire しない、admin role の 1h STS session のみ `creds_expiring_soon` で検出して re-source で refresh。

### 対話型 terminal 必須の明記

`confirm` が `read -r -p` で stdin から `y` を読むため、pipe / CI / nohup 経由などの非対話実行ではプロンプトで EOF となり `set -e` で即終了する旨を Prerequisites に追加 (= dry-run 検証時に `yes y | make ...` の workaround が必要だった理由)。

## Test plan

- [x] markdown lint (= 既存 docs スタイルとの整合)
- [x] 操作者視点での read-through (= recreate 中の手動 edit 手順が独立して理解できるか)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced EKS cluster lifecycle operational guide with clarified IAM prerequisites, expanded pre-flight validation, and detailed step-by-step procedures for cluster teardown and recreation, including improved credential and failure-handling guidance.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/panicboat/platform/pull/394)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->