### PR TITLE
fix(scripts/eks-lifecycle): sweep orphan EBS / Route53 in teardown chain

### DIFF
--- a/scripts/eks-lifecycle/lib/00-auth.sh
+++ b/scripts/eks-lifecycle/lib/00-auth.sh
@@ -34,6 +34,42 @@ ORIG_AWS_SECRET_ACCESS_KEY="${AWS_SECRET_ACCESS_KEY:-}"
 ORIG_AWS_SESSION_TOKEN="${AWS_SESSION_TOKEN:-}"
 export ORIG_AWS_ACCESS_KEY_ID ORIG_AWS_SECRET_ACCESS_KEY ORIG_AWS_SESSION_TOKEN
 
+# Helper for sub-scripts that need admin credentials (= kubectl ops in 10/60/70).
+# Split declare + assign so jq failure (= file corrupted) propagates under set -e.
+# Defined before the admin-role assume attempt so that CLUSTER_EXISTS=false 経路
+# (= 10-k8s-cleanup.sh の AWS-API fallback など) からも safe に呼び出せる。
+use_admin_creds() {
+  if [ -n "${ADMIN_CREDS_FILE:-}" ] && [ -f "$ADMIN_CREDS_FILE" ]; then
+    local _id _secret _token
+    _id=$(jq -r .AccessKeyId "$ADMIN_CREDS_FILE")
+    _secret=$(jq -r .SecretAccessKey "$ADMIN_CREDS_FILE")
+    _token=$(jq -r .SessionToken "$ADMIN_CREDS_FILE")
+    export AWS_ACCESS_KEY_ID="$_id"
+    export AWS_SECRET_ACCESS_KEY="$_secret"
+    export AWS_SESSION_TOKEN="$_token"
+  fi
+}
+
+# Restore operator's default credential state for terragrunt operations.
+# When operator uses AWS_PROFILE / IAM Identity Center / instance profile,
+# unsetting AWS_*_KEY env returns the SDK to its default lookup chain.
+# When operator had AWS_*_KEY set directly, restore the captured values.
+use_apply_creds() {
+  if [ -n "${ORIG_AWS_ACCESS_KEY_ID}" ]; then
+    export AWS_ACCESS_KEY_ID="$ORIG_AWS_ACCESS_KEY_ID"
+    export AWS_SECRET_ACCESS_KEY="$ORIG_AWS_SECRET_ACCESS_KEY"
+    if [ -n "${ORIG_AWS_SESSION_TOKEN}" ]; then
+      export AWS_SESSION_TOKEN="$ORIG_AWS_SESSION_TOKEN"
+    else
+      unset AWS_SESSION_TOKEN
+    fi
+  else
+    unset AWS_ACCESS_KEY_ID
+    unset AWS_SECRET_ACCESS_KEY
+    unset AWS_SESSION_TOKEN
+  fi
+}
+
 REGION="$(resolve_aws_region)"
 CALLER_ARN="$(aws sts get-caller-identity --query Arn --output text)"
 ACCOUNT_ID="$(aws sts get-caller-identity --query Account --output text)"
@@ -50,6 +86,7 @@ if ! ADMIN_CREDS=$(aws sts assume-role \
   --output json 2>/dev/null); then
   warn "Admin role not found (= cluster may already be destroyed). Setting CLUSTER_EXISTS=false."
   export CLUSTER_EXISTS="false"
+  use_apply_creds
   return 0 2>/dev/null || exit 0
 fi
 
@@ -90,40 +127,6 @@ else
   warn "Cluster not reachable (= already destroyed?). Setting CLUSTER_EXISTS=false."
   export CLUSTER_EXISTS="false"
 fi
