### PR TITLE
chore(ci): remove release-as override now that v0.1.0 is released

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,4 +23,3 @@ jobs:
         with:
           token: ${{ steps.app-token.outputs.token }}
           release-type: simple
-          release-as: "0.1.0" # 初回 release 後にこの行を削除する追従 PR を出す


### PR DESCRIPTION
## Summary

Remove the one-time \`release-as: \"0.1.0\"\` override from \`.github/workflows/release.yml\`. With the initial \`v0.1.0\` tag now in place, release-please can resume normal Conventional Commit-based bump semantics.

## Why this is required

\`release-as\` pins the next release version regardless of commit history. If left in place, every subsequent release would be forced back to \`0.1.0\`, blocking real version bumps.

## Test plan

- [ ] CI (lint-actions / semantic-pull-request / CI Gatekeeper) passes
- [ ] After merge, release-please does NOT create a new release PR (no \`feat:\` / \`fix:\` commits since \`v0.1.0\` to bump)
- [ ] Next \`feat:\` / \`fix:\` commit produces a release-please PR bumping from \`0.1.0\` (e.g. to \`0.2.0\` for feat, \`0.1.1\` for fix)