### PR TITLE
fix(aws/ai-assistant): drop GitHubOrg + GitHubRepos tags from actions role

### DIFF
--- a/aws/ai-assistant/modules/role_actions.tf
+++ b/aws/ai-assistant/modules/role_actions.tf
@@ -28,10 +28,8 @@ resource "aws_iam_role" "actions_role" {
   })
 
   tags = merge(var.common_tags, {
-    Name        = "${var.project_name}-${var.environment}-github-actions-role"
-    GitHubOrg   = var.github_org
-    GitHubRepos = join("+", var.github_repos)
-    Purpose     = "ai-assistant-github-actions"
+    Name    = "${var.project_name}-${var.environment}-github-actions-role"
+    Purpose = "ai-assistant-github-actions"
   })
 }
 


### PR DESCRIPTION
## Summary

Surfaced by PR #427 post-merge apply (= `ai-assistant:develop` job failed).

`aws/ai-assistant/modules/role_actions.tf` set `GitHubRepos = join("+", var.github_repos)`. In `develop` env (`aws/ai-assistant/envs/develop/actions.hcl`) `github_repos = ["*"]`, so the rendered tag value is `"*"`. AWS IAM rejects this because IAM tag values must match `[\p{L}\p{Z}\p{N}_.:/=+\-@]*` (= `*` not in the allowed set):

```
api error ValidationError: Value at 'tags.3.member.value' failed to satisfy constraint:
Member must satisfy regular expression pattern: [\p{L}\p{Z}\p{N}_.:/=+\-@]*
```

The wildcard in `github_repos` is intentional for the OIDC trust policy (= `StringLike` allows `*`), so the source value is correct; the issue is only the tag rendering.

`GitHubOrg` and `GitHubRepos` were documentation tags. Provenance is already covered by the unified schema introduced in #427 (= `Component=ai-assistant`, `Project=ai-assistant`, `Name=...-github-actions-role`, `Purpose=ai-assistant-github-actions`). Drop both tags to keep apply unblocked when `github_repos` contains wildcards.

## Test plan
- [ ] CI `terragrunt plan` for `ai-assistant:develop` shows only tag deletions (= `GitHubOrg` + `GitHubRepos` removed) + the previously-pending tag schema + assume_role_policy drift
- [ ] After merge, post-merge `terragrunt apply` for `ai-assistant:develop` succeeds (= no more IAM TagRole validation error)
- [ ] `aws iam list-role-tags --role-name ai-assistant-develop-github-actions-role` shows the role tagged with `Component=ai-assistant` + `ManagedBy=terraform` + `Project=ai-assistant` + `Repository=panicboat/platform` + `Name` + `Purpose=ai-assistant-github-actions` + `Environment=develop` + `Owner=panicboat` (= 8 tags, no `GitHubOrg` / `GitHubRepos`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified AWS IAM role tagging configuration by removing GitHub-specific metadata while maintaining essential resource identifiers and purpose tracking.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/panicboat/platform/pull/429?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->