### PR TITLE
fix(eks-lifecycle): 40-orphan-verify.sh exit 0 in DRY_RUN

### DIFF
--- a/scripts/eks-lifecycle/README.md
+++ b/scripts/eks-lifecycle/README.md
@@ -125,7 +125,7 @@ marker convention の design rationale は `kubernetes/helmfile.yaml.gotmpl` 冒
 - partial state からの再 run は idempotent: `make eks-teardown` / `make eks-recreate` は何度叩いても安全
 - ロールバックは前進復旧のみ (= teardown 中断は再 teardown、recreate 中断は再 recreate)
 - admin role 一時 credentials の expire (= 1h STS session) は `30-destroy-stacks.sh` / `50-apply-stacks.sh` の各 stack 開始時に `creds_expiring_soon` (< 5min) で検出して `00-auth.sh` を re-source、admin role を assume し直す
-- `40-orphan-verify.sh` は read-only verify で auto-delete しない (= false-positive 含み得る出力を operator が目視精査し、必要なら提示された AWS CLI コマンドで個別削除)
+- `40-orphan-verify.sh` は read-only verify で auto-delete しない (= false-positive 含み得る出力を operator が目視精査し、必要なら提示された AWS CLI コマンドで個別削除)。検出時の exit code は live run = 1 (= operator 注意喚起 + make chain 停止)、DRY_RUN=1 = 0 (= live cluster の現役 resource を warn として列挙、make chain は継続)
 
 ## What is preserved through teardown
 

--- a/scripts/eks-lifecycle/lib/40-orphan-verify.sh
+++ b/scripts/eks-lifecycle/lib/40-orphan-verify.sh
@@ -83,6 +83,11 @@ if [ -n "$LG_NAMES" ]; then
 fi
 
 if [ "$ORPHAN_FOUND" -eq 1 ]; then
+  if [ "${DRY_RUN:-0}" = "1" ]; then
+    warn "[DRY-RUN] Resources listed above are CURRENT live-cluster resources, not real orphans. In a real teardown this step would require operator cleanup before proceeding."
+    info "[DRY-RUN] Exiting 0 so the make chain (= eks-teardown) can continue end-to-end validation."
+    exit 0
+  fi
   error "Orphan resources detected. Resolve manually using the delete commands above, then re-run make eks-teardown-verify to confirm."
   exit 1
 fi


### PR DESCRIPTION
PR #390 後の dry-run validation で発見した UX 問題の fix。

## Problem

`DRY_RUN=1 make eks-teardown ENV=production` を **live cluster** に対して走らせると:

1. `10-k8s-cleanup.sh` (= DRY-RUN で kubectl delete 等 echo のみ) → 通る
2. `30-destroy-stacks.sh` (= DRY-RUN で terragrunt destroy echo のみ) → 通る
3. `40-orphan-verify.sh` (= **read-only AWS describe-*\* を実行**) → live resource が大量に検出され、`exit 1` で chain 中断

DRY_RUN の意図は「destructive な操作を echo に置き換えて chain を end-to-end 通せるか確認」であり、live cluster 状態を「実 teardown 後の orphan」として exit 1 するのは紛らわしい。

## Fix

`40-orphan-verify.sh` の exit logic を 2 系統に分岐:

| Mode | ORPHAN_FOUND=0 | ORPHAN_FOUND=1 |
|---|---|---|
| live run (DRY_RUN unset / != 1) | exit 0 + `[OK] No orphan resources detected.` | **exit 1** + `[ERROR] Orphan resources detected. ...` (= 従来挙動、operator 注意喚起 + chain 停止) |
| **DRY_RUN=1** (new) | exit 0 + `[OK]` | **exit 0** + `[WARN] [DRY-RUN] Resources listed above are CURRENT live-cluster resources, not real orphans.` + `[INFO] [DRY-RUN] Exiting 0 so the make chain can continue end-to-end validation.` |

`30-destroy-stacks.sh` / `50-apply-stacks.sh` の `run` wrapper パターン (= DRY_RUN で命令を echo に置換) と semantics 整合。

## README

`Failure handling` 節に exit code 仕様を追記。

## Test

- [x] live cluster に対する `DRY_RUN=1 bash scripts/eks-lifecycle/lib/40-orphan-verify.sh` → ENI / TG / SG / Route53 / CW log group を WARN 列挙、最後に DRY-RUN 説明 WARN + INFO、exit 0
- [x] shellcheck (= info 7 件、warning / error なし。spec の '致命的 warning 0 件 (= info / hint 程度は許容)' 範囲内)