### PR TITLE
chore: remove unused Terragrunt stack convention and disable guard

### DIFF
--- a/.github/workflows/auto-label--deploy-trigger.yaml
+++ b/.github/workflows/auto-label--deploy-trigger.yaml
@@ -95,7 +95,6 @@ jobs:
     if: |
       needs.deploy-trigger.outputs.has-targets == 'true' &&
       contains(needs.deploy-trigger.outputs.targets, '"stack":"terragrunt"')
-      && true == 'false' # TODO: Terragrunt deployment is currently disabled as we have no active Terragrunt targets; re-enable when needed by removing this line
     strategy:
       matrix:
         target: ${{ fromJson(needs.deploy-trigger.outputs.targets) }}

--- a/workflow-config.yaml
+++ b/workflow-config.yaml
@@ -14,11 +14,12 @@ environments:
         iam_role_apply: arn:aws:iam::559744160976:role/github-oidc-auth-production-github-actions-apply-role
 
 stack_conventions:
-  - root: "aws/{service}"
-    stacks:
-      - name: terragrunt
-        directory: "envs/{environment}"
-        required_attributes: [aws_region, iam_role_plan, iam_role_apply]
+  # TODO: Define conventions for Terragrunt stacks when we have active Terragrunt targets.
+  # - root: "aws/{service}"
+  #   stacks:
+  #     - name: terragrunt
+  #       directory: "envs/{environment}"
+  #       required_attributes: [aws_region, iam_role_plan, iam_role_apply]
 
   - root: "github/{service}"
     stacks:


### PR DESCRIPTION
## Summary

- Comment out the Terragrunt entry under `stack_conventions: aws/{service}` in `workflow-config.yaml` because no active Terragrunt targets exist in this repo.
- Drop the redundant `&& true == 'false'` guard on the Terragrunt deploy job in `.github/workflows/auto-label--deploy-trigger.yaml`. With the convention removed, no targets carry `stack="terragrunt"`, so the outer `contains(..., '"stack":"terragrunt"')` check already gates the job; the extra guard becomes unnecessary.

## Test plan

- [ ] Open a PR that touches a non-Terragrunt path and confirm the Terragrunt deploy job is skipped (no targets generated).
- [ ] Confirm the `github/{service}` deploy path is unaffected.