-
-# Helper for sub-scripts that need admin credentials (= kubectl ops in 60/70).
-# Split declare + assign so jq failure (= file corrupted) propagates under set -e.
-use_admin_creds() {
-  if [ -f "$ADMIN_CREDS_FILE" ]; then
-    local _id _secret _token
-    _id=$(jq -r .AccessKeyId "$ADMIN_CREDS_FILE")
-    _secret=$(jq -r .SecretAccessKey "$ADMIN_CREDS_FILE")
-    _token=$(jq -r .SessionToken "$ADMIN_CREDS_FILE")
-    export AWS_ACCESS_KEY_ID="$_id"
-    export AWS_SECRET_ACCESS_KEY="$_secret"
-    export AWS_SESSION_TOKEN="$_token"
-  fi
-}
-
-# Restore operator's default credential state for terragrunt operations.
-# When operator uses AWS_PROFILE / IAM Identity Center / instance profile,
-# unsetting AWS_*_KEY env returns the SDK to its default lookup chain.
-# When operator had AWS_*_KEY set directly, restore the captured values.
-use_apply_creds() {
-  if [ -n "${ORIG_AWS_ACCESS_KEY_ID}" ]; then
-    export AWS_ACCESS_KEY_ID="$ORIG_AWS_ACCESS_KEY_ID"
-    export AWS_SECRET_ACCESS_KEY="$ORIG_AWS_SECRET_ACCESS_KEY"
-    if [ -n "${ORIG_AWS_SESSION_TOKEN}" ]; then
-      export AWS_SESSION_TOKEN="$ORIG_AWS_SESSION_TOKEN"
-    else
-      unset AWS_SESSION_TOKEN
-    fi
-  else
-    unset AWS_ACCESS_KEY_ID
-    unset AWS_SECRET_ACCESS_KEY
-    unset AWS_SESSION_TOKEN
-  fi
-}
 
 # Default to operator credentials for terragrunt operations
 use_apply_creds

--- a/scripts/eks-lifecycle/lib/10-k8s-cleanup.sh
+++ b/scripts/eks-lifecycle/lib/10-k8s-cleanup.sh
@@ -1,10 +1,12 @@
 #!/usr/bin/env bash
 # 10-k8s-cleanup.sh - Pre-teardown k8s resource cleanup.
 #
-# Deletes Ingress / LoadBalancer Service / Karpenter NodePool to release
-# AWS resources (target groups / ENIs / EC2 instances) BEFORE we run
-# terragrunt destroy on the EKS cluster itself. Skipped if cluster is
-# not reachable.
+# Deletes Ingress / LoadBalancer Service / PVC / Karpenter NodePool to
+# release AWS resources (target groups / ENIs / EBS volumes / EC2
+# instances / external-dns Route53 records) BEFORE we run terragrunt
+# destroy on the EKS cluster itself. Skipped if cluster is not reachable,
+# except for the AWS-API fallbacks which run regardless to mop up
+# resources whose owning controller is already gone.
 
 LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=lib/common.sh
@@ -15,19 +17,27 @@ LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 require_env
 
 if [ "${CLUSTER_EXISTS:-}" != "true" ]; then
-  warn "CLUSTER_EXISTS=false. Skipping k8s cleanup."
-  exit 0
+  warn "CLUSTER_EXISTS=false. Skipping cluster-side cleanup; running AWS-API fallbacks only."
 fi
 
-use_admin_creds
+if [ "${CLUSTER_EXISTS:-}" = "true" ]; then
+  use_admin_creds
 
-info "Step 10.1: Deleting all Ingress resources (= ALB target group / ENI release; finalizer 完了まで最大 600s 待機)"
-run kubectl delete ingress --all -A --timeout=600s || warn "ingress deletion incomplete (= will rely on AWS-tag fallback in Step 10.3)"
+  info "Step 10.1: Deleting all Ingress resources (= ALB target group / ENI / external-dns Route53 release; finalizer 完了まで最大 600s 待機)"
+  run kubectl delete ingress --all -A --timeout=600s || warn "ingress deletion incomplete (= will rely on AWS-tag fallback in Step 10.4)"
 
-info "Step 10.2: Deleting LoadBalancer Services (= NLB / ENI release; finalizer 完了まで最大 600s 待機)"
-run kubectl delete svc -A --field-selector spec.type=LoadBalancer --timeout=600s || warn "LB service deletion incomplete (= will rely on AWS-tag fallback in Step 10.3)"
+  info "Step 10.2: Deleting LoadBalancer Services (= NLB / ENI release; finalizer 完了まで最大 600s 待機)"
+  run kubectl delete svc -A --field-selector spec.type=LoadBalancer --timeout=600s || warn "LB service deletion incomplete (= will rely on AWS-tag fallback in Step 10.4)"
 
-info "Step 10.3: AWS-tag fallback — delete leftover ALB / NLB tagged for this cluster"
+  info "Step 10.3: Deleting all PVCs (= ebs-csi-driver volume reclaim via reclaimPolicy=Delete; finalizer 完了まで最大 600s 待機)"
+  # StatefulSet delete (= helmfile destroy 等) は PVC を残す default 仕様。
+  # ここで明示削除しないと NodePool drain 後に EBS が 'available' で残り、
+  # 後段 terragrunt eks destroy で IAM/CSI controller が消えると orphan 化する。
+  # cluster + ebs-csi-driver pod が alive なうちに reclaim を走らせる必要がある (= Step 10.5 NodePool delete より前)。
+  run kubectl delete pvc --all -A --timeout=600s || warn "PVC deletion incomplete (= will rely on AWS-tag fallback in Step 10.7)"
+fi
+
+info "Step 10.4: AWS-tag fallback — delete leftover ALB / NLB tagged for this cluster"
 # AWS Load Balancer Controller は ALB / NLB に tag:elbv2.k8s.aws/cluster=<name>
 # を付与する。 Step 10.1 / 10.2 で finalizer が完了せず ALB / NLB が残った場合、
 # 後段の Karpenter NodePool delete で ALB controller pod が巻き込まれて
