### PR TITLE
feat(scripts): post-flight Pod Identity injection probe + #25 upstream block note

### DIFF
--- a/docs/superpowers/plans/2026-05-17-pod-identity-injection-detection.md
+++ b/docs/superpowers/plans/2026-05-17-pod-identity-injection-detection.md
@@ -1,0 +1,76 @@
+# Pod Identity Injection Detection Implementation Plan
+
+> **Spec**: `docs/superpowers/specs/2026-05-17-pod-identity-injection-detection-design.md`
+>
+> **Goal**: 引き継ぎ事項 #15 の初期着手として、 Pod Identity injection 状態を probe する ad-hoc shell script を 1 本作成。
+
+---
+
+## Tasks
+
+### Task 1: scripts/post-flight/ directory + script 実装
+
+**Files**:
+- Create: `scripts/post-flight/check-pod-identity-injection.sh`
+
+**Steps**:
+
+- [ ] **Step 1: directory 作成 + script file**
+
+```bash
+mkdir -p scripts/post-flight
+# script content は spec doc Section 2 + 3 参照
+```
+
+- [ ] **Step 2: shebang + set -euo pipefail + 引数 parse**
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+cluster_name="${1:-eks-production}"
+region="${AWS_REGION:-ap-northeast-1}"
+```
+
+- [ ] **Step 3: AWS API で Pod Identity Association list 取得 (= namespace + SA)**
+
+- [ ] **Step 4: 各 (ns, sa) で kubectl で Pod list 取得**
+
+- [ ] **Step 5: 各 Pod の env field に `AWS_CONTAINER_CREDENTIALS_FULL_URI` 存在 check**
+
+- [ ] **Step 6: OK / FAIL / INFO line 出力 + fail count carry-over (= temp file 経由、 subshell scope 問題回避)**
+
+- [ ] **Step 7: chmod +x で実行権限付与**
+
+**Test**:
+- `bash scripts/post-flight/check-pod-identity-injection.sh eks-production` 実行
+- 既存 Pod Identity Association 全件で "OK" 出力されること確認 (= cilium-operator 等)
+- exit code 0 確認
+
+---
+
+### Task 2: README に script 解説追加 (= 任意、 scope 軽い場合のみ)
+
+**Files**:
+- Modify: `scripts/post-flight/README.md` (= 新規 directory なので新規作成、 directory level の解説)
+
+**Steps**:
+
+- [ ] **Step 1: README 簡潔に**: directory purpose (= post-flight check 群)、 個別 script の usage、 future expansion note
+
+---
+
+## Out of scope (= 別 phase)
+
+- K8s CronJob 化
+- Prometheus metrics expose
+- AlertManager rule
+- 他 post-flight check (= cert mTLS chain verify 等)
+
+---
+
+## Validation checklist
+
+- [ ] script 実行で all Pod 健全時 exit 0
+- [ ] script の AWS API call (= `aws eks list-pod-identity-associations`) が eks-admin role で動くこと、 もしくは IAM 権限不足を明確に error 表示
+- [ ] script の output が CI / cron 整合 (= stderr / stdout 適切に分離)
+- [ ] spec doc が現実装と整合 (= 実装後 spec の "現状" を update する必要があれば反映)

--- a/docs/superpowers/specs/2026-05-13-eks-production-phase-6-closure-design.md
+++ b/docs/superpowers/specs/2026-05-13-eks-production-phase-6-closure-design.md
@@ -297,13 +297,14 @@ Phase 5 closure Section 2 と同 13 checklist を application stack (= monolith 
 
 #### Category H: Application + production grade (= 5 件)
 
-**#25 OTel Operator chart upgrade (= Ruby auto-injection native support)**
+**#25 OTel Operator chart upgrade (= Ruby auto-injection native support)** — **blocked upstream**
 
-- 現在: OTel Operator chart 0.112.1 は `spec.ruby` schema 非対応、 workaround として monolith Pod に env vars 6 個 hardcode (= ENDPOINT / RESOURCE_ATTRIBUTES / TRACES_EXPORTER / METRICS_EXPORTER / LOGS_EXPORTER / PROPAGATORS)
-- 体験 / impact: 新 Ruby service 追加で 同じ env vars hardcode 6 個を deployment.yaml に手動 copy 必要 → toil。 改善後 chart 0.155+ upgrade で `inject-ruby: "true"` annotation 1 行に置換 → **新 Ruby service 追加コスト 大幅削減**、 architecture 整合 (= "OTel Operator が auto-inject" 設計に復帰)
-- **Repo**: platform (= `kubernetes/components/otel-operator/production/` chart version upgrade) + monorepo (= `services/monolith/kubernetes/base/deployment.yaml` の env vars hardcode 撤去 + annotation 復活)
-- Phase 7+ task: OTel Operator chart 0.155+ upgrade、 env vars hardcode 撤去 + annotation 復活
-- priority: medium (= #38 と関連)
+- 現在: OTel Operator chart 0.113.1 (= app version 0.151.0、 helm repo 最新) でも `spec.ruby` schema 非対応、 monolith Pod の env vars 6 個 hardcode (= ENDPOINT / RESOURCE_ATTRIBUTES / TRACES_EXPORTER / METRICS_EXPORTER / LOGS_EXPORTER / PROPAGATORS) は workaround として継続
+- 体験 / impact: 新 Ruby service 追加で 同じ env vars hardcode 6 個を deployment.yaml に手動 copy 必要 → toil
+- **Upstream status (= 2026-05-17 確認)**: OTel Operator CHANGELOG 全文に "ruby" 文字列 0 件。 GitHub issue [open-telemetry/opentelemetry-operator#3762](https://github.com/open-telemetry/opentelemetry-operator/issues/3762) "Autoinstrumentation for opentelemetry ruby" が 2025-03 から **OPEN のまま** (= comment 1 件、 implementation 進展なし)。 Ruby auto-instrumentation の operator side 実装は upstream で未着手で、 chart upgrade では解消不可
+- **Repo**: platform (= 該当なし、 chart upgrade で対応不可) + monorepo (= env vars hardcode 継続)
+- Phase 7+ task: actionable not。 upstream 動向 watch + 実装後 chart upgrade + monorepo env vars hardcode 撤去 (= upstream merge までは backlog hold)。 代替案 (= ConfigMap envFrom 等) は scope 増 vs benefit が見合わないため見送り
+- priority: low (= upstream blocking、 workaround は env-agnostic value で運用安定)
 
 **#33 panicboat staging / production env active 化 + release-please + dystopia.city** (= Phase 7 Theme A primary focus)
 

--- a/docs/superpowers/specs/2026-05-17-pod-identity-injection-detection-design.md
+++ b/docs/superpowers/specs/2026-05-17-pod-identity-injection-detection-design.md
@@ -1,0 +1,126 @@
+# Pod Identity Injection Detection (= 引き継ぎ事項 #15)
+
+> **Goal**: AWS EKS Pod Identity webhook が Pod に `AWS_CONTAINER_CREDENTIALS_FULL_URI` env を inject し損なう timing race を自動検出する framework の初期着手。 ad-hoc shell script を 1 本作成し、 manual run で immediate value を確保。 cron / alert backend 連携は別 phase。
+
+---
+
+## 1. Problem
+
+### Pod Identity injection の仕組み
+
+EKS Pod Identity Association では、 `aws-eks-pod-identity-webhook` (= `eks-pod-identity-agent` DaemonSet が webhook を兼ねる、 cluster recreate runbook で confirmed) が Pod schedule 時に対象 SA を持つ Pod へ以下を inject:
+
+- `AWS_CONTAINER_CREDENTIALS_FULL_URI` env var (= AWS SDK が credential 取得 endpoint として参照)
+- `AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE` env var (= token file path)
+- token を mount する volume
+
+application は AWS SDK 経由でこの env を見て、 endpoint から短期 credential を取得して AWS API call。
+
+### Race condition
+
+webhook は Pod admission tag で fire するが、 以下条件で **inject 失敗 silent fail** が観測されている:
+
+1. webhook DaemonSet 自体が起動前に Pod が schedule された (= cluster bootstrap 時)
+2. webhook Pod が一時 down 中に target Pod recreate
+3. ServiceAccount に Pod Identity Association が deploy 順序で 後付け (= Pod 先 schedule)
+
+結果: env 不在で Pod 起動 → AWS SDK が credential 不在 → AWS API call 全て fail。 specific symptom:
+- ESO (= external-secrets) Pod が AWS Secrets Manager から secret を取れず、 ESO 経由作成の Secret が stale / 不在
+- cilium-operator Pod が AWS EC2 ENI 操作不可 (= Phase 4-1 でも observed)
+- 一般的に「Pod は Running だが AWS access だけ silent fail」 で symptom が出にくい
+
+### 現状
+
+- 検出は **manual** (= `kubectl exec <pod> -- env | grep AWS_CONTAINER_CREDENTIALS_FULL_URI`)
+- sporadic な race のため、 偶発発生時に気付くのが遅れる
+
+---
+
+## 2. Detection approach
+
+### Probe target
+
+「Pod Identity Association を持つ ServiceAccount を使う 全 Pod」 が probe 対象:
+
+1. AWS API (`aws eks list-pod-identity-associations`) で cluster の全 PIA を取得
+2. 各 PIA の `(namespace, serviceAccount)` を抽出
+3. kubectl で 該当 SA を使う Pod を list
+4. 各 Pod の env field に `AWS_CONTAINER_CREDENTIALS_FULL_URI` 存在 verify
+
+### Env 存在 check 方法
+
+`kubectl get pod -o json` で取得した spec の env を見るだけで判定可能:
+
+```jsonpath
+.spec.containers[].env[] | select(.name == "AWS_CONTAINER_CREDENTIALS_FULL_URI")
+```
+
+webhook が inject する env は **Pod manifest の env field** に追加されるため、 `kubectl exec` 不要 (= Pod が CrashLoop でも probe 可)。
+
+### Output
+
+- `OK: ns=<> sa=<> pod=<>` (= injected)
+- `FAIL: ns=<> sa=<> pod=<>: AWS_CONTAINER_CREDENTIALS_FULL_URI not injected`
+- `INFO: ns=<> sa=<>: no Pods using this SA` (= association exists but Pod 不在)
+- exit code: 0 (= all OK)、 1 (= fail あり)
+
+manual run + cron / CI 統合の両 case で exit code 解釈可。
+
+---
+
+## 3. Implementation scope (本 PR)
+
+### 含む
+
+- `scripts/post-flight/check-pod-identity-injection.sh` (= 上記 logic の bash 実装)
+- spec doc + plan doc
+
+### 含まない (別 phase)
+
+- K8s CronJob 化 (= 定期 probe)
+- alert backend 連携 (= Prometheus AlertManager / PagerDuty)
+- Pod admission validator (= webhook 失敗時 deploy block)
+- post-flight check framework 全般 (= 引き継ぎ #5 と統合検討)
+
+---
+
+## 4. Limitations
+
+### Race-window detection の限界
+
+本 script は probe 実行時点の Pod state を見るため、 「Pod schedule 時の race → 不在 → 後で recreated で recover」 のような transient case は probe 時点で healthy なら detect 不可。 真の検出には webhook event hook (= Pod admission audit) が必要だが scope 外。
+
+### AWS API rate limit
+
+`aws eks list-pod-identity-associations` は paginated API、 association 数 100+ で次 page 取得必要。 panicboat の現状 association 数は少ない (= cilium-operator + ESO 程度) ため初期は無視可。
+
+### IAM 権限
+
+probe 実行 IAM principal は `eks:ListPodIdentityAssociations` 権限必要。 eks-admin role には付与なしの可能性 (= 確認 + 必要なら追加)。 現状 IAM user `panicboat` で実行する場合は AdministratorAccess で OK。
+
+---
+
+## 5. Phase 7+ extension
+
+| Step | content |
+|---|---|
+| A (本 PR) | ad-hoc script 1 本 + spec / plan doc |
+| B | K8s CronJob 化 (= 1 時間間隔等で定期 probe、 Job log を Loki で aggregate) |
+| C | alert backend 連携 (= Prometheus textfile collector 経由 metric expose → AlertManager rule) |
+| D | post-flight check framework (= 引き継ぎ #5) との統合 (= cert-manager mTLS chain verify 等 他 probe と同 framework) |
+
+---
+
+## 6. Out of scope
+
+- 引き継ぎ #5 post-flight check framework 全般 (= 本 #15 は同 framework の 1 probe として 位置付け、 framework 設計は別 spec)
+- 引き継ぎ #16 distributed system chart audit (= 別 categorize)
+- 引き継ぎ #19 mTLS chain verify default 化 (= 同上)
+
+---
+
+## 7. Validation
+
+- `bash scripts/post-flight/check-pod-identity-injection.sh eks-production` を eks-production cluster で実行、 OK + FAIL 各 line を 想定通り出力
+- 既存 cilium-operator / ESO 等の Pod Identity 関連 Pod が "OK" になることを baseline 確認
+- 意図的に env を持たない Pod (= Pod Identity 関連ではない Pod) は probe 対象から除外されていることを確認

--- a/scripts/post-flight/README.md
+++ b/scripts/post-flight/README.md
@@ -1,0 +1,33 @@
+# Post-flight checks
+
+Cluster deploy / reconcile 後の自動 verify script 群。
+
+## Scripts
+
+| script | purpose |
+|---|---|
+| `check-pod-identity-injection.sh` | AWS EKS Pod Identity webhook が target Pod に `AWS_CONTAINER_CREDENTIALS_FULL_URI` env を inject しているか probe (= 引き継ぎ事項 #15) |
+
+## Usage
+
+```bash
+# 認証 (eks-admin role assume)
+eks-login
+
+# probe 実行 (default cluster: eks-production、 region: ap-northeast-1)
+bash scripts/post-flight/check-pod-identity-injection.sh
+
+# exit code 0 = all OK、 1 = injection 不在 Pod あり、 2 = tool / AWS API error
+```
+
+## Convention
+
+- 各 script は **single purpose** (= 1 probe / 1 verify)
+- stdout に OK / FAIL / INFO line、 stderr に error / summary
+- exit code: 0 (= success)、 1 (= fail)、 2 (= prerequisite error)
+- ad-hoc manual run + CI / cron 統合の両方で再利用可
+
+## Related
+
+- spec: `docs/superpowers/specs/2026-05-17-pod-identity-injection-detection-design.md`
+- backlog: 引き継ぎ事項 #5 (= post-flight check framework 全般) と統合検討

--- a/scripts/post-flight/check-pod-identity-injection.sh
+++ b/scripts/post-flight/check-pod-identity-injection.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+# =============================================================================
+# Pod Identity Injection Detection (= 引き継ぎ事項 #15)
+# =============================================================================
+# Probe AWS EKS Pod Identity webhook が AWS_CONTAINER_CREDENTIALS_FULL_URI を
+# 対象 Pod に inject しているか確認。 webhook timing race で env 不在のまま Pod
+# が起動した場合 (= ESO / cilium-operator 等で observed) を検出する。
+#
+# Spec: docs/superpowers/specs/2026-05-17-pod-identity-injection-detection-design.md
+#
+# Usage:
+#   eks-login           # = eks-admin role assume + AWS_ env vars export
+#   bash check-pod-identity-injection.sh [cluster_name]
+#
+# 認証要件:
+# - aws cli は eks:ListPodIdentityAssociations 権限が必要だが eks-admin role
+#   には現在付与されていない (= 別 phase で role policy 修正検討)。 本 script は
+#   `unset AWS_*` で IAM user creds に fallback して aws cli call、 kubectl は
+#   eks-admin role env vars を保持した sub-shell で実行する mixed approach。
+# - IAM user 側に AdministratorAccess (= AssumeRole + EKS describe 含む) が必要。
+#
+# Requires: aws cli / kubectl / jq
+#
+# Exit codes:
+# - 0: 全 Pod injection OK
+# - 1: 1 つ以上の Pod で env 不在 (= injection 失敗)
+# - 2: tool 不在 / AWS API error
+# =============================================================================
+
+set -euo pipefail
+
+cluster_name="${1:-eks-production}"
+region="${AWS_REGION:-ap-northeast-1}"
+
+for cmd in aws kubectl jq; do
+  if ! command -v "$cmd" >/dev/null 2>&1; then
+    echo "ERROR: $cmd not found in PATH" >&2
+    exit 2
+  fi
+done
+
+echo "Probing Pod Identity injection on cluster=$cluster_name region=$region"
+echo ""
+
+# eks-admin role env vars を保存 (= kubectl exec plugin で復元)
+saved_key="${AWS_ACCESS_KEY_ID:-}"
+saved_secret="${AWS_SECRET_ACCESS_KEY:-}"
+saved_token="${AWS_SESSION_TOKEN:-}"
+
+# 1. AWS から Pod Identity Association list 取得 (= IAM user creds 経由)
+assocs=$(
+  unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_SESSION_TOKEN
+  aws eks list-pod-identity-associations \
+    --cluster-name "$cluster_name" \
+    --region "$region" \
+    --query 'associations[].{ns:namespace,sa:serviceAccount}' \
+    --output json
+) || {
+  echo "ERROR: aws eks list-pod-identity-associations failed (= IAM user creds で eks:ListPodIdentityAssociations 必要)" >&2
+  exit 2
+}
+
+assoc_count=$(echo "$assocs" | jq 'length')
+echo "Found $assoc_count Pod Identity Association(s)"
+echo ""
+
+# subshell scope 問題回避のため fail list を temp file に蓄積
+fail_list=$(mktemp)
+trap 'rm -f "$fail_list"' EXIT
+
+# kubectl call は eks-admin role env vars で (= 上記 saved 値 が現在 env に残存)
+echo "$assocs" | jq -c '.[]' | while read -r assoc; do
+  ns=$(echo "$assoc" | jq -r '.ns')
+  sa=$(echo "$assoc" | jq -r '.sa')
+
+  pods=$(kubectl get pods -n "$ns" -o json 2>/dev/null | \
+    jq -r --arg sa "$sa" '.items[] | select(.spec.serviceAccountName == $sa) | .metadata.name') || pods=""
+
+  if [ -z "$pods" ]; then
+    echo "INFO: ns=$ns sa=$sa: no Pods using this SA"
+    continue
+  fi
+
+  for pod in $pods; do
+    has_creds=$(kubectl get pod -n "$ns" "$pod" -o json | \
+      jq '[.spec.containers[].env? // [] | .[] | select(.name == "AWS_CONTAINER_CREDENTIALS_FULL_URI")] | length')
+
+    if [ "$has_creds" = "0" ]; then
+      echo "FAIL: ns=$ns sa=$sa pod=$pod: AWS_CONTAINER_CREDENTIALS_FULL_URI not injected"
+      echo "$ns/$pod" >> "$fail_list"
+    else
+      echo "OK:   ns=$ns sa=$sa pod=$pod"
+    fi
+  done
+done
+
+echo ""
+
+fail_count=$(wc -l < "$fail_list" | tr -d ' ')
+if [ "$fail_count" != "0" ]; then
+  echo "Detected $fail_count Pod(s) without Pod Identity env injection" >&2
+  exit 1
+fi
+
+echo "All Pod Identity associated Pods have AWS_CONTAINER_CREDENTIALS_FULL_URI injected"


### PR DESCRIPTION
## Summary

引き継ぎ事項 **#15** の初期着手として ad-hoc shell script (= `scripts/post-flight/check-pod-identity-injection.sh`) を 1 本追加。 同時に 引き継ぎ事項 **#25** の status を update (= upstream blocked と確認、 priority 下げ)。

## #15: Pod Identity injection probe

Pod Identity webhook が `AWS_CONTAINER_CREDENTIALS_FULL_URI` env を inject し損なう timing race を検出する script。 manual run で 即時 cluster state probe。

### Test result (= eks-production で実行)

```
Probing Pod Identity injection on cluster=eks-production region=ap-northeast-1
Found 6 Pod Identity Association(s)

