### PR TITLE
fix(aws/karpenter): set force_update_version on system_critical MNG

### DIFF
--- a/aws/karpenter/modules/main.tf
+++ b/aws/karpenter/modules/main.tf
@@ -135,6 +135,14 @@ module "system_critical" {
     max_unavailable_percentage = 33
   }
 
+  # LT version 変更 (= 例: common_tags 経由の tag_specifications 更新) で MNG が
+  # rolling update を trigger した際、 PDB が evict を阻止すると PodEvictionFailure
+  # で update が Failed 状態で停止する。 force_update_version=true で PDB タイムアウト
+  # 後に AWS が force kill して update を完遂させる。
+  # system_critical workload (Karpenter / cilium-operator / CoreDNS) は stateless
+  # で 1-2 分の forced restart を許容する設計。
+  force_update_version = true
+
   iam_role_additional_policies = {
     ssm = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
   }


### PR DESCRIPTION
## Summary

prevents PodEvictionFailure from stalling MNG version updates on the `system_critical` managed node group.

when an LT version bump triggers a rolling update (= e.g., `common_tags` propagation to `tag_specifications`), AWS cordons one node and attempts to evict pods. if a PodDisruptionBudget denies eviction (= e.g., CoreDNS minAvailable with a single replica on the node), AWS retries until max_retries and the version update enters `Failed` state, leaving the MNG partially updated.

`force_update_version = true` makes AWS force-kill blocked pods after the eviction timeout instead of failing the update.

**Trade-off**: short disruption (= ~1-2 minutes) of system_critical workloads (Karpenter controller / cilium-operator / CoreDNS) during rolling. these are stateless and recover quickly; the trade-off is acceptable for this bootstrap MNG.

## Test plan
- [ ] CI `terragrunt plan` for `aws/karpenter/envs/production` shows `~ force_update_version = true` on `module.system_critical.aws_eks_node_group.this[0]` (= in-place attribute update, no resource recreation)
- [ ] After merge, post-merge `terragrunt apply` succeeds without rolling system_critical nodes (= attribute-only change)
- [ ] Subsequent LT version bumps (= future tag changes, AMI updates) complete successfully even if a PDB initially denies eviction