### PR TITLE
fix(renovate): extract major.minor from EKS cluster_version updates

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -109,7 +109,8 @@
       ],
       "matchStrings": [
         "#\\s*renovate:\\s*datasource=(?<datasource>\\S+)\\s+depName=(?<depName>\\S+)(?:\\s+versioning=(?<versioning>\\S+))?\\s*\\n\\s*cluster_version\\s*=\\s*\"(?<currentValue>[^\"]+)\""
-      ]
+      ],
+      "extractVersionTemplate": "^(?<version>\\d+\\.\\d+)"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- `aws/eks/envs/production/env.hcl` の `cluster_version` が Renovate によって `1.36-eks-6` のような不正な形式に更新され、 EKS `CreateCluster` API が `InvalidParameterException` で拒否する事象が bootstrap 作業中に発生した (対症療法は別 PR #669 で `1.36` に修正済)
- 原因: `endoflife-date` datasource の `amazon-eks` エントリは `cycle` (`"1.36"`) と `latest` (`"1.36-eks-6"`) の2フィールドを持つが、 Renovate は既定で `latest` を version として使用するため、 AWS 独自の release 番号 suffix がそのまま書き込まれていた
- `customManagers[0]` に `extractVersionTemplate: "^(?<version>\\d+\\.\\d+)"` を追加し、 major.minor 部分のみを抽出して `cluster_version` に反映されるよう修正

## Test plan
- [x] `npx -p renovate@44.3.3 renovate-config-validator .github/renovate.json` で schema validation 成功
- [x] regex 抽出ロジックを実際の endoflife-date API レスポンス値 (`1.36-eks-6` / `1.35-eks-17` / `1.34-eks-27`) に対して確認、 全て `major.minor` のみ正しく抽出
- [ ] 次回 Renovate run 時に `aws/eks/envs/production/env.hcl` への PR が `1.xx` 形式 (suffix なし) で作成されることを確認

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved automated tracking of EKS Kubernetes versions.
  * Version updates are now detected more reliably using the major and minor version format.
  * This helps keep environment configuration updates accurate and consistent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->