### PR TITLE
docs(eks-lifecycle): operator workarounds (= eks-login unset + init -upgrade loop)

### DIFF
--- a/scripts/eks-lifecycle/README.md
+++ b/scripts/eks-lifecycle/README.md
@@ -20,6 +20,13 @@ teardown / recreate 開始前に以下を確認:
 ```bash
 # 1. operator identity (= 期待する IAM user / role か)
 aws sts get-caller-identity
+# → user/panicboat (= 操作者本人の IAM principal) が出ること。
+# → assumed-role/eks-admin-production/... (= eks-login 等で事前 assume 済) の場合は
+#    AWS env を unset して操作者本来の credential chain に戻す:
+#       unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_SESSION_TOKEN
+#    eks-admin は EC2 / VPC describe 権限を持たないため、 unset せずに進むと
+#    `40-orphan-verify.sh` の `aws ec2 describe-network-interfaces` 等が
+#    UnauthorizedOperation で fail する。
 
 # 2. cluster 接続性 (= recreate 後の検証にも使う)
 kubectl config current-context
@@ -126,6 +133,15 @@ marker convention の design rationale は `kubernetes/helmfile.yaml.gotmpl` 冒
 - ロールバックは前進復旧のみ (= teardown 中断は再 teardown、recreate 中断は再 recreate)
 - admin role 一時 credentials の expire (= 1h STS session) は `30-destroy-stacks.sh` / `50-apply-stacks.sh` の各 stack 開始時に `creds_expiring_soon` (< 5min) で検出して `00-auth.sh` を re-source、admin role を assume し直す
 - `40-orphan-verify.sh` は read-only verify で auto-delete しない (= false-positive 含み得る出力を operator が目視精査し、必要なら提示された AWS CLI コマンドで個別削除)。検出時の exit code は live run = 1 (= operator 注意喚起 + make chain 停止)、DRY_RUN=1 = 0 (= live cluster の現役 resource を warn として列挙、make chain は継続)
+- `terragrunt destroy / apply` で `Module version requirements have changed` (= 既存 `.terragrunt-cache/` の module version と現行 main.tf の constraint が乖離) のエラーが出たら、対象 stack を `terragrunt init -upgrade` で更新してから再開する。 8 stack 一括は以下:
+  ```bash
+  for stack in karpenter eks-secrets eks-logs eks-metrics eks-traces eks alb vpc; do
+    echo "=== init: $stack ==="
+    ( cd aws/$stack/envs/production && TG_TF_PATH=tofu terragrunt init -upgrade )
+  done
+  make eks-teardown-aws ENV=production   # 中断地点から再開、 fail fast 後の再 run は idempotent
+  ```
+  発生例: Renovate PR で `terraform-aws-modules/eks/aws` を `~> 21.20` に更新済みだが、 操作者の `.terragrunt-cache/` には v21.19.0 がキャッシュされているケース
 
 ## What is preserved through teardown
 

--- a/scripts/eks-lifecycle/README.md
+++ b/scripts/eks-lifecycle/README.md
@@ -18,21 +18,21 @@ Temporary teardown / idempotent recreate of `eks-production` cluster + 周辺 AW
 teardown / recreate 開始前に以下を確認:
 
 ```bash
-# 1. operator identity (= 期待する IAM user / role か)
+# 1. AWS env をリセット (= eks-login 等で assumed-role creds が export されている状態を解除)
+unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_SESSION_TOKEN
+
+# 2. operator identity (= 期待する IAM user / role か)
 aws sts get-caller-identity
 # → user/panicboat (= 操作者本人の IAM principal) が出ること。
-# → assumed-role/eks-admin-production/... (= eks-login 等で事前 assume 済) の場合は
-#    AWS env を unset して操作者本来の credential chain に戻す:
-#       unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_SESSION_TOKEN
-#    eks-admin は EC2 / VPC describe 権限を持たないため、 unset せずに進むと
-#    `40-orphan-verify.sh` の `aws ec2 describe-network-interfaces` 等が
-#    UnauthorizedOperation で fail する。
+# assumed-role/eks-admin-production/... のままだと、 eks-admin は EC2 / VPC
+# describe 権限を持たないため後段 (= 40-orphan-verify.sh の aws ec2 describe-*)
+# が UnauthorizedOperation で fail する。
 
-# 2. cluster 接続性 (= recreate 後の検証にも使う)
+# 3. cluster 接続性 (= recreate 後の検証にも使う)
 kubectl config current-context
 kubectl get nodes
 
-# 3. 70-reconcile-watch.sh が wait する HelmRelease の audit
+# 4. 70-reconcile-watch.sh が wait する HelmRelease の audit
 #    (= 出力が lib/70-reconcile-watch.sh の wait_helmreleases 引数と一致するか確認)
 kubectl get helmreleases -A -o json | \
   jq -r '.items[] | "\(.metadata.namespace)/\(.metadata.name)"' | sort


### PR DESCRIPTION
PR #390 + #394 後、実 teardown で operator (= panicboat) が踏んだ 2 件の落とし穴を README に追記する follow-up。

## 追記内容

### 1. Pre-flight: eks-login 後の AWS env unset (= operator identity)

\`eks-login\` zsh 関数を実行済の shell から \`make eks-teardown\` を起動すると、env に **eks-admin role の assumed-role credentials** (session name = \`kubectl-takanokenichi\`) が export 済。 \`00-auth.sh\` の \`use_apply_creds\` が ORIG env を restore する設計のため、 その後の \`terragrunt destroy\` や \`aws ec2 describe-*\` も eks-admin で実行される → eks-admin は EC2 / VPC describe 権限を持たないため fail。

Pre-flight checks の \`aws sts get-caller-identity\` 直後に、 出力が \`assumed-role/eks-admin-production/...\` だった場合に \`unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_SESSION_TOKEN\` を実行する手順 + 影響を明示。

### 2. Failure handling: \`Module version requirements have changed\` の init -upgrade loop

操作者の \`.terragrunt-cache/\` に古い module version (= 例 \`terraform-aws-modules/eks/aws\` v21.19.0) がキャッシュされ、 Renovate PR (例: PR #356 で v21.20.0 に更新) で main.tf の constraint が乖離すると、 \`terragrunt destroy\` / \`apply\` が以下のように fail:

> \`Module version requirements have changed. The installed version (21.19.0) is no longer acceptable. Run \"tofu init\" to install all modules required by this configuration.\`

\`terragrunt destroy\` は自動 init しないため、 8 stack を一括で \`init -upgrade\` する loop snippet を Failure handling 節に提示。

\`\`\`bash
for stack in karpenter eks-secrets eks-logs eks-metrics eks-traces eks alb vpc; do
  echo \"=== init: \$stack ===\"
  ( cd aws/\$stack/envs/production && TG_TF_PATH=tofu terragrunt init -upgrade )
done
make eks-teardown-aws ENV=production
\`\`\`

## Why script 修正ではなく README

\`30-destroy-stacks.sh\` / \`50-apply-stacks.sh\` に \`terragrunt init -upgrade\` step を組み込む選択肢もあるが、 各 stack 開始時に毎回 init を走らせると normal flow でも数十秒の overhead。 この事象は cache lifecycle (= renovate update から operator の local run までの span) で時々踏むものなので、 README 手順で operator が判断する方が defensive と判断 (= follow-up でスクリプトに自動 init を入れるかは別途検討)。

## Test plan

- [x] markdown lint (= 既存 docs スタイルとの整合)
- [x] operator 視点での read-through (= Pre-flight + Failure handling 節に独立して追記、 既存の文脈を壊さない)