### PR TITLE
feat(kubernetes): add bootstrap-webhooks kustomize root

### DIFF
--- a/kubernetes/clusters/production/bootstrap-webhooks/kustomization.yaml
+++ b/kubernetes/clusters/production/bootstrap-webhooks/kustomization.yaml
@@ -1,0 +1,42 @@
+# =============================================================================
+# Bootstrap webhooks kustomize root
+# =============================================================================
+# cold-start recreate (= 全 stack destroy 後の cluster 再構築) で initial
+# `kubectl apply -k clusters/production/` を実行すると、 dependent CR
+# (= ExternalSecret / Certificate / Instrumentation 等) が webhook 提供
+# HelmRelease 未起動状態で dry-run reject され部分 fail になる。
+#
+# 本 kustomize root は webhook 提供 component のみを subset として束ね、
+# operator が cold-start で先に apply して webhook を起動完了させてから、
+# clusters/production/ の full apply を行う 2 step bootstrap を可能にする。
+#
+# 用途は initial bootstrap のみで、 steady state の Flux reconcile は
+# clusters/production/ root が引き続き全 manifest を管理する (= 本 root と
+# overlap するが、 server-side apply の field manager 共存で問題ない)。
+#
+# Failure handling: cold-start での "初回 apply 部分 fail → Flux reconcile
+# loop で self-heal" workaround の代替手段。 詳細は
+# docs/runbooks/eks-production-recreate.md Phase 9 参照。
+#
+# 含む component (= validating / mutating webhook を提供する HelmRelease):
+#   - 00-namespaces           : 各 component の namespace を先に作成
+#   - cert-manager            : Certificate / Issuer の admission webhook
+#   - external-secrets        : ExternalSecret / SecretStore の admission webhook
+#   - prometheus-operator     : Alertmanager / Prometheus / ServiceMonitor 等の
+#                               admission webhook (= kube-prometheus-stack)
+#   - opentelemetry           : Instrumentation / OpenTelemetryCollector 等の
+#                               admission webhook (= opentelemetry-operator)
+#   - aws-load-balancer-controller : Ingress / TargetGroupBinding の mutating webhook
+#   - keda                    : ScaledObject / TriggerAuthentication 等の admission webhook
+# =============================================================================
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../../manifests/production/00-namespaces
+  - ../../../manifests/production/cert-manager
+  - ../../../manifests/production/external-secrets
+  - ../../../manifests/production/prometheus-operator
+  - ../../../manifests/production/opentelemetry
+  - ../../../manifests/production/aws-load-balancer-controller
+  - ../../../manifests/production/keda


### PR DESCRIPTION
2026-05-16 cold-start recreate live run の Phase 9.3 で発見した webhook chicken-and-egg 解消策。

## Symptom

cold-start recreate (= 全 stack destroy 後の cluster 再構築) で initial \`kubectl apply -k clusters/production/\` を実行すると以下の error 多数発生:

\`\`\`
Error from server (InternalError): failed calling webhook "validate.externalsecret.external-secrets.io":
  no endpoints available for service "external-secrets-webhook"
Error from server (InternalError): failed calling webhook "minstrumentation.kb.io":
  no endpoints available for service "opentelemetry-operator-webhook"
Error from server (InternalError): failed calling webhook "webhook.cert-manager.io":
  tls: failed to verify certificate
\`\`\`

webhook 提供 HelmRelease (= cert-manager / external-secrets / opentelemetry-operator) が未起動状態で、 dependent CR (= ExternalSecret / Certificate / Instrumentation 等) の dry-run validation が失敗し apply が部分 fail する。

live run では Flux 起動後に reconcile loop で self-heal するのを待った workaround だったが、 \"部分 fail なのに OK\" な状況は operator にとって紛らわしい。

## Fix

新 kustomize root \`kubernetes/clusters/production/bootstrap-webhooks/kustomization.yaml\` を追加。 webhook 提供 component のみを subset として束ねる:

| Component | Webhook |
|---|---|
| 00-namespaces | (= namespace を先に作成) |
| cert-manager | Certificate / Issuer admission webhook |
| external-secrets | ExternalSecret / SecretStore admission webhook |
| prometheus-operator | Alertmanager / Prometheus / ServiceMonitor 等 admission webhook |
| opentelemetry | Instrumentation / OpenTelemetryCollector 等 admission webhook |
| aws-load-balancer-controller | Ingress / TargetGroupBinding mutating webhook |
| keda | ScaledObject / TriggerAuthentication 等 admission webhook |

## Usage (= bootstrap 中の operator 手順)

\`\`\`bash
# Step 1: webhook 提供 HelmRelease を先に install + 起動完了 wait
kubectl apply -k kubernetes/clusters/production/bootstrap-webhooks/ --server-side --force-conflicts
kubectl wait --for=condition=Available deployment --all -n cert-manager --timeout=300s
kubectl wait --for=condition=Available deployment --all -n external-secrets --timeout=300s
# (similar for other namespaces)

# Step 2: full apply (= dependent CR も apply、 webhook が応答するため成功)
kubectl apply -k kubernetes/clusters/production/ --server-side --force-conflicts
\`\`\`

## Steady state での扱い

\`bootstrap-webhooks/\` root は **initial bootstrap 時のみ** operator が手動 apply する。 steady state の Flux reconcile は \`clusters/production/\` root が引き続き全 manifest を管理する (= 本 root と overlap するが server-side apply の field manager 共存で問題ない)。

## Follow-up

runbook (= \`docs/runbooks/eks-production-recreate.md\`、 PR #408 で配置変更) の Phase 9.3 を 2-step に書き換える follow-up は別 PR で実施 (= PR #408 merge 待ち)。

## Test plan

- [x] kustomize build で render success (= 165995 lines)
- [x] 含む全 component (= 7 dirs) の存在確認
- [ ] 次回 cold-start recreate で 2-step bootstrap が webhook 部分 fail なしで完走することを確認