### PR TITLE
fix(eks-lifecycle): 10-k8s-cleanup.sh ALB/NLB foreground cascade + AWS-tag fallback

### DIFF
--- a/scripts/eks-lifecycle/lib/10-k8s-cleanup.sh
+++ b/scripts/eks-lifecycle/lib/10-k8s-cleanup.sh
@@ -21,13 +21,44 @@ fi
 
 use_admin_creds
 
-info "Step 10.1: Deleting all Ingress resources (= ALB target group / ENI release)"
-run kubectl delete ingress --all -A --timeout=180s || warn "ingress deletion incomplete (= some may need manual finalizer removal)"
+info "Step 10.1: Deleting all Ingress resources (= ALB target group / ENI release; finalizer 完了まで最大 600s 待機)"
+run kubectl delete ingress --all -A --timeout=600s || warn "ingress deletion incomplete (= will rely on AWS-tag fallback in Step 10.3)"
 
-info "Step 10.2: Deleting LoadBalancer Services (= NLB / ENI release)"
-run kubectl delete svc -A --field-selector spec.type=LoadBalancer --timeout=180s || warn "LB service deletion incomplete"
+info "Step 10.2: Deleting LoadBalancer Services (= NLB / ENI release; finalizer 完了まで最大 600s 待機)"
+run kubectl delete svc -A --field-selector spec.type=LoadBalancer --timeout=600s || warn "LB service deletion incomplete (= will rely on AWS-tag fallback in Step 10.3)"
 
-info "Step 10.3: Deleting Karpenter NodePools (= synchronous EC2 drain + terminate via --cascade=foreground)"
+info "Step 10.3: AWS-tag fallback — delete leftover ALB / NLB tagged for this cluster"
+# AWS Load Balancer Controller は ALB / NLB に tag:elbv2.k8s.aws/cluster=<name>
+# を付与する。 Step 10.1 / 10.2 で finalizer が完了せず ALB / NLB が残った場合、
+# 後段の Karpenter NodePool delete で ALB controller pod が巻き込まれて
+# 残 finalizer が永久 stuck → terragrunt alb destroy が
+# ACM cert in-use で fail する pattern (= 過去事故 patterns) を防ぐ。
+if [ "${DRY_RUN:-0}" != "1" ]; then
+  REGION="$(resolve_aws_region)"
+  use_apply_creds  # = need elbv2 / tag API permissions (= operator's chain)
+  LEFTOVER_LB_ARNS=$(aws resourcegroupstaggingapi get-resources --region "$REGION" \
+    --resource-type-filters "elasticloadbalancing:loadbalancer" \
+    --tag-filters "Key=elbv2.k8s.aws/cluster,Values=eks-${ENV}" \
+    --query 'ResourceTagMappingList[].ResourceARN' --output text)
+  if [ -n "$LEFTOVER_LB_ARNS" ]; then
+    warn "Found leftover load balancers: $LEFTOVER_LB_ARNS — force-deleting."
+    for arn in $LEFTOVER_LB_ARNS; do
+      aws elbv2 delete-load-balancer --region "$REGION" --load-balancer-arn "$arn" >/dev/null
+    done
+    info "Waiting for load balancers to fully delete (= listeners / cert references released)..."
+    for arn in $LEFTOVER_LB_ARNS; do
+      while aws elbv2 describe-load-balancers --region "$REGION" --load-balancer-arns "$arn" >/dev/null 2>&1; do
+        sleep 5
+      done
+    done
+    ok "Leftover load balancers deleted."
+  else
+    info "No leftover load balancers found."
+  fi
+  use_admin_creds  # = back to kubectl creds
+fi
+
+info "Step 10.4: Deleting Karpenter NodePools (= synchronous EC2 drain + terminate via --cascade=foreground)"
 # --cascade=foreground waits for owned NodeClaims (= and their EC2 instances)
 # to be deleted before returning. This avoids the historical failure mode where
 # NodePool delete returned immediately while leaving EC2 alive, eventually
@@ -37,7 +68,7 @@ if kubectl get nodepools.karpenter.sh >/dev/null 2>&1; then
     warn "NodePool foreground deletion incomplete (= will rely on AWS-tag fallback below)"
 fi
 
-info "Step 10.4: AWS-tag fallback — terminate any leftover Karpenter EC2 (= NodePool already gone but instances still alive)"
+info "Step 10.5: AWS-tag fallback — terminate any leftover Karpenter EC2 (= NodePool already gone but instances still alive)"
 if [ "${DRY_RUN:-0}" != "1" ]; then
   REGION="$(resolve_aws_region)"
   use_apply_creds  # = need EC2 permissions (= operator's chain), not eks-admin (kubectl-only)
