### PR TITLE
feat(eks): cilium-operator IRSA → Pod Identity Association

### DIFF
--- a/aws/eks/modules/addons.tf
+++ b/aws/eks/modules/addons.tf
@@ -68,7 +68,7 @@ module "external_dns_irsa" {
   tags = var.common_tags
 }
 
-# Cilium operator IRSA role.
+# Cilium operator IAM role (= Pod Identity Association).
 #
 # Cilium native CNI mode = ENI IPAM では cilium-operator が EC2 API 経由で:
 # - ENI を node に attach / detach (CreateNetworkInterface / Attach... 等)
@@ -77,10 +77,20 @@ module "external_dns_irsa" {
 # を実行する。 必要 permission は Cilium 公式 ENI mode docs に準拠:
 # https://docs.cilium.io/en/v1.19/network/concepts/ipam/eni/
 #
-# IRSA で `kube-system:cilium-operator` SA を本 role に紐付ける。 chart 側
+# EKS Pod Identity Association (= eks-pod-identity-agent addon 経由) で
+# `kube-system:cilium-operator` SA を本 role に紐付ける。 chart 側
 # values.yaml.gotmpl の serviceAccounts.operator.annotations
-# (`eks.amazonaws.com/role-arn`) で完全な loop を成立させる。
-module "cilium_operator_irsa" {
+# (`eks.amazonaws.com/role-arn`) は併存可能だが Pod Identity が優先される。
+#
+# Pod Identity 採用理由 (= 2026-05-16 cold-start bootstrap incident):
+# IRSA path (= SA token → sts:AssumeRoleWithWebIdentity → cache → EC2 call) は
+# 初回 STS round-trip + AWS SDK 内 retry で cilium-operator の 5 秒 hardcoded
+# "initial EC2 API limits update" timeout を時に超過し crashloop となる
+# (= IPAM init failure → 全 Pod IP allocate 不能 → cluster bootstrap 詰む)。
+# Pod Identity は local eks-pod-identity-agent (= hostNetwork DS、 CNI 不要で
+# bootstrap 後すぐ Ready) を介して credential 取得するため STS round-trip 不要、
+# 5 秒 timeout 内に余裕で完了する。 karpenter sub-module も同 path を採用済。
+module "cilium_operator" {
   source  = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts"
   version = "~> 6.6"
 
@@ -125,10 +135,11 @@ module "cilium_operator_irsa" {
     }
   }
 
-  oidc_providers = {
+  pod_identity_associations = {
     main = {
-      provider_arn               = module.eks.oidc_provider_arn
-      namespace_service_accounts = ["kube-system:cilium-operator"]
+      cluster_name    = module.eks.cluster.name
+      namespace       = "kube-system"
+      service_account = "cilium-operator"
     }
   }
 

--- a/aws/eks/modules/addons.tf
+++ b/aws/eks/modules/addons.tf
@@ -68,7 +68,7 @@ module "external_dns_irsa" {
   tags = var.common_tags
 }
 
-# Cilium operator IAM role (= Pod Identity Association).
+# Cilium operator IAM role (= EKS Pod Identity Association).
 #
 # Cilium native CNI mode = ENI IPAM では cilium-operator が EC2 API 経由で:
 # - ENI を node に attach / detach (CreateNetworkInterface / Attach... 等)
@@ -78,9 +78,7 @@ module "external_dns_irsa" {
 # https://docs.cilium.io/en/v1.19/network/concepts/ipam/eni/
 #
 # EKS Pod Identity Association (= eks-pod-identity-agent addon 経由) で
-# `kube-system:cilium-operator` SA を本 role に紐付ける。 chart 側
-# values.yaml.gotmpl の serviceAccounts.operator.annotations
-# (`eks.amazonaws.com/role-arn`) は併存可能だが Pod Identity が優先される。
+# `kube-system:cilium-operator` SA を本 role に紐付ける。
 #
 # Pod Identity 採用理由 (= 2026-05-16 cold-start bootstrap incident):
 # IRSA path (= SA token → sts:AssumeRoleWithWebIdentity → cache → EC2 call) は
@@ -90,60 +88,78 @@ module "external_dns_irsa" {
 # Pod Identity は local eks-pod-identity-agent (= hostNetwork DS、 CNI 不要で
 # bootstrap 後すぐ Ready) を介して credential 取得するため STS round-trip 不要、
 # 5 秒 timeout 内に余裕で完了する。 karpenter sub-module も同 path を採用済。
-module "cilium_operator" {
-  source  = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts"
-  version = "~> 6.6"
-
-  name            = "eks-${var.environment}-cilium-operator"
-  use_name_prefix = false
-
-  create_inline_policy = true
-  inline_policy_permissions = {
-    EC2Describe = {
-      actions = [
-        "ec2:DescribeInstances",
-        "ec2:DescribeInstanceTypes",
-        "ec2:DescribeSubnets",
-        "ec2:DescribeSecurityGroups",
-        "ec2:DescribeVpcs",
-        "ec2:DescribeNetworkInterfaces",
-        "ec2:DescribeTags",
-      ]
-      resources = ["*"]
-      effect    = "Allow"
-    }
-    EC2ENIManagement = {
-      actions = [
-        "ec2:CreateNetworkInterface",
-        "ec2:AssignPrivateIpAddresses",
-        "ec2:UnassignPrivateIpAddresses",
-        "ec2:AttachNetworkInterface",
-        "ec2:DetachNetworkInterface",
-        "ec2:DeleteNetworkInterface",
-        "ec2:ModifyNetworkInterfaceAttribute",
-      ]
-      resources = ["*"]
-      effect    = "Allow"
-    }
-    EC2TagManagement = {
-      actions = [
-        "ec2:CreateTags",
-        "ec2:DeleteTags",
-      ]
-      resources = ["*"]
-      effect    = "Allow"
+#
+# terraform-aws-modules/iam v6.6 の iam-role-for-service-accounts module は
+# Pod Identity 未対応 (= oidc_providers 専用) のため、 raw aws_iam_role +
+# aws_eks_pod_identity_association resource で構成。
+data "aws_iam_policy_document" "cilium_operator_assume" {
+  statement {
+    actions = ["sts:AssumeRole", "sts:TagSession"]
+    principals {
+      type        = "Service"
+      identifiers = ["pods.eks.amazonaws.com"]
     }
   }
+}
 
-  pod_identity_associations = {
-    main = {
-      cluster_name    = module.eks.cluster.name
-      namespace       = "kube-system"
-      service_account = "cilium-operator"
-    }
-  }
+resource "aws_iam_role" "cilium_operator" {
+  name               = "eks-${var.environment}-cilium-operator"
+  assume_role_policy = data.aws_iam_policy_document.cilium_operator_assume.json
+  tags               = var.common_tags
+}
 
-  tags = var.common_tags
+resource "aws_iam_role_policy" "cilium_operator" {
+  name = "cilium-operator"
+  role = aws_iam_role.cilium_operator.id
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "EC2Describe"
+        Effect = "Allow"
+        Action = [
+          "ec2:DescribeInstances",
+          "ec2:DescribeInstanceTypes",
+          "ec2:DescribeSubnets",
+          "ec2:DescribeSecurityGroups",
+          "ec2:DescribeVpcs",
+          "ec2:DescribeNetworkInterfaces",
+          "ec2:DescribeTags",
+        ]
+        Resource = "*"
+      },
+      {
+        Sid    = "EC2ENIManagement"
+        Effect = "Allow"
+        Action = [
+          "ec2:CreateNetworkInterface",
+          "ec2:AssignPrivateIpAddresses",
+          "ec2:UnassignPrivateIpAddresses",
+          "ec2:AttachNetworkInterface",
+          "ec2:DetachNetworkInterface",
+          "ec2:DeleteNetworkInterface",
+          "ec2:ModifyNetworkInterfaceAttribute",
+        ]
+        Resource = "*"
+      },
+      {
+        Sid    = "EC2TagManagement"
+        Effect = "Allow"
+        Action = [
+          "ec2:CreateTags",
+          "ec2:DeleteTags",
+        ]
+        Resource = "*"
+      },
+    ]
+  })
+}
+
+resource "aws_eks_pod_identity_association" "cilium_operator" {
+  cluster_name    = module.eks.cluster_name
+  namespace       = "kube-system"
+  service_account = "cilium-operator"
+  role_arn        = aws_iam_role.cilium_operator.arn
 }
 
 locals {

--- a/aws/eks/modules/outputs.tf
+++ b/aws/eks/modules/outputs.tf
@@ -73,7 +73,7 @@ output "external_dns_role_arn" {
 
 output "cilium_operator_role_arn" {
   description = "Pod Identity Association role ARN for Cilium operator (ENI mode IPAM、EC2 API での ENI / IP 操作)"
-  value       = module.cilium_operator.arn
+  value       = aws_iam_role.cilium_operator.arn
 }
 
 output "vpc_id" {

--- a/aws/eks/modules/outputs.tf
+++ b/aws/eks/modules/outputs.tf
@@ -72,8 +72,8 @@ output "external_dns_role_arn" {
 }
 
 output "cilium_operator_role_arn" {
-  description = "IRSA role ARN for Cilium operator (ENI mode IPAM、EC2 API での ENI / IP 操作)"
-  value       = module.cilium_operator_irsa.arn
+  description = "Pod Identity Association role ARN for Cilium operator (ENI mode IPAM、EC2 API での ENI / IP 操作)"
+  value       = module.cilium_operator.arn
 }
 
 output "vpc_id" {

--- a/kubernetes/components/cilium/production/helmfile.yaml
+++ b/kubernetes/components/cilium/production/helmfile.yaml
@@ -16,8 +16,6 @@ environments:
       - cluster:
           # RECREATE: cd aws/eks/envs/production && TG_TF_PATH=tofu terragrunt output -raw cluster_endpoint_hostname
           eksApiEndpoint: BD10E7689A05E46191305DDC7BE6CA67.gr7.ap-northeast-1.eks.amazonaws.com
-          # STABLE: aws/eks/modules/addons.tf で use_name_prefix = false に設定済
-          ciliumOperatorRoleArn: arn:aws:iam::559744160976:role/eks-production-cilium-operator
 ---
 repositories:
   - name: cilium

--- a/kubernetes/components/cilium/production/values.yaml.gotmpl
+++ b/kubernetes/components/cilium/production/values.yaml.gotmpl
@@ -16,12 +16,14 @@ eni:
   enabled: true
 
 # =============================================================================
-# Service Accounts: cilium-operator に IRSA role 紐付け (= EC2 ENI 操作権限)
+# Service Accounts: cilium-operator は EKS Pod Identity Association で
+# `eks-production-cilium-operator` role に紐付け (= EC2 ENI 操作権限)。
+# aws/eks/modules/addons.tf の cilium_operator module の pod_identity_associations
+# が紐付けを provision し、 eks-pod-identity-agent (= EKS managed addon、
+# hostNetwork DS で CNI 不要) が pod の AWS_CONTAINER_CREDENTIALS_FULL_URI env
+# 経由で credential を提供する。 SA annotation `eks.amazonaws.com/role-arn`
+# (= IRSA marker) は本構成では不要、 chart default の cilium-operator SA を採用。
 # =============================================================================
-serviceAccounts:
-  operator:
-    annotations:
-      eks.amazonaws.com/role-arn: {{ .Values.cluster.ciliumOperatorRoleArn }}
 
 # =============================================================================
 # Routing & Masquerade

--- a/kubernetes/helmfile.yaml.gotmpl
+++ b/kubernetes/helmfile.yaml.gotmpl
@@ -43,8 +43,6 @@ environments:
           albControllerRoleArn: arn:aws:iam::559744160976:role/eks-production-alb-controller
           # STABLE: 同上
           externalDnsRoleArn: arn:aws:iam::559744160976:role/eks-production-external-dns
-          # STABLE: 同上 (= Cilium ENI mode で cilium-operator が EC2 ENI / IP API を IRSA 経由で呼ぶ)
-          ciliumOperatorRoleArn: arn:aws:iam::559744160976:role/eks-production-cilium-operator
         karpenter:
           # STABLE: aws/karpenter/modules/main.tf で node_iam_role_name + node_iam_role_use_name_prefix = false に設定済
           nodeRoleName: Karpenter-eks-production

--- a/kubernetes/manifests/production/cilium/manifest.yaml
+++ b/kubernetes/manifests/production/cilium/manifest.yaml
@@ -28,8 +28,6 @@ kind: ServiceAccount
 metadata:
   name: "cilium-operator"
   namespace: kube-system
-  annotations:
-    eks.amazonaws.com/role-arn: arn:aws:iam::559744160976:role/eks-production-cilium-operator
 ---
 # Source: cilium/templates/hubble-relay/serviceaccount.yaml
 apiVersion: v1


### PR DESCRIPTION
2026-05-16 の cold-start recreate live run (= runbook PR #400) で cilium-operator が ENI mode bootstrap で 5 秒 hardcoded "initial EC2 API limits update" timeout に毎回引っかかり crashloop。 cluster が pod IP allocate 不能で詰むことが live run で確認された。

## Root cause hypothesis

IRSA path (= SA token → \`sts:AssumeRoleWithWebIdentity\` 経由 → cache → EC2 call) の **STS round-trip + AWS SDK 内 retry が 5 秒 hardcoded timeout 内に完了しない** ことが疑わしい。

検証ずみ:
- DNS + HTTPS to ec2.ap-northeast-1.amazonaws.com from hostNetwork pod = ~30ms OK
- IRSA trust policy + IAM role permissions = 正常
- `dnsPolicy=Default` + \`AWS_EC2_METADATA_DISABLED=true\` + \`AWS_RETRY_MODE=adaptive\` + \`AWS_MAX_ATTEMPTS=10\` 追加 → 改善せず
- cilium-cli minimal config (= 我々の values 捨てる) → 同じ症状

systemic に cilium 1.19.4 + ENI mode + IRSA の combination で詰む可能性が高い。

## Fix

cilium-operator を **EKS Pod Identity Association** に切替。 Pod Identity は:

| auth path | flow | first-call latency |
|---|---|---|
| IRSA (旧) | SA token → \`sts:AssumeRoleWithWebIdentity\` (STS round-trip ~200-500ms) → cache → EC2 call | ~500-1000ms |
| Pod Identity (新) | env \`AWS_CONTAINER_CREDENTIALS_FULL_URI\` → local Pod Identity Agent (~1ms、cred cached) → EC2 call | ~50-100ms |

STS round-trip を bypass するため 5 秒 timeout に余裕で間に合う想定。 \`eks-pod-identity-agent\` (= EKS managed addon、 hostNetwork DS で CNI 不要、 bootstrap 後すぐ Ready) が credential 提供を担う。

## Changes

| File | Change |
|---|---|
| \`aws/eks/modules/addons.tf\` | \`module "cilium_operator"\` (旧 \`cilium_operator_irsa\`): \`oidc_providers\` 撤去 → \`pod_identity_associations\` 追加。 module 名から \`_irsa\` suffix 撤去 |
| \`aws/eks/modules/outputs.tf\` | \`cilium_operator_role_arn\`: module 参照を新名に + description 更新 |
| \`kubernetes/components/cilium/production/values.yaml.gotmpl\` | \`serviceAccounts.operator.annotations\` 撤去 (= IRSA marker 不要、 Pod Identity Agent が env inject) |
| \`kubernetes/helmfile.yaml.gotmpl\` + \`cilium/production/helmfile.yaml\` | \`ciliumOperatorRoleArn\` 値定義撤去 (= 参照なし) |

## Consistency

karpenter sub-module は既に Pod Identity 採用済 (= \`create_pod_identity_association = true\`)。 本 PR で cilium-operator も同 path に統一される。

## Test plan

- [x] terraform-aws-modules/iam v6.6 \`iam-role-for-service-accounts\` module の \`pod_identity_associations\` input 確認
- [ ] 本 PR merge 後の cold-start recreate live run (= USER ONLY、 cluster destroy 完了後)
- [ ] cilium-operator が EC2 API limits update を完走するか確認
- [ ] CiliumNode CRD に \`spec.ipam.pools\` が populate されるか確認
- [ ] addon (coredns / aws-ebs-csi-driver) ACTIVE 化確認

## Related

- runbook: docs/superpowers/specs/2026-05-16-eks-recreate-manual-bootstrap-runbook.md (PR #400 merged)
- AWS Pod Identity docs: https://docs.aws.amazon.com/eks/latest/userguide/pod-identities.html
- terraform-aws-modules/iam \`iam-role-for-service-accounts\` v6: pod_identity_associations input

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Cilium operator authentication mechanism for enhanced security and operational management on EKS clusters.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/panicboat/platform/pull/401?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->