### PR TITLE
fix(eks-lifecycle): 10-k8s-cleanup.sh Karpenter foreground cascade + AWS-tag fallback

### DIFF
--- a/scripts/eks-lifecycle/lib/10-k8s-cleanup.sh
+++ b/scripts/eks-lifecycle/lib/10-k8s-cleanup.sh
@@ -27,17 +27,35 @@ run kubectl delete ingress --all -A --timeout=180s || warn "ingress deletion inc
 info "Step 10.2: Deleting LoadBalancer Services (= NLB / ENI release)"
 run kubectl delete svc -A --field-selector spec.type=LoadBalancer --timeout=180s || warn "LB service deletion incomplete"
 
-info "Step 10.3: Deleting Karpenter NodePools (= EC2 drain + terminate)"
+info "Step 10.3: Deleting Karpenter NodePools (= synchronous EC2 drain + terminate via --cascade=foreground)"
+# --cascade=foreground waits for owned NodeClaims (= and their EC2 instances)
+# to be deleted before returning. This avoids the historical failure mode where
+# NodePool delete returned immediately while leaving EC2 alive, eventually
+# stranded after karpenter stack destroy (= controller gone, no terminate path).
 if kubectl get nodepools.karpenter.sh >/dev/null 2>&1; then
-  run kubectl delete nodepools.karpenter.sh --all --timeout=300s || warn "NodePool deletion incomplete"
+  run kubectl delete nodepools.karpenter.sh --all --cascade=foreground --timeout=600s || \
+    warn "NodePool foreground deletion incomplete (= will rely on AWS-tag fallback below)"
 fi
 
-info "Step 10.4: Waiting for Karpenter nodes to be removed"
+info "Step 10.4: AWS-tag fallback — terminate any leftover Karpenter EC2 (= NodePool already gone but instances still alive)"
 if [ "${DRY_RUN:-0}" != "1" ]; then
-  if kubectl get nodes -l karpenter.sh/nodepool >/dev/null 2>&1; then
-    kubectl wait nodes -l karpenter.sh/nodepool --for=delete --timeout=600s || \
-      warn "Karpenter nodes did not all drain in 600s. Manually run: kubectl get nodes -l karpenter.sh/nodepool; kubectl delete node <name> --force"
+  REGION="$(resolve_aws_region)"
+  use_apply_creds  # = need EC2 permissions (= operator's chain), not eks-admin (kubectl-only)
+  LEFTOVER_IDS=$(aws ec2 describe-instances --region "$REGION" \
+    --filters "Name=tag:karpenter.sh/nodepool,Values=*" \
+              "Name=instance-state-name,Values=pending,running,shutting-down,stopping,stopped" \
+    --query 'Reservations[].Instances[].InstanceId' --output text)
+  if [ -n "$LEFTOVER_IDS" ]; then
+    warn "Found leftover Karpenter-managed EC2: $LEFTOVER_IDS — force-terminating."
+    # shellcheck disable=SC2086
+    aws ec2 terminate-instances --region "$REGION" --instance-ids $LEFTOVER_IDS >/dev/null
+    # shellcheck disable=SC2086
+    aws ec2 wait instance-terminated --region "$REGION" --instance-ids $LEFTOVER_IDS
+    ok "Leftover Karpenter EC2 terminated."
+  else
+    info "No leftover Karpenter EC2 found."
   fi
+  use_admin_creds  # = back to kubectl creds for sanity check
 fi
 
 info "Step 10.5: Sanity check - listing remaining pods"


### PR DESCRIPTION
PR #390 後の実 teardown で発生した事故の再発防止。

## Incident

`make eks-teardown ENV=production` 実行中、`module.eks.aws_eks_cluster.this[0]: Destroying...` の段階で **Karpenter-managed EC2 が 6 台残存** していることが判明。

| 確認内容 | 結果 |
|---|---|
| EC2 tag | `karpenter.sh/nodepool=system-components` + `karpenter.sh/nodeclaim=system-components-...` |
| kubectl 接続 | 不可 (= cluster API endpoint 既に no such host) |
| Karpenter stack | 既に terragrunt destroy 済 (= controller dead、 自力 terminate path 消失) |
| 影響 | この後 vpc destroy が EC2 / ENI で fail する可能性 |

operator が手動で `aws ec2 terminate-instances` で 6 台を強制 terminate して unblock した。

## Root cause hypothesis

旧 `10-k8s-cleanup.sh`:

```bash
# Step 10.3
run kubectl delete nodepools.karpenter.sh --all --timeout=300s || warn "..."

# Step 10.4
kubectl wait nodes -l karpenter.sh/nodepool --for=delete --timeout=600s || warn "..."
```

- `kubectl delete` は default `--cascade=background` で即 return (= NodeClaim / EC2 削除完了を待たない)
- `kubectl wait nodes -l karpenter.sh/nodepool` は前回 run 等で NodePool が既に削除済 + label が外れた node には match しない → 空集合で即 success
- 結果、 chain がそのまま `30-destroy-stacks.sh` へ進み karpenter stack destroy + eks stack destroy が走り EC2 が孤立

## Fix

### Step 10.3 — synchronous foreground cascade

```bash
run kubectl delete nodepools.karpenter.sh --all --cascade=foreground --timeout=600s
```

`--cascade=foreground` で NodePool が owner の NodeClaim (= 各 EC2) の deletion 完了まで synchronous wait。

### Step 10.4 — AWS-tag fallback (新規)

```bash
LEFTOVER_IDS=$(aws ec2 describe-instances --region "$REGION" \
  --filters "Name=tag:karpenter.sh/nodepool,Values=*" \
            "Name=instance-state-name,Values=pending,running,shutting-down,stopping,stopped" \
  --query 'Reservations[].Instances[].InstanceId' --output text)
if [ -n "$LEFTOVER_IDS" ]; then
  aws ec2 terminate-instances --region "$REGION" --instance-ids $LEFTOVER_IDS
  aws ec2 wait instance-terminated --region "$REGION" --instance-ids $LEFTOVER_IDS
fi
```

`--cascade=foreground` が timeout / fail した場合、 および NodePool が既に削除済 + EC2 のみ alive の状態 (= 今回 incident と同じ pattern) に対応。 tag による grep で確実に Karpenter 管理 EC2 を識別、 `terminate-instances` + `wait instance-terminated` で karpenter stack destroy 前に消す。

EC2 permissions は eks-admin role に無いため、 `use_apply_creds` で operator's default credential chain に切り替えてから terminate を実行、 完了後 `use_admin_creds` で kubectl op 用に戻す。

### Step 10.4 (旧) — 削除

`kubectl wait nodes --for=delete` は `--cascade=foreground` + AWS-tag fallback で redundant。

## Test plan

- [x] shellcheck (= SC1091 info のみ、 spec 許容範囲)
- [ ] 次回 teardown で実 cluster 検証 (= USER ONLY)