@@ -58,7 +89,7 @@ if [ "${DRY_RUN:-0}" != "1" ]; then
   use_admin_creds  # = back to kubectl creds for sanity check
 fi
 
-info "Step 10.5: Sanity check - listing remaining pods"
+info "Step 10.6: Sanity check - listing remaining pods"
 run kubectl get pods -A -o wide || true
 
 ok "k8s cleanup complete"


### PR DESCRIPTION
PR #397 と同方針で、 ingress / LoadBalancer Service 側の取り残し対策。

## Incident

`make eks-teardown ENV=production` の実 run で、 PR #397 の事象 (= Karpenter EC2 残存) を手動で unblock した後、 続く alb stack destroy で:

\`\`\`
Error: deleting ACM Certificate (...0cb475d4...): ResourceInUseException: Certificate ... is in use.
\`\`\`

調査結果:

| LB ARN | tag | 状態 |
|---|---|---|
| `k8s-monitoringuis-1577bc5126` | `elbv2.k8s.aws/cluster=eks-production` | 443 listener が当該 ACM cert を使用 |
| `k8s-application-92fded7941` | 同上 | 同上 |

operator が `aws elbv2 delete-load-balancer` で 2 台手動削除 → alb stack destroy 再開で unblock。

## Root cause

旧 `10-k8s-cleanup.sh`:

\`\`\`bash
# Step 10.1
run kubectl delete ingress --all -A --timeout=180s || warn "..."
\`\`\`

- `--timeout=180s` は ALB Controller の finalizer 完了 (= ALB / listener / target group の AWS 側 destroy → k8s Ingress object 削除) には時に短い
- 180s で warn + chain 継続するパスを通ると、 Step 10.3 (= Karpenter NodePool delete) で alb-controller pod が EC2 終了に巻き込まれて停止
- 残 Ingress の finalizer 処理が永久 stuck → ALB / listener / cert reference が AWS 側に残存
- terragrunt alb destroy が ACM cert in-use で fail

## Fix

### Step 10.1 / 10.2 — timeout 180s → 600s

ALB Controller finalizer 完了に十分な時間を確保 (= LB svc も同様の pattern)。

### Step 10.3 (新) — AWS-tag fallback for ALB / NLB

\`\`\`bash
LEFTOVER_LB_ARNS=\$(aws resourcegroupstaggingapi get-resources --region \"\$REGION\" \\
  --resource-type-filters \"elasticloadbalancing:loadbalancer\" \\
  --tag-filters \"Key=elbv2.k8s.aws/cluster,Values=eks-\${ENV}\" \\
  --query 'ResourceTagMappingList[].ResourceARN' --output text)
if [ -n \"\$LEFTOVER_LB_ARNS\" ]; then
  for arn in \$LEFTOVER_LB_ARNS; do
    aws elbv2 delete-load-balancer --region \"\$REGION\" --load-balancer-arn \"\$arn\" >/dev/null
  done
  # describe-load-balancers で全消失まで poll
  for arn in \$LEFTOVER_LB_ARNS; do
    while aws elbv2 describe-load-balancers --region \"\$REGION\" --load-balancer-arns \"\$arn\" >/dev/null 2>&1; do
      sleep 5
    done
  done
fi
\`\`\`

`elbv2.k8s.aws/cluster=eks-\${ENV}` は AWS Load Balancer Controller が ALB / NLB 双方に付与する標準 tag。 これで残存 LB を確実に検出。

これを Karpenter NodePool delete (= 新 Step 10.4) より前に置くことで、 alb-controller pod が EC2 終了で死ぬ前に AWS 側 LB を全消去。 ACM cert は listener 削除直後に detach されるので、 後段の terragrunt alb destroy で in-use error が出ない。

EC2 / elbv2 / tag API permissions は eks-admin role に無いため、 `use_apply_creds` で operator's default credential chain に切り替えてから実行、 完了後 `use_admin_creds` で kubectl op 用に戻す。

### Renumbering

| 旧 | 新 |
|---|---|
| 10.1 ingress delete | 10.1 (timeout 600s 化のみ) |
| 10.2 LB svc delete | 10.2 (timeout 600s 化のみ) |
| -- | **10.3 AWS-tag fallback for LB (新)** |
| 10.3 NodePool delete | 10.4 (= PR #397 のまま) |
| 10.4 EC2 AWS-tag fallback | 10.5 |
| 10.5 sanity check | 10.6 |

## Test plan

- [x] shellcheck (= SC1091 info のみ)
- [ ] 次回 teardown で実 cluster 検証 (= USER ONLY)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Increased ingress and load balancer service deletion timeouts during EKS teardown to improve cleanup reliability.
  * Enhanced AWS-based fallback cleanup to better identify and remove leftover load balancers, preventing lingering certificate references.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/panicboat/platform/pull/398)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->