### PR TITLE
fix(kubernetes): stop Karpenter node churn loop from hubble-relay affinity

### DIFF
--- a/kubernetes/components/cilium/production/values.yaml.gotmpl
+++ b/kubernetes/components/cilium/production/values.yaml.gotmpl
@@ -135,6 +135,24 @@ hubble:
         group: cert-manager.io
   relay:
     enabled: true
+    # chart default は podAffinity を requiredDuringScheduling で指定するが、
+    # Karpenter が新 node を provision した直後はまだ cilium DaemonSet pod が
+    # 存在しないため hubble-relay を配置できず、Karpenter が「capacity 不足」と
+    # 誤認して node を作り続けるループに入る (= spot 入れ替え時に発生、
+    # 1h で 8 launch / 5 delete の churn を観測)。
+    # cilium は全 node に DaemonSet で入るため preferred で実害はない。
+    # NOTE: chart default の requiredDuringScheduling は Helm の map deep merge
+    # で残るため、null で明示的に打ち消す必要がある。
+    affinity:
+      podAffinity:
+        requiredDuringSchedulingIgnoredDuringExecution: null
+        preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  k8s-app: cilium
+              topologyKey: kubernetes.io/hostname
   ui:
     enabled: true
   metrics:

--- a/kubernetes/components/karpenter/production/kustomization/nodepool.yaml
+++ b/kubernetes/components/karpenter/production/kustomization/nodepool.yaml
@@ -61,6 +61,10 @@ spec:
     # Karpenter v1+ valid values: WhenEmpty | WhenEmptyOrUnderutilized
     # (v0.x の WhenUnderutilized は廃止されているので使えない)。
     consolidationPolicy: WhenEmptyOrUnderutilized
-    consolidateAfter: 30s
+    # 30s は node 起動 (= EC2 boot + cilium CNI 準備で 1-2 分) より短く、
+    # provisioning 途中の一時的な低利用率を underutilized と誤判定して
+    # delete → 再 provision の往復を増幅させる。起動が落ち着いてから
+    # 判定させる。
+    consolidateAfter: 5m
   limits:
     cpu: "200"

--- a/kubernetes/manifests/production/cilium/manifest.yaml
+++ b/kubernetes/manifests/production/cilium/manifest.yaml
@@ -2290,11 +2290,13 @@ spec:
       terminationGracePeriodSeconds: 1
       affinity:
         podAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-          - labelSelector:
-              matchLabels:
-                k8s-app: cilium
-            topologyKey: kubernetes.io/hostname
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  k8s-app: cilium
+              topologyKey: kubernetes.io/hostname
+            weight: 100
       nodeSelector:
         kubernetes.io/os: linux
       volumes:

--- a/kubernetes/manifests/production/cilium/manifest.yaml
+++ b/kubernetes/manifests/production/cilium/manifest.yaml
@@ -7,7 +7,6 @@ metadata:
   labels:
     app.kubernetes.io/part-of: cilium
   annotations:
-
 ---
 # Source: cilium/templates/cilium-agent/serviceaccount.yaml
 apiVersion: v1
@@ -15,7 +14,6 @@ kind: ServiceAccount
 metadata:
   name: "cilium"
   namespace: kube-system
-
 ---
 # Source: cilium/templates/cilium-envoy/serviceaccount.yaml
 apiVersion: v1
@@ -23,7 +21,6 @@ kind: ServiceAccount
 metadata:
   name: "cilium-envoy"
   namespace: kube-system
-
 ---
 # Source: cilium/templates/cilium-operator/serviceaccount.yaml
 apiVersion: v1
@@ -31,7 +28,6 @@ kind: ServiceAccount
 metadata:
   name: "cilium-operator"
   namespace: kube-system
-
 ---
 # Source: cilium/templates/hubble-relay/serviceaccount.yaml
 apiVersion: v1
@@ -40,7 +36,6 @@ metadata:
   name: "hubble-relay"
   namespace: kube-system
 automountServiceAccountToken: false
-
 ---
 # Source: cilium/templates/hubble-ui/serviceaccount.yaml
 apiVersion: v1