OK:   ns=monitoring sa=tempo pod=tempo-0
OK:   ns=monitoring sa=mimir pod=mimir-distributed-chunks-cache-0
... (16 Pods total)
OK:   ns=external-secrets sa=external-secrets pod=external-secrets-d4479f4c4-2hpc6

All Pod Identity associated Pods have AWS_CONTAINER_CREDENTIALS_FULL_URI injected
EXIT=0
```

### 認証要件

- aws cli は `eks:ListPodIdentityAssociations` 必要だが eks-admin role に未付与
- script は sub-shell で `AWS_*` env vars を unset → IAM user creds (= AdministratorAccess) で aws cli call、 kubectl は eks-admin role env vars を保持
- 別 phase で eks-admin role policy 修正検討 (= IAM 管理整理 task)

### Scope (本 PR)

- ✓ ad-hoc shell script 1 本
- ✓ spec + plan doc

### Out of scope (= 別 phase)

- K8s CronJob 化 / Prometheus metric expose / AlertManager rule
- 引き継ぎ #5 post-flight check framework との統合

## #25: OTel Operator chart upgrade — upstream blocked

phase 6 closure doc (line 300-306) を update。 chart 0.113.1 (= helm repo 最新) でも `spec.ruby` schema 非対応、 GitHub issue [open-telemetry/opentelemetry-operator#3762](https://github.com/open-telemetry/opentelemetry-operator/issues/3762) "Autoinstrumentation for opentelemetry ruby" が 2025-03 から OPEN のままで upstream implementation 進展なし。

→ stance: backlog hold (= upstream 動向 watch、 actionable not)、 priority medium → low

## Files

- `docs/superpowers/specs/2026-05-17-pod-identity-injection-detection-design.md` (新規、 #15)
- `docs/superpowers/plans/2026-05-17-pod-identity-injection-detection.md` (新規、 #15)
- `scripts/post-flight/check-pod-identity-injection.sh` (新規、 実行権限付与)
- `scripts/post-flight/README.md` (新規)
- `docs/superpowers/specs/2026-05-13-eks-production-phase-6-closure-design.md` (#25 entry update)

## Test plan

- [x] script 実行で eks-production の 16 Pod 全 injection OK (= 手元 verify 済)
- [ ] doc review (= 引き継ぎ事項 #15 + #25 の closure status 整合確認)