### PR TITLE
fix(aws/eks): disable unused ebs-csi-driver snapshotter sidecar

### DIFF
--- a/aws/eks/modules/addons.tf
+++ b/aws/eks/modules/addons.tf
@@ -204,10 +204,21 @@ locals {
       # Tag dynamically provisioned EBS volumes (= PVC-driven) with the
       # controller's provenance label so they match the unified ManagedBy
       # schema. Per spec section 4-2-c.
+      #
+      # sidecars.snapshotter.forceEnable: addon default is true、 VolumeSnapshot
+      # を使わない本 cluster では snapshot.storage.k8s.io CRD (= 別途
+      # external-snapshotter install が必要、未導入) が無いため csi-snapshotter
+      # container が "failed to list *v1.VolumeSnapshotClass" を出し続ける。
+      # VolumeSnapshot 機能を使う予定がないため sidecar 自体を無効化する。
       configuration_values = jsonencode({
         controller = {
           extraVolumeTags = {
             ManagedBy = "aws-ebs-csi-driver"
+          }
+        }
+        sidecars = {
+          snapshotter = {
+            forceEnable = false
           }
         }
       })


### PR DESCRIPTION
## Summary
`ebs-csi-controller` の `csi-snapshotter` sidecar (aws-ebs-csi-driver addon default: `sidecars.snapshotter.forceEnable=true`) が、 `VolumeSnapshotClass` CRD (`snapshot.storage.k8s.io`、 external-snapshotter 別途 install が必要、 本 cluster では未導入) を watch できず以下のエラーを数秒おきに出し続けていた:

```
E... reflector.go:227] "Failed to watch" err="failed to list *v1.VolumeSnapshotClass: the server could not find the requested resource (get volumesnapshotclasses.snapshot.storage.k8s.io)"
```

VolumeSnapshot 機能を使う予定がないため、 CRD を追加導入するのではなく sidecar 自体を `sidecars.snapshotter.forceEnable=false` で無効化する。

## Test plan
- [x] `aws eks describe-addon-configuration` で正しい config path (`sidecars.snapshotter.forceEnable`、 `controller` 配下ではない) を確認
- [x] production cluster で apply 実施。 `ebs-csi-controller` pod の container 数が 6→5 (`csi-snapshotter` 消失) を確認
- [x] 60秒観測でエラーログの再発なしを確認
- [x] 全 PVC Bound、 全 pod Running (影響なし) を確認