@@ -48,7 +43,6 @@ kind: ServiceAccount
 metadata:
   name: "hubble-ui"
   namespace: kube-system
-
 ---
 # Source: cilium/templates/cilium-configmap.yaml
 # Will also do this for ipv6 when ENI mode works with ipv6.---
@@ -82,11 +76,13 @@ data:
 
   # If you want to run cilium in debug mode change this value to true
   debug: "false"
+  debug-verbose: ""
   metrics-sampling-interval: "5m"
   # The agent can be put into the following three policy enforcement modes
   # default, always and never.
   # https://docs.cilium.io/en/latest/security/policy/intro/#policy-enforcement-modes
   enable-policy: "default"
+  policy-cidr-match-mode: ""
   # If you want metrics enabled in all of your Cilium agents, set the port for
   # which the Cilium agents will have their metrics exposed.
   # This option deprecates the "prometheus-serve-addr" in the
@@ -233,6 +229,7 @@ data:
   kube-proxy-replacement-healthz-bind-address: ""
   enable-no-service-endpoints-routable: "true"
   bpf-lb-sock: "true"
+  nodeport-addresses: ""
   enable-health-check-nodeport: "true"
   enable-health-check-loadbalancer-ip: "false"
   node-port-bind-protection: "true"
@@ -368,7 +365,6 @@ data:
   # Keep the key name as bootstrap-config.json to avoid breaking changes
   bootstrap-config.json: |
     {"admin":{"address":{"pipe":{"mode":432,"path":"/var/run/cilium/envoy/sockets/admin.sock"}}},"applicationLogConfig":{"logFormat":{"textFormat":"[%Y-%m-%d %T.%e][%t][%l][%n] [%g:%#] %v"}},"bootstrapExtensions":[{"name":"envoy.bootstrap.internal_listener","typedConfig":{"@type":"type.googleapis.com/envoy.extensions.bootstrap.internal_listener.v3.InternalListener"}}],"dynamicResources":{"cdsConfig":{"apiConfigSource":{"apiType":"GRPC","grpcServices":[{"envoyGrpc":{"clusterName":"xds-grpc-cilium"}}],"setNodeOnFirstMessageOnly":true,"transportApiVersion":"V3"},"initialFetchTimeout":"30s","resourceApiVersion":"V3"},"ldsConfig":{"apiConfigSource":{"apiType":"GRPC","grpcServices":[{"envoyGrpc":{"clusterName":"xds-grpc-cilium"}}],"setNodeOnFirstMessageOnly":true,"transportApiVersion":"V3"},"initialFetchTimeout":"30s","resourceApiVersion":"V3"}},"node":{"cluster":"ingress-cluster","id":"host~127.0.0.1~no-id~localdomain"},"overloadManager":{"resourceMonitors":[{"name":"envoy.resource_monitors.global_downstream_max_connections","typedConfig":{"@type":"type.googleapis.com/envoy.extensions.resource_monitors.downstream_connections.v3.DownstreamConnectionsConfig","max_active_downstream_connections":"50000"}}]},"staticResources":{"clusters":[{"circuitBreakers":{"thresholds":[{"maxConnections":1024,"maxRequests":1024,"maxRetries":128}]},"cleanupInterval":"2.500s","connectTimeout":"2s","lbPolicy":"CLUSTER_PROVIDED","name":"ingress-cluster","type":"ORIGINAL_DST","typedExtensionProtocolOptions":{"envoy.extensions.upstreams.http.v3.HttpProtocolOptions":{"@type":"type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions","commonHttpProtocolOptions":{"idleTimeout":"60s","maxConnectionDuration":"0s","maxRequestsPerConnection":0},"useDownstreamProtocolConfig":{}}}},{"circuitBreakers":{"thresholds":[{"maxConnections":1024,"maxRequests":1024,"maxRetries":128}]},"cleanupInterval":"2.500s","connectTimeout":"2s","lbPolicy":"CLUSTER_PROVIDED","name":"egress-cluster-tls","transportSocket":{"name":"cilium.tls_wrapper","typedConfig":{"@type":"type.googleapis.com/cilium.UpstreamTlsWrapperContext"}},"type":"ORIGINAL_DST","typedExtensionProtocolOptions":{"envoy.extensions.upstreams.http.v3.HttpProtocolOptions":{"@type":"type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions","commonHttpProtocolOptions":{"idleTimeout":"60s","maxConnectionDuration":"0s","maxRequestsPerConnection":0},"upstreamHttpProtocolOptions":{},"useDownstreamProtocolConfig":{}}}},{"circuitBreakers":{"thresholds":[{"maxConnections":1024,"maxRequests":1024,"maxRetries":128}]},"cleanupInterval":"2.500s","connectTimeout":"2s","lbPolicy":"CLUSTER_PROVIDED","name":"egress-cluster","type":"ORIGINAL_DST","typedExtensionProtocolOptions":{"envoy.extensions.upstreams.http.v3.HttpProtocolOptions":{"@type":"type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions","commonHttpProtocolOptions":{"idleTimeout":"60s","maxConnectionDuration":"0s","maxRequestsPerConnection":0},"useDownstreamProtocolConfig":{}}}},{"circuitBreakers":{"thresholds":[{"maxConnections":1024,"maxRequests":1024,"maxRetries":128}]},"cleanupInterval":"2.500s","connectTimeout":"2s","lbPolicy":"CLUSTER_PROVIDED","name":"ingress-cluster-tls","transportSocket":{"name":"cilium.tls_wrapper","typedConfig":{"@type":"type.googleapis.com/cilium.UpstreamTlsWrapperContext"}},"type":"ORIGINAL_DST","typedExtensionProtocolOptions":{"envoy.extensions.upstreams.http.v3.HttpProtocolOptions":{"@type":"type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions","commonHttpProtocolOptions":{"idleTimeout":"60s","maxConnectionDuration":"0s","maxRequestsPerConnection":0},"upstreamHttpProtocolOptions":{},"useDownstreamProtocolConfig":{}}}},{"connectTimeout":"2s","loadAssignment":{"clusterName":"xds-grpc-cilium","endpoints":[{"lbEndpoints":[{"endpoint":{"address":{"pipe":{"path":"/var/run/cilium/envoy/sockets/xds.sock"}}}}]}]},"name":"xds-grpc-cilium","type":"STATIC","typedExtensionProtocolOptions":{"envoy.extensions.upstreams.http.v3.HttpProtocolOptions":{"@type":"type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions","explicitHttpConfig":{"http2ProtocolOptions":{}}}}},{"connectTimeout":"2s","loadAssignment":{"clusterName":"/envoy-admin","endpoints":[{"lbEndpoints":[{"endpoint":{"address":{"pipe":{"path":"/var/run/cilium/envoy/sockets/admin.sock"}}}}]}]},"name":"/envoy-admin","type":"STATIC"}],"listeners":[{"address":{"socketAddress":{"address":"0.0.0.0","portValue":9964}},"filterChains":[{"filters":[{"name":"envoy.filters.network.http_connection_manager","typedConfig":{"@type":"type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager","httpFilters":[{"name":"envoy.filters.http.router","typedConfig":{"@type":"type.googleapis.com/envoy.extensions.filters.http.router.v3.Router"}}],"internalAddressConfig":{"cidrRanges":[{"addressPrefix":"10.0.0.0","prefixLen":8},{"addressPrefix":"172.16.0.0","prefixLen":12},{"addressPrefix":"192.168.0.0","prefixLen":16},{"addressPrefix":"127.0.0.1","prefixLen":32}]},"routeConfig":{"virtualHosts":[{"domains":["*"],"name":"prometheus_metrics_route","routes":[{"match":{"prefix":"/metrics"},"name":"prometheus_metrics_route","route":{"cluster":"/envoy-admin","prefixRewrite":"/stats/prometheus"}}]}]},"statPrefix":"envoy-prometheus-metrics-listener","streamIdleTimeout":"300s"}}]}],"name":"envoy-prometheus-metrics-listener"},{"address":{"socketAddress":{"address":"127.0.0.1","portValue":9878}},"filterChains":[{"filters":[{"name":"envoy.filters.network.http_connection_manager","typedConfig":{"@type":"type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager","httpFilters":[{"name":"envoy.filters.http.router","typedConfig":{"@type":"type.googleapis.com/envoy.extensions.filters.http.router.v3.Router"}}],"internalAddressConfig":{"cidrRanges":[{"addressPrefix":"10.0.0.0","prefixLen":8},{"addressPrefix":"172.16.0.0","prefixLen":12},{"addressPrefix":"192.168.0.0","prefixLen":16},{"addressPrefix":"127.0.0.1","prefixLen":32}]},"routeConfig":{"virtual_hosts":[{"domains":["*"],"name":"health","routes":[{"match":{"prefix":"/healthz"},"name":"health","route":{"cluster":"/envoy-admin","prefixRewrite":"/ready"}}]}]},"statPrefix":"envoy-health-listener","streamIdleTimeout":"300s"}}]}],"name":"envoy-health-listener"}]}}
