### PR TITLE
feat(aws/karpenter): create EC2 Spot service-linked role

### DIFF
--- a/aws/karpenter/modules/main.tf
+++ b/aws/karpenter/modules/main.tf
@@ -23,6 +23,24 @@
 # に紐付けるため、Helm chart の serviceAccount.annotations に IRSA 情報を
 # 入れる必要がない。
 
+# EC2 Spot service-linked role. system-components NodePool の capacity-type
+# [spot, on-demand] が spot instance を起動する際、AWS は初回リクエスト時に
+# このロールを自動作成しようとするが、Karpenter controller IAM policy
+# (terraform-aws-modules 標準policy) は least-privilege 設計で
+# iam:CreateServiceLinkedRole を含まないため自動作成に失敗し、spot 経由の
+# node 起動/consolidation が AuthFailure.ServiceLinkedRoleCreationNotPermitted
+# で失敗する。operator の admin credentials で明示的に作成しておく。
+#
+# account に1つだけ存在する singleton resource。karpenter stack の
+# destroy/recreate cycle (docs/runbooks/eks-production-recreate.md) に
+# 巻き込まれる点に注意: destroy 時に spot instance が残っていると
+# DeleteServiceLinkedRole が AWS 側で非同期に遅延/失敗しうる。詰まった場合は
+# `aws iam get-service-linked-role-deletion-status --deletion-task-id <id>`
+# で状態確認してから再 destroy する。
+resource "aws_iam_service_linked_role" "spot" {
+  aws_service_name = "spot.amazonaws.com"
+}
+
 module "karpenter" {
   source  = "terraform-aws-modules/eks/aws//modules/karpenter"
   version = "21.24.0"

--- a/docs/runbooks/eks-production-recreate.md
+++ b/docs/runbooks/eks-production-recreate.md
@@ -352,6 +352,8 @@ done
 | `flux-system` Kustomization `False` で webhook validation error | webhook 提供 HelmRelease (= cert-manager / external-secrets / opentelemetry-operator) が未起動 | **Phase 9.3a の bootstrap-webhooks apply (= PR #410) を実行済か確認**。 9.3a を skip した場合は数分待って Flux reconcile loop で self-heal 期待、 起動済なのに stuck なら `flux reconcile kustomization flux-system` で force trigger |
 | Pending pods が `pod has unbound immediate PersistentVolumeClaims` | gp3 StorageClass 未作成 | **PR #406 merge 後は不要**。 旧 cluster recreate で pre-PR #406 commit から始める場合のみ手動作成 |
 | post-merge CI が apply 中に operator local apply 試行で衝突 | CI が state lock 保持 | CI 完走待ち、 OR CI cancel + force-unlock。 将来は `skip-deploy` label scheme (= PR #404 design Phase B) で防止 |
+| Karpenter が spot node を起動できず consolidation/scale-out が進まない (= karpenter controller log に `AuthFailure.ServiceLinkedRoleCreationNotPermitted`) | `AWSServiceRoleForEC2Spot` service-linked role が account に未作成。 Karpenter controller IAM policy は least-privilege 設計で `iam:CreateServiceLinkedRole` を含まないため AWS 側の自動作成が失敗する | `aws/karpenter/modules/main.tf` の `aws_iam_service_linked_role.spot` で Phase 5 apply 時に作成される (= 過去に一度も spot instance を使ったことがない account での初回 bootstrap のみ発生しうる)。 それでも発生する場合は `aws iam get-role --role-name AWSServiceRoleForEC2Spot` で存在確認 |
+| `aws/karpenter` の `terragrunt destroy` (= teardown) が `aws_iam_service_linked_role.spot` で hang/fail する | spot instance が残っていて `DeleteServiceLinkedRole` が AWS 側で非同期に遅延/拒否される | `eks-teardown-k8s` (= spot instance 含む node 全 drain) が `eks-teardown-aws` より先に完走しているか確認。 詰まった場合は `aws iam get-service-linked-role-deletion-status --deletion-task-id <id>` で状態確認してから再 destroy |
 
 ## 6. Future improvements
 


### PR DESCRIPTION
## Summary
- Karpenter の `system-components` NodePool は `capacity-type: [spot, on-demand]` を採用しているが、 account に `AWSServiceRoleForEC2Spot` service-linked role が未作成だった (spot を一度も使ったことがない account だったため)
- Karpenter controller IAM policy (terraform-aws-modules 標準) は least-privilege 設計で `iam:CreateServiceLinkedRole` を含まないため、 AWS 側の自動作成が失敗し、 spot 経由の node 起動/consolidation が `AuthFailure.ServiceLinkedRoleCreationNotPermitted` で失敗し続けていた (monitoring namespace 削除後の consolidation 観測作業で発見)
- `aws/karpenter/modules/main.tf` に `aws_iam_service_linked_role.spot` を追加。 account 単位の singleton resource だが、 karpenter stack の destroy/recreate cycle に意図的に同居させる (詳細はコード comment 参照)
- `docs/runbooks/eks-production-recreate.md` の Failure handling に本事象と destroy 時の注意点を追記

## Test plan
- [x] `terragrunt plan` で `1 to add, 0 to change, 0 to destroy` を確認
- [x] `terragrunt apply` 実施、 `aws iam get-role --role-name AWSServiceRoleForEC2Spot` で存在確認
- [x] production cluster で Karpenter の spot replace consolidation が成功することを確認 (on-demand → spot 化 + empty node delete が正常動作)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of EC2 Spot node provisioning and consolidation by ensuring the required AWS service-linked role is available.

* **Documentation**
  * Added troubleshooting guidance for Spot service-linked role errors and teardown delays during production EKS recreation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->