### PR TITLE
feat(github/branch): allow GitHub App bypass for monorepo main ruleset

### DIFF
--- a/github/branch/envs/develop/monorepo.hcl
+++ b/github/branch/envs/develop/monorepo.hcl
@@ -12,6 +12,10 @@ locals {
             "Validate PR title",
             "Ensure actions are pinned to SHAs",
           ]
+          # panicboat App (1371999) bypasses the pull_request rule for direct
+          # push from Flux ImageUpdateAutomation (= release-driven image bump
+          # commits to overlays/production/deployment.yaml).
+          bypass_app_ids = [1371999]
         }
       )
     }

--- a/github/branch/modules/main.tf
+++ b/github/branch/modules/main.tf
@@ -24,6 +24,7 @@ locals {
         allow_force_pushes              = rule.allow_force_pushes
         allow_deletions                 = rule.allow_deletions
         admin_bypass                    = rule.admin_bypass
+        bypass_app_ids                  = rule.bypass_app_ids
       }
     }
   ]...)

--- a/github/branch/modules/main.tf
+++ b/github/branch/modules/main.tf
@@ -55,6 +55,19 @@ resource "github_repository_ruleset" "branches" {
     }
   }
 
+  # GitHub App bypass: each App ID in bypass_app_ids generates a bypass_actor.
+  # Used for automation that must direct-push to the protected branch
+  # (e.g., Flux ImageUpdateAutomation bumping image tags).
+  dynamic "bypass_actors" {
+    for_each = each.value.bypass_app_ids
+    iterator = app_id
+    content {
+      actor_id    = app_id.value
+      actor_type  = "Integration"
+      bypass_mode = "always"
+    }
+  }
+
   rules {
     # Requiring a PR effectively blocks direct pushes to the branch,
     # replacing the legacy restrict_pushes setting.

--- a/github/branch/modules/variables.tf
+++ b/github/branch/modules/variables.tf
@@ -60,6 +60,12 @@ variable "repositories" {
       # When true, organization admins can bypass this ruleset.
       # Set false to enforce rules for everyone (legacy enforce_admins=true equivalent).
       admin_bypass = bool
+
+      # GitHub App (Integration) IDs that bypass this ruleset for direct pushes.
+      # Required for automation that must commit/push to the protected branch
+      # without going through a pull request (e.g., Flux ImageUpdateAutomation).
+      # Empty list = no GitHub App bypass.
+      bypass_app_ids = optional(list(number), [])
     }))
   }))
 }


### PR DESCRIPTION
## Summary

Resolve \`push declined due to repository rule violations\` from Flux ImageUpdateAutomation by adding the panicboat GitHub App (\`App ID 1371999\`) to the \`monorepo-main\` ruleset's \`bypass_actors\`.

- \`modules/variables.tf\`: new optional field \`bypass_app_ids: list(number)\` (default \`[]\`) on \`branch_protection\` object
- \`modules/main.tf\`: new dynamic \`bypass_actors\` block iterating \`bypass_app_ids\`, each emitted as \`actor_type=Integration, bypass_mode=always\`
- \`envs/develop/monorepo.hcl\`: \`bypass_app_ids = [1371999]\` added to \`branch_protection.main\`

Other repos (\`ansible\` / \`dotfiles\` / \`panicboat-actions\` / \`platform\` / \`deploy-actions\`) keep the default empty list — no behavior change for them.

## Why \`bypass_mode = always\` and not \`pull_request\`

Flux ImageUpdateAutomation pushes directly to main (= no PR). \`pull_request\` mode would still block direct pushes; \`always\` is required for the automation to work. The blast radius is limited to commits authored by the panicboat App (= ImageUpdateAutomation commits and any other automation using this same App).

## What does NOT change

- monorepo リポ自身 (= 変更不要)
- 他 GitHub App
- panicboat App の権限 (= already has Contents: Read & Write)
- 他リポの ruleset

## Test plan

- [ ] CI passes (Terragrunt plan/apply jobs for github/branch develop env)
- [ ] After merge, \`gh api repos/panicboat/monorepo/rulesets/15519991 --jq '.bypass_actors'\` shows 1 entry with \`actor_id: 1371999, actor_type: Integration, bypass_mode: always\`
- [ ] Force reconcile of Flux ImageUpdateAutomation → \`kubectl get events -n flux-system --field-selector involvedObject.kind=ImageUpdateAutomation --sort-by=lastTimestamp\` の最新 event が \`push declined\` / \`GitOperationFailed\` でなくなる
- [ ] 数十分以内に monorepo main に \`panicboat[bot]\` author の \`chore(monolith): bump image to ...\` commit が乗る