@@ -55,20 +65,24 @@ if [ "${DRY_RUN:-0}" != "1" ]; then
   else
     info "No leftover load balancers found."
   fi
-  use_admin_creds  # = back to kubectl creds
+  if [ "${CLUSTER_EXISTS:-}" = "true" ]; then
+    use_admin_creds  # = back to kubectl creds
+  fi
 fi
 
-info "Step 10.4: Deleting Karpenter NodePools (= synchronous EC2 drain + terminate via --cascade=foreground)"
-# --cascade=foreground waits for owned NodeClaims (= and their EC2 instances)
-# to be deleted before returning. This avoids the historical failure mode where
-# NodePool delete returned immediately while leaving EC2 alive, eventually
-# stranded after karpenter stack destroy (= controller gone, no terminate path).
-if kubectl get nodepools.karpenter.sh >/dev/null 2>&1; then
-  run kubectl delete nodepools.karpenter.sh --all --cascade=foreground --timeout=600s || \
-    warn "NodePool foreground deletion incomplete (= will rely on AWS-tag fallback below)"
+if [ "${CLUSTER_EXISTS:-}" = "true" ]; then
+  info "Step 10.5: Deleting Karpenter NodePools (= synchronous EC2 drain + terminate via --cascade=foreground)"
+  # --cascade=foreground waits for owned NodeClaims (= and their EC2 instances)
+  # to be deleted before returning. This avoids the historical failure mode where
+  # NodePool delete returned immediately while leaving EC2 alive, eventually
+  # stranded after karpenter stack destroy (= controller gone, no terminate path).
+  if kubectl get nodepools.karpenter.sh >/dev/null 2>&1; then
+    run kubectl delete nodepools.karpenter.sh --all --cascade=foreground --timeout=600s || \
+      warn "NodePool foreground deletion incomplete (= will rely on AWS-tag fallback below)"
+  fi
 fi
 
-info "Step 10.5: AWS-tag fallback — terminate any leftover Karpenter EC2 (= NodePool already gone but instances still alive)"
+info "Step 10.6: AWS-tag fallback — terminate any leftover Karpenter EC2 (= NodePool already gone but instances still alive)"
 if [ "${DRY_RUN:-0}" != "1" ]; then
   REGION="$(resolve_aws_region)"
   use_apply_creds  # = need EC2 permissions (= operator's chain), not eks-admin (kubectl-only)
@@ -86,10 +100,70 @@ if [ "${DRY_RUN:-0}" != "1" ]; then
   else
     info "No leftover Karpenter EC2 found."
   fi
-  use_admin_creds  # = back to kubectl creds for sanity check
 fi
 
