### PR TITLE
chore(kubernetes): suspend monorepo-cluster Kustomization

### DIFF
--- a/docs/runbooks/eks-production-recreate.md
+++ b/docs/runbooks/eks-production-recreate.md
@@ -316,6 +316,8 @@ kubectl get pvc -A | grep -v Bound
 >
 > ただし **git 側で値を消した (= key ごと削除した) field は自動解除されない**。 Phase 4 の `cilium install` は field manager `cilium` で `Update` するため、 Flux (= field manager `kustomize-controller`) の server-side apply では他 manager 所有 field を削除できず、 cluster 上に残り続ける。 §5 Failure handling の該当行を参照。
 
+> **NOTE on monorepo**: `monorepo-cluster` Kustomization は `suspend: true` (= `kubernetes/clusters/production/repositories/monorepo.yaml`) で **意図的に停止中**。 monorepo 側 workload (= monolith / frontend) は production で正常動作しないため、 bootstrap 時も起動させない。 `default` namespace に pod が居ない / `monorepo-cluster` が `Suspended` なのは正常。 再開する場合は monorepo 側の動作を確認してから `suspend: false` に戻す。
+
 ## 4. Verification
 
 ```bash
@@ -329,7 +331,7 @@ cilium status
 
 # Kustomizations
 kubectl get kustomizations -A
-# → flux-system Ready=True、 monorepo-cluster は monorepo 側 manifests 依存
+# → flux-system Ready=True、 monorepo-cluster は Suspended (= 意図的に停止中、 Phase 10 NOTE 参照)
 
 # CiliumNode IP allocate
 kubectl get ciliumnodes -o jsonpath='{range .items[*]}{.metadata.name}{": "}{.spec.ipam.pool}{"\n"}{end}'

--- a/kubernetes/clusters/production/repositories/monorepo.yaml
+++ b/kubernetes/clusters/production/repositories/monorepo.yaml
@@ -32,7 +32,11 @@ spec:
   sourceRef:
     kind: GitRepository
     name: monorepo
-  suspend: false  # active; flip to `true` to halt monorepo Kustomization
+  # monorepo 側の workload (= monolith / frontend) は現状 production で正常に
+  # 動作しないため停止中。monolith は required な Secret (= monolith-database)
+  # が無く CreateContainerConfigError で起動しない。
+  # 再開する場合は monorepo 側の動作を確認してから `false` に戻す。
+  suspend: true
 ---
 # =============================================================================
 # ExternalSecret: Sync GitHub App credentials from AWS Secrets Manager


### PR DESCRIPTION
## Summary
monorepo 側の workload (monolith / frontend) は production で正常に動作しないため、`monorepo-cluster` Kustomization を `suspend: true` にして停止する。

- `monolith` は required な Secret (`monolith-database`) が存在せず `CreateContainerConfigError` で起動しない状態が続いていた
- `monorepo-cluster` は monorepo 側の各 service Kustomization を cascading で deploy する設計のため、root で suspend すれば配下ごと停止できる
- monorepo repository 側 (panicboat/monorepo) には手を加えない
- 再開する場合は monorepo 側の動作を確認してから `suspend: false` に戻す

あわせて runbook を更新:
- Phase 10 に NOTE を追加し、bootstrap 時も monorepo workload を起動させないこと・`default` namespace が空なのは正常であることを明記
- Verification の Kustomizations 期待値を `Suspended` に合わせて修正

## Test plan
- [x] git 側の `suspend: true` 反映
- [ ] merge 後、Flux reconcile で `monorepo-cluster` が Suspended になることを確認
- [ ] `default` namespace の monolith / frontend が除去されることを確認