### PR TITLE
fix(aws/eks): grant ExternalDNS IAM access to dystopia.city zone

### DIFF
--- a/aws/eks/modules/addons.tf
+++ b/aws/eks/modules/addons.tf
@@ -56,7 +56,10 @@ module "external_dns_irsa" {
   name                          = "eks-${var.environment}-external-dns"
   use_name_prefix               = false
   attach_external_dns_policy    = true
-  external_dns_hosted_zone_arns = [module.route53.zones.panicboat_net.arn]
+  external_dns_hosted_zone_arns = [
+    module.route53.zones.panicboat_net.arn,
+    module.route53.zones.dystopia_city.arn,
+  ]
 
   oidc_providers = {
     main = {


### PR DESCRIPTION
## Summary

PR #433 (= dystopia.city migration) で spec の見落とし: ExternalDNS の `domainFilters` に `dystopia.city` を追加したが、 `external_dns_irsa` module の `external_dns_hosted_zone_arns` には panicboat.net のみ。 ExternalDNS の IAM policy が `route53:ChangeResourceRecordSets` を panicboat.net zone のみ permit、 dystopia.city A record 作成が **AccessDenied** で fail。

## Fix

`aws/eks/modules/addons.tf:59` で `external_dns_hosted_zone_arns` を 2 zone permit に変更:

```hcl
external_dns_hosted_zone_arns = [
  module.route53.zones.panicboat_net.arn,
  module.route53.zones.dystopia_city.arn,
]
```

## Pre-PR apply (= 完了済)

- terragrunt apply で IAM policy v2 (= dystopia.city zone ARN 含む) 作成
- ExternalDNS Pod restart で reconcile 開始
- Route53 dystopia.city zone に A + AAAA record (= ALB ALIAS) 作成成功
- DNS propagation 完了
- `curl https://dystopia.city/` → **HTTP 200 OK** 確認済

## Test plan

- [x] cluster 側 IAM policy + Route53 record + curl 200 確認
- [ ] PR merge 後 Flux reconcile で manifest source 反映 (= 既に AWS 側 effective、 no-op の見込み)