### PR TITLE
chore(.github): pin opentofu and terragrunt versions in aqua.yaml

### DIFF
--- a/.github/aqua.yaml
+++ b/.github/aqua.yaml
@@ -11,3 +11,5 @@ packages:
   - name: kubernetes-sigs/kustomize@kustomize/v5.6.0
   - name: nektos/act@v0.2.87
   - name: rhysd/actionlint@v1.7.7
+  - name: opentofu/opentofu@v1.12.0
+  - name: gruntwork-io/terragrunt@v1.0.2


### PR DESCRIPTION
## Summary

Adds `opentofu/opentofu@v1.12.0` and `gruntwork-io/terragrunt@v1.0.2` to the existing `.github/aqua.yaml`. Part 2/3 of the rollout in `docs/superpowers/plans/2026-05-16-renovate-tofu-aqua.md`.

No behavior change. The composite migration in panicboat-actions will start consuming these once landed.

## Test plan

- [ ] yamllint passes
- [ ] CI green (no-op for terragrunt workflow)