### PR TITLE
refactor(aws): move EC2 Spot service-linked role out of karpenter stack

### DIFF
--- a/aws/iam-service-linked-roles/modules/main.tf
+++ b/aws/iam-service-linked-roles/modules/main.tf
@@ -1,0 +1,25 @@
+# main.tf - Account 単位の IAM service-linked role。
+#
+# 新しい service-linked role が必要になったら、この module 内に resource
+# block を追加する (stack を分けない。理由は terragrunt.hcl 参照)。
+
+# EC2 Spot: Karpenter の system-components NodePool
+# (kubernetes/components/karpenter/production/kustomization/nodepool.yaml)
+# が capacity-type [spot, on-demand] で spot instance を起動する際に必要。
+#
+# Karpenter controller IAM policy (terraform-aws-modules 標準 policy) は
+# least-privilege 設計で iam:CreateServiceLinkedRole を含まないため、AWS 側
+# の自動作成に失敗し spot 経由の node 起動/consolidation が
+# AuthFailure.ServiceLinkedRoleCreationNotPermitted で失敗する。
+#
+# aws/karpenter (per-env stack) には埋め込まない。理由:
+# 1. account 単位 singleton なので、複数 env (production 以外に将来
+#    staging/develop 等) が同一 account に増えると 2 つ目以降の env の
+#    apply が確実に EntityAlreadyExists で失敗する。
+# 2. aws/karpenter は docs/runbooks/eks-production-recreate.md の
+#    destroy/recreate cycle 対象。spot instance が残っている間は
+#    DeleteServiceLinkedRole が AWS 側で非同期に遅延/失敗しうるため、
+#    destroy/recreate に巻き込むと無用な失敗点になる。
+resource "aws_iam_service_linked_role" "spot" {
+  aws_service_name = "spot.amazonaws.com"
+}

--- a/aws/iam-service-linked-roles/modules/terraform.tf
+++ b/aws/iam-service-linked-roles/modules/terraform.tf
@@ -1,0 +1,20 @@
+# terraform.tf - OpenTofu and provider configuration
+
+terraform {
+  required_version = "1.12.5"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "6.56.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.aws_region
+
+  default_tags {
+    tags = var.common_tags
+  }
+}

--- a/aws/iam-service-linked-roles/modules/variables.tf
+++ b/aws/iam-service-linked-roles/modules/variables.tf
@@ -1,0 +1,13 @@
+# variables.tf - Input variables for ec2-spot-service-role module
+
+variable "aws_region" {
+  description = "AWS region"
+  type        = string
+  default     = "ap-northeast-1"
+}
+
+variable "common_tags" {
+  description = "Common tags to apply to all resources"
+  type        = map(string)
+  default     = {}
+}

--- a/aws/iam-service-linked-roles/terragrunt.hcl
+++ b/aws/iam-service-linked-roles/terragrunt.hcl
@@ -1,0 +1,49 @@
+# terragrunt.hcl - Account 単位の IAM service-linked role 管理。
+#
+# aws_iam_service_linked_role は account 単位の singleton resource (IAM は
+# global service)。他 stack の envs/<env>/ 構成をここでは意図的に採らない:
+# 複数 env フォルダを許す構造は「env を増やしてよい」という誤った前例に
+# なり、2 つ目の env が apply された瞬間 EntityAlreadyExists で失敗する。
+# この stack は常にこの 1 folder = 1 apply target のみ。
+#
+# 対象は service ごとに増えうる (現状は spot.amazonaws.com のみ)。
+# 新しい service-linked role が必要になったら、新規 stack を作らず
+# modules/main.tf に resource block を追加する。
+
+locals {
+  project_name = "iam-service-linked-roles"
+
+  common_tags = {
+    Project    = local.project_name
+    ManagedBy  = "terragrunt"
+    Repository = "monorepo"
+    Component  = "iam-service-linked-roles"
+    Team       = "panicboat"
+  }
+}
+
+remote_state {
+  backend = "s3"
+  generate = {
+    path      = "backend.tf"
+    if_exists = "overwrite_terragrunt"
+  }
+  config = {
+    bucket = "terragrunt-state-${get_aws_account_id()}"
+
+    key    = "platform/iam-service-linked-roles/terraform.tfstate"
+    region = "ap-northeast-1"
+
+    dynamodb_table = "terragrunt-state-locks"
+    encrypt        = true
+  }
+}
+
+terraform {
+  source = "./modules"
+}
+
+inputs = {
+  aws_region  = "ap-northeast-1"
+  common_tags = local.common_tags
+}