-
 ---
 # Source: cilium/templates/hubble-relay/configmap.yaml
 apiVersion: v1
@@ -391,7 +387,6 @@ data:
     tls-hubble-server-ca-files: /var/lib/hubble-relay/tls/hubble-server-ca.crt
     
     disable-server-tls: true
-
 ---
 # Source: cilium/templates/hubble-ui/configmap.yaml
 apiVersion: v1
@@ -401,7 +396,6 @@ metadata:
   namespace: kube-system
 data:
   nginx.conf: "server {\n    listen       8081;\n    listen       [::]:8081;\n    server_name  localhost;\n    root /app;\n    index index.html;\n    client_max_body_size 1G;\n\n    location / {\n        proxy_set_header Host $host;\n        proxy_set_header X-Real-IP $remote_addr;\n\n        location /api {\n            proxy_http_version 1.1;\n            proxy_pass_request_headers on;\n            proxy_pass http://127.0.0.1:8090;\n        }\n        location / {\n            if ($http_user_agent ~* \"kube-probe\") { access_log off; }\n            # double `/index.html` is required here\n            try_files $uri $uri/ /index.html /index.html;\n        }\n\n        # Liveness probe\n        location /healthz {\n            access_log off;\n            add_header Content-Type text/plain;\n            return 200 'ok';\n        }\n    }\n}"
