### PR TITLE
fix(kubernetes/dashboard): correct kube_pod_status_phase query filters

### DIFF
--- a/kubernetes/components/dashboard/production/kustomization/grafana/app-monitoring.json
+++ b/kubernetes/components/dashboard/production/kustomization/grafana/app-monitoring.json
@@ -143,7 +143,7 @@
             "type": "prometheus",
             "uid": "mimir"
           },
-          "expr": "count(kube_pod_status_phase{namespace=~\"$namespace\", phase!=\"Running\", phase!=\"Succeeded\"})",
+          "expr": "count(kube_pod_status_phase{namespace=~\"$namespace\", phase!=\"Running\", phase!=\"Succeeded\"} == 1)",
           "refId": "A"
         }
       ],

--- a/kubernetes/components/dashboard/production/kustomization/grafana/infra-monitoring.json
+++ b/kubernetes/components/dashboard/production/kustomization/grafana/infra-monitoring.json
@@ -257,7 +257,7 @@
             "type": "prometheus",
             "uid": "mimir"
           },
-          "expr": "count(kube_pod_status_phase{namespace=~\"$namespace\", phase=\"Running\"})",
+          "expr": "count(kube_pod_status_phase{namespace=~\"$namespace\", phase=\"Running\"} == 1)",
           "refId": "A"
         }
       ],
@@ -318,7 +318,7 @@
             "type": "prometheus",
             "uid": "mimir"
           },
-          "expr": "count(kube_pod_status_phase{namespace=~\"$namespace\", phase!=\"Running\", phase!=\"Succeeded\"})",
+          "expr": "count(kube_pod_status_phase{namespace=~\"$namespace\", phase!=\"Running\", phase!=\"Succeeded\"} == 1)",
           "refId": "A"
         }
       ],

--- a/kubernetes/components/dashboard/production/kustomization/grafana/unified-monitoring.json
+++ b/kubernetes/components/dashboard/production/kustomization/grafana/unified-monitoring.json
@@ -143,7 +143,7 @@
             "type": "prometheus",
             "uid": "mimir"
           },
-          "expr": "count(kube_pod_status_phase{namespace=~\"$namespace\", phase!=\"Running\", phase!=\"Succeeded\"})",
+          "expr": "count(kube_pod_status_phase{namespace=~\"$namespace\", phase!=\"Running\", phase!=\"Succeeded\"} == 1)",
           "refId": "A"
         }
       ],

--- a/kubernetes/manifests/production/dashboard/manifest.yaml
+++ b/kubernetes/manifests/production/dashboard/manifest.yaml
@@ -147,7 +147,7 @@ data:
                 "type": "prometheus",
                 "uid": "mimir"
               },
-              "expr": "count(kube_pod_status_phase{namespace=~\"$namespace\", phase!=\"Running\", phase!=\"Succeeded\"})",
+              "expr": "count(kube_pod_status_phase{namespace=~\"$namespace\", phase!=\"Running\", phase!=\"Succeeded\"} == 1)",
               "refId": "A"
             }
           ],
@@ -1106,7 +1106,7 @@ data:
                 "type": "prometheus",
                 "uid": "mimir"
               },
-              "expr": "count(kube_pod_status_phase{namespace=~\"$namespace\", phase=\"Running\"})",
+              "expr": "count(kube_pod_status_phase{namespace=~\"$namespace\", phase=\"Running\"} == 1)",
               "refId": "A"
             }
           ],
@@ -1167,7 +1167,7 @@ data:
                 "type": "prometheus",
                 "uid": "mimir"
               },
-              "expr": "count(kube_pod_status_phase{namespace=~\"$namespace\", phase!=\"Running\", phase!=\"Succeeded\"})",
+              "expr": "count(kube_pod_status_phase{namespace=~\"$namespace\", phase!=\"Running\", phase!=\"Succeeded\"} == 1)",
               "refId": "A"
             }
           ],
@@ -2023,7 +2023,7 @@ data:
                 "type": "prometheus",
                 "uid": "mimir"
               },
-              "expr": "count(kube_pod_status_phase{namespace=~\"$namespace\", phase!=\"Running\", phase!=\"Succeeded\"})",
+              "expr": "count(kube_pod_status_phase{namespace=~\"$namespace\", phase!=\"Running\", phase!=\"Succeeded\"} == 1)",
               "refId": "A"
             }
           ],


### PR DESCRIPTION
## Summary
Grafana ダッシュボードの Unhealthy Pods 数値が異常という報告を受けて調査。3 dashboard (infra-monitoring / app-monitoring / unified-monitoring) 共通で使われている PromQL が典型的な `kube_pod_status_phase` 誤用だった。

`kube_pod_status_phase` は kube-state-metrics が pod ごとに **全 phase (Pending/Running/Succeeded/Failed/Unknown) の time series** を出力し、実際にその phase かどうかは metric value (0 or 1) で示す仕様。value を見ずに label だけで絞ると、`phase!="Running"` のような条件では該当しない phase の `value=0` series まで全て count してしまう。

実測 (production Prometheus, 全 94 pod Running な状態):
| query | 表示値 | 実際 |
|---|---|---|
| `count(kube_pod_status_phase{phase!="Running", phase!="Succeeded"})` (旧) | **282** | 0 |
| `count(kube_pod_status_phase{phase!="Running", phase!="Succeeded"} == 1)` (新) | **0** | 0 |

282 ≈ 94 pod × 3 phase (Pending/Failed/Unknown の value=0 series を計上) と一致。

Running Pods panel (infra-monitoring のみ) も同型のバグで、`phase="Running"` の series を value 無視で数えていたため実質「total pod 数」を表示していた。全 pod healthy な間はたまたま正しい値に見えるだけで、1 pod でも unhealthy になった瞬間から不正確になる。

`Total Pods` (`kube_pod_info`, info-metric で 0/1 問題なし) と `Pod Status` (table panel、raw 0/1 を value mapping で意図的に表示) は対象外。

## Test plan
- [x] production Prometheus に対して修正前後の query を実行し、282→0 (正しい値) を確認
- [x] `kubectl kustomize` で構文確認
- [x] 全 JSON の valid 確認

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Grafana pod-status monitoring by counting only active phase metrics.
  * Updated “Running Pods” and “Unhealthy Pods” panels to provide more accurate counts.
  * Unhealthy pod totals now exclude pods in `Running` or `Succeeded` states and avoid counting zero-valued metrics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->