### PR TITLE
fix(flux): K8s Secret keys to camelCase for source-controller compatibility

### DIFF
--- a/kubernetes/clusters/production/repositories/monorepo.yaml
+++ b/kubernetes/clusters/production/repositories/monorepo.yaml
@@ -57,15 +57,15 @@ spec:
     name: panicboat-github-app
     creationPolicy: Owner
   data:
-    - secretKey: github-app-id
+    - secretKey: githubAppID
       remoteRef:
         key: panicboat/github-app/panicboat
         property: appID
-    - secretKey: github-installation-id
+    - secretKey: githubAppInstallationID
       remoteRef:
         key: panicboat/github-app/panicboat
         property: installationID
-    - secretKey: github-private-key
+    - secretKey: githubAppPrivateKey
       remoteRef:
         key: panicboat/github-app/panicboat
         property: privateKey


### PR DESCRIPTION
## Summary

Follow-up to PR #442. After applying PR #436 + #442, the GitRepository auth error shifted from \`authentication required\` to:

\`\`\`
secretRef with github app data must be specified when provider is set to github
\`\`\`

Flux source-controller v1 GitHub App provider expects K8s Secret keys in **camelCase** (per official docs):

- \`githubAppID\` (not \`github-app-id\`)
- \`githubAppInstallationID\` (not \`github-installation-id\`)
- \`githubAppPrivateKey\` (not \`github-private-key\`)

This PR updates the ExternalSecret \`data[*].secretKey\` to match Flux's expectation.

## What does NOT change

- AWS Secrets Manager \`panicboat/github-app/panicboat\` の secret value (\`appID\` / \`installationID\` / \`privateKey\` property 名) はそのまま (= user 側で再 put 不要)
- GitRepository spec は変更なし

## After merge

- Flux source-controller が K8s Secret から正しい key を読む
- App token 生成成功 → GitRepository auth エラー消える
- ImageUpdateAutomation が push 試行 → 次は ruleset error (= 別 PR で対応予定)

## Test plan

- [ ] CI passes
- [ ] After merge, \`kubectl get secret -n flux-system panicboat-github-app -o jsonpath='{.data}'\` returns the 3 camelCase keys
- [ ] \`kubectl get gitrepository -n flux-system monorepo\` is Ready True without \`secretRef with github app data\` error
- [ ] \`kubectl get imageupdateautomation -n flux-system\` の error が auth/secretRef 系から ruleset/protected-branch 系に shift