### PR TITLE
docs(specs): add GWS SSO design for AWS Identity Center and Grafana

### DIFF
--- a/docs/superpowers/plans/2026-08-02-gws-sso-aws-identity-center.md
+++ b/docs/superpowers/plans/2026-08-02-gws-sso-aws-identity-center.md
@@ -1,0 +1,1020 @@
+# GWS SSO: AWS Identity Center Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** AWS ログイン（Console + kubectl/EKS API）を、AWS IAM Identity Center + Google Workspace SAML/SCIM 連携によるロールベース SSO（Admin/Viewer の 2 Permission Set）に置き換える。既存の root-trust `eks-admin` role は、Identity Center 経由アクセスの動作確認後に削除する。
+
+**Architecture:** account-wide singleton stack `aws/iam-identity-center` を新設し、`PlatformAdmin`（`AdministratorAccess`）/ `PlatformViewer`（`ReadOnlyAccess`）の 2 Permission Set を Google Workspace 側で SCIM 同期済の Google Group（`aws-admins@panicboat.net` / `aws-viewers@panicboat.net`）に Account Assignment する。`aws/eks/modules/access_entries.tf` は Identity Center が発行する Reserved SSO Role ARN を `data "aws_iam_roles"`（name_regex）で直接解決し、EKS Access Entry（`AmazonEKSClusterAdminPolicy` / `AmazonEKSViewPolicy`）に紐付ける。ロールバック不能なロックアウトを避けるため、新旧 2 経路を一時的に並走させてから旧経路（root-trust `eks-admin` role）を削除する 2 段階ロールアウトにする。
+
+**Tech Stack:** OpenTofu `1.12.5`, Terragrunt, AWS provider `6.56.0`（`aws/eks` の既存 pin に合わせる）, AWS IAM Identity Center (`aws_ssoadmin_*` / `aws_identitystore_group`)
+
+**Spec:** `docs/superpowers/specs/2026-08-01-gws-sso-design.md`
+
+## Global Constraints
+
+- OpenTofu `required_version = "1.12.5"`, AWS provider `version = "6.56.0"`（`aws/eks/modules/terraform.tf` と同一 pin）
+- AWS region: `ap-northeast-1`
+- Google Workspace domain: `panicboat.net`
+- Google Group: `aws-admins@panicboat.net`（Admin）/ `aws-viewers@panicboat.net`（Viewer）、SCIM で Identity Store に同期済であることが前提
+- EKS Access Policy ARN scheme: `arn:aws:eks::aws:cluster-access-policy/<NAME>`（IAM managed policy 形式ではない）
+- git commit は `-s`（signoff）を付与、`Co-Authored-By` は付与しない
+
+---
+
+## File Structure
+
+| File | Status | Responsibility |
+|---|---|---|
+| `aws/iam-identity-center/root.hcl` | create | Terragrunt root 設定（remote state / common tags） |
+| `aws/iam-identity-center/envs/production/env.hcl` | create | production 環境設定 |
+| `aws/iam-identity-center/envs/production/terragrunt.hcl` | create | production terragrunt 設定 |
+| `aws/iam-identity-center/modules/terraform.tf` | create | OpenTofu / AWS provider 宣言 |
+| `aws/iam-identity-center/modules/variables.tf` | create | 入力変数 |
+| `aws/iam-identity-center/modules/main.tf` | create | Permission Set × 2、managed policy attachment × 2、account assignment × 2 |
+| `aws/iam-identity-center/modules/outputs.tf` | create | permission set ARN 等の output |
+| `aws/iam-identity-center/README.md` | create | singleton stack の運用メモ |
+| `aws/eks/modules/access_entries.tf` | modify（2 回: Task 2 で追加、Task 4 で `human_admin` 削除） | Identity Center Reserved Role → EKS Access Entry |
+| `aws/eks/modules/iam_admin.tf` | delete（Task 4） | root-trust `eks-admin` role（不要になる） |
+| `aws/eks/modules/outputs.tf` | modify（Task 4） | `admin_role_arn` / `admin_role_name` output 削除 |
+| `aws/eks/README.md` | modify（Task 5） | kubectl access 手順を Identity Center ベースに更新 |
+
+**変更しないもの**: `aws/github-oidc-auth/*`（CI 用 machine identity）、`kubernetes/*`（別 plan `2026-08-02-gws-sso-grafana-domain.md` で扱う）
+
+---
+
+## Task 0: Pre-flight — worktree/branch 状態 + 手動 Manual Setup の完了確認
+
+**Files:** (確認のみ、変更なし)
+
+**Context:** `docs/superpowers/specs/2026-08-01-gws-sso-design.md` の Manual Setup（1〜4）が完了していないと、本 plan の Terraform は `NotFound` で失敗する。Terraform を書き始める前に前提を確認する。
+
+- [ ] **Step 1: worktree/branch 状態確認**
+
+```bash
+cd /Users/takanokenichi/GitHub/panicboat/platform/.claude/worktrees/feat-gws-sso
+git fetch origin main
+git log --oneline origin/main..HEAD
+```
+
+Expected: spec commit 1 つのみ ahead（`docs(specs): add GWS SSO design for AWS Identity Center and Grafana`）
+
+- [ ] **Step 2: AWS IAM Identity Center instance の有効化を確認**
+
+```bash
+aws sso-admin list-instances --region ap-northeast-1 --output table
+```
+
+Expected: 1 件の instance が `Status: ACTIVE` で表示される。表示されない場合は spec の Manual Setup Step 1 が未完了 — panicboat に完了を依頼してから先に進む。
+
+- [ ] **Step 3: Google Workspace Group の SCIM 同期を確認**
+
+Step 2 の出力から `IdentityStoreId` を控え、以下を実行:
+
+```bash
+IDENTITY_STORE_ID="<Step 2 で取得した IdentityStoreId>"
+aws identitystore list-groups \
+  --identity-store-id "${IDENTITY_STORE_ID}" \
+  --region ap-northeast-1 \
+  --query "Groups[].DisplayName" \
+  --output table
+```
+
+Expected: `aws-admins` と `aws-viewers` の 2 件が表示される。表示されない場合は spec の Manual Setup Step 2〜4（SAML/SCIM 設定 + Google Group 作成）が未完了。
+
+---
+
+## Task 1: `aws/iam-identity-center` stack 新設（Permission Set + Account Assignment）
+
+**Files:**
+- Create: `aws/iam-identity-center/root.hcl`
+- Create: `aws/iam-identity-center/envs/production/env.hcl`
+- Create: `aws/iam-identity-center/envs/production/terragrunt.hcl`
+- Create: `aws/iam-identity-center/modules/terraform.tf`
+- Create: `aws/iam-identity-center/modules/variables.tf`
+- Create: `aws/iam-identity-center/modules/main.tf`
+- Create: `aws/iam-identity-center/modules/outputs.tf`
+- Create: `aws/iam-identity-center/README.md`
+
+**Context:** `aws/iam-service-linked-roles` と同じ account-wide singleton stack パターン（`envs/production` のみ）を踏襲する。
+
+- [ ] **Step 1: `aws/iam-identity-center/modules/terraform.tf` を作成**
+
+```hcl
+# terraform.tf - OpenTofu and provider configuration
+
+terraform {
+  required_version = "1.12.5"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "6.56.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.aws_region
+
+  default_tags {
+    tags = var.common_tags
+  }
+}
+```
+
+- [ ] **Step 2: `aws/iam-identity-center/modules/variables.tf` を作成**
+
+```hcl
+# variables.tf - Input variables for the IAM Identity Center module
+
+variable "environment" {
+  description = "Environment name"
+  type        = string
+}
+
+variable "aws_region" {
+  description = "AWS region"
+  type        = string
+  default     = "ap-northeast-1"
+}
+
+variable "common_tags" {
+  description = "Common tags to apply to all resources"
+  type        = map(string)
+  default     = {}
+}
+
+variable "admin_group_display_name" {
+  description = "Google Workspace group (SCIM 同期済) に付与する PlatformAdmin permission set の対象グループ名"
+  type        = string
+  default     = "aws-admins"
+}
+
+variable "viewer_group_display_name" {
+  description = "Google Workspace group (SCIM 同期済) に付与する PlatformViewer permission set の対象グループ名"
+  type        = string
+  default     = "aws-viewers"
+}
+```
+
+- [ ] **Step 3: `aws/iam-identity-center/modules/main.tf` を作成**
+
+```hcl
+# main.tf - Account 単位の IAM Identity Center Permission Set / Account Assignment。
+#
+# Identity Center instance 自体の有効化と、Google Workspace 側の SAML app /
+# SCIM provisioning 設定は AWS Console / Google Admin Console での手動作業
+# (= docs/superpowers/specs/2026-08-01-gws-sso-design.md の Manual Setup 参照)。
+# ここでは既存 instance を data source で参照し、Permission Set と
+# Google Group (SCIM 同期済) への Account Assignment のみを管理する。
+#
+# aws/iam-service-linked-roles と同様、account 単位 singleton stack として
+# envs/production のみを使う。
+
+data "aws_ssoadmin_instances" "this" {}
+
+data "aws_caller_identity" "current" {}
+
+locals {
+  instance_arn      = tolist(data.aws_ssoadmin_instances.this.arns)[0]
+  identity_store_id = tolist(data.aws_ssoadmin_instances.this.identity_store_ids)[0]
+}
+
+# Google Workspace 側で作成し SCIM で Identity Store に同期済のグループ。
+# 未同期の状態で apply すると NotFound で失敗する (= Task 0 の pre-flight で確認済の前提)。
+data "aws_identitystore_group" "admin" {
+  identity_store_id = local.identity_store_id
+
+  alternate_identifier {
+    unique_attribute {
+      attribute_path  = "DisplayName"
+      attribute_value = var.admin_group_display_name
+    }
+  }
+}
+
+data "aws_identitystore_group" "viewer" {
+  identity_store_id = local.identity_store_id
+
+  alternate_identifier {
+    unique_attribute {
+      attribute_path  = "DisplayName"
+      attribute_value = var.viewer_group_display_name
+    }
+  }
+}
+
+resource "aws_ssoadmin_permission_set" "admin" {
+  name             = "PlatformAdmin"
+  description      = "Full AWS account access via Google Workspace SSO (aws-admins group)"
+  instance_arn     = local.instance_arn
+  session_duration = "PT1H"
+}
+
+resource "aws_ssoadmin_managed_policy_attachment" "admin" {
+  instance_arn       = local.instance_arn
+  permission_set_arn = aws_ssoadmin_permission_set.admin.arn
+  managed_policy_arn = "arn:aws:iam::aws:policy/AdministratorAccess"
+}
+
+# account_assignment は managed_policy_attachment とは互いに他方を
+# 参照しないため、暗黙の依存関係が発生しない。Account Assignment の
+# provisioning 時点でポリシーが未アタッチだと不完全な状態で provision
+# されうるため、明示的に depends_on で順序を固定する。
+resource "aws_ssoadmin_account_assignment" "admin" {
+  instance_arn       = local.instance_arn
+  permission_set_arn = aws_ssoadmin_permission_set.admin.arn
+
+  principal_id   = data.aws_identitystore_group.admin.group_id
+  principal_type = "GROUP"
+
+  target_id   = data.aws_caller_identity.current.account_id
+  target_type = "AWS_ACCOUNT"
+
+  depends_on = [aws_ssoadmin_managed_policy_attachment.admin]
+}
+
+resource "aws_ssoadmin_permission_set" "viewer" {
+  name             = "PlatformViewer"
+  description      = "Read-only AWS account access via Google Workspace SSO (aws-viewers group)"
+  instance_arn     = local.instance_arn
+  session_duration = "PT1H"
+}
+
+resource "aws_ssoadmin_managed_policy_attachment" "viewer" {
+  instance_arn       = local.instance_arn
+  permission_set_arn = aws_ssoadmin_permission_set.viewer.arn
+  managed_policy_arn = "arn:aws:iam::aws:policy/ReadOnlyAccess"
+}
+
+resource "aws_ssoadmin_account_assignment" "viewer" {
+  instance_arn       = local.instance_arn
+  permission_set_arn = aws_ssoadmin_permission_set.viewer.arn
+
+  principal_id   = data.aws_identitystore_group.viewer.group_id
+  principal_type = "GROUP"
+
+  target_id   = data.aws_caller_identity.current.account_id
+  target_type = "AWS_ACCOUNT"
+
+  depends_on = [aws_ssoadmin_managed_policy_attachment.viewer]
+}
+```
+
+- [ ] **Step 4: `aws/iam-identity-center/modules/outputs.tf` を作成**
+
+```hcl
+# outputs.tf - Outputs for the IAM Identity Center module
+
+output "instance_arn" {
+  description = "IAM Identity Center instance ARN"
+  value       = local.instance_arn
+}
+
+output "admin_permission_set_arn" {
+  description = "ARN of the PlatformAdmin permission set"
+  value       = aws_ssoadmin_permission_set.admin.arn
+}
+
+output "viewer_permission_set_arn" {
+  description = "ARN of the PlatformViewer permission set"
+  value       = aws_ssoadmin_permission_set.viewer.arn
+}
+```
+
+- [ ] **Step 5: `aws/iam-identity-center/root.hcl` を作成**
+
+```hcl
+# root.hcl - Root Terragrunt configuration for iam-identity-center
+# This file contains common settings shared across all environments
+
+locals {
+  # Project metadata
+  project_name = "iam-identity-center"
+
+  # Parse environment from the directory path
+  # This assumes environments are in envs/<environment>/ directories
+  path_parts  = split("/", path_relative_to_include())
+  environment = element(local.path_parts, length(local.path_parts) - 1)
+
+  # Common tags applied to all resources
+  common_tags = {
+    Project     = local.project_name
+    Environment = local.environment
+    ManagedBy   = "terragrunt"
+    Repository  = "monorepo"
+    Component   = "iam-identity-center"
+    Team        = "panicboat"
+  }
+}
+
+# Remote state configuration using shared S3 bucket
+remote_state {
+  backend = "s3"
+  generate = {
+    path      = "backend.tf"
+    if_exists = "overwrite_terragrunt"
+  }
+  config = {
+    # Shared bucket for all monorepo services
+    bucket = "terragrunt-state-${get_aws_account_id()}"
+
+    # Service-specific path: iam-identity-center/<environment>/terraform.tfstate
+    key    = "platform/iam-identity-center/${local.environment}/terraform.tfstate"
+    region = "ap-northeast-1"
+
+    # Shared DynamoDB table for state locking across all services
+    dynamodb_table = "terragrunt-state-locks"
+
+    # Enable server-side encryption
+    encrypt = true
+  }
+}
+
+# Common inputs passed to all Terraform modules
+inputs = {
+  environment = local.environment
+  common_tags = local.common_tags
+}
+```
+
+- [ ] **Step 6: `aws/iam-identity-center/envs/production/env.hcl` を作成**
+
+```hcl
+# env.hcl - Environment-specific configuration for production
+
+locals {
+  # Environment-specific settings
+  environment = "production"
+
+  # AWS configuration
+  aws_region = "ap-northeast-1"
+
+  # Environment-specific tags
+  environment_tags = {
+    Environment = local.environment
+    Component   = "iam-identity-center"
+    Owner       = "panicboat"
+  }
+}
+```
+
+- [ ] **Step 7: `aws/iam-identity-center/envs/production/terragrunt.hcl` を作成**
+
+```hcl
+# terragrunt.hcl - Terragrunt configuration for production environment
+
+# Include root configuration
+include "root" {
+  path = find_in_parent_folders("root.hcl")
+}
+
+# Include environment-specific configuration
+include "env" {
+  path   = "env.hcl"
+  expose = true
+}
+
+# Reference to Terraform modules
+terraform {
+  source = "../../modules"
+}
+
+# Input variables for the module
+inputs = {
+  environment = include.env.locals.environment
+  aws_region  = include.env.locals.aws_region
+
+  common_tags = merge(
+    include.env.locals.environment_tags,
+    {
+      Project    = "iam-identity-center"
+      ManagedBy  = "terraform"
+      Repository = "panicboat/platform"
+    }
+  )
+}
+```
+
+- [ ] **Step 8: `aws/iam-identity-center/README.md` を作成**
+
+```markdown
+# iam-identity-center
+
+AWS IAM Identity Center の Permission Set (`PlatformAdmin` / `PlatformViewer`) と、Google Workspace (SCIM 同期済) Group への Account Assignment を管理する stack。
+
+## Instance 自体は Terraform 管理外
+
+Identity Center instance の有効化、Google Workspace 側の SAML app 設定、SCIM provisioning は AWS Console / Google Admin Console での手動作業。手順は `docs/superpowers/specs/2026-08-01-gws-sso-design.md` の Manual Setup を参照。
+
+## envs/production のみを使う
+
+account 単位の singleton stack（Identity Center instance は 1 account 1 instance）。`envs/production` 以外の環境ディレクトリを追加しないこと。
+
+## 前提: Google Group が SCIM 同期済であること
+
+`data.aws_identitystore_group` は Google Workspace 側で作成し SCIM 同期済のグループ（`aws-admins` / `aws-viewers`）を name lookup する。未同期の状態で apply すると `NotFound` で失敗する。
+```
+
+- [ ] **Step 9: format + validate（AWS 認証不要）**
+
+```bash
+terraform fmt -check aws/iam-identity-center/modules/*.tf
+terraform -chdir=aws/iam-identity-center/modules init -backend=false
+terraform -chdir=aws/iam-identity-center/modules validate
+```
+
+Expected: `fmt -check` は差分なし（exit 0）。`validate` は `Success! The configuration is valid.`
+
+- [ ] **Step 10: terragrunt plan（要 AWS 認証 + Task 0 の前提確認済）**
+
+```bash
+cd aws/iam-identity-center/envs/production
+TG_TF_PATH=tofu terragrunt init
+TG_TF_PATH=tofu terragrunt plan
+```
+
+Expected: `Plan: 6 to add, 0 to change, 0 to destroy`（`aws_ssoadmin_permission_set` × 2、`aws_ssoadmin_managed_policy_attachment` × 2、`aws_ssoadmin_account_assignment` × 2）。`NotFound` エラーが出る場合は Task 0 の Manual Setup 確認に戻る。
+
+- [ ] **Step 11: terragrunt apply**
+
+```bash
+cd aws/iam-identity-center/envs/production
+TG_TF_PATH=tofu terragrunt apply -auto-approve
+```
+
+Expected: Step 10 と同じ 6 resources が `Apply complete!` で作成される。
+
+- [ ] **Step 12: Commit**
+
+```bash
+git add aws/iam-identity-center/
+git commit -s -m "feat(aws): add IAM Identity Center Permission Sets for Google Workspace SSO
+
+PlatformAdmin / PlatformViewer permission set を SCIM 同期済の Google
+Group (aws-admins / aws-viewers) に account assignment する。Identity
+Center instance と Google 側 SAML/SCIM 設定は手動 (spec の Manual Setup 参照)。"
+```
+
+---
+
+## Task 2: `aws/eks` に Identity Center 経由の Access Entry を追加（既存 `eks-admin` 経路と並走）
+
+**Files:**
+- Modify: `aws/eks/modules/access_entries.tf`
+
+**Context:** ロックアウトを避けるため、旧 root-trust `eks-admin` role 経路を残したまま Identity Center 経路を追加する。両方が並走した状態で Task 3 の動作確認を行い、確認が取れてから Task 4 で旧経路を削除する。
+
+- [ ] **Step 1: `aws/eks/modules/access_entries.tf` を編集**
+
+Old:
+```hcl
+# access_entries.tf - EKS Access Entries (Kubernetes RBAC mapping for IAM principals).
+#
+# We keep this minimal: only the human kubectl admin role is granted RBAC.
+# The CI apply role (github-oidc-auth-production-github-actions-role)
+# operates on AWS APIs only and never touches Kubernetes API; under the
+# GitOps model, all Kubernetes-side changes flow through Flux CD.
+#
+# Note on policy_arn format: EKS Access Policies use a dedicated ARN
+# scheme `arn:aws:eks::aws:cluster-access-policy/<NAME>`, NOT the IAM
+# managed policy form `arn:aws:iam::aws:policy/<NAME>`. Passing the IAM
+# form to AssociateAccessPolicy yields InvalidParameterException (400).
+
+locals {
+  access_entries = {
+    human_admin = {
+      principal_arn = aws_iam_role.eks_admin.arn
+
+      policy_associations = {
+        cluster_admin = {
+          policy_arn = "arn:aws:eks::aws:cluster-access-policy/AmazonEKSClusterAdminPolicy"
+          access_scope = {
+            type = "cluster"
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+New:
+```hcl
+# access_entries.tf - EKS Access Entries (Kubernetes RBAC mapping for IAM principals).
+#
+# We keep this minimal: only human kubectl principals get RBAC. The CI apply
+# role (github-oidc-auth-production-github-actions-role) operates on AWS APIs
+# only and never touches Kubernetes API; under the GitOps model, all
+# Kubernetes-side changes flow through Flux CD.
+#
+# human_admin (root-trust eks-admin role) is being phased out in favor of AWS
+# IAM Identity Center (aws/iam-identity-center, Google Workspace SSO). Both
+# paths are active in parallel until Identity Center kubectl access is
+# verified end-to-end, after which human_admin is removed
+# (docs/superpowers/plans/2026-08-02-gws-sso-aws-identity-center.md Task 4).
+#
+# Reserved SSO role ARNs are only assigned by AWS after the Permission Set's
+# Account Assignment exists (aws/iam-identity-center), so the data sources
+# below return an empty list if that stack hasn't been applied yet.
+#
+# Note on policy_arn format: EKS Access Policies use a dedicated ARN
+# scheme `arn:aws:eks::aws:cluster-access-policy/<NAME>`, NOT the IAM
+# managed policy form `arn:aws:iam::aws:policy/<NAME>`. Passing the IAM
+# form to AssociateAccessPolicy yields InvalidParameterException (400).
+
+data "aws_iam_roles" "identity_center_admin" {
+  name_regex  = "AWSReservedSSO_PlatformAdmin_.*"
+  path_prefix = "/aws-reserved/sso.amazonaws.com/"
+}
+
+data "aws_iam_roles" "identity_center_viewer" {
+  name_regex  = "AWSReservedSSO_PlatformViewer_.*"
+  path_prefix = "/aws-reserved/sso.amazonaws.com/"
+}
+
+locals {
+  access_entries = {
+    human_admin = {
+      principal_arn = aws_iam_role.eks_admin.arn
+
+      policy_associations = {
+        cluster_admin = {
+          policy_arn = "arn:aws:eks::aws:cluster-access-policy/AmazonEKSClusterAdminPolicy"
+          access_scope = {
+            type = "cluster"
+          }
+        }
+      }
+    }
+
+    identity_center_admin = {
+      principal_arn = tolist(data.aws_iam_roles.identity_center_admin.arns)[0]
+
+      policy_associations = {
+        cluster_admin = {
+          policy_arn = "arn:aws:eks::aws:cluster-access-policy/AmazonEKSClusterAdminPolicy"
+          access_scope = {
+            type = "cluster"
+          }
+        }
+      }
+    }
+
+    identity_center_viewer = {
+      principal_arn = tolist(data.aws_iam_roles.identity_center_viewer.arns)[0]
+
+      policy_associations = {
+        view = {
+          policy_arn = "arn:aws:eks::aws:cluster-access-policy/AmazonEKSViewPolicy"
+          access_scope = {
+            type = "cluster"
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+- [ ] **Step 2: format check**
+
+```bash
+terraform fmt -check aws/eks/modules/access_entries.tf
+```
+
+Expected: 出力なし（exit 0）
+
+- [ ] **Step 3: terragrunt plan**
+
+```bash
+cd aws/eks/envs/production
+TG_TF_PATH=tofu terragrunt plan
+```
+
+Expected: `Plan: 2 to add, 0 to change, 0 to destroy`（`identity_center_admin` / `identity_center_viewer` の access entry 2 件のみ追加、既存 `human_admin` は無変更）。`data.aws_iam_roles` が空リストを返す場合は Task 1 の apply が未完了か、Permission Set 名の typo が原因 — `aws iam list-roles --path-prefix /aws-reserved/sso.amazonaws.com/ --query "Roles[].RoleName"` で実際の Reserved Role 名を確認する。
+
+- [ ] **Step 4: terragrunt apply**
+
+```bash
+cd aws/eks/envs/production
+TG_TF_PATH=tofu terragrunt apply -auto-approve
+```
+
+Expected: Step 3 と同じ 2 resources が `Apply complete!` で作成される。
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add aws/eks/modules/access_entries.tf
+git commit -s -m "feat(aws/eks): add Identity Center access entries alongside eks-admin
+
+PlatformAdmin/PlatformViewer の Reserved SSO Role に対する EKS Access
+Entry を追加する。ロックアウト防止のため、root-trust eks-admin role
+の human_admin entry は動作確認が取れるまで並走させる。"
+```
+
+---
+
+## Task 3: Identity Center 経由 kubectl access の end-to-end 確認
+
+**Files:** (確認のみ、変更なし)
+
+**Context:** Task 4 で旧経路を削除する前に、新経路（Identity Center → Permission Set → Access Entry）が実際に動作することを確認する。この確認が取れない限り Task 4 に進まない。
+
+- [ ] **Step 1: AWS CLI に Identity Center profile を設定**
+
+```bash
+aws configure sso
+```
+
+対話プロンプトで以下を入力:
+- `SSO session name`: `panicboat`
+- `SSO start URL`: Identity Center Access Portal の URL（AWS Console の IAM Identity Center → Settings で確認）
+- `SSO region`: `ap-northeast-1`
+- ブラウザでログイン（`panicboat@panicboat.net`）後、Account を選択
+- `PlatformAdmin` role を選択
+- `CLI default client Region`: `ap-northeast-1`
+- `profile name`: `platform-admin`
+
+- [ ] **Step 2: SSO login**
+
+```bash
+aws sso login --profile platform-admin
+```
+
+Expected: ブラウザが開き Google ログイン画面へリダイレクト → `panicboat@panicboat.net` でログイン → `Successfully logged into Start URL` が表示される
+
+- [ ] **Step 3: kubeconfig 更新 + kubectl 疎通確認**
+
+```bash
+aws eks update-kubeconfig --region ap-northeast-1 --name eks-production --profile platform-admin
+AWS_PROFILE=platform-admin kubectl get nodes
+```
+
+Expected: node 一覧が返る（`Unauthorized` にならない）
+
+- [ ] **Step 4: Admin 権限の確認**
+
+```bash
+AWS_PROFILE=platform-admin kubectl auth can-i create namespaces
+```
+
+Expected: `yes`
+
+---
+
+## Task 4: root-trust `eks-admin` role の削除（Identity Center への完全移行）
+
+**Files:**
+- Modify: `aws/eks/modules/access_entries.tf`
+- Delete: `aws/eks/modules/iam_admin.tf`
+- Modify: `aws/eks/modules/outputs.tf`
+
+**Context:** Task 3 で Identity Center 経由の kubectl access が確認できたので、旧 root-trust `eks-admin` role とその access entry を削除する。**Task 3 の確認が取れていない場合はこのタスクを実行しない**（現状唯一の kubectl access 経路を壊すリスクがある）。
+
+- [ ] **Step 1: `aws/eks/modules/access_entries.tf` から `human_admin` を削除**
+
+Old（Task 2 で追加した状態）:
+```hcl
+locals {
+  access_entries = {
+    human_admin = {
+      principal_arn = aws_iam_role.eks_admin.arn
+
+      policy_associations = {
+        cluster_admin = {
+          policy_arn = "arn:aws:eks::aws:cluster-access-policy/AmazonEKSClusterAdminPolicy"
+          access_scope = {
+            type = "cluster"
+          }
+        }
+      }
+    }
+
+    identity_center_admin = {
+      principal_arn = tolist(data.aws_iam_roles.identity_center_admin.arns)[0]
+
+      policy_associations = {
+        cluster_admin = {
+          policy_arn = "arn:aws:eks::aws:cluster-access-policy/AmazonEKSClusterAdminPolicy"
+          access_scope = {
+            type = "cluster"
+          }
+        }
+      }
+    }
+
+    identity_center_viewer = {
+      principal_arn = tolist(data.aws_iam_roles.identity_center_viewer.arns)[0]
+
+      policy_associations = {
+        view = {
+          policy_arn = "arn:aws:eks::aws:cluster-access-policy/AmazonEKSViewPolicy"
+          access_scope = {
+            type = "cluster"
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+New（ファイル全体）:
+```hcl
+# access_entries.tf - EKS Access Entries (Kubernetes RBAC mapping for IAM principals).
+#
+# Human kubectl access flows entirely through AWS IAM Identity Center (SAML
+# federation with Google Workspace, see aws/iam-identity-center). The CI
+# apply role (github-oidc-auth-production-github-actions-role) operates on
+# AWS APIs only and never touches Kubernetes API; under the GitOps model, all
+# Kubernetes-side changes flow through Flux CD.
+#
+# Reserved SSO role ARNs are only assigned by AWS after the Permission Set's
+# Account Assignment exists (aws/iam-identity-center), so the data sources
+# below return an empty list if that stack hasn't been applied yet.
+#
+# Note on policy_arn format: EKS Access Policies use a dedicated ARN
+# scheme `arn:aws:eks::aws:cluster-access-policy/<NAME>`, NOT the IAM
+# managed policy form `arn:aws:iam::aws:policy/<NAME>`. Passing the IAM
+# form to AssociateAccessPolicy yields InvalidParameterException (400).
+
+data "aws_iam_roles" "identity_center_admin" {
+  name_regex  = "AWSReservedSSO_PlatformAdmin_.*"
+  path_prefix = "/aws-reserved/sso.amazonaws.com/"
+}
+
+data "aws_iam_roles" "identity_center_viewer" {
+  name_regex  = "AWSReservedSSO_PlatformViewer_.*"
+  path_prefix = "/aws-reserved/sso.amazonaws.com/"
+}
+
+locals {
+  access_entries = {
+    identity_center_admin = {
+      principal_arn = tolist(data.aws_iam_roles.identity_center_admin.arns)[0]
+
+      policy_associations = {
+        cluster_admin = {
+          policy_arn = "arn:aws:eks::aws:cluster-access-policy/AmazonEKSClusterAdminPolicy"
+          access_scope = {
+            type = "cluster"
+          }
+        }
+      }
+    }
+
+    identity_center_viewer = {
+      principal_arn = tolist(data.aws_iam_roles.identity_center_viewer.arns)[0]
+
+      policy_associations = {
+        view = {
+          policy_arn = "arn:aws:eks::aws:cluster-access-policy/AmazonEKSViewPolicy"
+          access_scope = {
+            type = "cluster"
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+- [ ] **Step 2: `aws/eks/modules/iam_admin.tf` を削除**
+
+```bash
+git rm aws/eks/modules/iam_admin.tf
+```
+
+- [ ] **Step 3: `aws/eks/modules/outputs.tf` から `admin_role_arn` / `admin_role_name` を削除**
+
+Old:
+```hcl
+output "admin_role_arn" {
+  description = "ARN of the IAM role for human kubectl admin access"
+  value       = aws_iam_role.eks_admin.arn
+}
+
+output "admin_role_name" {
+  description = "Name of the IAM role for human kubectl admin access"
+  value       = aws_iam_role.eks_admin.name
+}
+
+output "alb_controller_role_arn" {
+```
+
+New:
+```hcl
+output "alb_controller_role_arn" {
+```
+
+- [ ] **Step 4: format check**
+
+```bash
+terraform fmt -check aws/eks/modules/*.tf
+```
+
+Expected: 出力なし（exit 0）
+
+- [ ] **Step 5: terragrunt plan**
+
+```bash
+cd aws/eks/envs/production
+TG_TF_PATH=tofu terragrunt plan
+```
+
+Expected: `Plan: 0 to add, 0 to change, 3 to destroy`（`aws_eks_access_entry.this["human_admin"]` / `aws_iam_role_policy.eks_admin_describe_cluster` / `aws_iam_role.eks_admin`）。`identity_center_admin` / `identity_center_viewer` の access entry には変更がないこと。
+
+- [ ] **Step 6: terragrunt apply**
+
+```bash
+cd aws/eks/envs/production
+TG_TF_PATH=tofu terragrunt apply -auto-approve
+```
+
+Expected: Step 5 と同じ 3 resources が `Apply complete!` で destroy される。
+
+- [ ] **Step 7: 旧 role の削除確認**
+
+```bash
+aws iam get-role --role-name eks-admin-production 2>&1 | head -3
+```
+
+Expected: `An error occurred (NoSuchEntity) when calling the GetRole operation`
+
+- [ ] **Step 8: Identity Center 経路が引き続き動作することを確認**
+
+```bash
+AWS_PROFILE=platform-admin kubectl get nodes
+```
+
+Expected: node 一覧が返る（旧経路削除の影響を受けない）
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add aws/eks/modules/access_entries.tf aws/eks/modules/outputs.tf
+git commit -s -m "feat(aws/eks): remove root-trust eks-admin role
+
+Identity Center 経由 kubectl access の動作確認が取れたため、root-trust
+eks-admin role と対応する access entry / output を削除する。人間の
+kubectl/Console access は AWS IAM Identity Center 経由の 1 本になる。"
+```
+
+---
+
+## Task 5: `aws/eks/README.md` を Identity Center ベースの手順に更新
+
+**Files:**
+- Modify: `aws/eks/README.md`
+
+- [ ] **Step 1: 「kubectl access」節を置き換え**
+
+Old:
+```markdown
+## kubectl access
+
+人間が kubectl を叩く経路は **`eks-admin-production` IAM role を assume する 1 本のみ**。CI 上の apply role は AWS API のみで Kubernetes API は触らない（GitOps 原則）。
+
+### Quick start (recommended: login script)
+
+`panicboat/ansible` で deploy される `eks-login.sh` を source する：
+
+```bash
+source ~/Workspace/eks-login.sh                          # → eks-production / ap-northeast-1
+source ~/Workspace/eks-login.sh production                # 同上 (明示)
+source ~/Workspace/eks-login.sh staging us-west-2        # 未知 env は region 必須
+```
+
+スクリプトは：
+
+1. env / region を解決（既知 env は default region、未知 env は明示必須）
+2. `aws sts get-caller-identity` で現在の account ID を動的取得
+3. `eks-admin-${env}` role を assume（session 1 時間）
+4. `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` / `AWS_SESSION_TOKEN` を export
+5. `aws eks update-kubeconfig` で kubeconfig 更新
+
+完了後 `kubectl get nodes` 等が通るようになる。
+
+> Source 必須（実行しても export が parent shell に反映されない）。スクリプトは `source` チェックで弾く。
+
+### Manual login (without script)
+
+```bash
+ENV=production
+REGION=ap-northeast-1
+
+ADMIN_ROLE_ARN=$(cd aws/eks/envs/${ENV} && TG_TF_PATH=tofu terragrunt output -raw admin_role_arn)
+CREDS=$(aws sts assume-role \
+  --role-arn "$ADMIN_ROLE_ARN" \
+  --role-session-name "kubectl-${USER:-debug}" \
+  --query 'Credentials' \
+  --output json)
+
+export AWS_ACCESS_KEY_ID=$(echo "$CREDS" | jq -r .AccessKeyId)
+export AWS_SECRET_ACCESS_KEY=$(echo "$CREDS" | jq -r .SecretAccessKey)
+export AWS_SESSION_TOKEN=$(echo "$CREDS" | jq -r .SessionToken)
+
+aws eks update-kubeconfig --region "${REGION}" --name "eks-${ENV}"
+```
+
+session を破棄するには `unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_SESSION_TOKEN`。
+```
+
+New:
+```markdown
+## kubectl access
+
+人間が kubectl を叩く経路は **AWS IAM Identity Center（Google Workspace SSO）経由の 1 本のみ**。CI 上の apply role は AWS API のみで Kubernetes API は触らない（GitOps 原則）。
+
+Permission Set は 2 種類:
+
+| Permission Set | Google Group | EKS Access Policy |
+|---|---|---|
+| `PlatformAdmin` | `aws-admins@panicboat.net` | `AmazonEKSClusterAdminPolicy`（cluster-admin 相当） |
+| `PlatformViewer` | `aws-viewers@panicboat.net` | `AmazonEKSViewPolicy`（読み取り専用） |
+
+### Quick start (recommended: pre-configured profile)
+
+初回のみ `aws configure sso` で profile を作成する（Identity Center Access Portal の Start URL は AWS Console の IAM Identity Center → Settings で確認）。
+
+```bash
+aws sso login --profile platform-admin
+aws eks update-kubeconfig --region ap-northeast-1 --name eks-production --profile platform-admin
+```
+
+完了後 `AWS_PROFILE=platform-admin kubectl get nodes` 等が通るようになる。session は Permission Set の `session_duration`（1 時間）で失効し、再度 `aws sso login` が必要。
+
+### Manual login (profile 未設定の場合)
+
+```bash
+aws sso login --sso-start-url <identity-center-start-url> --sso-region ap-northeast-1
+```
+
+ログイン後に所属する Google Group（`aws-admins` / `aws-viewers`）に応じた Permission Set が選択できる。
+```
+
+- [ ] **Step 2: Architecture 節の Access Entries 行を更新**
+
+Old:
+```markdown
+- **Access Entries**: `eks-admin-production` role 1 本のみに `AmazonEKSClusterAdminPolicy` を付与。`enable_cluster_creator_admin_permissions = false` でステルス admin を防止。
+```
+
+New:
+```markdown
+- **Access Entries**: AWS IAM Identity Center の Permission Set 2 本（`PlatformAdmin` → `AmazonEKSClusterAdminPolicy` / `PlatformViewer` → `AmazonEKSViewPolicy`）に対応する Reserved SSO Role にのみ付与。`enable_cluster_creator_admin_permissions = false` でステルス admin を防止。
+```
+
+- [ ] **Step 3: Troubleshooting 表の assume-role 行を更新**
+
+Old:
+```markdown
+| `kubectl: error: You must be logged in to the server (Unauthorized)` | session credentials が expired（max 1 時間）または未 export。`eks-login.sh` を再 source。 |
+| `kubectl: error: ... credentials` after switching shells | 新 shell では assume-role の env vars が引き継がれない。再 source。 |
+| `aws sts assume-role: AccessDenied` | 実行している IAM principal に `sts:AssumeRole` resource permission がない。IAM 側で付与（リポジトリ管理外）。 |
+```
+
+New:
+```markdown
+| `kubectl: error: You must be logged in to the server (Unauthorized)` | SSO session credentials が expired（max 1 時間）。`aws sso login --profile platform-admin` を再実行。 |
+| `kubectl: error: ... credentials` after switching shells | 新 shell では `AWS_PROFILE` が引き継がれない。`export AWS_PROFILE=platform-admin` を再実行するか都度 `--profile` を指定。 |
+| `aws sso login` 後も Permission Set が選択できない | Google Group（`aws-admins` / `aws-viewers`）への所属が SCIM 同期されていない可能性。Google Admin Console でグループ所属を確認。 |
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add aws/eks/README.md
+git commit -s -m "docs(aws/eks): document Identity Center kubectl access flow
+
+root-trust eks-admin role の削除に合わせ、kubectl access 手順を
+aws sso login ベースに更新する。"
+```
+
+---
+
+## Task 6: 最終確認 + 外部ツールの引き継ぎ事項の明記
+
+**Files:** (確認のみ、変更なし)
+
+**Context:** `panicboat/ansible` 側の `eks-login.sh`（もしくはユーザーの zsh 環境の `eks-login` 関数）は `eks-admin-${env}` role の `sts:AssumeRole` に依存しており、この repo の管理外。Task 4 で role を削除した時点でこれらは動作しなくなるため、repo 外での更新が必要であることを明記する（このタスク自体はコード変更を行わない）。
+
+- [ ] **Step 1: kubectl access の最終疎通確認**
+
+```bash
+AWS_PROFILE=platform-admin kubectl get nodes
+AWS_PROFILE=platform-admin kubectl get pods -A --field-selector=status.phase!=Running,status.phase!=Succeeded
+```
+
+Expected: node 一覧が返り、異常 Pod がないこと（あれば本 plan とは無関係な既存問題の可能性、別途調査）
+
+- [ ] **Step 2: 引き継ぎ事項を panicboat に共有**
+
+以下は本 repo の変更では対応できない、repo 外の手動対応が必要な事項:
+
+- `panicboat/ansible` 側の `eks-login.sh`（または個人の zsh 環境の `eks-login` 関数）が `eks-admin-${env}` role の assume に依存している場合、`aws sso login --profile platform-admin` ベースに書き換える必要がある（`eks-admin-production` role は Task 4 で削除済のため、既存スクリプトは `AccessDenied` または `NoSuchEntity` で失敗する）
+- Viewer（`PlatformViewer`）権限の動作確認は、Google Workspace 側に `aws-viewers` グループのメンバーが実在する場合にのみ実施可能。本 plan 実行時点で該当メンバーがいなければ、実際に Viewer メンバーが追加された際に別途確認する
+
+---

--- a/docs/superpowers/plans/2026-08-02-gws-sso-grafana-domain.md
+++ b/docs/superpowers/plans/2026-08-02-gws-sso-grafana-domain.md
@@ -1,0 +1,318 @@
+# GWS SSO: Grafana Workspace Domain Migration Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Grafana（および同じ oauth2-proxy ゲートを共有する Hubble UI / Alertmanager / Prometheus）の Google ログイン許可判定を、個人 Gmail 1 件の ConfigMap allowlist から Google Workspace ドメイン (`panicboat.net`) ベースに切り替える。Grafana の org role デフォルトを `Admin` → `Viewer` に変更し、Admin は Grafana UI での手動昇格に一本化する。
+
+**Architecture:** oauth2-proxy の `config.configFile` を `email_domains = [ "panicboat.net" ]` に変更し、`authenticated_emails_file` と、それが参照する ConfigMap `oauth2-proxy-allowed-emails`（および付随する `extraVolumes`/`extraVolumeMounts`）を削除する。既存の oauth2-proxy + Grafana `auth.proxy` 構成（真の SSO・二重ログインなし）自体は変更しない。Grafana 側は `grafana.ini.users.auto_assign_org_role` を `Admin` → `Viewer` に変更する。両変更とも Google OAuth Client が `Internal` に切り替わっていることを前提とする（Task 0 で確認）。
+
+**Tech Stack:** Helm + helmfile / `oauth2-proxy/oauth2-proxy` chart（既 deploy 済）/ `prometheus-community/kube-prometheus-stack` chart（既 deploy 済、Grafana subchart）
+
+**Spec:** `docs/superpowers/specs/2026-08-01-gws-sso-design.md`
+
+## Global Constraints
+
+- Google Workspace domain: `panicboat.net`
+- 既存の cookie 共有 SSO（`cookie_domains = [ ".panicboat.net" ]`）・`auth.proxy` header 連携は変更しない
+- Grafana admin/password ログイン（ESO 経由 `grafana-admin` Secret）は緊急時 fallback として維持する（削除しない）
+- git commit は `-s`（signoff）を付与、`Co-Authored-By` は付与しない
+
+---
+
+## File Structure
+
+| File | Status | Responsibility |
+|---|---|---|
+| `kubernetes/components/oauth2-proxy/production/values.yaml.gotmpl` | modify | `email_domains` をドメイン指定に変更、ConfigMap volume mount 削除 |
+| `kubernetes/components/oauth2-proxy/production/kustomization/allowed-emails-configmap.yaml` | delete | 個人 Gmail allowlist が不要になる |
+| `kubernetes/components/oauth2-proxy/production/kustomization/kustomization.yaml` | modify | 削除した ConfigMap の参照を除去 |
+| `kubernetes/components/prometheus-operator/production/values.yaml.gotmpl` | modify | `auto_assign_org_role` を `Viewer` に変更 |
+| `kubernetes/manifests/production/oauth2-proxy/manifest.yaml` | auto-generate | hydrate 出力 |
+| `kubernetes/manifests/production/prometheus-operator/manifest.yaml` | auto-generate | hydrate 出力 |
+
+**変更しないもの**: `kubernetes/components/prometheus-operator/production/kustomization/grafana-admin-external-secret.yaml`（admin/password fallback）、Hubble UI / Alertmanager / Prometheus の component 定義、`aws/*`（別 plan `2026-08-02-gws-sso-aws-identity-center.md` で扱う）
+
+---
+
+## Task 0: Pre-flight — worktree/branch 状態 + Google OAuth Client Internal 化の確認
+
+**Files:** (確認のみ、変更なし)
+
+**Context:** Google OAuth Client が `Internal` に切り替わる前に oauth2-proxy 側の `email_domains` を `panicboat.net` に変更すると、Google 側はまだ `panicboat@gmail.com` を認証できてしまう一方で oauth2-proxy 側は `gmail.com` ドメインを拒否するため、**先に手動切り替えが完了していないと個人 Gmail が即座にログインできなくなる**（Grafana admin/password fallback は使えるが、意図しないタイミングでの遮断は避ける）。実行順序を明示的に確認する。
+
+- [ ] **Step 1: worktree/branch 状態確認**
+
+```bash
+cd /Users/takanokenichi/GitHub/panicboat/platform/.claude/worktrees/feat-gws-sso
+git fetch origin main
+git log --oneline origin/main..HEAD
+```
+
+Expected: spec commit + （実行済であれば）AWS Identity Center plan の commit 群が ahead
+
+- [ ] **Step 2: Google OAuth Client が Internal であることを確認**
+
+Google Cloud Console → API とサービス → OAuth 同意画面 → 対象クライアントの「公開ステータス」を確認する（spec の Manual Setup Step 5）。
+
+Expected: `Internal` と表示される。`Testing`（External）のままの場合は、本 plan の Task 1〜2 を実行する前に panicboat に Internal 化を依頼する。
+
+- [ ] **Step 3: Grafana admin/password fallback が機能することを確認（切替中の safety net）**
+
+```bash
+AWS_PROFILE=platform-admin kubectl get secret grafana-admin -n monitoring -o jsonpath='{.data.admin-user}' | base64 -d && echo
+```
+
+Expected: `admin` が出力される（Secret が存在し、fallback login に使える状態であることの確認）
+
+---
+
+## Task 1: oauth2-proxy をドメインベース allowlist に変更
+
+**Files:**
+- Modify: `kubernetes/components/oauth2-proxy/production/values.yaml.gotmpl`
+- Delete: `kubernetes/components/oauth2-proxy/production/kustomization/allowed-emails-configmap.yaml`
+- Modify: `kubernetes/components/oauth2-proxy/production/kustomization/kustomization.yaml`
+
+- [ ] **Step 1: `values.yaml.gotmpl` の `config.configFile` を編集**
+
+Old:
+```yaml
+config:
+  existingSecret: oauth2-proxy-google
+  configFile: |-
+    provider = "google"
+    email_domains = [ "*" ]
+    upstreams = [ "{{ $upstreamUrl }}" ]
+    cookie_domains = [ ".panicboat.net" ]
+    whitelist_domains = [ ".panicboat.net" ]
+    cookie_secure = true
+    cookie_httponly = true
+    cookie_samesite = "lax"
+    pass_authorization_header = true
+    pass_access_token = true
+    set_authorization_header = true
+    set_xauthrequest = true
+    skip_provider_button = true
+    reverse_proxy = true
+    authenticated_emails_file = "/etc/oauth2-proxy/emails/allowed"
+```
+
+New:
+```yaml
+config:
+  existingSecret: oauth2-proxy-google
+  configFile: |-
+    provider = "google"
+    email_domains = [ "panicboat.net" ]
+    upstreams = [ "{{ $upstreamUrl }}" ]
+    cookie_domains = [ ".panicboat.net" ]
+    whitelist_domains = [ ".panicboat.net" ]
+    cookie_secure = true
+    cookie_httponly = true
+    cookie_samesite = "lax"
+    pass_authorization_header = true
+    pass_access_token = true
+    set_authorization_header = true
+    set_xauthrequest = true
+    skip_provider_button = true
+    reverse_proxy = true
+```
+
+- [ ] **Step 2: `values.yaml.gotmpl` から ConfigMap volume mount を削除**
+
+Old:
+```yaml
+# =============================================================================
+# Extra Volumes & Volume Mounts (= ConfigMap allowlist)
+# =============================================================================
+# ConfigMap `oauth2-proxy-allowed-emails` (= kustomization で deploy) を 4 releases が
+# 共有 mount、config.configFile の `authenticated_emails_file` で参照。
+# ConfigMap 変更時は Reloader が 4 Deployments 全部を auto-rollout
+# (= deploymentAnnotations 参照、annotation が同じ namespace 内の全 ConfigMap watch を trigger)。
+extraVolumes:
+  - name: emails
+    configMap:
+      name: oauth2-proxy-allowed-emails
+extraVolumeMounts:
+  - name: emails
+    mountPath: /etc/oauth2-proxy/emails
+    readOnly: true
+
+# =============================================================================
+# Deployment Annotations (= Reloader watch)
+# =============================================================================
+# ESO 由来 Secret `oauth2-proxy-google` 変更時 + ConfigMap `oauth2-proxy-allowed-emails`
+# 変更時に Reloader が自動 rollout する。
+deploymentAnnotations:
+  reloader.stakater.com/auto: "true"
+```
+
+New:
+```yaml
+# =============================================================================
+# Deployment Annotations (= Reloader watch)
+# =============================================================================
+# ESO 由来 Secret `oauth2-proxy-google` 変更時に Reloader が自動 rollout する。
+deploymentAnnotations:
+  reloader.stakater.com/auto: "true"
+```
+
+- [ ] **Step 3: ConfigMap を削除**
+
+```bash
+git rm kubernetes/components/oauth2-proxy/production/kustomization/allowed-emails-configmap.yaml
+```
+
+- [ ] **Step 4: `kustomization.yaml` から ConfigMap の参照を削除**
+
+Old:
+```yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - external-secret.yaml
+  - allowed-emails-configmap.yaml
+  - ingress-monitoring-uis.yaml
+```
+
+New:
+```yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - external-secret.yaml
+  - ingress-monitoring-uis.yaml
+```
+
+- [ ] **Step 5: helmfile template で反映確認（cluster 接続不要）**
+
+```bash
+helmfile -f kubernetes/components/oauth2-proxy/production/helmfile.yaml -e production template --skip-tests 2>/dev/null | grep -A2 "email_domains\|authenticated_emails_file"
+```
+
+Expected: `email_domains = [ "panicboat.net" ]` が 4 release 分（grafana/hubble/alertmanager/prometheus）出力され、`authenticated_emails_file` は出力に含まれない
+
+- [ ] **Step 6: 生成物を hydrate**
+
+```bash
+./scripts/kubernetes-hydrate/hydrate-component.sh oauth2-proxy production
+git status --short kubernetes/manifests/production/oauth2-proxy/
+```
+
+Expected: `manifest.yaml` に差分（`email_domains` 変更、ConfigMap `oauth2-proxy-allowed-emails` 削除、Deployment の volume/volumeMount 削除）。TLS material 以外の差分がない場合は Step 1〜4 の編集を見直す。
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add kubernetes/components/oauth2-proxy/production/ kubernetes/manifests/production/oauth2-proxy/
+git commit -s -m "feat(kubernetes/oauth2-proxy): switch to Workspace domain allowlist
+
+個人 Gmail 1 件の ConfigMap allowlist を廃止し、oauth2-proxy 組込みの
+email_domains でドメインベースの許可判定に切り替える。Google OAuth
+Client が Internal 化済であることが前提 (Task 0 で確認済)。"
+```
+
+---
+
+## Task 2: Grafana の org role デフォルトを Viewer に変更
+
+**Files:**
+- Modify: `kubernetes/components/prometheus-operator/production/values.yaml.gotmpl`
+
+- [ ] **Step 1: `auto_assign_org_role` を編集**
+
+Old:
+```yaml
+  grafana.ini:
+    auth.proxy:
+      enabled: true
+      header_name: X-Forwarded-User
+      header_property: username
+      auto_sign_up: true
+      sync_ttl: 60
+    users:
+      auto_assign_org: true
+      auto_assign_org_role: Admin
+```
+
+New:
+```yaml
+  grafana.ini:
+    auth.proxy:
+      enabled: true
+      header_name: X-Forwarded-User
+      header_property: username
+      auto_sign_up: true
+      sync_ttl: 60
+    users:
+      auto_assign_org: true
+      # 新規ログインは最小権限 Viewer で auto-create、Admin は Grafana UI
+      # で手動昇格する (= Google Group ベースの自動 role 連携は行わない、
+      # spec の Out of Scope 参照)。
+      auto_assign_org_role: Viewer
+```
+
+- [ ] **Step 2: 生成物を hydrate**
+
+```bash
+./scripts/kubernetes-hydrate/hydrate-component.sh prometheus-operator production
+git status --short kubernetes/manifests/production/prometheus-operator/
+```
+
+Expected: `manifest.yaml` に `auto_assign_org_role` の差分のみ
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add kubernetes/components/prometheus-operator/production/ kubernetes/manifests/production/prometheus-operator/
+git commit -s -m "feat(kubernetes/grafana): default new SSO logins to Viewer role
+
+複数メンバー運用に備え、auth.proxy 経由の新規ユーザーを一律 Admin では
+なく最小権限 Viewer で auto-create する。Admin 昇格は Grafana UI で
+手動実施する運用に切り替える。"
+```
+
+---
+
+## Task 3: End-to-end 動作確認
+
+**Files:** (確認のみ、変更なし)
+
+**Context:** Flux が Task 1〜2 の変更を reconcile した後に確認する。cluster 側の反映を待つため、`kubectl get pods` で対象 Deployment が新しい Pod に入れ替わっていることを先に確認してからブラウザ確認に進む。
+
+- [ ] **Step 1: Flux reconcile 完了 + Pod rollout 確認**
+
+```bash
+AWS_PROFILE=platform-admin kubectl get pods -n oauth2-proxy -o jsonpath='{range .items[*]}{.metadata.name}{"\t"}{.status.phase}{"\n"}{end}'
+AWS_PROFILE=platform-admin kubectl get pods -n monitoring -l app.kubernetes.io/name=grafana -o jsonpath='{range .items[*]}{.metadata.name}{"\t"}{.status.phase}{"\n"}{end}'
+```
+
+Expected: 全 Pod `Running`（Reloader による rollout が完了済であること）
+
+- [ ] **Step 2: `panicboat@panicboat.net` でログイン確認**
+
+ブラウザで `https://grafana.panicboat.net` を開き `panicboat@panicboat.net` でログインする。
+
+Expected: Google 認証画面に遷移し、ログイン後 Grafana に auto-login される（初回は Viewer role で auto-create）
+
+- [ ] **Step 3: Grafana UI で Admin に昇格**
+
+Grafana admin/password（`grafana-admin` Secret 由来）で別途ログインし、Administration → Users で `panicboat@panicboat.net` を Admin に変更する。
+
+- [ ] **Step 4: 再ログインで Admin 反映確認**
+
+`panicboat@panicboat.net` で再度ログインし、Admin 権限（例: Data sources の編集画面が見える）を確認する。
+
+- [ ] **Step 5: 個人 Gmail が拒否されることを確認**
+
+`panicboat@gmail.com` で `https://grafana.panicboat.net` へのログインを試行する。
+
+Expected: Google 側の OAuth 同意画面で拒否される（Internal app のため Workspace ドメイン外のアカウントは選択肢に出ない、または明示的にエラーになる）
+
+- [ ] **Step 6: 他 3 UI への SSO 疎通確認**
+
+同一 browser session のまま `https://hubble.panicboat.net`、`https://alertmanager.panicboat.net`、`https://prometheus.panicboat.net` にアクセスする。
+
+Expected: 再ログインなしでアクセスできる（cookie domain `.panicboat.net` による既存 SSO が継続していることの確認）
+
+---

--- a/docs/superpowers/specs/2026-08-01-gws-sso-design.md
+++ b/docs/superpowers/specs/2026-08-01-gws-sso-design.md
@@ -1,0 +1,193 @@
+# GWS (Google Workspace) SSO 導入 Design
+
+> **Goal**: Google Workspace (`panicboat.net`) を IdP として (1) AWS ログインをロールベースアクセス制御付きで SSO 化し、(2) 既存 Grafana SSO を個人 Gmail 依存から Workspace ドメイン依存に切り替える。対象範囲はこの repository が管理する AWS / Kubernetes 基盤のみ。
+
+---
+
+## Context
+
+### 現状
+
+- **AWS**: 人間の kubectl/Console アクセスは `eks-admin-production` IAM role（account root が assume 可能）を経由する 1 本のみ（`aws/eks/modules/iam_admin.tf`、`aws/eks/modules/access_entries.tf`）。IAM Identity Center 等の SSO は未導入。IAM user 側の `sts:AssumeRole` 許可は repo 管理外
+- **Grafana**: すでに oauth2-proxy + Google OAuth + Grafana `auth.proxy` mode で SSO 化済み（`docs/superpowers/specs/2026-05-09-eks-production-grafana-auth-ingress-design.md`）。ただし allowlist は個人 Gmail (`panicboat@gmail.com`) 1 件の ConfigMap、OAuth Client は `External + Testing`、Grafana 側は allowlist 通過者全員が一律 `auto_assign_org_role: Admin`。同 spec の引き継ぎ事項 #11 に「Google Workspace 契約後の OAuth Internal 化 + email_domain allowlist 移行」が明記されており、本 design はその実行にあたる
+- **Hubble UI / Alertmanager / Prometheus**: oauth2-proxy 経由で Grafana と同じ SSO cookie を共有するのみ。ロール概念を持たないツールのため、認証ゲート通過の可否のみが意味を持つ
+
+### GWS 導入の前提（brainstorming で確定）
+
+- GWS は未契約。これから契約し、将来の複数メンバー運用に備える（現時点の実利用者は panicboat のみ）
+- ドメインは既存 Route53 保有の `panicboat.net` を使用
+- panicboat 自身のログインアカウントは契約後 `panicboat@panicboat.net`（Workspace）に一本化し、個人 Gmail (`panicboat@gmail.com`) は引退させる
+- AWS 側のロール粒度は Admin / Viewer の 2 区分から開始
+- 調査範囲はこの repository が管理する AWS / Kubernetes 基盤に限定（GitHub organization や他 SaaS の SSO は対象外）
+
+---
+
+## Architecture
+
+### AWS 側
+
+```
+panicboat@panicboat.net (Google Workspace)
+        │ SAML federation（SCIM でグループ同期）
+        ▼
+AWS IAM Identity Center (account instance)
+        │
+  ┌─────┴─────┐
+  │           │
+Permission Set    Permission Set
+"Admin"           "Viewer"
+(AdministratorAccess)   (ReadOnlyAccess)
+  │           │
+  ▼           ▼
+AWSReservedSSO_Admin_*    AWSReservedSSO_Viewer_*   ← Identity Center が Account Assignment 実行後に発行する IAM role
+  │           │
+  ▼           ▼
+EKS Access Entry          EKS Access Entry
+AmazonEKSClusterAdminPolicy   AmazonEKSViewPolicy
+```
+
+- Google Group `aws-admins@panicboat.net` / `aws-viewers@panicboat.net` を作成し、SCIM で Identity Center に同期。`panicboat@panicboat.net` は `aws-admins` に所属
+- **Console**: Identity Center の Access Portal 経由でログイン → 所属 Group に紐づく Permission Set を選択 → temporary credentials で AWS Console へ
+- **CLI/kubectl**: `aws sso login` → 同じ Permission Set の temporary credentials を取得 → `aws eks update-kubeconfig` → kubectl は Access Entry の policy 通りに動作
+- 既存の root-trust `eks-admin` role と対応する access entry は削除し、Identity Center 経由に完全移行。AWS account root user によるログイン（repo 管理外）は最終手段として引き続き存在する
+
+### Grafana 側（他 3 UI は現状維持）
+
+- oauth2-proxy + Grafana `auth.proxy` mode の構成自体は変更しない（true SSO・二重ログインなしを継続）
+- oauth2-proxy の許可判定を「個別 email の ConfigMap allowlist」から oauth2-proxy 組込みの `email_domains: panicboat.net` に変更
+- Grafana 用 Google OAuth Client を `External + Testing` → `Internal` に変更（Workspace ドメインが確立するため未検証アプリ警告も解消）
+- Grafana `grafana.ini.users.auto_assign_org_role` を `Admin` → `Viewer` に変更（最小権限デフォルト）。Admin にする対象者は初回ログイン後に Grafana UI 上で手動昇格
+- Hubble UI / Alertmanager / Prometheus はロール概念を持たないため変更なし
+
+---
+
+## Components & File Structure
+
+### 新規: `aws/iam-identity-center/`（AWS）
+
+既存の account-wide singleton stack（`aws/iam-service-linked-roles`）と同じ構成パターンを踏襲する。
+
+```
+aws/iam-identity-center/
+├── root.hcl
+├── modules/
+│   ├── terraform.tf
+│   ├── variables.tf
+│   ├── main.tf              # aws_ssoadmin_permission_set × 2 (Admin/Viewer)
+│   │                         # + aws_ssoadmin_managed_policy_attachment (AdministratorAccess/ReadOnlyAccess)
+│   │                         # + aws_ssoadmin_account_assignment × 2 (Google Group → Permission Set)
+│   └── outputs.tf            # Reserved SSO Role ARN (Admin/Viewer)、permission_set_arn 等
+└── envs/production/
+    ├── env.hcl
+    └── terragrunt.hcl
+```
+
+- Identity Center instance 自体の有効化と、Google 側 SAML app / SCIM 設定は Terraform 管理対象外（Manual Setup で後述）
+- `data "aws_ssoadmin_instances"` で既存 instance を参照する
+
+### 修正: `aws/eks/modules/`（AWS）
+
+- **`access_entries.tf`**: `human_admin` の 1 entry を、Identity Center Reserved Role ARN を参照する `identity_center_admin`（`AmazonEKSClusterAdminPolicy`）/ `identity_center_viewer`（`AmazonEKSViewPolicy`）の 2 entries に置き換え
+- **`iam_admin.tf`**: 削除（root-trust `eks-admin` role が不要になるため）
+- Reserved Role ARN の解決方法: Permission Set 作成時点では Reserved Role は未発行で、Account Assignment 実行後に初めて発行される。`aws/iam-identity-center` stack 側で `data "aws_iam_roles"`（`name_regex = "AWSReservedSSO_<permission-set-name>_.*"`）により解決し、output として `aws/eks` 側に terragrunt `dependency` block 経由で渡す（既存 `aws/eks/lookup` のクロススタック参照パターンを踏襲）。このため初回投入時は `aws/iam-identity-center` → `aws/eks` の 2 phase apply が必要（Risks 参照）
+
+### 修正: `aws/eks/README.md`
+
+- 「kubectl access」節を Identity Center ベースの手順（`aws sso login` + `update-kubeconfig`）に置き換え
+- Troubleshooting 表の `assume-role` 関連の記述を更新
+
+### 修正: `kubernetes/components/oauth2-proxy/production/`
+
+- **`values.yaml.gotmpl`**: `email_domains: - panicboat.net` を追加
+- **`kustomization/allowed-emails-configmap.yaml`**: 削除（`email_domains` 設定に置き換えるため不要）
+- **`kustomization/kustomization.yaml`**: 上記 ConfigMap の参照を削除
+
+### 修正: `kubernetes/components/prometheus-operator/production/`
+
+- **`values.yaml.gotmpl`**: `grafana.ini` の `users.auto_assign_org_role` を `Admin` → `Viewer` に変更
+
+### 自動生成（production hydrate output）
+
+- `kubernetes/manifests/production/oauth2-proxy/manifest.yaml`
+- `kubernetes/manifests/production/prometheus-operator/manifest.yaml`
+
+### 変更しないもの
+
+- `aws/github-oidc-auth/*`（CI 用 machine identity、human SSO とは無関係）
+- Hubble UI / Alertmanager / Prometheus の component 定義
+- Grafana の `auth.proxy` 自体の仕組み（header 由来の username 認証は継続）
+
+---
+
+## Manual Setup（AWS Console + Google Admin Console）
+
+初回のプロバイダ間ハンドシェイクは GitOps / Terraform で完結しないため手動（既存 Grafana design の Manual Setup と同じ方針）。
+
+1. **AWS IAM Identity Center を account instance として有効化**（AWS Console、AWS Organizations 不要）
+2. **Google Admin Console**: 「SAML apps」で AWS IAM Identity Center 用アプリを追加し、Identity Center が提供する SP metadata（ACS URL / Entity ID）を設定、Google 側の IdP metadata を Identity Center にアップロード（相互設定）
+3. **SCIM provisioning 設定**: Identity Center が発行する SCIM endpoint URL + bearer token を Google 側の該当 SAML app 設定に投入し、自動プロビジョニングを有効化
+4. **Google Workspace 側でグループ作成**: `aws-admins@panicboat.net` / `aws-viewers@panicboat.net` を作成し、`panicboat@panicboat.net` を `aws-admins` に追加
+5. **Grafana 用 Google OAuth Client** を Google Cloud Console で `Internal` に変更（承認済みドメイン等は既存のまま）
+6. **初回 Grafana ログイン後の手動昇格**: `panicboat@panicboat.net` で Grafana にログイン（初回は Viewer で auto-create）→ 既存 admin/password（ESO 経由の fallback login）でログインし、GUI から `panicboat@panicboat.net` を Admin に昇格
+
+**参照 docs**:
+- AWS: [IAM Identity Center - Google Workspace as identity source](https://docs.aws.amazon.com/singlesignon/latest/userguide/gs-gwp.html)
+- Google: [SAML apps でカスタムアプリを追加](https://support.google.com/a/answer/6087519)
+
+**実装時 friction の許容**: AWS Console / Google Admin Console の UI 変更により実 navigation は本 spec と異なる場合あり、要件を満たす設定に到達すれば手順は不問（既存 Grafana design と同じ方針）。
+
+---
+
+## Testing / Post-flight Check
+
+1. Identity Center Access Portal から `panicboat@panicboat.net` でログイン → Admin Permission Set が選択可能
+2. `aws sso login` → `aws eks update-kubeconfig` → `kubectl get nodes` が通る（ClusterAdmin 権限）
+3. （可能であれば）Viewer 想定のテストユーザーで同様に確認 → 書き込み系 kubectl コマンドが `Forbidden` で reject される
+4. `https://grafana.panicboat.net` に `@panicboat.net` アカウントでログイン → 初回は Viewer role で auto-create されることを確認
+5. 上記アカウントを Grafana UI で Admin に昇格 → 再ログインで Admin 権限が反映されることを確認
+6. `panicboat@gmail.com` でのログイン試行 → Internal OAuth Client のため Google 側で拒否されることを確認（意図した挙動）
+7. 同一 browser session で Hubble UI / Alertmanager / Prometheus に再ログインなしでアクセスできる（既存 SSO 継続の確認）
+
+---
+
+## Rollback Patterns
+
+| Pattern | 適用条件 | 操作 |
+|---|---|---|
+| **A. Standard rollback** | 本 design 全体を巻き戻したい | Flux suspend（Grafana 側変更分）→ merge commit を revert PR → resume。AWS 側は `aws/iam-identity-center` と `aws/eks` の変更を revert PR で戻す |
+| **B. Grafana のみ rollback** | AWS 側は問題ないが Grafana の domain allowlist / role default に問題がある | `email_domains` / `auto_assign_org_role` の変更のみ revert |
+| **C. AWS 側 緊急アクセス** | Identity Center 障害で Console/CLI アクセス不能 | AWS account root user でログインし、Identity Center 設定を修正するか、緊急用の IAM role を一時的に作成 |
+
+---
+
+## Risks & Mitigations
+
+| Risk | Mitigation |
+|---|---|
+| root-trust `eks-admin` role 削除により Identity Center 障害時の break-glass 手段がなくなる | AWS account root user ログイン（repo 管理外）が最終手段として残る。長期障害時は root user で緊急 IAM role を作成 |
+| Reserved SSO Role ARN が Account Assignment 実行後にしか解決できない | `aws/iam-identity-center` → `aws/eks` の 2 phase apply が必要。Plan 側で明示的な実行順序として記載する |
+| Google Workspace 側 SAML/SCIM 設定は console 手動のため誤設定リスク | Manual Setup 手順を明文化し、Testing で早期に end-to-end 検証する |
+| `panicboat@gmail.com` が Internal 化した瞬間にログイン不能になる | 事前に `panicboat@panicboat.net` を `aws-admins` Google Group に追加し、Grafana Admin 昇格を完了させてから Gmail アカウントの利用を止める（切替順序を Plan に明記） |
+
+---
+
+## Out of Scope
+
+| 項目 | 理由 |
+|---|---|
+| Google Group → oauth2-proxy → header 経由の Grafana role 完全自動化 | oauth2-proxy に group→role 変換機能がなく、実現には自作コンポーネントが必要。Grafana 自身の RBAC（Approach B）で代替 |
+| Grafana 自身の Google OAuth (`auth.google`/generic_oauth) への切替 | Grafana だけ二重ログインが復活し、既存 Grafana design の Decision #3 が避けた問題が再発する |
+| GitHub organization の SSO | 調査範囲をこの repository が管理する AWS / Kubernetes 基盤に限定したため対象外 |
+| AWS Identity Center Permission Set の 3 区分以上への細分化（Developer 等） | 現時点では Admin / Viewer の 2 区分で十分（YAGNI）。将来必要になった時点で Permission Set を追加 |
+| Google Workspace 側の Group 自体の Terraform 管理 | この repo に Google Cloud/Workspace provider が存在せず、Google 側リソースは対象外。Manual Setup で手動運用 |
+
+---
+
+## References
+
+- Grafana SSO 既存 design: `docs/superpowers/specs/2026-05-09-eks-production-grafana-auth-ingress-design.md`
+- 既存 kubectl access 実装: `aws/eks/modules/access_entries.tf`, `aws/eks/modules/iam_admin.tf`
+- account-wide singleton stack の既存パターン: `aws/iam-service-linked-roles/`
+- クロススタック参照の既存パターン: `aws/eks/lookup/`, `docs/superpowers/plans/2026-04-29-aws-vpc-cross-stack-lookup.md`
+- AWS IAM Identity Center + Google Workspace: <https://docs.aws.amazon.com/singlesignon/latest/userguide/gs-gwp.html>
+- oauth2-proxy `email_domains` config: <https://oauth2-proxy.github.io/oauth2-proxy/configuration/overview>


### PR DESCRIPTION
## Summary
- Google Workspace (`panicboat.net`) を IdP とした AWS ログインのロールベース SSO 化（IAM Identity Center + SAML/SCIM、Admin/Viewer の 2 Permission Set）の design doc
- 既存 Grafana SSO を個人 Gmail allowlist から Workspace ドメインベース (`email_domains`) に移行する design doc
- 調査範囲はこの repository が管理する AWS / Kubernetes 基盤のみ

## Test plan
- [ ] spec doc の内容レビュー
- [ ] 承認後、実装 plan（writing-plans）を別途作成