### PR TITLE
feat(kubernetes): add gp3 StorageClass for production cluster

### DIFF
--- a/kubernetes/clusters/production/kustomization.yaml
+++ b/kubernetes/clusters/production/kustomization.yaml
@@ -15,3 +15,4 @@ kind: Kustomization
 resources:
   - ../../manifests/production
   - ./repositories
+  - ./storageclasses.yaml

--- a/kubernetes/clusters/production/storageclasses.yaml
+++ b/kubernetes/clusters/production/storageclasses.yaml
@@ -1,0 +1,29 @@
+# =============================================================================
+# StorageClasses for production cluster
+# =============================================================================
+# EKS が cluster create 時に作る default は gp2 (= kubernetes.io/aws-ebs
+# in-tree provisioner)。 platform で使う stateful component (= mimir / loki
+# / tempo / grafana / prometheus 等) は gp3 を要求するため、 ebs.csi.aws.com
+# provisioner で gp3 SC を明示的に provision する。
+#
+# default class を gp3 に切替: storageclass.kubernetes.io/is-default-class
+# annotation を true にし、 EKS default の gp2 は手元 / 別 PR で
+# `is-default-class: false` に上書きするか、 kubectl 操作で外す。
+#
+# WaitForFirstConsumer: pod schedule 先 zone が決まってから volume を
+# allocate するため、 multi-AZ Karpenter NodePool での schedule 不整合を
+# 回避する。
+# =============================================================================
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: gp3
+  annotations:
+    storageclass.kubernetes.io/is-default-class: "true"
+provisioner: ebs.csi.aws.com
+parameters:
+  type: gp3
+  encrypted: "true"
+volumeBindingMode: WaitForFirstConsumer
+reclaimPolicy: Delete
+allowVolumeExpansion: true


### PR DESCRIPTION
2026-05-16 cold-start recreate live run の Phase 9 で stateful pod (= mimir-distributed-* / loki-0 / tempo-0 / kube-prometheus-stack-grafana) が PVC unbound で stuck することが判明。

## Symptom

\`\`\`
Warning  ProvisioningFailed  ... persistentvolume-controller  storageclass.storage.k8s.io "gp3" not found
\`\`\`

EKS が cluster create 時に作る default の \`gp2\` SC (= \`kubernetes.io/aws-ebs\` in-tree provisioner) のみで、 manifest が要求する \`gp3\` SC が存在しなかった。

## Fix

\`kubernetes/clusters/production/storageclasses.yaml\` を新規追加し、 root Kustomization に登録。 cluster bootstrap の root Flux Kustomization で apply される。

| Field | Value |
|---|---|
| provisioner | \`ebs.csi.aws.com\` (= aws-ebs-csi-driver addon) |
| type | \`gp3\` |
| encrypted | \`true\` (= EBS at-rest encryption) |
| volumeBindingMode | \`WaitForFirstConsumer\` (= multi-AZ Karpenter NodePool で pod schedule 先 zone が決まってから volume allocate) |
| is-default-class | \`true\` |

\`is-default-class: true\` は既存 \`gp2\` default と競合するが、 EKS の \`gp2\` は別 PR で \`false\` 化を検討予定 (= 今回は新 default を追加するだけ、 既存 PV は in-place で gp2 のまま)。

## Live run state

live run では \`kubectl apply -f -\` で gp3 SC を手動作成して unblock 済 (= terraform / manifests と drift 状態)。 本 PR merge → Flux apply で drift 解消。

## Test plan

- [x] live run で manual SC 作成 → PVC bound + stateful pods Running 確認
- [ ] PR merge → Flux apply で gp3 SC が再作成されないこと (= server-side apply で field manager 共存) を確認