### PR TITLE
feat: introduce Keycloak as toC authentication infrastructure (Phase 1)

### DIFF
--- a/aws/keycloak-database/Makefile
+++ b/aws/keycloak-database/Makefile
@@ -1,0 +1,79 @@
+# Makefile for keycloak-database
+
+# Default values
+ENV ?= production
+
+# Colors for output
+RED := \033[0;31m
+GREEN := \033[0;32m
+YELLOW := \033[0;33m
+BLUE := \033[0;34m
+NC := \033[0m # No Color
+
+.PHONY: help init plan apply destroy validate fmt check clean
+
+help: ## Show this help message
+	@echo "keycloak-database - Terragrunt Commands"
+	@echo ""
+	@echo "Usage: make <target> [ENV=<environment>]"
+	@echo ""
+	@echo "Available targets:"
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "  $(BLUE)%-15s$(NC) %s\n", $$1, $$2}'
+	@echo ""
+	@echo "Available environments:"
+	@echo "  - production"
+	@echo ""
+	@echo "Examples:"
+	@echo "  make plan ENV=production"
+	@echo "  make apply ENV=production"
+
+init: ## Initialize Terragrunt
+	@printf "$(YELLOW)Initializing Terragrunt for $(ENV)...$(NC)\n"
+	cd envs/$(ENV) && terragrunt init
+
+plan: ## Plan Terragrunt changes
+	@printf "$(YELLOW)Planning Terragrunt changes for $(ENV)...$(NC)\n"
+	cd envs/$(ENV) && terragrunt plan
+
+apply: ## Apply Terragrunt changes
+	@printf "$(YELLOW)Applying Terragrunt changes for $(ENV)...$(NC)\n"
+	cd envs/$(ENV) && terragrunt apply -auto-approve
+
+destroy: ## Destroy Terragrunt resources
+	@printf "$(RED)Destroying Terragrunt resources for $(ENV)...$(NC)\n"
+	@printf "$(RED)WARNING: This will destroy all resources!$(NC)\n"
+	@read -p "Are you sure? [y/N] " -n 1 -r; \
+	echo; \
+	if [[ $$REPLY =~ ^[Yy]$$ ]]; then \
+		cd envs/$(ENV) && terragrunt destroy; \
+	else \
+		printf "$(YELLOW)Cancelled.$(NC)\n"; \
+	fi
+
+validate: ## Validate Terragrunt configuration
+	@printf "$(YELLOW)Validating Terragrunt configuration for $(ENV)...$(NC)\n"
+	cd envs/$(ENV) && terragrunt validate
+
+fmt: ## Format Terraform files
+	@printf "$(YELLOW)Formatting Terraform files...$(NC)\n"
+	terraform fmt -recursive .
+
+check: validate fmt ## Run validation and formatting checks
+	@printf "$(GREEN)All checks completed for $(ENV)$(NC)\n"
+
+clean: ## Clean Terragrunt cache
+	@printf "$(YELLOW)Cleaning Terragrunt cache...$(NC)\n"
+	find . -type d -name ".terragrunt-cache" -exec rm -rf {} + 2>/dev/null || true
+	find . -name "*.tfplan" -delete 2>/dev/null || true
+
+show: ## Show current Terragrunt state
+	@printf "$(YELLOW)Showing current state for $(ENV)...$(NC)\n"
+	cd envs/$(ENV) && terragrunt show
+
+output: ## Show Terragrunt outputs
+	@printf "$(YELLOW)Showing outputs for $(ENV)...$(NC)\n"
+	cd envs/$(ENV) && terragrunt output
+
+refresh: ## Refresh Terragrunt state
+	@printf "$(YELLOW)Refreshing state for $(ENV)...$(NC)\n"
+	cd envs/$(ENV) && terragrunt refresh

--- a/aws/keycloak-database/envs/production/env.hcl
+++ b/aws/keycloak-database/envs/production/env.hcl
@@ -1,0 +1,16 @@
+# env.hcl - Environment-specific configuration for production
+
+locals {
+  # Environment-specific settings
+  environment = "production"
+
+  # AWS configuration
+  aws_region = "ap-northeast-1"
+
+  # Environment-specific tags
+  environment_tags = {
+    Environment = local.environment
+    Component   = "keycloak-database"
+    Owner       = "panicboat"
+  }
+}

--- a/aws/keycloak-database/envs/production/terragrunt.hcl
+++ b/aws/keycloak-database/envs/production/terragrunt.hcl
@@ -1,0 +1,36 @@
+# terragrunt.hcl - Terragrunt configuration for production environment
+
+# Include root configuration
+include "root" {
+  path = find_in_parent_folders("root.hcl")
+}
+
+# Include environment-specific configuration
+include "env" {
+  path   = "env.hcl"
+  expose = true
+}
+
+# Reference to Terraform modules.
+# Use go-getter `//` subdir notation so the entire `aws/` tree is copied to
+# the Terragrunt cache. This lets `module "vpc"` / `module "eks"` in
+# modules/lookups.tf resolve `../../vpc/lookup` / `../../eks/lookup` from
+# within the cache.
+terraform {
+  source = "../../..//keycloak-database/modules"
+}
+
+# Input variables for the module
+inputs = {
+  environment = include.env.locals.environment
+  aws_region  = include.env.locals.aws_region
+
+  common_tags = merge(
+    include.env.locals.environment_tags,
+    {
+      Project    = "keycloak-database"
+      ManagedBy  = "terraform"
+      Repository = "panicboat/platform"
+    }
+  )
+}

--- a/aws/keycloak-database/modules/lookups.tf
+++ b/aws/keycloak-database/modules/lookups.tf
@@ -1,0 +1,14 @@
+# lookups.tf - External stack lookups.
+
+# VPC / subnet / DB subnet group info (= database_subnet_group_name consumed
+# by aws_db_instance below).
+module "vpc" {
+  source      = "../../vpc/lookup"
+  environment = var.environment
+}
+
+# EKS cluster info (= node_security_group_id, RDS ingress source).
+module "eks" {
+  source      = "../../eks/lookup"
+  environment = var.environment
+}

--- a/aws/keycloak-database/modules/main.tf
+++ b/aws/keycloak-database/modules/main.tf
@@ -1,0 +1,126 @@
+# main.tf - RDS PostgreSQL for Keycloak (= toC 認証基盤の user/realm ストア).
+#
+# 個人運用スケール (single-AZ, db.t4g.micro) だが、EKS cluster teardown/recreate
+# (docs/runbooks/eks-production-recreate.md) から独立させたいため in-cluster
+# Postgres ではなく managed RDS を採用。DB subnet group は aws/vpc module が
+# `create_database_subnet_group = true` で provision 済のものを再利用する。
+#
+# Credential は本 module が生成し AWS Secrets Manager に格納する (= Google OAuth
+# のような外部 console 由来の secret と異なり、Terraform 側で完結できるため手動
+# 投入にしない)。ESO IAM role (aws/eks-secrets、`secretsmanager:GetSecretValue`
+# on `secret:*`) が新規 secret も自動的に read 可能、追加 IAM 変更は不要。
+
+# =============================================================================
+# Security Group: RDS ingress from EKS nodes only
+# =============================================================================
+resource "aws_security_group" "keycloak_db" {
+  name        = "keycloak-database-${var.environment}"
+  description = "Allow PostgreSQL access from EKS nodes to the Keycloak RDS instance"
+  vpc_id      = module.vpc.vpc.id
+
+  tags = merge(var.common_tags, {
+    Name = "keycloak-database-${var.environment}"
+  })
+}
+
+resource "aws_vpc_security_group_ingress_rule" "keycloak_db_from_eks_nodes" {
+  security_group_id            = aws_security_group.keycloak_db.id
+  description                  = "PostgreSQL from EKS node security group"
+  referenced_security_group_id = module.eks.cluster.node_security_group_id
+  from_port                    = 5432
+  to_port                      = 5432
+  ip_protocol                  = "tcp"
+}
+
+resource "aws_vpc_security_group_egress_rule" "keycloak_db_all_egress" {
+  security_group_id = aws_security_group.keycloak_db.id
+  description        = "Allow all egress (= RDS management traffic)"
+  cidr_ipv4          = "0.0.0.0/0"
+  ip_protocol        = "-1"
+}
+
+# =============================================================================
+# RDS PostgreSQL instance
+# =============================================================================
+resource "random_password" "db_master" {
+  length  = 32
+  special = false # KC_DB_PASSWORD env var 経由、記号による shell/YAML escape trouble を避ける
+}
+
+resource "aws_db_instance" "keycloak" {
+  identifier     = "keycloak-${var.environment}"
+  engine         = "postgres"
+  engine_version = "17.4"
+  instance_class = "db.t4g.micro"
+
+  allocated_storage     = 20
+  max_allocated_storage = 100 # storage autoscaling (= 突発的な user 増加に対応)
+  storage_type          = "gp3"
+  storage_encrypted     = true
+
+  db_name  = "keycloak"
+  username = "keycloak_admin"
+  password = random_password.db_master.result
+  port     = 5432
+
+  db_subnet_group_name   = module.vpc.db_subnet_group.name
+  vpc_security_group_ids = [aws_security_group.keycloak_db.id]
+  publicly_accessible    = false
+  multi_az                = false # 個人運用スケール、コスト優先 (= 引き継ぎ: 要件顕在化時に Multi-AZ 検討)
+
+  backup_retention_period    = 7
+  auto_minor_version_upgrade = true
+  deletion_protection        = true
+  skip_final_snapshot        = false
+  final_snapshot_identifier  = "keycloak-${var.environment}-final"
+  apply_immediately          = false
+
+  tags = merge(var.common_tags, {
+    Name = "keycloak-${var.environment}"
+  })
+}
+
+# =============================================================================
+# AWS Secrets Manager: database connection info
+# =============================================================================
+# key 名は Kubernetes 側 (kubernetes/components/keycloak) の ExternalSecret が
+# そのまま K8s Secret のキーとして 1:1 sync し、keycloakx chart の
+# `extraEnvFrom` で Keycloak container に直接環境変数注入する前提 (= chart の
+# `database.hostname` 等の static values は使わない、RDS endpoint は apply 時
+# まで不定のため)。
+resource "aws_secretsmanager_secret" "keycloak_database" {
+  name = "panicboat/keycloak/database"
+  tags = var.common_tags
+}
+
+resource "aws_secretsmanager_secret_version" "keycloak_database" {
+  secret_id = aws_secretsmanager_secret.keycloak_database.id
+  secret_string = jsonencode({
+    KC_DB_URL_HOST     = aws_db_instance.keycloak.address
+    KC_DB_URL_PORT     = tostring(aws_db_instance.keycloak.port)
+    KC_DB_URL_DATABASE = aws_db_instance.keycloak.db_name
+    KC_DB_USERNAME     = aws_db_instance.keycloak.username
+    KC_DB_PASSWORD     = random_password.db_master.result
+  })
+}
+
+# =============================================================================
+# AWS Secrets Manager: Keycloak admin bootstrap credentials
+# =============================================================================
+resource "random_password" "admin" {
+  length  = 24
+  special = false
+}
+
+resource "aws_secretsmanager_secret" "keycloak_admin" {
+  name = "panicboat/keycloak/admin"
+  tags = var.common_tags
+}
+
+resource "aws_secretsmanager_secret_version" "keycloak_admin" {
+  secret_id = aws_secretsmanager_secret.keycloak_admin.id
+  secret_string = jsonencode({
+    KEYCLOAK_ADMIN          = "admin"
+    KEYCLOAK_ADMIN_PASSWORD = random_password.admin.result
+  })
+}

--- a/aws/keycloak-database/modules/outputs.tf
+++ b/aws/keycloak-database/modules/outputs.tf
@@ -1,0 +1,21 @@
+# outputs.tf - Outputs for the keycloak-database module.
+
+output "db_instance_identifier" {
+  description = "RDS instance identifier. Used for verification (aws rds describe-db-instances)."
+  value       = aws_db_instance.keycloak.identifier
+}
+
+output "db_instance_endpoint" {
+  description = "RDS instance endpoint (host:port)."
+  value       = aws_db_instance.keycloak.endpoint
+}
+
+output "database_secret_arn" {
+  description = "ARN of the Secrets Manager secret holding DB connection info (panicboat/keycloak/database)."
+  value       = aws_secretsmanager_secret.keycloak_database.arn
+}
+
+output "admin_secret_arn" {
+  description = "ARN of the Secrets Manager secret holding Keycloak admin bootstrap credentials (panicboat/keycloak/admin)."
+  value       = aws_secretsmanager_secret.keycloak_admin.arn
+}

--- a/aws/keycloak-database/modules/terraform.tf
+++ b/aws/keycloak-database/modules/terraform.tf
@@ -1,0 +1,24 @@
+# terraform.tf - OpenTofu and provider configuration
+
+terraform {
+  required_version = "1.12.5"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "6.56.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "3.7.2"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.aws_region
+
+  default_tags {
+    tags = var.common_tags
+  }
+}

--- a/aws/keycloak-database/modules/variables.tf
+++ b/aws/keycloak-database/modules/variables.tf
@@ -1,0 +1,17 @@
+# variables.tf - Inputs for the keycloak-database module
+
+variable "environment" {
+  description = "Environment name (e.g., production). Used in resource naming."
+  type        = string
+}
+
+variable "aws_region" {
+  description = "AWS region"
+  type        = string
+}
+
+variable "common_tags" {
+  description = "Common tags applied to all resources"
+  type        = map(string)
+  default     = {}
+}

--- a/aws/keycloak-database/root.hcl
+++ b/aws/keycloak-database/root.hcl
@@ -1,0 +1,52 @@
+# root.hcl - Root Terragrunt configuration for keycloak-database
+# This file contains common settings shared across all environments
+
+locals {
+  # Project metadata
+  project_name = "keycloak-database"
+
+  # Parse environment from the directory path
+  # This assumes environments are in envs/<environment>/ directories
+  path_parts  = split("/", path_relative_to_include())
+  environment = element(local.path_parts, length(local.path_parts) - 1)
+
+  # Common tags applied to all resources
+  common_tags = {
+    Project     = local.project_name
+    Environment = local.environment
+    ManagedBy   = "terragrunt"
+    Repository  = "monorepo"
+    Component   = "keycloak-database"
+    Team        = "panicboat"
+  }
+}
+
+# Remote state configuration using shared S3 bucket
+remote_state {
+  backend = "s3"
+  generate = {
+    path      = "backend.tf"
+    if_exists = "overwrite_terragrunt"
+  }
+  config = {
+    # Shared bucket for all monorepo services
+    bucket = "terragrunt-state-${get_aws_account_id()}"
+
+    # Service-specific path: keycloak-database/<environment>/terraform.tfstate
+    key    = "platform/keycloak-database/${local.environment}/terraform.tfstate"
+    region = "ap-northeast-1"
+
+    # Shared DynamoDB table for state locking across all services
+    dynamodb_table = "terragrunt-state-locks"
+
+    # Enable server-side encryption
+    encrypt = true
+  }
+}
+
+# Common inputs passed to all Terraform modules
+inputs = {
+  environment = local.environment
+  common_tags = local.common_tags
+  aws_region  = "ap-northeast-1"
+}

--- a/docs/superpowers/specs/2026-07-30-keycloak-introduction-design.md
+++ b/docs/superpowers/specs/2026-07-30-keycloak-introduction-design.md
@@ -1,0 +1,122 @@
+# Keycloak Introduction (Phase 1: Core Infra) Design
+
+> **Goal**: toC 向けアプリケーションの認証基盤として Keycloak を production EKS に導入する。RDS PostgreSQL + Keycloak (codecentric/keycloakx chart) を `auth.dystopia.city` で公開し、Google ソーシャルログインを Identity Provider federation で有効化する。
+>
+> **Phase 2 (別 spec)**: 電話番号 (SMS OTP) 認証。外部 SMS provider 連携 + custom 実装が必要なため本 Phase の scope 外。
+
+---
+
+## Context
+
+- panicboat.net (非公開 monitoring UIs) は既に oauth2-proxy + Google OAuth で認証ゲート済 (= `docs/superpowers/specs/2026-05-09-eks-production-grafana-auth-ingress-design.md`)。
+- dystopia.city (公開 application ドメイン) は無認証で公開中 (= `docs/superpowers/specs/2026-05-17-dystopia-city-migration-design.md`)。`*.dystopia.city` ACM wildcard cert 発行済、ALB IngressGroup `application` で 1 ALB 共有、external-dns の domainFilters に `dystopia.city` 追加済。
+- toC アプリ (= application monorepo、本 repo 外) 向けの user 認証基盤が不在。Keycloak を IdP として導入し、`auth.dystopia.city` で OIDC を提供する。
+- 本 repo にはこれまで RDS / Postgres の provisioning パターンが存在しない (= 新規)。VPC module (`aws/vpc/modules`) は `database_subnets` + `create_database_subnet_group = true` で DB subnet group を既に provision 済、RDS 追加の前提が揃っている。
+
+---
+
+## Architecture
+
+```
+                Internet
+                    │ HTTPS (*.dystopia.city cert, ACM auto-discovery)
+                    ▼
+              AWS ALB (internet-facing, IngressGroup: application, 既存 ALB 共有)
+                    │ host: auth.dystopia.city
+                    ▼
+            keycloak Service (ClusterIP, target-type=ip)
+                    │
+            keycloak StatefulSet (codecentric/keycloakx chart, replicas: 2)
+                    │
+        ┌───────────┴───────────┐
+        ▼                       ▼
+  RDS PostgreSQL           Google Identity Provider federation
+  (aws/keycloak-database)  (Realm: dystopia, IdP: google)
+  private/database subnet  client id/secret は operator が
+                            Google Cloud Console で手動作成
+                            → AWS Secrets Manager 手動投入
+```
+
+### Request flow (Google ソーシャルログイン)
+
+1. toC アプリ (application monorepo, 別 repo) が Keycloak の `dystopia-app` OIDC client へ authorization code flow で redirect
+2. `https://auth.dystopia.city/realms/dystopia/protocol/openid-connect/auth` → Keycloak ログイン画面、"Google でログイン" ボタン表示 (= IdP federation)
+3. Google 側で認証 → Keycloak `/broker/google/endpoint` へ callback → Keycloak が Google の OIDC token を検証し、Keycloak 側 session + user レコード作成 (= 初回は自動 registration)
+4. Keycloak がアプリの redirect_uri へ authorization code を返す → アプリが token exchange
+
+---
+
+## Components & File Structure
+
+### AWS (Terragrunt, 新規 stack)
+
+```
+aws/keycloak-database/
+├── root.hcl                          # remote state (既存 stack と同一 bucket/DynamoDB)
+├── Makefile
+├── envs/production/{env.hcl,terragrunt.hcl}
+└── modules/
+    ├── terraform.tf
+    ├── variables.tf
+    ├── lookups.tf                    # aws/vpc/lookup + aws/eks/lookup 参照
+    ├── main.tf                       # SG + aws_db_instance + Secrets Manager (db + admin creds)
+    └── outputs.tf
+```
+
+- **Engine**: PostgreSQL 17.4、`db.t4g.micro`、gp3 20GB、single-AZ (= 個人運用スケール、既存 stack のコスト意識に合わせる)
+- **Network**: `aws/vpc` の `database_subnet_group_name` を再利用、SG ingress は `aws/eks` の node security group からの 5432 のみ許可
+- **Credentials**: `random_password` で Terraform が生成、AWS Secrets Manager `panicboat/keycloak/database` (KC_DB_URL_HOST / KC_DB_URL_PORT / KC_DB_URL_DATABASE / KC_DB_USERNAME / KC_DB_PASSWORD) + `panicboat/keycloak/admin` (KEYCLOAK_ADMIN / KEYCLOAK_ADMIN_PASSWORD) に格納。ESO IAM role (`eks-production-eso`、`secret:*` read 権限保有済) が自動的に read 可能、新規 IAM 変更不要。
+- **Google IdP client secret**: Terraform 管理外。operator が Google Cloud Console で OAuth Client を手動作成し、`panicboat/keycloak/google-idp` (client_id / client_secret) に手動投入 (= 既存 oauth2-proxy Google OAuth と同じ運用パターン)。
+
+### Kubernetes (新規 component)
+
+```
+kubernetes/components/keycloak/
+├── namespace.yaml
+└── production/
+    ├── helmfile.yaml                          # codecentric/keycloakx v7.2.2 (Keycloak 26.6.4)
+    ├── values.yaml.gotmpl                      # postgres 接続は extraEnvFrom 経由、proxy.mode=xforwarded
+    └── kustomization/
+        ├── kustomization.yaml
+        ├── external-secret-database.yaml       # panicboat/keycloak/database → Secret keycloak-database
+        ├── external-secret-admin.yaml          # panicboat/keycloak/admin → Secret keycloak-admin
+        ├── external-secret-google-idp.yaml      # panicboat/keycloak/google-idp → Secret keycloak-google-idp
+        ├── ingress.yaml                        # ALB IngressGroup application, host auth.dystopia.city
+        ├── realm-import-configmap.yaml         # Realm "dystopia" + Client "dystopia-app" + IdP "google" (JSON)
+        └── realm-config-job.yaml               # adorsys/keycloak-config-cli Job (var-substitution で google secret 注入)
+```
+
+- DB 接続情報は Terraform が Secrets Manager に書き込んだ全 5 key を ExternalSecret で 1:1 に K8s Secret 化し、chart の `extraEnvFrom` で Keycloak コンテナに直接環境変数注入 (`KC_DB_URL_HOST` 等、chart の `database.hostname` 等の static values は使わない、= RDS endpoint は apply 時まで不定のため values.yaml に書けない)。
+- Admin bootstrap は `KEYCLOAK_ADMIN` / `KEYCLOAK_ADMIN_PASSWORD` も同様に `extraEnvFrom`。
+- Ingress は cilium application-ingress と同じ IngressGroup `application` に相乗り (= 1 ALB 共有)、healthcheck は `/` + `success-codes: "200-499"` (= cilium ingress と同じ workaround、Keycloak root がログイン画面へ redirect するため 200 単独では通らない)。
+- Realm/Client/Google IdP 設定は `keycloak-config-cli` の Job で宣言的に適用。ConfigMap の realm JSON 内で `${GOOGLE_CLIENT_ID}` / `${GOOGLE_CLIENT_SECRET}` を var-substitution 参照、Job の env に `keycloak-google-idp` Secret を渡す。
+
+---
+
+## Decisions
+
+| # | Decision | 採用理由 |
+|---|---|---|
+| 1 | Helm chart: codecentric/keycloakx | Bitnami は 2025 の Bitnami Legacy 移行で free tag が signed/paywalled registry に移行、可用性が不安定。keycloakx は公式 `quay.io/keycloak/keycloak` image を直接使用、community 活発 |
+| 2 | DB: 新規 RDS PostgreSQL (in-cluster Postgres operator は不採用) | 認証基盤という性質上、DB は EKS ライフサイクルと分離しマネージドで運用したい (= 既存 `docs/runbooks/eks-production-recreate.md` の teardown/recreate 運用と相性が良い) |
+| 3 | hostname: auth.dystopia.city | 公開 toC ドメイン配下、将来複数アプリ/サブドメイン追加を見据えて `auth.` を採用 (= panicboat 指定) |
+| 4 | Realm/Client/IdP: keycloak-config-cli Job で宣言的管理 | GitOps 単一 source of truth。Admin Console 手動操作は再現性がなく、cluster recreate 時の復旧が困難 |
+| 5 | Google IdP client secret: Terraform 管理外・手動投入 | 既存 oauth2-proxy Google OAuth と同じ運用パターン、Google Cloud Console 操作は元々 IaC 化不可 |
+| 6 | Phase 2 (電話番号認証) は別 spec | SMS provider 選定 + custom SPI/extension 開発が必要、Phase 1 (基本 IdP 疎通) を先に確立してから着手 |
+
+---
+
+## Manual Setup (Phase 1 完了に必要な手動操作)
+
+1. **Google OAuth Client 作成** (Google Cloud Console): Authorized redirect URI = `https://auth.dystopia.city/realms/dystopia/broker/google/endpoint`
+2. **AWS Secrets Manager**: `panicboat/keycloak/google-idp` に `{"client_id": "...", "client_secret": "..."}` を投入 (region: ap-northeast-1)
+3. **terragrunt apply**: `aws/keycloak-database/envs/production` (CI の terragrunt-executor 経由、main merge で自動 apply)
+
+---
+
+## Known Limitations / Out of Scope
+
+- **realm-config-job の再実行**: Job は immutable なため、realm JSON 変更時は `kubectl delete job -n keycloak keycloak-realm-config` を手動実行して Flux に再作成させる必要がある (= Reloader は Job を watch しない)。自動化は Phase 2+ で検討。
+- **電話番号 (SMS OTP) 認証**: Phase 2。SMS provider 選定 (AWS SNS 想定) + custom authentication flow (SPI or community extension) が必要。
+- **toC アプリ側の統合**: application monorepo (別 repo) 側での Keycloak client 利用実装は本 repo の scope 外。
+- **HA / DR**: RDS は single-AZ (コスト優先)。運用実績を見て Multi-AZ 化を検討。

--- a/kubernetes/components/keycloak/namespace.yaml
+++ b/kubernetes/components/keycloak/namespace.yaml
@@ -1,0 +1,12 @@
+# =============================================================================
+# keycloak Namespace
+# =============================================================================
+# toC 向けアプリの認証基盤 (= Identity Provider)。RDS PostgreSQL (aws/keycloak-database)
+# を backend に持ち、auth.dystopia.city で OIDC を公開する。
+# =============================================================================
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: keycloak
+  labels:
+    app.kubernetes.io/name: keycloak

--- a/kubernetes/components/keycloak/production/helmfile.yaml
+++ b/kubernetes/components/keycloak/production/helmfile.yaml
@@ -1,0 +1,21 @@
+# =============================================================================
+# keycloak Helmfile for production
+# =============================================================================
+# codecentric/keycloakx chart (= 公式 quay.io/keycloak/keycloak image を直接使用、
+# Bitnami legacy 移行の影響を受けない) を使用。
+# =============================================================================
+environments:
+  production:
+
+---
+repositories:
+  - name: codecentric
+    url: https://codecentric.github.io/helm-charts
+
+releases:
+  - name: keycloak
+    namespace: keycloak
+    chart: codecentric/keycloakx
+    version: "7.2.2"
+    values:
+      - values.yaml.gotmpl

--- a/kubernetes/components/keycloak/production/kustomization/external-secret-admin.yaml
+++ b/kubernetes/components/keycloak/production/kustomization/external-secret-admin.yaml
@@ -1,0 +1,32 @@
+# =============================================================================
+# ExternalSecret: Keycloak admin bootstrap credentials
+# =============================================================================
+# AWS Secrets Manager の panicboat/keycloak/admin (aws/keycloak-database が
+# Terraform で生成・格納) を K8s Secret keycloak-admin に sync。key 名
+# (KEYCLOAK_ADMIN / KEYCLOAK_ADMIN_PASSWORD) は codecentric/keycloakx chart が
+# 期待する env var 名と一致 (= values.yaml.gotmpl の extraEnvFrom で注入)。
+# realm-config-job も同じ Secret から admin 認証情報を読む (= keycloak-config-cli
+# の KEYCLOAK_USER / KEYCLOAK_PASSWORD)。
+# =============================================================================
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: keycloak-admin
+  namespace: keycloak
+spec:
+  secretStoreRef:
+    name: aws-secrets-manager
+    kind: ClusterSecretStore
+  refreshInterval: 1h
+  target:
+    name: keycloak-admin
+    creationPolicy: Owner
+  data:
+    - secretKey: KEYCLOAK_ADMIN
+      remoteRef:
+        key: panicboat/keycloak/admin
+        property: KEYCLOAK_ADMIN
+    - secretKey: KEYCLOAK_ADMIN_PASSWORD
+      remoteRef:
+        key: panicboat/keycloak/admin
+        property: KEYCLOAK_ADMIN_PASSWORD

--- a/kubernetes/components/keycloak/production/kustomization/external-secret-database.yaml
+++ b/kubernetes/components/keycloak/production/kustomization/external-secret-database.yaml
@@ -1,0 +1,43 @@
+# =============================================================================
+# ExternalSecret: Keycloak database connection info
+# =============================================================================
+# AWS Secrets Manager の panicboat/keycloak/database (aws/keycloak-database が
+# Terraform で生成・格納) を K8s Secret keycloak-database に sync。key 名は
+# Keycloak container が直接読む env var 名と 1:1 (= values.yaml.gotmpl の
+# extraEnvFrom が本 Secret を丸ごと envFrom で注入する前提)。
+# Reloader が Secret 変更を検知して Keycloak StatefulSet auto-rollout。
+# =============================================================================
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: keycloak-database
+  namespace: keycloak
+spec:
+  secretStoreRef:
+    name: aws-secrets-manager
+    kind: ClusterSecretStore
+  refreshInterval: 1h
+  target:
+    name: keycloak-database
+    creationPolicy: Owner
+  data:
+    - secretKey: KC_DB_URL_HOST
+      remoteRef:
+        key: panicboat/keycloak/database
+        property: KC_DB_URL_HOST
+    - secretKey: KC_DB_URL_PORT
+      remoteRef:
+        key: panicboat/keycloak/database
+        property: KC_DB_URL_PORT
+    - secretKey: KC_DB_URL_DATABASE
+      remoteRef:
+        key: panicboat/keycloak/database
+        property: KC_DB_URL_DATABASE
+    - secretKey: KC_DB_USERNAME
+      remoteRef:
+        key: panicboat/keycloak/database
+        property: KC_DB_USERNAME
+    - secretKey: KC_DB_PASSWORD
+      remoteRef:
+        key: panicboat/keycloak/database
+        property: KC_DB_PASSWORD

--- a/kubernetes/components/keycloak/production/kustomization/external-secret-google-idp.yaml
+++ b/kubernetes/components/keycloak/production/kustomization/external-secret-google-idp.yaml
@@ -1,0 +1,33 @@
+# =============================================================================
+# ExternalSecret: Google Identity Provider client credentials
+# =============================================================================
+# AWS Secrets Manager の panicboat/keycloak/google-idp は Terraform 管理外 (=
+# operator が Google Cloud Console で OAuth Client を手動作成し、既存
+# oauth2-proxy Google OAuth と同じ手順で手動投入する。design spec の
+# "Manual Setup" 参照)。
+# realm-config-job (keycloak-config-cli) が本 Secret を envFrom で読み、realm
+# import JSON 内の ${GOOGLE_CLIENT_ID} / ${GOOGLE_CLIENT_SECRET} を
+# var-substitution で解決する。
+# =============================================================================
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: keycloak-google-idp
+  namespace: keycloak
+spec:
+  secretStoreRef:
+    name: aws-secrets-manager
+    kind: ClusterSecretStore
+  refreshInterval: 1h
+  target:
+    name: keycloak-google-idp
+    creationPolicy: Owner
+  data:
+    - secretKey: GOOGLE_CLIENT_ID
+      remoteRef:
+        key: panicboat/keycloak/google-idp
+        property: client_id
+    - secretKey: GOOGLE_CLIENT_SECRET
+      remoteRef:
+        key: panicboat/keycloak/google-idp
+        property: client_secret

--- a/kubernetes/components/keycloak/production/kustomization/kustomization.yaml
+++ b/kubernetes/components/keycloak/production/kustomization/kustomization.yaml
@@ -1,0 +1,15 @@
+# =============================================================================
+# keycloak production kustomization
+# =============================================================================
+# chart 範囲外 resource (= 3 ExternalSecrets + realm import ConfigMap/Job) を
+# helmfile output に上乗せする overlay。Ingress は chart native (ingress.enabled)
+# で values.yaml.gotmpl 側から生成。
+# =============================================================================
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - external-secret-database.yaml
+  - external-secret-admin.yaml
+  - external-secret-google-idp.yaml
+  - realm-import-configmap.yaml
+  - realm-config-job.yaml

--- a/kubernetes/components/keycloak/production/kustomization/realm-config-job.yaml
+++ b/kubernetes/components/keycloak/production/kustomization/realm-config-job.yaml
@@ -1,0 +1,61 @@
+# =============================================================================
+# Job: keycloak-config-cli (= Realm/Client/IdP の宣言的 apply)
+# =============================================================================
+# adorsys/keycloak-config-cli が起動時に Keycloak Admin REST API へ接続し、
+# ConfigMap keycloak-realm-import の内容を realm に反映する (= Keycloak 自体の
+# --import-realm 起動時 import ではなく、稼働中の Keycloak に対して都度 apply
+# する運用)。
+#
+# KNOWN LIMITATION: Job は immutable なため、realm JSON (ConfigMap) を変更
+# しても本 Job は再実行されない (= Reloader は Job を watch 対象外)。反映するには
+# `kubectl delete job -n keycloak keycloak-realm-config` を手動実行し、Flux に
+# 再作成させる必要がある。設計 spec の Known Limitations 参照。
+# =============================================================================
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: keycloak-realm-config
+  namespace: keycloak
+spec:
+  backoffLimit: 5
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: keycloak-realm-config
+    spec:
+      restartPolicy: OnFailure
+      containers:
+        - name: keycloak-config-cli
+          image: adorsys/keycloak-config-cli:6.5.1-26
+          env:
+            - name: KEYCLOAK_URL
+              value: http://keycloak.keycloak.svc.cluster.local
+            - name: KEYCLOAK_USER
+              valueFrom:
+                secretKeyRef:
+                  name: keycloak-admin
+                  key: KEYCLOAK_ADMIN
+            - name: KEYCLOAK_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: keycloak-admin
+                  key: KEYCLOAK_ADMIN_PASSWORD
+            - name: KEYCLOAK_AVAILABILITYCHECK_ENABLED
+              value: "true"
+            - name: KEYCLOAK_AVAILABILITYCHECK_TIMEOUT
+              value: 300s
+            - name: IMPORT_FILES_LOCATIONS
+              value: /config/*
+            - name: IMPORT_VARSUBSTITUTION_ENABLED
+              value: "true"
+          envFrom:
+            - secretRef:
+                name: keycloak-google-idp
+          volumeMounts:
+            - name: realm-import
+              mountPath: /config
+              readOnly: true
+      volumes:
+        - name: realm-import
+          configMap:
+            name: keycloak-realm-import

--- a/kubernetes/components/keycloak/production/kustomization/realm-import-configmap.yaml
+++ b/kubernetes/components/keycloak/production/kustomization/realm-import-configmap.yaml
@@ -1,0 +1,69 @@
+# =============================================================================
+# ConfigMap: Keycloak realm import (keycloak-config-cli format)
+# =============================================================================
+# keycloak-config-cli の config file は Keycloak の realm export JSON 形式を
+# そのまま使う。$(env:VAR) は keycloak-config-cli の variable substitution
+# 構文 (= デフォルト prefix/suffix `$(` / `)`、realm-config-job.yaml で
+# IMPORT_VARSUBSTITUTION_ENABLED=true を設定して有効化)。
+#
+# - identityProviders.google: toC アプリ向け Google ソーシャルログイン。
+#   client_id/secret は Google Cloud Console で手動作成し AWS Secrets Manager
+#   panicboat/keycloak/google-idp に手動投入 (design spec の Manual Setup 参照)。
+# - clients.dystopia-app: toC アプリ (application monorepo、本 repo 外) が使う
+#   public client (= SPA/mobile 想定、standard flow のみ)。redirect URI は
+#   dystopia.city 配下を許可。
+# - registrationAllowed: false (= Phase 1 は Google ソーシャルログインのみ、
+#   realm native の email/password self-registration は対象外)。
+# =============================================================================
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: keycloak-realm-import
+  namespace: keycloak
+data:
+  dystopia-realm.json: |
+    {
+      "realm": "dystopia",
+      "enabled": true,
+      "displayName": "dystopia.city",
+      "sslRequired": "external",
+      "registrationAllowed": false,
+      "loginWithEmailAllowed": true,
+      "resetPasswordAllowed": true,
+      "identityProviders": [
+        {
+          "alias": "google",
+          "providerId": "google",
+          "enabled": true,
+          "trustEmail": true,
+          "storeToken": false,
+          "addReadTokenRoleOnCreate": false,
+          "firstBrokerLoginFlowAlias": "first broker login",
+          "config": {
+            "clientId": "$(env:GOOGLE_CLIENT_ID)",
+            "clientSecret": "$(env:GOOGLE_CLIENT_SECRET)",
+            "syncMode": "IMPORT",
+            "useJwksUrl": "true"
+          }
+        }
+      ],
+      "clients": [
+        {
+          "clientId": "dystopia-app",
+          "name": "dystopia.city application",
+          "enabled": true,
+          "publicClient": true,
+          "protocol": "openid-connect",
+          "standardFlowEnabled": true,
+          "implicitFlowEnabled": false,
+          "directAccessGrantsEnabled": false,
+          "serviceAccountsEnabled": false,
+          "redirectUris": [
+            "https://dystopia.city/*"
+          ],
+          "webOrigins": [
+            "https://dystopia.city"
+          ]
+        }
+      ]
+    }

--- a/kubernetes/components/keycloak/production/values.yaml.gotmpl
+++ b/kubernetes/components/keycloak/production/values.yaml.gotmpl
@@ -1,0 +1,119 @@
+# keycloak (codecentric/keycloakx) Configuration for production
+# toC 向けアプリの認証基盤。DB 接続情報 / admin bootstrap 情報は values に書かず
+# extraEnvFrom 経由で K8s Secret (ExternalSecret 由来) から直接注入する
+# (= RDS endpoint は Terraform apply 時まで不定のため、values.yaml.gotmpl に
+# static 値として書けない)。
+
+fullnameOverride: keycloak
+
+# =============================================================================
+# Replicas (HA = 2、jdbc-ping による cluster discovery は外部 Postgres 経由)
+# =============================================================================
+replicas: 2
+
+# =============================================================================
+# Priority Class
+# =============================================================================
+priorityClassName: system-cluster-critical
+
+# =============================================================================
+# Resources
+# =============================================================================
+resources:
+  requests:
+    cpu: 250m
+    memory: 768Mi
+  limits:
+    cpu: 1000m
+    memory: 1536Mi
+
+# =============================================================================
+# Startup command (= chart default の command/args は空、公式 image の default
+# CMD は dev mode になるため明示的に production start を指定)
+# =============================================================================
+command:
+  - /opt/keycloak/bin/kc.sh
+  - start
+  - --http-enabled=true
+  - --hostname-strict=false
+
+# =============================================================================
+# Proxy (= ALB が TLS 終端、X-Forwarded-* header で Keycloak に転送)
+# =============================================================================
+proxy:
+  enabled: true
+  mode: xforwarded # AWS ALB は RFC7239 Forwarded ではなく X-Forwarded-* を付与
+
+# =============================================================================
+# HTTP (= レガシー /auth prefix を使わず root で公開)
+# =============================================================================
+http:
+  relativePath: "/"
+
+# =============================================================================
+# Database (= vendor のみ static、hostname/port/database/username/password は
+# extraEnvFrom 経由の env var (KC_DB_URL_HOST 等) で注入。database.hostname 等
+# を空のままにすることで chart 側の該当 env 生成を skip させる)
+# =============================================================================
+database:
+  vendor: postgres
+
+# =============================================================================
+# extraEnv (= 静的な非機密設定のみ)
+# =============================================================================
+extraEnv: |
+  - name: KC_HOSTNAME
+    value: https://auth.dystopia.city
+
+# =============================================================================
+# extraEnvFrom (= DB 接続情報 + admin bootstrap 情報を Secret から一括注入)
+# =============================================================================
+extraEnvFrom: |
+  - secretRef:
+      name: keycloak-database
+  - secretRef:
+      name: keycloak-admin
+
+# =============================================================================
+# StatefulSet Annotations (= Reloader watch、Secret rotation 時に auto-rollout)
+# =============================================================================
+statefulsetAnnotations:
+  reloader.stakater.com/auto: "true"
+
+# =============================================================================
+# Service (= ClusterIP、ALB Ingress backend として利用)
+# =============================================================================
+service:
+  type: ClusterIP
+  httpPort: 80
+
+# =============================================================================
+# Ingress (= ALB IngressGroup `application` に相乗り、dystopia.city 系 1 ALB 共有)
+# =============================================================================
+# ACM cert auto-discovery: ALB Controller が wildcard cert *.dystopia.city を
+# 自動 attach (= Ingress.host が SAN match)。
+#
+# healthcheck: Keycloak root ("/") はログイン/リダイレクトを返すため 200 単独
+# では ALB healthcheck を通らない。cilium application-ingress と同じ workaround
+# (success-codes: 200-499) を採用。
+# =============================================================================
+ingress:
+  enabled: true
+  ingressClassName: alb
+  servicePort: http
+  annotations:
+    alb.ingress.kubernetes.io/scheme: internet-facing
+    alb.ingress.kubernetes.io/listen-ports: '[{"HTTPS":443}]'
+    alb.ingress.kubernetes.io/group.name: application
+    alb.ingress.kubernetes.io/target-type: ip
+    alb.ingress.kubernetes.io/healthcheck-path: /
+    alb.ingress.kubernetes.io/success-codes: "200-499"
+    alb.ingress.kubernetes.io/healthcheck-port: traffic-port
+    alb.ingress.kubernetes.io/ssl-policy: ELBSecurityPolicy-TLS13-1-2-2021-06
+    alb.ingress.kubernetes.io/ssl-redirect: "443"
+    external-dns.alpha.kubernetes.io/hostname: auth.dystopia.city
+  rules:
+    - host: auth.dystopia.city
+      paths:
+        - path: /
+          pathType: Prefix

--- a/kubernetes/manifests/production/00-namespaces/namespaces.yaml
+++ b/kubernetes/manifests/production/00-namespaces/namespaces.yaml
@@ -66,6 +66,19 @@ metadata:
     app.kubernetes.io/name: keda
 ---
 # =============================================================================
+# keycloak Namespace
+# =============================================================================
+# toC 向けアプリの認証基盤 (= Identity Provider)。RDS PostgreSQL (aws/keycloak-database)
+# を backend に持ち、auth.dystopia.city で OIDC を公開する。
+# =============================================================================
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: keycloak
+  labels:
+    app.kubernetes.io/name: keycloak
+---
+# =============================================================================
 # oauth2-proxy Namespace
 # =============================================================================
 # oauth2-proxy (= Google OAuth gate + reverse-proxy) の専用 namespace。

--- a/kubernetes/manifests/production/keycloak/kustomization.yaml
+++ b/kubernetes/manifests/production/keycloak/kustomization.yaml
@@ -1,0 +1,2 @@
+resources:
+  - manifest.yaml

--- a/kubernetes/manifests/production/keycloak/manifest.yaml
+++ b/kubernetes/manifests/production/keycloak/manifest.yaml
@@ -1,0 +1,444 @@
+---
+# Source: keycloakx/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: keycloak
+  namespace: keycloak
+  labels:
+    helm.sh/chart: keycloakx-7.2.2
+    app.kubernetes.io/name: keycloakx
+    app.kubernetes.io/instance: keycloak
+    app.kubernetes.io/version: "26.6.4"
+    app.kubernetes.io/managed-by: Helm
+automountServiceAccountToken: true
+---
+# Source: keycloakx/templates/service-headless.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: keycloak-headless
+  namespace: keycloak
+  labels:
+    helm.sh/chart: keycloakx-7.2.2
+    app.kubernetes.io/name: keycloakx
+    app.kubernetes.io/instance: keycloak
+    app.kubernetes.io/version: "26.6.4"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: headless
+spec:
+  type: ClusterIP
+  clusterIP: None
+  ports:
+    - name: http
+      port: 80
+      targetPort: http
+      protocol: TCP
+  selector:
+    app.kubernetes.io/name: keycloakx
+    app.kubernetes.io/instance: keycloak
+---
+# Source: keycloakx/templates/service-http.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: keycloak-http
+  namespace: keycloak
+  labels:
+    helm.sh/chart: keycloakx-7.2.2
+    app.kubernetes.io/name: keycloakx
+    app.kubernetes.io/instance: keycloak
+    app.kubernetes.io/version: "26.6.4"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: http
+spec:
+  type: ClusterIP
+  ports:
+    - name: 'http-internal'
+      port: 9000
+      protocol: TCP
+      targetPort: 'http-internal'
+    - name: http
+      port: 80
+      targetPort: http
+      protocol: TCP
+    - name: https
+      port: 8443
+      targetPort: https
+      protocol: TCP
+  selector:
+    app.kubernetes.io/name: keycloakx
+    app.kubernetes.io/instance: keycloak
+---
+# Source: keycloakx/templates/statefulset.yaml
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: keycloak
+  namespace: keycloak
+  annotations:
+    reloader.stakater.com/auto: "true"
+  labels:
+    helm.sh/chart: keycloakx-7.2.2
+    app.kubernetes.io/name: keycloakx
+    app.kubernetes.io/instance: keycloak
+    app.kubernetes.io/version: "26.6.4"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: keycloakx
+      app.kubernetes.io/instance: keycloak
+  replicas: 2
+  serviceName: keycloak-headless
+  podManagementPolicy: OrderedReady
+  updateStrategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      annotations:
+        checksum/config-startup: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+        checksum/secrets: 44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a
+      labels:
+        app.kubernetes.io/name: keycloakx
+        app.kubernetes.io/instance: keycloak
+    spec:
+      containers:
+        - name: keycloak
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1000
+          image: "quay.io/keycloak/keycloak:26.6.4"
+          imagePullPolicy: IfNotPresent
+          command:
+            - /opt/keycloak/bin/kc.sh
+            - start
+            - --http-enabled=true
+            - --hostname-strict=false
+          env:
+            - name: KC_HTTP_RELATIVE_PATH
+              value: /
+            
+            - name: KC_CACHE
+              value: "ispn"
+            - name: KC_CACHE_STACK
+              value: "jdbc-ping"
+            - name: KC_PROXY_HEADERS
+              value: xforwarded
+            - name: KC_HTTP_ENABLED
+              value: "true"
+            - name: KC_DB
+              value: postgres
+            - name: KC_METRICS_ENABLED
+              value: "true"
+            - name: KC_HEALTH_ENABLED
+              value: "true"
+            - name: KC_HOSTNAME
+              value: https://auth.dystopia.city
+            
+          envFrom:
+            - secretRef:
+                name: keycloak-database
+            - secretRef:
+                name: keycloak-admin
+            
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+            - name: 'http-internal'
+              containerPort: 9000
+              protocol: TCP
+            - name: https
+              containerPort: 8443
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: '/health/live'
+              port: 'http-internal'
+              scheme: 'HTTP'
+            initialDelaySeconds: 0
+            timeoutSeconds: 5
+            
+          readinessProbe:
+            httpGet:
+              path: '/health/ready'
+              port: 'http-internal'
+              scheme: 'HTTP'
+            initialDelaySeconds: 10
+            timeoutSeconds: 1
+            
+          startupProbe:
+            httpGet:
+              path: '/health'
+              port: 'http-internal'
+              scheme: 'HTTP'
+            initialDelaySeconds: 15
+            timeoutSeconds: 1
+            failureThreshold: 60
+            periodSeconds: 5
+            
+          resources:
+            limits:
+              cpu: 1000m
+              memory: 1536Mi
+            requests:
+              cpu: 250m
+              memory: 768Mi
+          volumeMounts:
+      serviceAccountName: keycloak
+      securityContext:
+        fsGroup: 1000
+      enableServiceLinks: true
+      restartPolicy: Always
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchLabels:
+                  app.kubernetes.io/name: keycloakx
+                  app.kubernetes.io/instance: keycloak
+                matchExpressions:
+                  - key: app.kubernetes.io/component
+                    operator: NotIn
+                    values:
+                      - test
+              topologyKey: kubernetes.io/hostname
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              podAffinityTerm:
+                labelSelector:
+                  matchLabels:
+                    app.kubernetes.io/name: keycloakx
+                    app.kubernetes.io/instance: keycloak
+                  matchExpressions:
+                    - key: app.kubernetes.io/component
+                      operator: NotIn
+                      values:
+                        - test
+                topologyKey: topology.kubernetes.io/zone
+        
+      priorityClassName: system-cluster-critical
+      terminationGracePeriodSeconds: 60
+      volumes:
+---
+# Source: keycloakx/templates/ingress.yaml
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: keycloak
+  namespace: keycloak
+  annotations:
+    alb.ingress.kubernetes.io/group.name: "application"
+    alb.ingress.kubernetes.io/healthcheck-path: "/"
+    alb.ingress.kubernetes.io/healthcheck-port: "traffic-port"
+    alb.ingress.kubernetes.io/listen-ports: "[{\"HTTPS\":443}]"
+    alb.ingress.kubernetes.io/scheme: "internet-facing"
+    alb.ingress.kubernetes.io/ssl-policy: "ELBSecurityPolicy-TLS13-1-2-2021-06"
+    alb.ingress.kubernetes.io/ssl-redirect: "443"
+    alb.ingress.kubernetes.io/success-codes: "200-499"
+    alb.ingress.kubernetes.io/target-type: "ip"
+    external-dns.alpha.kubernetes.io/hostname: "auth.dystopia.city"
+  labels:
+    helm.sh/chart: keycloakx-7.2.2
+    app.kubernetes.io/name: keycloakx
+    app.kubernetes.io/instance: keycloak
+    app.kubernetes.io/version: "26.6.4"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  ingressClassName: alb
+  rules:
+    - host: "auth.dystopia.city"
+      http:
+        paths:
+          - path: "/"
+            pathType: Prefix
+            backend:
+              service:
+                name: keycloak-http
+                port:
+                  name: http
+
+---
+apiVersion: v1
+data:
+  dystopia-realm.json: |
+    {
+      "realm": "dystopia",
+      "enabled": true,
+      "displayName": "dystopia.city",
+      "sslRequired": "external",
+      "registrationAllowed": false,
+      "loginWithEmailAllowed": true,
+      "resetPasswordAllowed": true,
+      "identityProviders": [
+        {
+          "alias": "google",
+          "providerId": "google",
+          "enabled": true,
+          "trustEmail": true,
+          "storeToken": false,
+          "addReadTokenRoleOnCreate": false,
+          "firstBrokerLoginFlowAlias": "first broker login",
+          "config": {
+            "clientId": "$(env:GOOGLE_CLIENT_ID)",
+            "clientSecret": "$(env:GOOGLE_CLIENT_SECRET)",
+            "syncMode": "IMPORT",
+            "useJwksUrl": "true"
+          }
+        }
+      ],
+      "clients": [
+        {
+          "clientId": "dystopia-app",
+          "name": "dystopia.city application",
+          "enabled": true,
+          "publicClient": true,
+          "protocol": "openid-connect",
+          "standardFlowEnabled": true,
+          "implicitFlowEnabled": false,
+          "directAccessGrantsEnabled": false,
+          "serviceAccountsEnabled": false,
+          "redirectUris": [
+            "https://dystopia.city/*"
+          ],
+          "webOrigins": [
+            "https://dystopia.city"
+          ]
+        }
+      ]
+    }
+kind: ConfigMap
+metadata:
+  name: keycloak-realm-import
+  namespace: keycloak
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: keycloak-realm-config
+  namespace: keycloak
+spec:
+  backoffLimit: 5
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: keycloak-realm-config
+    spec:
+      containers:
+      - env:
+        - name: KEYCLOAK_URL
+          value: http://keycloak.keycloak.svc.cluster.local
+        - name: KEYCLOAK_USER
+          valueFrom:
+            secretKeyRef:
+              key: KEYCLOAK_ADMIN
+              name: keycloak-admin
+        - name: KEYCLOAK_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              key: KEYCLOAK_ADMIN_PASSWORD
+              name: keycloak-admin
+        - name: KEYCLOAK_AVAILABILITYCHECK_ENABLED
+          value: "true"
+        - name: KEYCLOAK_AVAILABILITYCHECK_TIMEOUT
+          value: 300s
+        - name: IMPORT_FILES_LOCATIONS
+          value: /config/*
+        - name: IMPORT_VARSUBSTITUTION_ENABLED
+          value: "true"
+        envFrom:
+        - secretRef:
+            name: keycloak-google-idp
+        image: adorsys/keycloak-config-cli:6.5.1-26
+        name: keycloak-config-cli
+        volumeMounts:
+        - mountPath: /config
+          name: realm-import
+          readOnly: true
+      restartPolicy: OnFailure
+      volumes:
+      - configMap:
+          name: keycloak-realm-import
+        name: realm-import
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: keycloak-admin
+  namespace: keycloak
+spec:
+  data:
+  - remoteRef:
+      key: panicboat/keycloak/admin
+      property: KEYCLOAK_ADMIN
+    secretKey: KEYCLOAK_ADMIN
+  - remoteRef:
+      key: panicboat/keycloak/admin
+      property: KEYCLOAK_ADMIN_PASSWORD
+    secretKey: KEYCLOAK_ADMIN_PASSWORD
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: aws-secrets-manager
+  target:
+    creationPolicy: Owner
+    name: keycloak-admin
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: keycloak-database
+  namespace: keycloak
+spec:
+  data:
+  - remoteRef:
+      key: panicboat/keycloak/database
+      property: KC_DB_URL_HOST
+    secretKey: KC_DB_URL_HOST
+  - remoteRef:
+      key: panicboat/keycloak/database
+      property: KC_DB_URL_PORT
+    secretKey: KC_DB_URL_PORT
+  - remoteRef:
+      key: panicboat/keycloak/database
+      property: KC_DB_URL_DATABASE
+    secretKey: KC_DB_URL_DATABASE
+  - remoteRef:
+      key: panicboat/keycloak/database
+      property: KC_DB_USERNAME
+    secretKey: KC_DB_USERNAME
+  - remoteRef:
+      key: panicboat/keycloak/database
+      property: KC_DB_PASSWORD
+    secretKey: KC_DB_PASSWORD
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: aws-secrets-manager
+  target:
+    creationPolicy: Owner
+    name: keycloak-database
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: keycloak-google-idp
+  namespace: keycloak
+spec:
+  data:
+  - remoteRef:
+      key: panicboat/keycloak/google-idp
+      property: client_id
+    secretKey: GOOGLE_CLIENT_ID
+  - remoteRef:
+      key: panicboat/keycloak/google-idp
+      property: client_secret
+    secretKey: GOOGLE_CLIENT_SECRET
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: aws-secrets-manager
+  target:
+    creationPolicy: Owner
+    name: keycloak-google-idp

--- a/kubernetes/manifests/production/kustomization.yaml
+++ b/kubernetes/manifests/production/kustomization.yaml
@@ -10,6 +10,7 @@ resources:
   - ./gateway-api
   - ./karpenter
   - ./keda
+  - ./keycloak
   - ./loki
   - ./metrics-server
   - ./mimir


### PR DESCRIPTION
## Summary

toC 向けアプリの認証基盤として Keycloak を production EKS に導入する (Phase 1: 本体 + RDS + Google 連携)。電話番号 (SMS OTP) 認証は Phase 2 として別 spec で扱う。

- **AWS** (`aws/keycloak-database/`): 新規 Terragrunt stack。RDS PostgreSQL (`db.t4g.micro`, single-AZ, gp3 20GB) を `aws/vpc` の既存 database subnet group に構築。DB master 認証情報 + Keycloak admin bootstrap 認証情報は Terraform (`random_password`) が生成し AWS Secrets Manager (`panicboat/keycloak/database`, `panicboat/keycloak/admin`) に格納。既存 ESO IAM role (`secret:*` read 権限保有済) がそのまま read 可能。
- **Kubernetes** (`kubernetes/components/keycloak/`): codecentric/keycloakx chart (Keycloak 26.6.4、公式 `quay.io/keycloak/keycloak` image。Bitnami legacy 移行の影響を受けないため採用) を `auth.dystopia.city` で公開。ALB IngressGroup `application` に相乗り (既存 dystopia.city 用 ALB + `*.dystopia.city` cert を再利用、追加コストなし)。DB/admin 認証情報は ExternalSecret → `extraEnvFrom` で直接環境変数注入。
- **Realm/Client/Google IdP**: `keycloak-config-cli` の宣言的 Job で Realm `dystopia` + public client `dystopia-app` + Google Identity Provider federation を apply。

## Manual steps required before this is fully functional (see design doc)

1. Google Cloud Console で OAuth Client 作成 (redirect URI: `https://auth.dystopia.city/realms/dystopia/broker/google/endpoint`)
2. AWS Secrets Manager `panicboat/keycloak/google-idp` に `client_id` / `client_secret` を手動投入
3. `aws/keycloak-database` の terragrunt apply (CI 経由、main merge で自動)

Design doc: `docs/superpowers/specs/2026-07-30-keycloak-introduction-design.md`

## Test plan

- [ ] `terragrunt plan` (CI) が `aws/keycloak-database/envs/production` で clean に通ることを確認
- [ ] merge 後、CI の kubernetes-hydrator が `kubernetes/manifests/production/keycloak/` を生成することを確認
- [ ] terragrunt apply 後、RDS `keycloak-production` が `available` になることを確認
- [ ] Flux reconcile 後、`keycloak` Pod が `Running` + StatefulSet ready になることを確認
- [ ] Manual Setup (Google OAuth Client + Secrets Manager 投入) 完了後、`keycloak-realm-config` Job が成功し realm `dystopia` が作成されることを確認
- [ ] `https://auth.dystopia.city/realms/dystopia/protocol/openid-connect/auth?client_id=dystopia-app&...` にアクセスし Google ログインボタンが表示され、ログインが完了することを確認


---
_Generated by [Claude Code](https://claude.ai/code/session_01ArVuD8QrymN7iu24WyYbSD)_