### PR TITLE
fix(eks-lifecycle): 00-auth.sh kubectl reachability check inside admin subshell

### DIFF
--- a/scripts/eks-lifecycle/lib/00-auth.sh
+++ b/scripts/eks-lifecycle/lib/00-auth.sh
@@ -65,20 +65,25 @@ date -d "$ADMIN_EXPIRATION" +%s 2>/dev/null > "$CREDS_EXPIRE_FILE" || \
 
 ok "Admin role credentials valid until: $ADMIN_EXPIRATION"
 
-# Use admin creds in a sub-shell to update kubeconfig
+# Update kubeconfig + verify cluster reachability with admin creds in a
+# sub-shell. kubectl exec plugin (= aws eks get-token) inherits caller's
+# AWS env at invocation time、 so the reachability check (= `kubectl get
+# nodes`) must also run inside the same subshell where admin creds are
+# active. 親 shell の operator IAM principal は EKS aws-auth に未登録の
+# ケースが多く、 subshell 外で kubectl test すると 401 で誤判定される。
 (
   AWS_ACCESS_KEY_ID=$(jq -r .AccessKeyId "$ADMIN_CREDS_FILE")
   AWS_SECRET_ACCESS_KEY=$(jq -r .SecretAccessKey "$ADMIN_CREDS_FILE")
   AWS_SESSION_TOKEN=$(jq -r .SessionToken "$ADMIN_CREDS_FILE")
   export AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_SESSION_TOKEN
-  if aws eks update-kubeconfig --region "$REGION" --name "eks-${ENV}" >/dev/null 2>&1; then
+  if aws eks update-kubeconfig --region "$REGION" --name "eks-${ENV}" >/dev/null 2>&1 && \
+     kubectl get nodes >/dev/null 2>&1; then
     exit 0
-  else
-    exit 1
   fi
+  exit 1
 ) && CLUSTER_REACHABLE="true" || CLUSTER_REACHABLE="false"
 
-if [ "$CLUSTER_REACHABLE" = "true" ] && kubectl get nodes >/dev/null 2>&1; then
+if [ "$CLUSTER_REACHABLE" = "true" ]; then
   ok "Cluster reachable via admin role"
   export CLUSTER_EXISTS="true"
 else


### PR DESCRIPTION
2026-05-16 cold-start recreate live run の Phase 9 で \`60-flux-bootstrap.sh\` が \`Cluster not reachable. Setting CLUSTER_EXISTS=false\` で誤判定し exit した bug の fix。

## Symptom

\`60-flux-bootstrap.sh\` が cluster 起動済の状態で \`CLUSTER_EXISTS=false\` 判定 → \`Cluster not reachable. Run make eks-recreate-aws ENV=production first.\` で exit 1。 live run では script bypass で manual に hydrate / kubectl apply / Flux setup を実行する workaround を取った。

## Root cause

\`00-auth.sh\` の cluster reachability check:

\`\`\`bash
(
  AWS_*_KEY = admin creds
  aws eks update-kubeconfig ...
) && CLUSTER_REACHABLE="true" || CLUSTER_REACHABLE="false"

if [ "\$CLUSTER_REACHABLE" = "true" ] && kubectl get nodes >/dev/null 2>&1; then
\`\`\`

- \`aws eks update-kubeconfig\` は subshell 内で admin creds 使用
- \`kubectl get nodes\` は subshell **外** で実行される
- 親 shell の AWS env は operator IAM principal (= panicboat user 等) のまま
- kubectl exec plugin (= \`aws eks get-token\`) は親 shell の env で動作 = operator creds で token 取得
- operator が EKS aws-auth に未登録のケース (= \`access_entries\` に \`eks-admin\` role のみ登録) で 401
- → \`CLUSTER_REACHABLE=false\` の誤判定

## Fix

\`aws eks update-kubeconfig\` + \`kubectl get nodes\` を同 subshell に集約:

\`\`\`bash
(
  AWS_*_KEY = admin creds
  if aws eks update-kubeconfig ... && \\
     kubectl get nodes >/dev/null 2>&1; then
    exit 0
  fi
  exit 1
) && CLUSTER_REACHABLE="true" || CLUSTER_REACHABLE="false"

if [ "\$CLUSTER_REACHABLE" = "true" ]; then
  ok "Cluster reachable via admin role"
  ...
\`\`\`

両者 admin creds で実行 + subshell 終了後 CLUSTER_REACHABLE 判定のみ親 shell。

## Test plan

- [x] live run で manual bypass 検証済 (= admin role assume + kubectl get nodes が動作することを確認)
- [ ] 次回 recreate live run で 60-flux-bootstrap.sh が CLUSTER_EXISTS=true で進むことを確認

## Related

- runbook: docs/superpowers/specs/2026-05-16-eks-recreate-manual-bootstrap-runbook.md (PR #400 merged)
- 2026-05-16 live run の Section 5 'Failure handling' で \"\`Cluster not reachable\` 誤判定 → manual bypass\" として記録 (= 後続 PR で runbook 更新候補)