--- a/aws/karpenter/modules/main.tf
+++ b/aws/karpenter/modules/main.tf
@@ -23,23 +23,11 @@
 # に紐付けるため、Helm chart の serviceAccount.annotations に IRSA 情報を
 # 入れる必要がない。
 
-# EC2 Spot service-linked role. system-components NodePool の capacity-type
-# [spot, on-demand] が spot instance を起動する際、AWS は初回リクエスト時に
-# このロールを自動作成しようとするが、Karpenter controller IAM policy
-# (terraform-aws-modules 標準policy) は least-privilege 設計で
-# iam:CreateServiceLinkedRole を含まないため自動作成に失敗し、spot 経由の
-# node 起動/consolidation が AuthFailure.ServiceLinkedRoleCreationNotPermitted
-# で失敗する。operator の admin credentials で明示的に作成しておく。
-#
-# account に1つだけ存在する singleton resource。karpenter stack の
-# destroy/recreate cycle (docs/runbooks/eks-production-recreate.md) に
-# 巻き込まれる点に注意: destroy 時に spot instance が残っていると
-# DeleteServiceLinkedRole が AWS 側で非同期に遅延/失敗しうる。詰まった場合は
-# `aws iam get-service-linked-role-deletion-status --deletion-task-id <id>`
-# で状態確認してから再 destroy する。
-resource "aws_iam_service_linked_role" "spot" {
-  aws_service_name = "spot.amazonaws.com"
-}
+# EC2 Spot service-linked role (AWSServiceRoleForEC2Spot) は
+# aws/ec2-spot-service-role で管理する (= account 単位 singleton かつ
+# 複数 env 共有のため、per-env stack である karpenter からは分離)。
+# system-components NodePool の capacity-type [spot, on-demand] はこの role
+# の存在を前提にする。
 
 module "karpenter" {
   source  = "terraform-aws-modules/eks/aws//modules/karpenter"

--- a/docs/runbooks/eks-production-recreate.md
+++ b/docs/runbooks/eks-production-recreate.md
@@ -23,6 +23,7 @@ EKS cluster cold-start は cilium native CNI ENI mode (= PR #393) との chicken
 - `eks-production` cluster + 周辺 EKS stack が完全 destroy 済
 - VPC stack も destroy 済
 - `make eks-teardown ENV=production` 完走 + `make eks-teardown-verify ENV=production` で `No orphan resources detected` 確認済
+- `aws/iam-service-linked-roles` (`AWSServiceRoleForEC2Spot` 等、 account 単位 singleton) は本 runbook の destroy/recreate cycle 対象外。 account 初回 bootstrap 時に一度 apply されていれば以降は不要 (`aws iam get-role --role-name AWSServiceRoleForEC2Spot` で存在確認可能)
 
 ### 2.2 Operator environment
 
@@ -352,8 +353,7 @@ done
 | `flux-system` Kustomization `False` で webhook validation error | webhook 提供 HelmRelease (= cert-manager / external-secrets / opentelemetry-operator) が未起動 | **Phase 9.3a の bootstrap-webhooks apply (= PR #410) を実行済か確認**。 9.3a を skip した場合は数分待って Flux reconcile loop で self-heal 期待、 起動済なのに stuck なら `flux reconcile kustomization flux-system` で force trigger |
 | Pending pods が `pod has unbound immediate PersistentVolumeClaims` | gp3 StorageClass 未作成 | **PR #406 merge 後は不要**。 旧 cluster recreate で pre-PR #406 commit から始める場合のみ手動作成 |
 | post-merge CI が apply 中に operator local apply 試行で衝突 | CI が state lock 保持 | CI 完走待ち、 OR CI cancel + force-unlock。 将来は `skip-deploy` label scheme (= PR #404 design Phase B) で防止 |
-| Karpenter が spot node を起動できず consolidation/scale-out が進まない (= karpenter controller log に `AuthFailure.ServiceLinkedRoleCreationNotPermitted`) | `AWSServiceRoleForEC2Spot` service-linked role が account に未作成。 Karpenter controller IAM policy は least-privilege 設計で `iam:CreateServiceLinkedRole` を含まないため AWS 側の自動作成が失敗する | `aws/karpenter/modules/main.tf` の `aws_iam_service_linked_role.spot` で Phase 5 apply 時に作成される (= 過去に一度も spot instance を使ったことがない account での初回 bootstrap のみ発生しうる)。 それでも発生する場合は `aws iam get-role --role-name AWSServiceRoleForEC2Spot` で存在確認 |
-| `aws/karpenter` の `terragrunt destroy` (= teardown) が `aws_iam_service_linked_role.spot` で hang/fail する | spot instance が残っていて `DeleteServiceLinkedRole` が AWS 側で非同期に遅延/拒否される | `eks-teardown-k8s` (= spot instance 含む node 全 drain) が `eks-teardown-aws` より先に完走しているか確認。 詰まった場合は `aws iam get-service-linked-role-deletion-status --deletion-task-id <id>` で状態確認してから再 destroy |
+| Karpenter が spot node を起動できず consolidation/scale-out が進まない (= karpenter controller log に `AuthFailure.ServiceLinkedRoleCreationNotPermitted`) | `AWSServiceRoleForEC2Spot` service-linked role が account に未作成。 Karpenter controller IAM policy は least-privilege 設計で `iam:CreateServiceLinkedRole` を含まないため AWS 側の自動作成が失敗する | `aws/iam-service-linked-roles` (account 単位 singleton、 `aws/karpenter` の destroy/recreate cycle 対象外) を apply する。 通常は §2.1 の pre-condition で済んでいるはずなので、 発生する場合は `aws iam get-role --role-name AWSServiceRoleForEC2Spot` で存在確認 |
 
 ## 6. Future improvements
 


### PR DESCRIPTION
## Summary
- PR #672 で `aws/karpenter/modules/main.tf` に直接追加した `aws_iam_service_linked_role.spot` を、 新規 `aws/iam-service-linked-roles` stack へ分離
- 理由:
  1. `aws_iam_service_linked_role` は account 単位の singleton resource。 per-env stack (`aws/karpenter`) に埋め込むと、 将来 staging/develop 等の env が同一 account に増えた際、 2 つ目以降の env の apply が `EntityAlreadyExists` で確実に失敗する
  2. `aws/karpenter` は `docs/runbooks/eks-production-recreate.md` の destroy/recreate cycle 対象。 spot instance が残っている間の `DeleteServiceLinkedRole` 非同期遅延が無用な失敗点になっていた
- 新 stack は `envs/` を持たない単一 apply target (1 folder = 1 apply target)。 `envs/<env>/` 構成にすると「env を増やしてよい」という誤った前例になり、 上記 1. の問題を構造的に再導入してしまうため
- stack 名は特定 service に紐付けず汎用化 (`iam-service-linked-roles`)。 将来他の service-linked role が必要になっても、 この stack に resource block を追加するだけで済み、 SLR ごとに stack を新設しない
- 既存の `AWSServiceRoleForEC2Spot` は `terragrunt state rm` (karpenter 側) + `terragrunt import` (新 stack 側) で無停止移行
- runbook の Pre-conditions / Failure handling を新構成に合わせて更新

## Test plan
- [x] `terragrunt state rm` で karpenter state から除去、 実 AWS resource は無傷であることを確認
- [x] `terragrunt import` で新 stack state に取り込み
- [x] 両 stack で `terragrunt plan` = `No changes` (tag 更新のみ apply 済み)
- [x] `tofu fmt -check` 通過