### PR TITLE
chore(ci): disable Terragrunt deploy job until targets exist

### DIFF
--- a/.github/workflows/auto-label--deploy-trigger.yaml
+++ b/.github/workflows/auto-label--deploy-trigger.yaml
@@ -95,6 +95,7 @@ jobs:
     if: |
       needs.deploy-trigger.outputs.has-targets == 'true' &&
       contains(needs.deploy-trigger.outputs.targets, '"stack":"terragrunt"')
+      && true == 'false' # TODO: Terragrunt deployment is currently disabled as we have no active Terragrunt targets; re-enable when needed by removing this line
     strategy:
       matrix:
         target: ${{ fromJson(needs.deploy-trigger.outputs.targets) }}


### PR DESCRIPTION
## Summary
- Gate the `deploy-terragrunt` job off with a constant-false guard while there are no active Terragrunt targets in this repo.

## Test Plan
- [ ] Workflow YAML parses without syntax errors (GitHub Actions linter)
- [ ] On a deploy-trigger event with `stack: terragrunt`, the `deploy-terragrunt` job is skipped
- [ ] Other deploy jobs still run unchanged