-
 ---
 # Source: cilium/templates/cilium-agent/clusterrole.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -514,7 +508,6 @@ rules:
   - ciliumbgpnodeconfigs/status
   verbs:
   - patch
-
 ---
 # Source: cilium/templates/cilium-operator/clusterrole.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -830,7 +823,6 @@ rules:
   - ciliumendpointslices
   verbs:
   - deletecollection
-
 ---
 # Source: cilium/templates/hubble-ui/clusterrole.yaml
 kind: ClusterRole
@@ -862,7 +854,6 @@ rules:
   - get
   - list
   - watch
-
 ---
 # Source: cilium/templates/cilium-agent/clusterrolebinding.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -879,7 +870,6 @@ subjects:
 - kind: ServiceAccount
   name: "cilium"
   namespace: kube-system
-
 ---
 # Source: cilium/templates/cilium-operator/clusterrolebinding.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -896,7 +886,6 @@ subjects:
 - kind: ServiceAccount
   name: "cilium-operator"
   namespace: kube-system
-
 ---
 # Source: cilium/templates/hubble-ui/clusterrolebinding.yaml
 kind: ClusterRoleBinding
@@ -914,7 +903,6 @@ subjects:
 - kind: ServiceAccount
   name: "hubble-ui"
   namespace: kube-system
-
 ---
 # Source: cilium/templates/cilium-agent/role.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -969,7 +957,6 @@ rules:
   - get
   - list
   - watch
-
 ---
 # Source: cilium/templates/cilium-operator/role.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -1031,7 +1018,6 @@ rules:
   - get
   - list
   - watch
