### PR TITLE
fix(flux): AWS Secrets Manager property names to snake_case

### DIFF
--- a/kubernetes/clusters/production/repositories/monorepo.yaml
+++ b/kubernetes/clusters/production/repositories/monorepo.yaml
@@ -60,12 +60,12 @@ spec:
     - secretKey: githubAppID
       remoteRef:
         key: panicboat/github-app/panicboat
-        property: appID
+        property: app_id
     - secretKey: githubAppInstallationID
       remoteRef:
         key: panicboat/github-app/panicboat
-        property: installationID
+        property: installation_id
     - secretKey: githubAppPrivateKey
       remoteRef:
         key: panicboat/github-app/panicboat
-        property: privateKey
+        property: private_key


### PR DESCRIPTION
## Summary

panicboat の既存 ExternalSecret (oauth2-proxy-google: \`client_id\` / \`client_secret\` / \`cookie_secret\`) の命名規約に揃えて、\`panicboat/github-app/panicboat\` 内の property 名を camelCase → snake_case に変更。

| field | before | after |
|---|---|---|
| AWS secret property | \`appID\` / \`installationID\` / \`privateKey\` | \`app_id\` / \`installation_id\` / \`private_key\` |
| K8s Secret key (secretKey) | \`githubAppID\` 等 (camelCase) | 変更なし (= Flux v1 仕様で固定) |

## Prerequisite (Manual, completed by user)

- AWS Secrets Manager \`panicboat/github-app/panicboat\` の secret value を再 put 済 (新 property 名: \`app_id\` / \`installation_id\` / \`private_key\`)

## After merge

- ESO 次回 sync (1h interval、もしくは force) で K8s Secret 再生成
- K8s Secret の 3 keys (camelCase) はそのまま、value だけ更新
- GitRepository monorepo の App token 生成が継続成功
- ImageUpdateAutomation の挙動は変わらず (依然として ruleset 違反で push 拒否、これは別 PR で対応中)

## Test plan

- [ ] CI passes
- [ ] After merge, force \`kubectl annotate externalsecret panicboat-github-app -n flux-system force-sync=...\` で再 sync
- [ ] \`kubectl get externalsecret -n flux-system panicboat-github-app\` が SecretSynced True 継続
- [ ] \`kubectl get gitrepository -n flux-system monorepo\` が Ready True 継続 (= App token 生成成功継続)