### PR TITLE
fix(flux): ExternalSecret apiVersion v1beta1 -> v1

### DIFF
--- a/kubernetes/clusters/production/repositories/monorepo.yaml
+++ b/kubernetes/clusters/production/repositories/monorepo.yaml
@@ -43,7 +43,7 @@ spec:
 # AWS Secrets Manager 内の secret は user が console で 1 回手動で put した
 # 既存 panicboat App の credentials (Contents: Read & Write 権限あり)。
 # =============================================================================
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: panicboat-github-app


### PR DESCRIPTION
## Summary

Fix the \`flux-system\` Kustomization dry-run failure observed after PR #436 merge:

\`\`\`
ExternalSecret/flux-system/panicboat-github-app dry-run failed:
no matches for kind "ExternalSecret" in version "external-secrets.io/v1beta1"
\`\`\`

The cluster ESO CRD does not serve \`v1beta1\` (existing ExternalSecret resources like \`monolith-database\` / \`grafana-admin\` / \`oauth2-proxy-google\` all use \`v1\`). Align this ExternalSecret with the existing pattern.

## After merge

- \`flux-system\` Kustomization dry-run passes
- ExternalSecret \`panicboat-github-app\` is applied to cluster (flux-system namespace)
- ESO syncs from AWS Secrets Manager \`panicboat/github-app/panicboat\` → K8s Secret \`panicboat-github-app\`
- GitRepository \`monorepo\` picks up the secret and source-controller generates App token

## Next expected observation (not in this PR's scope)

ImageUpdateAutomation's error message is expected to shift from \`authentication required: No anonymous write access\` to something like \`protected branch hook declined\` (= ruleset \`pull_request\` rule blocks Flux direct push). The ruleset bypass fix will be a separate follow-up PR.

## Test plan

- [ ] CI passes
- [ ] After merge, \`kubectl get kustomization flux-system -n flux-system\` reaches lastAppliedRevision matching the new main HEAD
- [ ] \`kubectl get externalsecret -n flux-system panicboat-github-app\` is SecretSynced True
- [ ] \`kubectl get secret -n flux-system panicboat-github-app\` exists with 3 keys
- [ ] \`kubectl get imageupdateautomation -n flux-system\` error message changes from auth to ruleset