-
 ---
 # Source: cilium/templates/cilium-agent/rolebinding.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -1083,7 +1069,6 @@ subjects:
 - kind: ServiceAccount
   name: "cilium"
   namespace: kube-system
-
 ---
 # Source: cilium/templates/cilium-operator/rolebinding.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -1135,7 +1120,6 @@ subjects:
 - kind: ServiceAccount
   name: "cilium-operator"
   namespace: kube-system
-
 ---
 # Source: cilium/templates/cilium-agent/service.yaml
 apiVersion: v1
@@ -1157,7 +1141,6 @@ spec:
     port: 9962
     protocol: TCP
     targetPort: prometheus
-
 ---
 # Source: cilium/templates/cilium-envoy/service.yaml
 apiVersion: v1
@@ -1183,7 +1166,6 @@ spec:
     port: 9964
     protocol: TCP
     targetPort: 9964
-
 ---
 # Source: cilium/templates/cilium-operator/service.yaml
 kind: Service
@@ -1207,7 +1189,6 @@ spec:
   selector:
     io.cilium/app: operator
     name: cilium-operator
-
 ---
 # Source: cilium/templates/hubble-relay/service.yaml
 kind: Service
@@ -1229,7 +1210,6 @@ spec:
   - protocol: TCP
     port: 80
     targetPort: grpc
-
 ---
 # Source: cilium/templates/hubble-ui/service.yaml
 kind: Service
@@ -1250,7 +1230,6 @@ spec:
     - name: http
       port: 80
       targetPort: 8081
-
 ---
 # Source: cilium/templates/hubble/metrics-service.yaml
 apiVersion: v1
@@ -1274,7 +1253,6 @@ spec:
     targetPort: hubble-metrics
   selector:
     k8s-app: cilium
-
 ---
 # Source: cilium/templates/hubble/peer-service.yaml
 apiVersion: v1
@@ -1296,7 +1274,6 @@ spec:
     protocol: TCP
     targetPort: 4244
   internalTrafficPolicy: Local
-
 ---
 # Source: cilium/templates/cilium-agent/daemonset.yaml
 apiVersion: apps/v1
@@ -1846,8 +1823,6 @@ spec:
                 path: server.key
               - key: ca.crt
                 path: client-ca.crt
-      
-
 ---
 # Source: cilium/templates/cilium-envoy/daemonset.yaml
 apiVersion: apps/v1
@@ -2025,8 +2000,6 @@ spec:
         hostPath:
           path: /sys/fs/bpf
           type: DirectoryOrCreate
-    
-
 ---
 # Source: cilium/templates/cilium-operator/deployment.yaml
 apiVersion: apps/v1
@@ -2060,7 +2033,7 @@ spec:
     metadata:
       annotations:
         # ensure pods roll when configmap updates
-        cilium.io/cilium-configmap-checksum: "568135bcba0e96d1c4b600b651c80eaab9e5be71b95e3765850937e2f8ef49ff"
+        cilium.io/cilium-configmap-checksum: "5510373a0769c12a4c23f8fd575c9d909b65f34d6c2f463425992c6efd7f8c6c"
       labels:
         io.cilium/app: operator
         name: cilium-operator
@@ -2186,8 +2159,6 @@ spec:
       - name: cilium-config-path
         configMap:
           name: cilium-config
-      
-
 ---
 # Source: cilium/templates/hubble-relay/deployment.yaml
 apiVersion: apps/v1
@@ -2320,8 +2291,6 @@ spec:
                   path: client.key
                 - key: ca.crt
                   path: hubble-server-ca.crt
-      
-
 ---
 # Source: cilium/templates/hubble-ui/deployment.yaml
 kind: Deployment
@@ -2405,7 +2374,6 @@ spec:
         name: hubble-ui-nginx-conf
       - name: tmp-dir
         emptyDir: {}
-
 ---
 # Source: cilium/templates/hubble/tls-certmanager/relay-client-secret.yaml
 apiVersion: cert-manager.io/v1
@@ -2430,7 +2398,6 @@ spec:
     - signing
     - key encipherment
     - client auth
