### PR TITLE
fix(aws/eks): grant eks:ListPodIdentityAssociations to eks-admin role

### DIFF
--- a/aws/eks/modules/iam_admin.tf
+++ b/aws/eks/modules/iam_admin.tf
@@ -34,12 +34,18 @@ resource "aws_iam_role_policy" "eks_admin_describe_cluster" {
   name = "eks-describe-cluster"
   role = aws_iam_role.eks_admin.id
 
+  # eks:ListPodIdentityAssociations は scripts/post-flight/check-pod-identity-injection.sh
+  # (= 引き継ぎ事項 #15) が AWS API で association list を取得するために必要。 同 cluster
+  # ARN scope で role 単独で完結、 script 側 sub-shell の IAM user creds fallback が不要に。
   policy = jsonencode({
     Version = "2012-10-17"
     Statement = [
       {
-        Effect   = "Allow"
-        Action   = "eks:DescribeCluster"
+        Effect = "Allow"
+        Action = [
+          "eks:DescribeCluster",
+          "eks:ListPodIdentityAssociations",
+        ]
         Resource = "arn:aws:eks:${var.aws_region}:${data.aws_caller_identity.current.account_id}:cluster/eks-${var.environment}"
       }
     ]


### PR DESCRIPTION
## Summary

`scripts/post-flight/check-pod-identity-injection.sh` (= 引き継ぎ事項 **#15**、 PR #419 で導入) が `eks:ListPodIdentityAssociations` を必要とするが、 `eks-admin-production` role には `eks:DescribeCluster` のみ付与で AccessDenied 発生。 script は workaround として sub-shell で `AWS_*` env vars を unset し IAM user creds (AdministratorAccess) に fallback する mixed approach で対応していたが、 本 PR で **eks-admin role 単独で完結する形に改善**。

## Security 影響

Action 追加範囲は同 cluster ARN scope 内 **read-only** (= リスト取得のみ、 IAM / secret manipulation 等は含まない)、 security 影響軽微。 cluster admin role の role boundary は維持。

## Diff

```hcl
# aws/eks/modules/iam_admin.tf

resource "aws_iam_role_policy" "eks_admin_describe_cluster" {
  ...
  policy = jsonencode({
    Statement = [
      {
        Effect = "Allow"
        Action = [
-         "eks:DescribeCluster"
+         "eks:DescribeCluster",
+         "eks:ListPodIdentityAssociations",
        ]
        Resource = "arn:aws:eks:.../cluster/eks-${var.environment}"
      }
    ]
  })
}
```

## Verify (= apply 後 確認済)

```
$ aws eks list-pod-identity-associations --cluster-name eks-production
→ 6 PIA list 取得成功
$ bash scripts/post-flight/check-pod-identity-injection.sh
→ Found 6 Pod Identity Association(s)、 16 Pod 全 OK、 sub-shell fallback 不要で完結
```

## Follow-up

PR #419 の script の sub-shell fallback 部分 (`unset AWS_*` block) の simplify は follow-up で:
- Option A: 本 PR merge + PR #419 merge 後の別 PR (= cleanup follow-up)
- Option B: PR #419 内 add commit (= IAM 拡張 merge を 待つ前提)

priority low (= 機能的には現状でも動作)。

## Test plan

- [x] `terragrunt plan` で IAM policy 1 件 in-place 確認 (= 手元 verify 済)
- [x] `terragrunt apply` 成功
- [x] eks-admin role で `aws eks list-pod-identity-associations` 動作確認
- [x] script `scripts/post-flight/check-pod-identity-injection.sh` を eks-login のみで再実行 (= 16 Pod OK)