-info "Step 10.6: Sanity check - listing remaining pods"
-run kubectl get pods -A -o wide || true
+info "Step 10.7: AWS-tag fallback — delete leftover EBS volumes tagged for this cluster"
+# StatefulSet delete が PVC を残した場合、 Step 10.3 で kubectl が届かない (= cluster 既消失)
+# 経路でも EBS は 'available' で生存する。 ebs-csi-driver は dynamic PVC volume に
+# tag:KubernetesCluster=<name> を付与するため、 controller 不在でも tag 経由で回収できる。
+if [ "${DRY_RUN:-0}" != "1" ]; then
+  REGION="$(resolve_aws_region)"
+  use_apply_creds  # = need EC2 permissions (= operator's chain)
+  LEFTOVER_VOL_IDS=$(aws ec2 describe-volumes --region "$REGION" \
+    --filters "Name=tag:KubernetesCluster,Values=eks-${ENV}" "Name=status,Values=available" \
+    --query 'Volumes[].VolumeId' --output text)
+  if [ -n "$LEFTOVER_VOL_IDS" ]; then
+    warn "Found leftover EBS volumes: $LEFTOVER_VOL_IDS — force-deleting."
+    for vol in $LEFTOVER_VOL_IDS; do
+      aws ec2 delete-volume --region "$REGION" --volume-id "$vol"
+    done
+    ok "Leftover EBS volumes deleted."
+  else
+    info "No leftover EBS volumes found."
+  fi
+fi
+
+info "Step 10.8: AWS-API fallback — delete leftover external-dns Route53 records owned by this cluster"
+# external-dns は cluster 内で動作し A/AAAA/CNAME 削除を Ingress finalizer 経由で実行する。
+# Ingress 削除 (= Step 10.1) 時点で external-dns pod が未稼働 (= 既 destroy / pending) だった
+# 場合、 Route53 上に owner=eks-${ENV} marker の TXT registry record + 対応 A/AAAA/CNAME が
+# 残る。 cluster destroy 後は external-dns 経路で消せないので、 ownership marker tag を頼りに
+# AWS API で直接削除する。
+if [ "${DRY_RUN:-0}" != "1" ]; then
+  use_apply_creds  # = need route53 permissions (= operator's chain)
+  HOSTED_ZONE_ID=$(aws route53 list-hosted-zones-by-name \
+    --dns-name panicboat.net --query 'HostedZones[0].Id' --output text 2>/dev/null | sed 's|/hostedzone/||')
+  if [ -n "$HOSTED_ZONE_ID" ] && [ "$HOSTED_ZONE_ID" != "None" ]; then
+    # external-dns の TXT registry name format は "<rtype>-<host>" (= txtPrefix 未設定時の default)。
+    # ownership marker (= heritage=external-dns,external-dns/owner=eks-<env>) を持つ TXT を起点に、
+    # 関連 A/AAAA/CNAME (= prefix 除去で導出した host name) を集めて一括 DELETE する。
+    OWNED_BATCH=$(aws route53 list-resource-record-sets --hosted-zone-id "$HOSTED_ZONE_ID" --output json | \
+      jq -c --arg owner "eks-${ENV}" '
+        .ResourceRecordSets as $all
+        | ($all | map(select(.Type == "TXT" and (.ResourceRecords | map(.Value) | join(" ") | contains("external-dns/owner=" + $owner))))) as $txt
+        | ($txt | map(.Name | sub("^[a-z]+-"; "")) | unique) as $hosts
+        | ($all | map(select((.Type == "A" or .Type == "AAAA" or .Type == "CNAME") and (.Name | IN($hosts[]))))) as $assoc
+        | {Changes: (($txt + $assoc) | map({Action: "DELETE", ResourceRecordSet: .}))}
+      ')
+    OWNED_COUNT=$(echo "$OWNED_BATCH" | jq '.Changes | length')
+    if [ "$OWNED_COUNT" -gt 0 ]; then
+      warn "Found leftover external-dns Route53 records: ${OWNED_COUNT} entries — force-deleting."
+      BATCH_FILE="/tmp/eks-lifecycle-route53-delete-$$.json"
+      ( umask 077 && : > "$BATCH_FILE" )
+      echo "$OWNED_BATCH" > "$BATCH_FILE"
+      aws route53 change-resource-record-sets --hosted-zone-id "$HOSTED_ZONE_ID" --change-batch "file://${BATCH_FILE}" >/dev/null
+      rm -f "$BATCH_FILE"
+      ok "Leftover external-dns Route53 records deleted."
+    else
+      info "No leftover external-dns Route53 records found."
+    fi
+  fi
+fi
+
+if [ "${CLUSTER_EXISTS:-}" = "true" ]; then
+  use_admin_creds  # = back to kubectl creds for sanity check
+  info "Step 10.9: Sanity check - listing remaining pods"
+  run kubectl get pods -A -o wide || true
+fi
 
 ok "k8s cleanup complete"

--- a/scripts/eks-lifecycle/lib/40-orphan-verify.sh
+++ b/scripts/eks-lifecycle/lib/40-orphan-verify.sh
@@ -60,10 +60,19 @@ info "Step 40.5: Route53 stale external-dns records"
 HOSTED_ZONE_ID=$(aws route53 list-hosted-zones-by-name \
   --dns-name panicboat.net --query 'HostedZones[0].Id' --output text 2>/dev/null | sed 's|/hostedzone/||')
 if [ -n "$HOSTED_ZONE_ID" ] && [ "$HOSTED_ZONE_ID" != "None" ]; then
-  STALE_RECORDS=$(aws route53 list-resource-record-sets \
-    --hosted-zone-id "$HOSTED_ZONE_ID" \
-    --query "ResourceRecordSets[?starts_with(Name, '_external-dns.') || (Type == 'A' && contains(Name, '.panicboat.net'))].[Name,Type]" \
-    --output text)
+  # external-dns は TXT registry record (= name format "<rtype>-<host>") に
+  # ownership marker (= heritage=external-dns,external-dns/owner=eks-<env>) を書く。
+  # この marker を起点に関連 A/AAAA/CNAME (= prefix 除去で導出した host name) を
+  # 集計する。 旧実装は "_external-dns." prefix と A record のみを参照しており、
+  # 実 deployment の prefix-less / "<rtype>-" registry format と AAAA / CNAME を取りこぼしていた。
+  STALE_RECORDS=$(aws route53 list-resource-record-sets --hosted-zone-id "$HOSTED_ZONE_ID" --output json | \
+    jq -r --arg owner "eks-${ENV}" '
+      .ResourceRecordSets as $all
+      | ($all | map(select(.Type == "TXT" and (.ResourceRecords | map(.Value) | join(" ") | contains("external-dns/owner=" + $owner))))) as $txt
+      | ($txt | map(.Name | sub("^[a-z]+-"; "")) | unique) as $hosts
+      | ($all | map(select((.Type == "A" or .Type == "AAAA" or .Type == "CNAME") and (.Name | IN($hosts[]))))) as $assoc
+      | ($txt + $assoc) | .[] | "\(.Name)\t\(.Type)"
+    ')
   if [ -n "$STALE_RECORDS" ]; then
     warn "Stale Route53 records (= external-dns owned, not auto-cleaned):"
     echo "$STALE_RECORDS" | sed 's/^/    /'


### PR DESCRIPTION
## Summary

`make eks-teardown ENV=production` exited 1 at `40-orphan-verify` because `10-k8s-cleanup.sh` did not release StatefulSet-owned PVCs or external-dns Route53 records before the cluster was destroyed. The verify step itself also missed AAAA records and the `aaaa-`/`cname-` TXT registry pairs because it assumed a `_external-dns.` prefix that this deployment does not use.

This change adds the missing cleanup steps and fixes the verify detection so the full chain exits 0 on a clean teardown.

## Changes

### `scripts/eks-lifecycle/lib/10-k8s-cleanup.sh`
- Step 10.3 (new): `kubectl delete pvc --all -A` before NodePool drain, so the ebs-csi-driver gets a chance to reclaim dynamic volumes via `reclaimPolicy=Delete` while CSI pods are still alive.
- Step 10.7 (new): AWS-tag fallback that deletes `available` EBS volumes tagged `KubernetesCluster=eks-<env>` (catches StatefulSet leftovers and Step 10.3 timeouts).
- Step 10.8 (new): AWS-API fallback that deletes Route53 records whose TXT registry carries `heritage=external-dns,external-dns/owner=eks-<env>`, plus the derived A/AAAA/CNAME records (for the case where external-dns is gone before it can sync).
- AWS-API fallbacks (Steps 10.4 / 10.6 / 10.7 / 10.8) now run even when `CLUSTER_EXISTS=false`, so a re-run can sweep an already-destroyed cluster.

### `scripts/eks-lifecycle/lib/40-orphan-verify.sh`
- Step 40.5 rewritten to use the external-dns ownership TXT marker (prefix-less, `<rtype>-<host>` registry format) and to enumerate the associated A / AAAA / CNAME records. The previous `_external-dns.` prefix check missed every record in this deployment.

### `scripts/eks-lifecycle/lib/00-auth.sh`
- `use_admin_creds` / `use_apply_creds` are now defined before the admin-role assume attempt, so the `CLUSTER_EXISTS=false` path can call them safely (previously triggered `command not found` when 10-k8s-cleanup ran AWS-API fallbacks on a destroyed cluster).

## Test plan
- [x] Live run on `eks-production` cluster: full chain (`make eks-teardown ENV=production`) executed successfully — k8s cleanup, 8-stack terragrunt destroy, and orphan verify all OK.
- [x] Re-run on a fully-destroyed cluster (= `CLUSTER_EXISTS=false`): `make` exits 0 with no orphan reports.
- [x] Manual cleanup of pre-existing orphans (8 EBS volumes + 16 Route53 records) executed via the same AWS calls that the new fallback steps use.
- [x] `bash -n` + `shellcheck` (info-level only) clean on all three scripts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced credential validation to ensure AWS credentials are properly set and accessible before use.
  * Improved cluster cleanup logic to conditionally execute steps based on cluster state, preventing errors during teardown.
  * Added detection and cleanup of orphaned EBS volumes and Route53 DNS records remaining after cluster destruction.
  * Refined external-dns record stale detection for more accurate orphan identification.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/panicboat/platform/pull/452?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->