-
 ---
 # Source: cilium/templates/hubble/tls-certmanager/server-secret.yaml
 apiVersion: cert-manager.io/v1
@@ -2456,7 +2423,6 @@ spec:
     - key encipherment
     - server auth
     - client auth
-
 ---
 # Source: cilium/templates/cilium-agent/servicemonitor.yaml
 apiVersion: monitoring.coreos.com/v1
@@ -2490,7 +2456,6 @@ spec:
   # If it is not enabled, that means envoy runs inside cilium-agent and we'll monitor using same service
   targetLabels:
   - k8s-app
-
 ---
 # Source: cilium/templates/cilium-operator/servicemonitor.yaml
 apiVersion: monitoring.coreos.com/v1
@@ -2517,7 +2482,6 @@ spec:
     path: /metrics
   targetLabels:
   - io.cilium/app
-
 ---
 # Source: cilium/templates/hubble/servicemonitor.yaml
 apiVersion: monitoring.coreos.com/v1

--- a/kubernetes/manifests/production/karpenter/manifest.yaml
+++ b/kubernetes/manifests/production/karpenter/manifest.yaml
@@ -1797,7 +1797,6 @@ spec:
     matchLabels:
       app.kubernetes.io/name: karpenter
       app.kubernetes.io/instance: karpenter
-
 ---
 # Source: karpenter/templates/serviceaccount.yaml
 apiVersion: v1
@@ -1832,7 +1831,6 @@ rules:
   - apiGroups: ["karpenter.k8s.aws"]
     resources: ["ec2nodeclasses"]
     verbs: ["get", "list", "watch", "create", "delete", "patch"]
-
 ---
 # Source: karpenter/templates/clusterrole-core.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -1993,7 +1991,6 @@ rules:
     resources: ["services"]
     resourceNames: ["kube-dns"]
     verbs: ["get"]
-
 ---
 # Source: karpenter/templates/rolebinding.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -2059,7 +2056,6 @@ spec:
   selector:
     app.kubernetes.io/name: karpenter
     app.kubernetes.io/instance: karpenter
-
 ---
 # Source: karpenter/templates/deployment.yaml
 apiVersion: apps/v1
@@ -2245,7 +2241,7 @@ metadata:
   name: system-components
 spec:
   disruption:
-    consolidateAfter: 30s
+    consolidateAfter: 5m
     consolidationPolicy: WhenEmptyOrUnderutilized
   limits:
     cpu: "200"


### PR DESCRIPTION
## Summary
spot 入れ替えを起点に Karpenter が node を作り続けるループが発生し、pod が再スケジュールされ続けていた (1h で 8 launch / 5 delete を観測)。

**根本原因**: `hubble-relay` は cilium chart の default で podAffinity を `requiredDuringSchedulingIgnoredDuringExecution` 指定し、cilium agent と同一 node を強制する。Karpenter が新 node を provision した直後はその node にまだ cilium DaemonSet pod が存在しないため `hubble-relay` を配置できず、Karpenter が「capacity 不足」と誤認して新 node を作り続ける chicken-and-egg に陥っていた。

karpenter controller log で以下が 5 秒おきに繰り返されていた:
```
could not schedule pod ... hubble-relay-758b8867dd-xrqdm
error: unsatisfiable topology constraint for pod affinity, key=kubernetes.io/hostname
```

**対応**:
1. `hubble.relay.affinity` を `preferred` に緩和。cilium は全 node に DaemonSet で入るため実害はない。chart default は Helm の map deep merge で残るため `null` で明示的に打ち消している
2. `consolidateAfter` 30s → 5m。30s は node 起動 (EC2 boot + cilium CNI 準備で 1-2 分) より短く、provisioning 途中の一時的な低利用率を `underutilized` と誤判定して churn を増幅させていた

## Test plan
- [x] hydrate 後の manifest で `requiredDuringScheduling` が消え `preferred` のみになることを確認
- [ ] merge 後、Flux reconcile で適用されることを確認
- [ ] spot 入れ替え発生時に node churn ループが再発しないことを確認 (要経過観察)