### PR TITLE
chore(flux): cutover monorepo Flux Kustomization path to clusters/production

### DIFF
--- a/kubernetes/clusters/production/repositories/monorepo.yaml
+++ b/kubernetes/clusters/production/repositories/monorepo.yaml
@@ -1,10 +1,10 @@
 # =============================================================================
 # Flux GitRepository + Kustomization for panicboat/monorepo
 # =============================================================================
-# monorepo は clusters/develop/ 配下に各 service ごとの Flux Kustomization を
-# 内蔵 (= monolith / frontend / reverse-proxy)、cascading で deploy される
-# 設計のため、本 platform stack からは monorepo を 1 つの GitRepository として
-# pull し、root Kustomization のみ管理する。
+# monorepo は clusters/production/ 配下に各 service ごとの Flux Kustomization を
+# 内蔵 (= monolith / frontend)、cascading で deploy される設計のため、本 platform
+# stack からは monorepo を 1 つの GitRepository として pull し、root Kustomization
+# のみ管理する。
 # =============================================================================
 apiVersion: source.toolkit.fluxcd.io/v1
 kind: GitRepository
@@ -24,7 +24,7 @@ metadata:
   namespace: flux-system
 spec:
   interval: 5m0s
-  path: "./clusters/develop"
+  path: "./clusters/production"
   prune: true
   sourceRef:
     kind: GitRepository


### PR DESCRIPTION
## Summary

monorepo PR [#621](https://github.com/panicboat/monorepo/pull/621) (= `clusters/develop → clusters/production` rename) との **connecting PR**。 monorepo PR merge 後、 本 PR を続けて merge することで Flux Kustomization `monorepo-cluster` が新 path を pull し始める。

連続 merge 中の transient 期間 (~1-2 分) は Flux が path mismatch 検出 → prune → 復旧 sequence で cluster traffic 短時間中断 risk あり (= user 明示認可済の downtime tolerance)。

## Changes

- `kubernetes/clusters/production/repositories/monorepo.yaml` の Flux Kustomization `spec.path` を `"./clusters/develop"` → `"./clusters/production"`
- 同 file の comment 内 `clusters/develop` reference + 廃止済 `reverse-proxy` reference を update

## Merge order (= 重要)

1. **monorepo PR #621 merge 先** (= clusters/develop → clusters/production rename)
2. **本 PR merge 続けて** (= platform 側 path 更新)
3. Flux reconcile (= 5 分 interval 内) で cluster Pod 復旧確認
   - `kubectl get pods -n default` 全 Running
   - `kubectl get kustomizations monorepo-cluster -n flux-system` Ready=True

本 PR を monorepo PR #621 より先に merge すると Flux Kustomization が NotFound state になり、 既存 monolith / frontend Pod が prune される (= 復旧は monorepo PR #621 merge 後の reconcile で自動)。

## Test plan

- [ ] monorepo PR #621 merge
- [ ] 本 PR merge
- [ ] Flux reconcile 確認 (= 5 分以内に monorepo-cluster Kustomization Ready)
- [ ] `kubectl get pods -n default` で monolith / frontend Pod Running 確認
- [ ] `curl https://develop.panicboat.net/` HTTP 200 確認

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated production cluster deployment configuration to ensure deployments are sourced from the correct production environment directory.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/panicboat/platform/pull/421?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->