### PR TITLE
feat: integrate OpenCost for AWS cost visibility in Grafana

### DIFF
--- a/aws/cost-management/modules/outputs.tf
+++ b/aws/cost-management/modules/outputs.tf
@@ -1,1 +1,11 @@
-# outputs.tf - No outputs; this service does not expose values to other stacks
+# outputs.tf - Outputs for the cost-management module.
+
+output "spot_datafeed_bucket_name" {
+  description = "S3 bucket name for the AWS Spot Instance Data Feed. Referenced (as a hardcoded value, see aws/eks-cost and kubernetes/components/opencost/ for why) by aws/eks-cost's IAM policy Resource ARN and kubernetes/components/opencost/ helmfile values (opencost.customPricing.costModel.awsSpotDataBucket)."
+  value       = module.spot_datafeed_bucket.s3_bucket_id
+}
+
+output "spot_datafeed_region" {
+  description = "AWS region of the Spot Instance Data Feed bucket. Used as opencost.customPricing.costModel.awsSpotDataRegion."
+  value       = local.spot_datafeed_region
+}

--- a/aws/cost-management/modules/spot_datafeed.tf
+++ b/aws/cost-management/modules/spot_datafeed.tf
@@ -1,0 +1,71 @@
+# spot_datafeed.tf - AWS Spot Instance Data Feed (S3 bucket + subscription)
+#
+# OpenCost (aws/eks-cost stack 側の Pod Identity role 経由) が Spot instance
+# の実勢価格を取得するための data feed。 `aws_spot_datafeed_subscription` は
+# 1 AWS account に1つしか作成できない singleton resource
+# (AWSServiceRoleForEC2Spot と同種の制約) のため、 cluster destroy/recreate
+# cycle の対象外である本 stack に配置する。
+#
+# bucket は EKS cluster と同じ ap-northeast-1 に置く (OpenCost pod からの S3
+# 読み取りで cross-region data transfer を避けるため)。 本 stack のデフォルト
+# provider は Cost Optimization Hub / Compute Optimizer 向けに us-east-1
+# 固定のため、 `region` 引数で resource 単位に上書きする。
+
+data "aws_caller_identity" "current" {}
+
+locals {
+  spot_datafeed_bucket_name = "opencost-spot-datafeed-${data.aws_caller_identity.current.account_id}"
+  spot_datafeed_region      = "ap-northeast-1"
+}
+
+module "spot_datafeed_bucket" {
+  source  = "terraform-aws-modules/s3-bucket/aws"
+  version = "5.15.3"
+
+  region = local.spot_datafeed_region
+  bucket = local.spot_datafeed_bucket_name
+
+  force_destroy = true
+
+  # Spot Data Feed は AWS が bucket ACL に write 権限を legacy 方式で付与する
+  # ため、 Object Ownership を S3 デフォルトの "Bucket owner enforced"
+  # (ACL 無効) から変更し ACL を有効化する必要がある。 明示的な grant は行わず
+  # (= acl 変数は未設定)、 AWS 側が subscribe 時に自動でつける ACL に任せる。
+  control_object_ownership = true
+  object_ownership         = "BucketOwnerPreferred"
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+
+  server_side_encryption_configuration = {
+    rule = {
+      apply_server_side_encryption_by_default = {
+        sse_algorithm = "AES256"
+      }
+    }
+  }
+
+  versioning = {
+    status = "Disabled"
+  }
+
+  # 30日: raw data feed file を長期保持する理由がないため最小化
+  lifecycle_rule = [
+    {
+      id     = "expire-old-datafeed-files"
+      status = "Enabled"
+      expiration = {
+        days = 30
+      }
+    }
+  ]
+
+  tags = var.common_tags
+}
+
+resource "aws_spot_datafeed_subscription" "this" {
+  region = local.spot_datafeed_region
+  bucket = module.spot_datafeed_bucket.s3_bucket_id
+}

--- a/aws/eks-cost/Makefile
+++ b/aws/eks-cost/Makefile
@@ -1,0 +1,79 @@
+# Makefile for EKS Cost (OpenCost Pod Identity)
+
+# Default values
+ENV ?= production
+
+# Colors for output
+RED := \033[0;31m
+GREEN := \033[0;32m
+YELLOW := \033[0;33m
+BLUE := \033[0;34m
+NC := \033[0m # No Color
+
+.PHONY: help init plan apply destroy validate fmt check clean
+
+help: ## Show this help message
+	@echo "EKS Cost - Terragrunt Commands"
+	@echo ""
+	@echo "Usage: make <target> [ENV=<environment>]"
+	@echo ""
+	@echo "Available targets:"
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "  $(BLUE)%-15s$(NC) %s\\n", $$1, $$2}'
+	@echo ""
+	@echo "Available environments:"
+	@echo "  - production"
+	@echo ""
+	@echo "Examples:"
+	@echo "  make plan ENV=production"
+	@echo "  make apply ENV=production"
+
+init: ## Initialize Terragrunt
+	@printf "$(YELLOW)Initializing Terragrunt for $(ENV)...$(NC)\\n"
+	cd envs/$(ENV) && terragrunt init
+
+plan: ## Plan Terragrunt changes
+	@printf "$(YELLOW)Planning Terragrunt changes for $(ENV)...$(NC)\\n"
+	cd envs/$(ENV) && terragrunt plan
+
+apply: ## Apply Terragrunt changes
+	@printf "$(YELLOW)Applying Terragrunt changes for $(ENV)...$(NC)\\n"
+	cd envs/$(ENV) && terragrunt apply -auto-approve
+
+destroy: ## Destroy Terragrunt resources
+	@printf "$(RED)Destroying Terragrunt resources for $(ENV)...$(NC)\\n"
+	@printf "$(RED)WARNING: This will destroy all resources!$(NC)\\n"
+	@read -p "Are you sure? [y/N] " -n 1 -r; \\
+	echo; \\
+	if [[ $$REPLY =~ ^[Yy]$$ ]]; then \\
+		cd envs/$(ENV) && terragrunt destroy; \\
+	else \\
+		printf "$(YELLOW)Cancelled.$(NC)\\n"; \\
+	fi
+
+validate: ## Validate Terragrunt configuration
+	@printf "$(YELLOW)Validating Terragrunt configuration for $(ENV)...$(NC)\\n"
+	cd envs/$(ENV) && terragrunt validate
+
+fmt: ## Format Terraform files
+	@printf "$(YELLOW)Formatting Terraform files...$(NC)\\n"
+	terraform fmt -recursive .
+
+check: validate fmt ## Run validation and formatting checks
+	@printf "$(GREEN)All checks completed for $(ENV)$(NC)\\n"
+
+clean: ## Clean Terragrunt cache
+	@printf "$(YELLOW)Cleaning Terragrunt cache...$(NC)\\n"
+	find . -type d -name ".terragrunt-cache" -exec rm -rf {} + 2>/dev/null || true
+	find . -name "*.tfplan" -delete 2>/dev/null || true
+
+show: ## Show current Terragrunt state
+	@printf "$(YELLOW)Showing current Terragrunt state for $(ENV)...$(NC)\\n"
+	cd envs/$(ENV) && terragrunt show
+
+output: ## Show Terragrunt outputs
+	@printf "$(YELLOW)Showing outputs for $(ENV)...$(NC)\\n"
+	cd envs/$(ENV) && terragrunt output
+
+refresh: ## Refresh Terragrunt state
+	@printf "$(YELLOW)Refreshing state for $(ENV)...$(NC)\\n"
+	cd envs/$(ENV) && terragrunt refresh

--- a/aws/eks-cost/Makefile
+++ b/aws/eks-cost/Makefile
@@ -18,7 +18,7 @@ help: ## Show this help message
 	@echo "Usage: make <target> [ENV=<environment>]"
 	@echo ""
 	@echo "Available targets:"
-	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "  $(BLUE)%-15s$(NC) %s\\n", $$1, $$2}'
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "  $(BLUE)%-15s$(NC) %s\n", $$1, $$2}'
 	@echo ""
 	@echo "Available environments:"
 	@echo "  - production"
@@ -28,52 +28,52 @@ help: ## Show this help message
 	@echo "  make apply ENV=production"
 
 init: ## Initialize Terragrunt
-	@printf "$(YELLOW)Initializing Terragrunt for $(ENV)...$(NC)\\n"
+	@printf "$(YELLOW)Initializing Terragrunt for $(ENV)...$(NC)\n"
 	cd envs/$(ENV) && terragrunt init
 
 plan: ## Plan Terragrunt changes
-	@printf "$(YELLOW)Planning Terragrunt changes for $(ENV)...$(NC)\\n"
+	@printf "$(YELLOW)Planning Terragrunt changes for $(ENV)...$(NC)\n"
 	cd envs/$(ENV) && terragrunt plan
 
 apply: ## Apply Terragrunt changes
-	@printf "$(YELLOW)Applying Terragrunt changes for $(ENV)...$(NC)\\n"
+	@printf "$(YELLOW)Applying Terragrunt changes for $(ENV)...$(NC)\n"
 	cd envs/$(ENV) && terragrunt apply -auto-approve
 
 destroy: ## Destroy Terragrunt resources
-	@printf "$(RED)Destroying Terragrunt resources for $(ENV)...$(NC)\\n"
-	@printf "$(RED)WARNING: This will destroy all resources!$(NC)\\n"
-	@read -p "Are you sure? [y/N] " -n 1 -r; \\
-	echo; \\
-	if [[ $$REPLY =~ ^[Yy]$$ ]]; then \\
-		cd envs/$(ENV) && terragrunt destroy; \\
-	else \\
-		printf "$(YELLOW)Cancelled.$(NC)\\n"; \\
+	@printf "$(RED)Destroying Terragrunt resources for $(ENV)...$(NC)\n"
+	@printf "$(RED)WARNING: This will destroy all resources!$(NC)\n"
+	@read -p "Are you sure? [y/N] " -n 1 -r; \
+	echo; \
+	if [[ $$REPLY =~ ^[Yy]$$ ]]; then \
+		cd envs/$(ENV) && terragrunt destroy; \
+	else \
+		printf "$(YELLOW)Cancelled.$(NC)\n"; \
 	fi
 
 validate: ## Validate Terragrunt configuration
-	@printf "$(YELLOW)Validating Terragrunt configuration for $(ENV)...$(NC)\\n"
+	@printf "$(YELLOW)Validating Terragrunt configuration for $(ENV)...$(NC)\n"
 	cd envs/$(ENV) && terragrunt validate
 
 fmt: ## Format Terraform files
-	@printf "$(YELLOW)Formatting Terraform files...$(NC)\\n"
+	@printf "$(YELLOW)Formatting Terraform files...$(NC)\n"
 	terraform fmt -recursive .
 
 check: validate fmt ## Run validation and formatting checks
-	@printf "$(GREEN)All checks completed for $(ENV)$(NC)\\n"
+	@printf "$(GREEN)All checks completed for $(ENV)$(NC)\n"
 
 clean: ## Clean Terragrunt cache
-	@printf "$(YELLOW)Cleaning Terragrunt cache...$(NC)\\n"
+	@printf "$(YELLOW)Cleaning Terragrunt cache...$(NC)\n"
 	find . -type d -name ".terragrunt-cache" -exec rm -rf {} + 2>/dev/null || true
 	find . -name "*.tfplan" -delete 2>/dev/null || true
 
 show: ## Show current Terragrunt state
-	@printf "$(YELLOW)Showing current Terragrunt state for $(ENV)...$(NC)\\n"
+	@printf "$(YELLOW)Showing current state for $(ENV)...$(NC)\n"
 	cd envs/$(ENV) && terragrunt show
 
 output: ## Show Terragrunt outputs
-	@printf "$(YELLOW)Showing outputs for $(ENV)...$(NC)\\n"
+	@printf "$(YELLOW)Showing outputs for $(ENV)...$(NC)\n"
 	cd envs/$(ENV) && terragrunt output
 
 refresh: ## Refresh Terragrunt state
-	@printf "$(YELLOW)Refreshing state for $(ENV)...$(NC)\\n"
+	@printf "$(YELLOW)Refreshing state for $(ENV)...$(NC)\n"
 	cd envs/$(ENV) && terragrunt refresh

--- a/aws/eks-cost/envs/production/env.hcl
+++ b/aws/eks-cost/envs/production/env.hcl
@@ -1,0 +1,12 @@
+# env.hcl - Environment-specific configuration for production
+
+locals {
+  environment = "production"
+  aws_region  = "ap-northeast-1"
+
+  environment_tags = {
+    Environment = local.environment
+    Component   = "eks-cost"
+    Owner       = "panicboat"
+  }
+}

--- a/aws/eks-cost/envs/production/terragrunt.hcl
+++ b/aws/eks-cost/envs/production/terragrunt.hcl
@@ -1,0 +1,32 @@
+# terragrunt.hcl - Terragrunt configuration for production environment
+
+include "root" {
+  path = find_in_parent_folders("root.hcl")
+}
+
+include "env" {
+  path   = "env.hcl"
+  expose = true
+}
+
+# Reference to Terraform modules.
+# Use go-getter `//` subdir notation so the entire `aws/` tree is copied to
+# the Terragrunt cache. This lets `module "eks"` in modules/lookups.tf
+# resolve `../../eks/lookup` from within the cache.
+terraform {
+  source = "../../..//eks-cost/modules"
+}
+
+inputs = {
+  environment = include.env.locals.environment
+  aws_region  = include.env.locals.aws_region
+
+  common_tags = merge(
+    include.env.locals.environment_tags,
+    {
+      Project    = "eks-cost"
+      ManagedBy  = "terraform"
+      Repository = "panicboat/platform"
+    }
+  )
+}

--- a/aws/eks-cost/modules/lookups.tf
+++ b/aws/eks-cost/modules/lookups.tf
@@ -1,0 +1,7 @@
+# lookups.tf - External stack lookups.
+
+# EKS cluster info (for Pod Identity Association cluster_name)
+module "eks" {
+  source      = "../../eks/lookup"
+  environment = var.environment
+}

--- a/aws/eks-cost/modules/main.tf
+++ b/aws/eks-cost/modules/main.tf
@@ -1,0 +1,76 @@
+# main.tf - OpenCost AWS-side infrastructure (Pod Identity for Spot Data Feed read access).
+#
+# Provides:
+# 1. IAM role bound by Pod Identity Association to K8s SA `monitoring:opencost`
+#    - S3 read-only access scoped to the Spot Instance Data Feed bucket
+#      created by aws/cost-management (spot_datafeed.tf). That bucket's name
+#      is deterministic (`opencost-spot-datafeed-<account_id>`, same
+#      convention as `mimir-<account_id>` referenced from
+#      kubernetes/components/mimir/), so it is hardcoded here rather than
+#      pulled via a live cross-stack Terragrunt `dependency` block.
+#    - AWS on-demand pricing comes from a public, unauthenticated HTTPS
+#      endpoint (verified against opencost.io/docs/configuration/aws), so no
+#      IAM permission is needed or granted for it.
+# 2. Pod Identity Association binding `monitoring:opencost` SA → IAM role
+
+data "aws_caller_identity" "current" {}
+
+locals {
+  service_name             = "opencost" # K8s ServiceAccount name
+  spot_datafeed_bucket_arn = "arn:aws:s3:::opencost-spot-datafeed-${data.aws_caller_identity.current.account_id}"
+}
+
+resource "aws_iam_role" "pod_identity" {
+  name = "eks-${var.environment}-${local.service_name}"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect = "Allow"
+      Principal = {
+        Service = "pods.eks.amazonaws.com"
+      }
+      Action = ["sts:AssumeRole", "sts:TagSession"]
+    }]
+  })
+
+  tags = var.common_tags
+}
+
+# Least-privilege read access to the Spot Data Feed bucket only. Split into
+# bucket-level vs object-level statements (same 2-statement shape as
+# aws/eks-metrics' s3_access policy) rather than the flat single-Resource
+# example in OpenCost's own docs, which incorrectly lists object-level
+# actions (s3:GetObject, s3:HeadObject) against a bucket-level ARN.
+resource "aws_iam_role_policy" "spot_datafeed_read" {
+  name = "spot-datafeed-read"
+  role = aws_iam_role.pod_identity.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid      = "BucketLevelListing"
+        Effect   = "Allow"
+        Action   = ["s3:ListBucket", "s3:HeadBucket", "s3:GetBucketLocation"]
+        Resource = local.spot_datafeed_bucket_arn
+      },
+      {
+        Sid      = "ObjectLevelRead"
+        Effect   = "Allow"
+        Action   = ["s3:GetObject", "s3:HeadObject"]
+        Resource = "${local.spot_datafeed_bucket_arn}/*"
+      }
+    ]
+  })
+}
+
+# Pod Identity Association binding K8s SA → IAM role
+resource "aws_eks_pod_identity_association" "this" {
+  cluster_name    = module.eks.cluster.name
+  namespace       = "monitoring"
+  service_account = local.service_name
+  role_arn        = aws_iam_role.pod_identity.arn
+
+  tags = var.common_tags
+}

--- a/aws/eks-cost/modules/main.tf
+++ b/aws/eks-cost/modules/main.tf
@@ -60,6 +60,12 @@ resource "aws_iam_role_policy" "spot_datafeed_read" {
         Effect   = "Allow"
         Action   = ["s3:GetObject", "s3:HeadObject"]
         Resource = "${local.spot_datafeed_bucket_arn}/*"
+      },
+      {
+        Sid      = "SpotPriceHistoryFallbackRead"
+        Effect   = "Allow"
+        Action   = ["ec2:DescribeSpotPriceHistory"]
+        Resource = "*"
       }
     ]
   })

--- a/aws/eks-cost/modules/outputs.tf
+++ b/aws/eks-cost/modules/outputs.tf
@@ -1,0 +1,11 @@
+# outputs.tf - Outputs for the eks-cost module.
+
+output "pod_identity_role_name" {
+  description = "IAM role name bound to monitoring:opencost SA via Pod Identity Association. Used for verification."
+  value       = aws_iam_role.pod_identity.name
+}
+
+output "pod_identity_role_arn" {
+  description = "IAM role ARN for monitoring:opencost SA Pod Identity binding."
+  value       = aws_iam_role.pod_identity.arn
+}

--- a/aws/eks-cost/modules/terraform.tf
+++ b/aws/eks-cost/modules/terraform.tf
@@ -1,0 +1,20 @@
+# terraform.tf - OpenTofu and provider configuration
+
+terraform {
+  required_version = "1.12.5"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "6.56.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.aws_region
+
+  default_tags {
+    tags = var.common_tags
+  }
+}

--- a/aws/eks-cost/modules/variables.tf
+++ b/aws/eks-cost/modules/variables.tf
@@ -1,0 +1,17 @@
+# variables.tf - Inputs for the eks-cost module
+
+variable "environment" {
+  description = "Environment name (e.g., production)."
+  type        = string
+}
+
+variable "aws_region" {
+  description = "AWS region"
+  type        = string
+}
+
+variable "common_tags" {
+  description = "Common tags applied to all resources"
+  type        = map(string)
+  default     = {}
+}

--- a/aws/eks-cost/root.hcl
+++ b/aws/eks-cost/root.hcl
@@ -1,0 +1,39 @@
+# root.hcl - Root Terragrunt configuration for EKS Cost
+# This file contains common settings shared across all environments
+
+locals {
+  project_name = "eks-cost"
+
+  path_parts  = split("/", path_relative_to_include())
+  environment = element(local.path_parts, length(local.path_parts) - 1)
+
+  common_tags = {
+    Project     = local.project_name
+    Environment = local.environment
+    ManagedBy   = "terragrunt"
+    Repository  = "monorepo"
+    Component   = "eks-cost"
+    Team        = "panicboat"
+  }
+}
+
+remote_state {
+  backend = "s3"
+  generate = {
+    path      = "backend.tf"
+    if_exists = "overwrite_terragrunt"
+  }
+  config = {
+    bucket         = "terragrunt-state-${get_aws_account_id()}"
+    key            = "platform/eks-cost/${local.environment}/terraform.tfstate"
+    region         = "ap-northeast-1"
+    dynamodb_table = "terragrunt-state-locks"
+    encrypt        = true
+  }
+}
+
+inputs = {
+  environment = local.environment
+  common_tags = local.common_tags
+  aws_region  = "ap-northeast-1"
+}

--- a/docs/runbooks/eks-production-recreate.md
+++ b/docs/runbooks/eks-production-recreate.md
@@ -196,7 +196,7 @@ done'
 ### Phase 7: 残り stack apply (= Terminal A)
 
 ```bash
-for stack in eks-secrets eks-logs eks-metrics eks-traces; do
+for stack in eks-secrets eks-logs eks-metrics eks-traces eks-cost; do
   echo "=== apply: $stack ==="
   ( cd aws/$stack/envs/production && TG_TF_PATH=tofu terragrunt init -upgrade && TG_TF_PATH=tofu terragrunt apply -auto-approve )
 done

--- a/docs/superpowers/plans/2026-08-02-opencost-integration.md
+++ b/docs/superpowers/plans/2026-08-02-opencost-integration.md
@@ -1,0 +1,882 @@
+# OpenCost Integration Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Deploy OpenCost to the `eks-production` cluster so AWS cost (especially spot instance cost) is visible in Grafana, without opening AWS Cost Explorer.
+
+**Architecture:** OpenCost runs as a new `monitoring` namespace component. On-demand pricing comes from a public, unauthenticated AWS endpoint (no IAM needed). Spot pricing comes from an AWS Spot Instance Data Feed (a new S3 bucket + subscription in the existing `aws/cost-management` stack), read via a new Pod Identity IAM role (`aws/eks-cost` stack). OpenCost reads existing cluster resource-usage metrics from the existing `kube-prometheus-stack` Prometheus, and exposes its own cost metrics back to that same Prometheus via a `ServiceMonitor`, which already remote-writes to Mimir. Three community-maintained OpenCost Grafana dashboards are added to the existing dashboard sidecar auto-discovery mechanism.
+
+**Tech Stack:** Terragrunt/OpenTofu (AWS resources), Helmfile (`opencost` chart v2.5.28 from `https://opencost.github.io/opencost-helm-chart`), Kustomize (Grafana dashboard ConfigMaps), FluxCD (deployment).
+
+## Global Constraints
+
+- OpenTofu `required_version = "1.12.5"`, AWS provider `version = "6.56.0"` (all new/modified `.tf` files must match the versions already pinned across every other `aws/*/modules/terraform.tf` in this repo)
+- `terraform-aws-modules/s3-bucket/aws` module version `"5.15.3"` (current pin used by `aws/eks-metrics`, `aws/eks-logs`, `aws/eks-traces`)
+- AWS account ID: `559744160976` (already hardcoded elsewhere in this repo, e.g. `kubernetes/components/aws-load-balancer-controller/production/helmfile.yaml`)
+- Cluster region: `ap-northeast-1`. `aws/cost-management`'s default provider is pinned to `us-east-1` (Cost Optimization Hub / Compute Optimizer are us-east-1-only); new resources in that stack must override with a per-resource `region = "ap-northeast-1"` argument rather than adding a provider alias (both `terraform-aws-modules/s3-bucket/aws` v5.15.3 and `aws_spot_datafeed_subscription` support this natively)
+- Auth pattern: EKS Pod Identity, not IRSA (no `eks.amazonaws.com/role-arn` annotation; `serviceAccount.name` must exactly match the Pod Identity Association's `service_account`)
+- OpenCost namespace: `monitoring` (shared with mimir/loki/tempo/prometheus-operator)
+- OpenCost chart: repo `https://opencost.github.io/opencost-helm-chart`, chart `opencost`, version `"2.5.28"`
+- Commit convention: `git commit -s` (signoff), no `Co-Authored-By` trailer
+- All Terraform tasks in this plan stop at `terragrunt plan`. Do NOT run `terragrunt apply` or any other live-infrastructure-mutating command without a separate, explicit confirmation from the user at execution time — this is a hard-to-reverse, shared-system action per the operator's standing policy.
+
+---
+
+## Task 1: `aws/cost-management` — Spot Instance Data Feed S3 bucket + subscription
+
+**Files:**
+- Create: `aws/cost-management/modules/spot_datafeed.tf`
+- Modify: `aws/cost-management/modules/outputs.tf`
+
+**Interfaces:**
+- Produces (Terraform outputs, consumed by Task 2 and Task 3 as hardcoded values — see Task 1 Step 4 rationale): `spot_datafeed_bucket_name = "opencost-spot-datafeed-559744160976"`, `spot_datafeed_region = "ap-northeast-1"`
+
+- [ ] **Step 1: Write `spot_datafeed.tf`**
+
+```hcl
+# spot_datafeed.tf - AWS Spot Instance Data Feed (S3 bucket + subscription)
+#
+# OpenCost (aws/eks-cost stack 側の Pod Identity role 経由) が Spot instance
+# の実勢価格を取得するための data feed。 `aws_spot_datafeed_subscription` は
+# 1 AWS account に1つしか作成できない singleton resource
+# (AWSServiceRoleForEC2Spot と同種の制約) のため、 cluster destroy/recreate
+# cycle の対象外である本 stack に配置する。
+#
+# bucket は EKS cluster と同じ ap-northeast-1 に置く (OpenCost pod からの S3
+# 読み取りで cross-region data transfer を避けるため)。 本 stack のデフォルト
+# provider は Cost Optimization Hub / Compute Optimizer 向けに us-east-1
+# 固定のため、 `region` 引数で resource 単位に上書きする。
+
+data "aws_caller_identity" "current" {}
+
+locals {
+  spot_datafeed_bucket_name = "opencost-spot-datafeed-${data.aws_caller_identity.current.account_id}"
+  spot_datafeed_region      = "ap-northeast-1"
+}
+
+module "spot_datafeed_bucket" {
+  source  = "terraform-aws-modules/s3-bucket/aws"
+  version = "5.15.3"
+
+  region = local.spot_datafeed_region
+  bucket = local.spot_datafeed_bucket_name
+
+  force_destroy = true
+
+  # Spot Data Feed は AWS が bucket ACL に write 権限を legacy 方式で付与する
+  # ため、 Object Ownership を S3 デフォルトの "Bucket owner enforced"
+  # (ACL 無効) から変更し ACL を有効化する必要がある。 明示的な grant は行わず
+  # (= acl 変数は未設定)、 AWS 側が subscribe 時に自動でつける ACL に任せる。
+  control_object_ownership = true
+  object_ownership          = "BucketOwnerPreferred"
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+
+  server_side_encryption_configuration = {
+    rule = {
+      apply_server_side_encryption_by_default = {
+        sse_algorithm = "AES256"
+      }
+    }
+  }
+
+  versioning = {
+    status = "Disabled"
+  }
+
+  # 30日: raw data feed file を長期保持する理由がないため最小化
+  lifecycle_rule = [
+    {
+      id     = "expire-old-datafeed-files"
+      status = "Enabled"
+      expiration = {
+        days = 30
+      }
+    }
+  ]
+
+  tags = var.common_tags
+}
+
+resource "aws_spot_datafeed_subscription" "this" {
+  region = local.spot_datafeed_region
+  bucket = module.spot_datafeed_bucket.s3_bucket_id
+}
+```
+
+- [ ] **Step 2: Append outputs to `outputs.tf`**
+
+Current file is a single comment line (`# outputs.tf - No outputs; this service does not expose values to other stacks`). Replace its entire content with:
+
+```hcl
+# outputs.tf - Outputs for the cost-management module.
+
+output "spot_datafeed_bucket_name" {
+  description = "S3 bucket name for the AWS Spot Instance Data Feed. Referenced (as a hardcoded value, see aws/eks-cost and kubernetes/components/opencost/ for why) by aws/eks-cost's IAM policy Resource ARN and kubernetes/components/opencost/ helmfile values (opencost.customPricing.costModel.awsSpotDataBucket)."
+  value       = module.spot_datafeed_bucket.s3_bucket_id
+}
+
+output "spot_datafeed_region" {
+  description = "AWS region of the Spot Instance Data Feed bucket. Used as opencost.customPricing.costModel.awsSpotDataRegion."
+  value       = local.spot_datafeed_region
+}
+```
+
+- [ ] **Step 3: Validate and format**
+
+Run:
+```bash
+cd aws/cost-management/envs/develop && TG_TF_PATH=tofu terragrunt validate
+cd /Users/takanokenichi/GitHub/panicboat/platform/.claude/worktrees/feat-opencost-integration/aws/cost-management && TG_TF_PATH=tofu terragrunt hclfmt 2>/dev/null; tofu fmt -recursive modules/
+```
+Expected: `terragrunt validate` reports `Success! The configuration is valid.`; `tofu fmt` makes no further changes (or auto-fixes indentation — re-run `validate` after if it does).
+
+- [ ] **Step 4: Plan (do not apply)**
+
+Run:
+```bash
+cd aws/cost-management/envs/develop && TG_TF_PATH=tofu terragrunt plan
+```
+Expected: plan shows `2 to add` (`module.spot_datafeed_bucket...` resources — actually the module itself creates multiple resources, so the exact count will be higher than 2; confirm no `to change` or `to destroy` against the two existing `cost_optimization_hub`/`compute_optimizer` resources) and `aws_spot_datafeed_subscription.this` to add. No errors.
+
+Note the exact `spot_datafeed_bucket_name` output value shown in the plan (should be `opencost-spot-datafeed-559744160976`) — Task 2 and Task 3 hardcode this string rather than using a live `dependency` block, following the same convention `kubernetes/components/mimir/production/helmfile.yaml` uses for its `aws/eks-metrics` bucket name (deterministic name, no need for a live cross-stack Terragrunt dependency).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add aws/cost-management/modules/spot_datafeed.tf aws/cost-management/modules/outputs.tf
+git commit -s -m "feat(aws/cost-management): add Spot Instance Data Feed S3 bucket and subscription"
+```
+
+---
+
+## Task 2: `aws/eks-cost` — new stack: Pod Identity IAM role for OpenCost
+
+**Files:**
+- Create: `aws/eks-cost/root.hcl`
+- Create: `aws/eks-cost/envs/production/env.hcl`
+- Create: `aws/eks-cost/envs/production/terragrunt.hcl`
+- Create: `aws/eks-cost/modules/main.tf`
+- Create: `aws/eks-cost/modules/variables.tf`
+- Create: `aws/eks-cost/modules/outputs.tf`
+- Create: `aws/eks-cost/modules/lookups.tf`
+- Create: `aws/eks-cost/modules/terraform.tf`
+- Create: `aws/eks-cost/Makefile`
+
+**Interfaces:**
+- Consumes: `aws/cost-management`'s deterministic bucket name `opencost-spot-datafeed-559744160976` (hardcoded, see Task 1 Step 4)
+- Produces: IAM role `eks-production-opencost`, Pod Identity Association binding K8s SA `monitoring:opencost` to that role (consumed implicitly by Task 3's Deployment at runtime — no Terraform output needs to be threaded into Helm values, since Pod Identity binds by SA name alone)
+
+This task mirrors `aws/eks-metrics` file-for-file, swapping the S3-storage-for-Mimir policy for a read-only policy scoped to the Spot Data Feed bucket, and dropping the `bucket_name`/`bucket_path_prefix` outputs since OpenCost needs no bucket of its own.
+
+- [ ] **Step 1: Write `root.hcl`**
+
+```hcl
+# root.hcl - Root Terragrunt configuration for EKS Cost
+# This file contains common settings shared across all environments
+
+locals {
+  project_name = "eks-cost"
+
+  path_parts  = split("/", path_relative_to_include())
+  environment = element(local.path_parts, length(local.path_parts) - 1)
+
+  common_tags = {
+    Project     = local.project_name
+    Environment = local.environment
+    ManagedBy   = "terragrunt"
+    Repository  = "monorepo"
+    Component   = "eks-cost"
+    Team        = "panicboat"
+  }
+}
+
+remote_state {
+  backend = "s3"
+  generate = {
+    path      = "backend.tf"
+    if_exists = "overwrite_terragrunt"
+  }
+  config = {
+    bucket         = "terragrunt-state-${get_aws_account_id()}"
+    key            = "platform/eks-cost/${local.environment}/terraform.tfstate"
+    region         = "ap-northeast-1"
+    dynamodb_table = "terragrunt-state-locks"
+    encrypt        = true
+  }
+}
+
+inputs = {
+  environment = local.environment
+  common_tags = local.common_tags
+  aws_region  = "ap-northeast-1"
+}
+```
+
+- [ ] **Step 2: Write `envs/production/env.hcl`**
+
+```hcl
+# env.hcl - Environment-specific configuration for production
+
+locals {
+  environment = "production"
+  aws_region  = "ap-northeast-1"
+
+  environment_tags = {
+    Environment = local.environment
+    Component   = "eks-cost"
+    Owner       = "panicboat"
+  }
+}
+```
+
+- [ ] **Step 3: Write `envs/production/terragrunt.hcl`**
+
+```hcl
+# terragrunt.hcl - Terragrunt configuration for production environment
+
+include "root" {
+  path = find_in_parent_folders("root.hcl")
+}
+
+include "env" {
+  path   = "env.hcl"
+  expose = true
+}
+
+# Reference to Terraform modules.
+# Use go-getter `//` subdir notation so the entire `aws/` tree is copied to
+# the Terragrunt cache. This lets `module "eks"` in modules/lookups.tf
+# resolve `../../eks/lookup` from within the cache.
+terraform {
+  source = "../../..//eks-cost/modules"
+}
+
+inputs = {
+  environment = include.env.locals.environment
+  aws_region  = include.env.locals.aws_region
+
+  common_tags = merge(
+    include.env.locals.environment_tags,
+    {
+      Project    = "eks-cost"
+      ManagedBy  = "terraform"
+      Repository = "panicboat/platform"
+    }
+  )
+}
+```
+
+- [ ] **Step 4: Write `modules/terraform.tf`**
+
+```hcl
+# terraform.tf - OpenTofu and provider configuration
+
+terraform {
+  required_version = "1.12.5"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "6.56.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.aws_region
+
+  default_tags {
+    tags = var.common_tags
+  }
+}
+```
+
+- [ ] **Step 5: Write `modules/variables.tf`**
+
+```hcl
+# variables.tf - Inputs for the eks-cost module
+
+variable "environment" {
+  description = "Environment name (e.g., production)."
+  type        = string
+}
+
+variable "aws_region" {
+  description = "AWS region"
+  type        = string
+}
+
+variable "common_tags" {
+  description = "Common tags applied to all resources"
+  type        = map(string)
+  default     = {}
+}
+```
+
+- [ ] **Step 6: Write `modules/lookups.tf`**
+
+```hcl
+# lookups.tf - External stack lookups.
+
+# EKS cluster info (for Pod Identity Association cluster_name)
+module "eks" {
+  source      = "../../eks/lookup"
+  environment = var.environment
+}
+```
+
+- [ ] **Step 7: Write `modules/main.tf`**
+
+```hcl
+# main.tf - OpenCost AWS-side infrastructure (Pod Identity for Spot Data Feed read access).
+#
+# Provides:
+# 1. IAM role bound by Pod Identity Association to K8s SA `monitoring:opencost`
+#    - S3 read-only access scoped to the Spot Instance Data Feed bucket
+#      created by aws/cost-management (spot_datafeed.tf). That bucket's name
+#      is deterministic (`opencost-spot-datafeed-<account_id>`, same
+#      convention as `mimir-<account_id>` referenced from
+#      kubernetes/components/mimir/), so it is hardcoded here rather than
+#      pulled via a live cross-stack Terragrunt `dependency` block.
+#    - AWS on-demand pricing comes from a public, unauthenticated HTTPS
+#      endpoint (verified against opencost.io/docs/configuration/aws), so no
+#      IAM permission is needed or granted for it.
+# 2. Pod Identity Association binding `monitoring:opencost` SA → IAM role
+
+data "aws_caller_identity" "current" {}
+
+locals {
+  service_name             = "opencost" # K8s ServiceAccount name
+  spot_datafeed_bucket_arn = "arn:aws:s3:::opencost-spot-datafeed-${data.aws_caller_identity.current.account_id}"
+}
+
+resource "aws_iam_role" "pod_identity" {
+  name = "eks-${var.environment}-${local.service_name}"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect = "Allow"
+      Principal = {
+        Service = "pods.eks.amazonaws.com"
+      }
+      Action = ["sts:AssumeRole", "sts:TagSession"]
+    }]
+  })
+
+  tags = var.common_tags
+}
+
+# Least-privilege read access to the Spot Data Feed bucket only. Split into
+# bucket-level vs object-level statements (same 2-statement shape as
+# aws/eks-metrics' s3_access policy) rather than the flat single-Resource
+# example in OpenCost's own docs, which incorrectly lists object-level
+# actions (s3:GetObject, s3:HeadObject) against a bucket-level ARN.
+resource "aws_iam_role_policy" "spot_datafeed_read" {
+  name = "spot-datafeed-read"
+  role = aws_iam_role.pod_identity.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid      = "BucketLevelListing"
+        Effect   = "Allow"
+        Action   = ["s3:ListBucket", "s3:HeadBucket", "s3:GetBucketLocation"]
+        Resource = local.spot_datafeed_bucket_arn
+      },
+      {
+        Sid      = "ObjectLevelRead"
+        Effect   = "Allow"
+        Action   = ["s3:GetObject", "s3:HeadObject"]
+        Resource = "${local.spot_datafeed_bucket_arn}/*"
+      }
+    ]
+  })
+}
+
+# Pod Identity Association binding K8s SA → IAM role
+resource "aws_eks_pod_identity_association" "this" {
+  cluster_name    = module.eks.cluster.name
+  namespace       = "monitoring"
+  service_account = local.service_name
+  role_arn        = aws_iam_role.pod_identity.arn
+
+  tags = var.common_tags
+}
+```
+
+- [ ] **Step 8: Write `modules/outputs.tf`**
+
+```hcl
+# outputs.tf - Outputs for the eks-cost module.
+
+output "pod_identity_role_name" {
+  description = "IAM role name bound to monitoring:opencost SA via Pod Identity Association. Used for verification."
+  value       = aws_iam_role.pod_identity.name
+}
+
+output "pod_identity_role_arn" {
+  description = "IAM role ARN for monitoring:opencost SA Pod Identity binding."
+  value       = aws_iam_role.pod_identity.arn
+}
+```
+
+- [ ] **Step 9: Write `Makefile`**
+
+Copy `aws/eks-metrics/Makefile` verbatim, changing only the header comment and `help` banner text from "EKS Metrics (Mimir S3 + Pod Identity)" / "EKS Metrics" to "EKS Cost (OpenCost Pod Identity)" / "EKS Cost".
+
+- [ ] **Step 10: Validate and plan (do not apply)**
+
+Run:
+```bash
+cd aws/eks-cost/envs/production && TG_TF_PATH=tofu terragrunt init -upgrade
+cd aws/eks-cost/envs/production && TG_TF_PATH=tofu terragrunt validate
+cd aws/eks-cost/envs/production && TG_TF_PATH=tofu terragrunt plan
+```
+Expected: `validate` succeeds; `plan` shows 3 resources to add (`aws_iam_role.pod_identity`, `aws_iam_role_policy.spot_datafeed_read`, `aws_eks_pod_identity_association.this`), 0 to change, 0 to destroy. No errors (the `module "eks"` lookup must successfully find the live `eks-production` cluster).
+
+- [ ] **Step 11: Commit**
+
+```bash
+git add aws/eks-cost/
+git commit -s -m "feat(aws/eks-cost): add Pod Identity IAM role for OpenCost"
+```
+
+---
+
+## Task 3: `kubernetes/components/opencost/production/` — new component
+
+**Files:**
+- Create: `kubernetes/components/opencost/production/helmfile.yaml`
+- Create: `kubernetes/components/opencost/production/values.yaml.gotmpl`
+
+**Interfaces:**
+- Consumes: `aws/cost-management` outputs `spot_datafeed_bucket_name` / `spot_datafeed_region` (Task 1, hardcoded per that task's Step 4 rationale); `aws/eks-cost`'s Pod Identity Association for `monitoring:opencost` (Task 2, binds automatically by SA name — no value wiring needed)
+- Produces: `Deployment/opencost` + `Service/opencost` in namespace `monitoring`, `ServiceMonitor/opencost` labeled `release: kube-prometheus-stack`
+
+- [ ] **Step 1: Write `helmfile.yaml`**
+
+```yaml
+# =============================================================================
+# OpenCost Helmfile for production
+# =============================================================================
+# Kubernetes cost allocation. On-demand pricing comes from a public,
+# unauthenticated AWS endpoint (no credentials involved). Spot pricing comes
+# from the AWS Spot Instance Data Feed (aws/cost-management) read via Pod
+# Identity (aws/eks-cost).
+# =============================================================================
+environments:
+  production:
+    values:
+      - opencost:
+          # Source: aws/cost-management/envs/develop terragrunt output spot_datafeed_bucket_name
+          spotDataBucket: opencost-spot-datafeed-559744160976
+          # Source: aws/cost-management/envs/develop terragrunt output spot_datafeed_region
+          spotDataRegion: ap-northeast-1
+          # STABLE: AWS account ID
+          awsAccountId: "559744160976"
+---
+repositories:
+  - name: opencost
+    url: https://opencost.github.io/opencost-helm-chart
+
+releases:
+  - name: opencost
+    namespace: monitoring
+    chart: opencost/opencost
+    version: "2.5.28"
+    values:
+      - values.yaml.gotmpl
+```
+
+- [ ] **Step 2: Write `values.yaml.gotmpl`**
+
+```yaml
+# OpenCost values for production
+
+serviceAccount:
+  create: true
+  name: opencost
+
+opencost:
+  metrics:
+    serviceMonitor:
+      enabled: true
+      # kube-prometheus-stack の serviceMonitorSelector match (cilium の
+      # ServiceMonitor と同じ pattern)
+      additionalLabels:
+        release: kube-prometheus-stack
+
+  prometheus:
+    internal:
+      enabled: true
+      serviceName: kube-prometheus-stack-prometheus
+      namespaceName: monitoring
+      port: 9090
+
+  # awsSpotDataBucket/awsSpotDataRegion/projectID の3つを渡すためだけに
+  # customPricing を有効化する。 CPU/RAM/GPU 等の costModel フィールドは未指定
+  # のまま chart デフォルトにフォールバックさせる (= 動的取得 (Pricing API)
+  # が失敗した場合のみ使われる fallback 値であり、 常用の静的価格ではない。
+  # opencost.io/docs/configuration/aws のソース調査で確認済)。
+  customPricing:
+    enabled: true
+    provider: aws
+    costModel:
+      description: "AWS Spot Instance Data Feed location for spot price accuracy"
+      awsSpotDataBucket: {{ .Values.opencost.spotDataBucket }}
+      awsSpotDataRegion: {{ .Values.opencost.spotDataRegion }}
+      projectID: {{ .Values.opencost.awsAccountId }}
+
+  exporter:
+    resources:
+      requests:
+        cpu: 25m
+        memory: 55Mi
+      limits:
+        memory: 256Mi
+
+  ui:
+    resources:
+      requests:
+        cpu: 10m
+        memory: 55Mi
+      limits:
+        memory: 256Mi
+```
+
+- [ ] **Step 3: Hydrate and inspect the rendered manifest**
+
+Run:
+```bash
+scripts/kubernetes-hydrate/hydrate-component.sh opencost production
+```
+Expected: exits 0, writes `kubernetes/manifests/production/opencost/manifest.yaml` and `kustomization.yaml`.
+
+Then verify the key pieces rendered correctly:
+```bash
+grep -n "^kind: ServiceAccount" -A3 kubernetes/manifests/production/opencost/manifest.yaml
+grep -n "^kind: ServiceMonitor" -A20 kubernetes/manifests/production/opencost/manifest.yaml | grep -E "release:|name:|namespace:"
+grep -n "awsSpotDataBucket\|awsSpotDataRegion\|projectID" kubernetes/manifests/production/opencost/manifest.yaml
+```
+Expected:
+- `ServiceAccount` named `opencost` in namespace `monitoring`, no `eks.amazonaws.com/role-arn` annotation
+- `ServiceMonitor` carries label `release: kube-prometheus-stack`
+- the custom-pricing ConfigMap (or Secret, whichever the chart renders) contains `"awsSpotDataBucket": "opencost-spot-datafeed-559744160976"`, `"awsSpotDataRegion": "ap-northeast-1"`, `"projectID": "559744160976"`
+
+- [ ] **Step 4: Regenerate the manifests index**
+
+Run:
+```bash
+scripts/kubernetes-hydrate/hydrate-index.sh production
+```
+Expected: `kubernetes/manifests/production/kustomization.yaml` now lists `./opencost` alphabetically between `./oauth2-proxy` and `./opentelemetry-collector`; `kubernetes/manifests/production/00-namespaces/namespaces.yaml` is unchanged (opencost has no `namespace.yaml` of its own — it reuses the `monitoring` namespace already created by `prometheus-operator`).
+
+- [ ] **Step 5: Dry-run validate against the live cluster**
+
+Run:
+```bash
+kubectl apply -k kubernetes/manifests/production/opencost/ --dry-run=server
+```
+Expected: no errors (server-side dry-run confirms the rendered manifest is structurally valid against the live API server's CRDs, including `ServiceMonitor`).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add kubernetes/components/opencost/ kubernetes/manifests/production/opencost/ kubernetes/manifests/production/kustomization.yaml
+git commit -s -m "feat(kubernetes/opencost): add OpenCost component for production"
+```
+
+---
+
+## Task 4: Grafana dashboards
+
+**Files:**
+- Create: `kubernetes/components/dashboard/production/kustomization/grafana/opencost-overview.json`
+- Create: `kubernetes/components/dashboard/production/kustomization/grafana/opencost-namespace.json`
+- Create: `kubernetes/components/dashboard/production/kustomization/grafana/opencost-workload.json`
+- Modify: `kubernetes/components/dashboard/production/kustomization/kustomization.yaml`
+
+**Interfaces:**
+- Consumes: `ServiceMonitor/opencost` metrics flowing into Mimir (Task 3); each dashboard's `$datasource` template variable (type `prometheus`, default `"default"`) auto-resolves to whichever datasource Grafana has marked default (Mimir, per existing `prometheus-operator` component config) — no per-dashboard datasource UID edit needed
+
+These three dashboards are community-maintained (`adinhodovic/opencost-mixin`), not published by the `opencost` GitHub org itself — the org's own `opencost/opencost-grafana-dashboard` repo is empty. This mixin's output is what backs the "OpenCost / Overview", "OpenCost / Namespace", and "OpenCost / Workload" listings on grafana.com, and is the closest thing to a de facto standard dashboard set. Pinned to commit `b63c14d687fd2463469c0afa36b06ab5f6bc7d70` (2026-07-17) for reproducibility.
+
+- [ ] **Step 1: Download the three dashboard JSON files**
+
+Run:
+```bash
+SHA=b63c14d687fd2463469c0afa36b06ab5f6bc7d70
+DEST=kubernetes/components/dashboard/production/kustomization/grafana
+for name in overview namespace workload; do
+  curl -fsSL "https://raw.githubusercontent.com/adinhodovic/opencost-mixin/${SHA}/dashboards_out/opencost-${name}.json" \
+    -o "${DEST}/opencost-${name}.json"
+done
+```
+Expected: three files created, sizes roughly 49KB (overview), 57KB (namespace), 41KB (workload).
+
+- [ ] **Step 2: Verify each file is valid JSON and uses the templated datasource**
+
+Run:
+```bash
+for f in overview namespace workload; do
+  python3 -c "import json; json.load(open('kubernetes/components/dashboard/production/kustomization/grafana/opencost-${f}.json'))" && echo "opencost-${f}.json: valid JSON"
+done
+grep -c '"uid": "\${datasource}"\|"uid": "\$datasource"' kubernetes/components/dashboard/production/kustomization/grafana/opencost-*.json
+```
+Expected: all three print "valid JSON"; each file has multiple matches for the templated datasource UID (confirms no hardcoded datasource UID was baked in).
+
+- [ ] **Step 3: Register the three dashboards in `kustomization.yaml`**
+
+Modify `kubernetes/components/dashboard/production/kustomization/kustomization.yaml`. Current content:
+
+```yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: monitoring
+
+configMapGenerator:
+  - name: grafana-dashboard-app-monitoring
+    files:
+      - grafana/app-monitoring.json
+    options:
+      labels:
+        grafana_dashboard: "1"
+  - name: grafana-dashboard-infra-monitoring
+    files:
+      - grafana/infra-monitoring.json
+    options:
+      labels:
+        grafana_dashboard: "1"
+  - name: grafana-dashboard-unified-monitoring
+    files:
+      - grafana/unified-monitoring.json
+    options:
+      labels:
+        grafana_dashboard: "1"
+
+generatorOptions:
+  disableNameSuffixHash: true
+```
+
+Add three more `configMapGenerator` entries (after `grafana-dashboard-unified-monitoring`, before `generatorOptions`):
+
+```yaml
+  - name: grafana-dashboard-opencost-overview
+    files:
+      - grafana/opencost-overview.json
+    options:
+      labels:
+        grafana_dashboard: "1"
+  - name: grafana-dashboard-opencost-namespace
+    files:
+      - grafana/opencost-namespace.json
+    options:
+      labels:
+        grafana_dashboard: "1"
+  - name: grafana-dashboard-opencost-workload
+    files:
+      - grafana/opencost-workload.json
+    options:
+      labels:
+        grafana_dashboard: "1"
+```
+
+- [ ] **Step 4: Build and verify**
+
+Run:
+```bash
+kustomize build kubernetes/components/dashboard/production/kustomization/ | grep -A2 "^kind: ConfigMap" | grep "name: grafana-dashboard-opencost"
+```
+Expected: three `ConfigMap` names printed (`grafana-dashboard-opencost-overview`, `grafana-dashboard-opencost-namespace`, `grafana-dashboard-opencost-workload`).
+
+- [ ] **Step 5: Hydrate the dashboard component**
+
+Run:
+```bash
+scripts/kubernetes-hydrate/hydrate-component.sh dashboard production
+```
+Expected: exits 0; `git diff --stat kubernetes/manifests/production/dashboard/manifest.yaml` shows only additions (the three new ConfigMaps), no unrelated changes.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add kubernetes/components/dashboard/production/kustomization/grafana/opencost-*.json \
+        kubernetes/components/dashboard/production/kustomization/kustomization.yaml \
+        kubernetes/manifests/production/dashboard/manifest.yaml
+git commit -s -m "feat(kubernetes/dashboard): add OpenCost Grafana dashboards"
+```
+
+---
+
+## Task 5: EKS lifecycle integration
+
+**Files:**
+- Modify: `scripts/eks-lifecycle/lib/30-destroy-stacks.sh`
+- Modify: `docs/runbooks/eks-production-recreate.md`
+
+**Interfaces:**
+- Consumes: stack name `eks-cost` (Task 2)
+
+- [ ] **Step 1: Add `eks-cost` to the destroy order**
+
+In `scripts/eks-lifecycle/lib/30-destroy-stacks.sh`, the `STACKS` array currently is:
+
+```bash
+STACKS=(
+  "karpenter"
+  "eks-secrets"
+  "eks-logs"
+  "eks-metrics"
+  "eks-traces"
+  "eks"
+  "alb"
+  "vpc"
+)
+```
+
+Add `"eks-cost"` alongside the other three EKS-addon stacks (order among these four doesn't matter — none depend on each other):
+
+```bash
+STACKS=(
+  "karpenter"
+  "eks-secrets"
+  "eks-logs"
+  "eks-metrics"
+  "eks-traces"
+  "eks-cost"
+  "eks"
+  "alb"
+  "vpc"
+)
+```
+
+Also update the header comment listing the destroy order (`# Order:\n#   karpenter -> eks-secrets -> ... -> vpc`) to include `eks-cost`, and the `# Destroy 8 stacks` comment to `# Destroy 9 stacks`.
+
+- [ ] **Step 2: Add `eks-cost` to the runbook's apply order**
+
+In `docs/runbooks/eks-production-recreate.md`, Phase 7 currently reads:
+
+```bash
+for stack in eks-secrets eks-logs eks-metrics eks-traces; do
+  echo "=== apply: $stack ==="
+  ( cd aws/$stack/envs/production && TG_TF_PATH=tofu terragrunt init -upgrade && TG_TF_PATH=tofu terragrunt apply -auto-approve )
+done
+```
+
+Change to:
+
+```bash
+for stack in eks-secrets eks-logs eks-metrics eks-traces eks-cost; do
+  echo "=== apply: $stack ==="
+  ( cd aws/$stack/envs/production && TG_TF_PATH=tofu terragrunt init -upgrade && TG_TF_PATH=tofu terragrunt apply -auto-approve )
+done
+```
+
+- [ ] **Step 3: Verify**
+
+Run:
+```bash
+bash -n scripts/eks-lifecycle/lib/30-destroy-stacks.sh
+grep -n "eks-cost" scripts/eks-lifecycle/lib/30-destroy-stacks.sh docs/runbooks/eks-production-recreate.md
+```
+Expected: `bash -n` prints nothing (syntax OK); both files show `eks-cost` in the expected lines.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add scripts/eks-lifecycle/lib/30-destroy-stacks.sh docs/runbooks/eks-production-recreate.md
+git commit -s -m "docs(runbook): register aws/eks-cost in the destroy/recreate cycle"
+```
+
+---
+
+## Task 6: End-to-end verification
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Full hydrate pass**
+
+Run:
+```bash
+for comp in opencost dashboard; do
+  scripts/kubernetes-hydrate/hydrate-component.sh "$comp" production
+done
+scripts/kubernetes-hydrate/hydrate-index.sh production
+git status --short kubernetes/manifests/
+```
+Expected: only `kubernetes/manifests/production/opencost/*` (new) and `kubernetes/manifests/production/dashboard/manifest.yaml` (modified) show up — everything from Tasks 3–4 should already be committed, so this should report a clean tree (confirms the hydrated output is reproducible and nothing was hand-edited out of sync with its source).
+
+- [ ] **Step 2: Full-cluster server-side dry-run**
+
+Run:
+```bash
+kubectl apply -k kubernetes/manifests/production/ --dry-run=server 2>&1 | grep -i "opencost\|error" 
+```
+Expected: only `configured`/`created` (dry-run) lines mentioning `opencost` resources, no `error` lines.
+
+- [ ] **Step 3: Confirm both Terraform stacks still plan cleanly together**
+
+Run:
+```bash
+( cd aws/cost-management/envs/develop && TG_TF_PATH=tofu terragrunt plan )
+( cd aws/eks-cost/envs/production && TG_TF_PATH=tofu terragrunt plan )
+```
+Expected: both show the same additive-only diff as Task 1 Step 4 / Task 2 Step 10 (no drift introduced by later tasks).
+
+- [ ] **Step 4: Push branch and open PR**
+
+Per this repo's established pattern, and only after the above all pass:
+```bash
+git push -u origin HEAD   # if not already tracking
+gh pr ready               # flip the existing draft PR to ready, or:
+gh pr create --draft ...  # if no PR exists yet for this branch
+```
+
+- [ ] **Step 5: Live apply and cluster verification — requires explicit user confirmation, do not run unattended**
+
+Once the user confirms:
+```bash
+( cd aws/cost-management/envs/develop && TG_TF_PATH=tofu terragrunt apply -auto-approve )
+( cd aws/eks-cost/envs/production && TG_TF_PATH=tofu terragrunt apply -auto-approve )
+git push
+flux reconcile source git flux-system
+flux reconcile kustomization flux-system
+kubectl -n monitoring get pods -l app.kubernetes.io/name=opencost
+kubectl -n monitoring logs deploy/opencost -c opencost --tail=50
+```
+Expected: `aws_spot_datafeed_subscription.this` and the `aws/eks-cost` IAM role/Pod Identity Association apply cleanly; the `opencost` pod reaches `Running`/`Ready`; its logs show successful AWS auth (no `AccessDenied` on S3) and no repeated `DownloadPricingData` errors. Note: the Spot Data Feed will have "no data" for up to an hour after first subscribing (AWS delivers feed files hourly) — this is expected per the spec's "Known Constraints", not a bug.
+
+- [ ] **Step 6: Confirm non-zero cost metrics reach Mimir (wait at least 30s after Step 5 for the first ServiceMonitor scrape)**
+
+Run:
+```bash
+kubectl -n monitoring exec deploy/kube-prometheus-stack-prometheus -c prometheus -- \
+  wget -qO- 'http://localhost:9090/api/v1/query?query=node_total_hourly_cost' | python3 -m json.tool
+```
+Expected: `status: "success"` with at least one non-zero `value` per node — confirms OpenCost's own `/metrics` are being scraped and forwarded through the existing remote-write pipeline, not just that the pod is up.
+
+- [ ] **Step 7: Sanity-check spot pricing against AWS ground truth (once the data feed has delivered its first hourly file — see Step 5 note)**
+
+Run:
+```bash
+NODE=$(kubectl get nodes -l karpenter.sh/capacity-type=spot -o jsonpath='{.items[0].metadata.name}')
+INSTANCE_TYPE=$(kubectl get node "$NODE" -o jsonpath='{.metadata.labels.node\.kubernetes\.io/instance-type}')
+AZ=$(kubectl get node "$NODE" -o jsonpath='{.metadata.labels.topology\.kubernetes\.io/zone}')
+aws ec2 describe-spot-price-history --region ap-northeast-1 \
+  --instance-types "$INSTANCE_TYPE" --availability-zone "$AZ" \
+  --product-descriptions "Linux/UNIX" --max-results 1 --query 'SpotPriceHistory[0].SpotPrice' --output text
+kubectl -n monitoring exec deploy/kube-prometheus-stack-prometheus -c prometheus -- \
+  wget -qO- "http://localhost:9090/api/v1/query?query=node_total_hourly_cost%7Bnode%3D%22${NODE}%22%7D" | python3 -m json.tool
+```
+Expected: the two hourly-price figures are within a small margin of each other (not off by orders of magnitude — the spec's Out-of-Scope explicitly accepts some drift from on-demand/spot rounding, but a >2x gap would indicate the data feed isn't being read and OpenCost fell back to its formula-based spot estimate).
+
+- [ ] **Step 8: Confirm the Grafana dashboards render without "no data"**
+
+Open Grafana (`kubectl -n monitoring port-forward svc/kube-prometheus-stack-grafana 3000:80`) and load each of the three dashboards added in Task 4 ("OpenCost / Overview", "OpenCost / Namespace", "OpenCost / Workload"). Expected: every panel shows data (not "No data"); if the `$datasource` variable dropdown doesn't default to Mimir, select it manually and confirm panels populate — this determines whether Task 4's assumption (Mimir already configured as Grafana's default datasource) held in practice.

--- a/docs/superpowers/plans/2026-08-02-opencost-integration.md
+++ b/docs/superpowers/plans/2026-08-02-opencost-integration.md
@@ -692,7 +692,7 @@ Add three more `configMapGenerator` entries (after `grafana-dashboard-unified-mo
 
 Run:
 ```bash
-kustomize build kubernetes/components/dashboard/production/kustomization/ | grep -A2 "^kind: ConfigMap" | grep "name: grafana-dashboard-opencost"
+kustomize build kubernetes/components/dashboard/production/kustomization/ | grep -A4 "^kind: ConfigMap" | grep "name: grafana-dashboard-opencost"
 ```
 Expected: three `ConfigMap` names printed (`grafana-dashboard-opencost-overview`, `grafana-dashboard-opencost-namespace`, `grafana-dashboard-opencost-workload`).
 

--- a/docs/superpowers/specs/2026-08-01-opencost-integration-design.md
+++ b/docs/superpowers/specs/2026-08-01-opencost-integration-design.md
@@ -43,8 +43,9 @@ node-exporter/cAdvisor -------┘              ▼
 新規 component。 既存 component (mimir 等) と同じ helmfile hydrate pattern に従う。
 
 - namespace: `monitoring` (mimir/loki/tempo/prometheus-operator/beyla/opentelemetry-collector と同居、 既存 convention)
-- 認証: EKS Pod Identity (IRSA ではなく、 mimir/cilium-operator/aws-load-balancer-controller/karpenter と同じ既存 pattern)
-- ServiceMonitor: `release: kube-prometheus-stack` label を付与し既存 Prometheus に scrape させる (cilium の ServiceMonitor と同じ pattern)。 `trustCRDsExist: true` で offline hydrate 時の CRD 未登録エラーを回避
+- 認証: EKS Pod Identity (IRSA ではなく、 mimir/cilium-operator/karpenter と同じ既存 pattern。 aws-load-balancer-controller は IRSA のままなので対象外)
+- ServiceMonitor: `release: kube-prometheus-stack` label を付与し既存 Prometheus (`kube-prometheus-stack-prometheus.monitoring.svc:9090`) に scrape させる (cilium の ServiceMonitor と同じ pattern)。 OpenCost chart の ServiceMonitor template は capability guard を持たないため offline hydrate でも無条件に描画される (cilium 固有の `trustCRDsExist` 相当の対応は不要)
+- OpenCost 自身は既存 Prometheus (`opencost.prometheus.internal` 経由) から kube-state-metrics/node-exporter/cAdvisor の使用量を読む
 
 ### `aws/eks-cost/` (新規 stack)
 

--- a/docs/superpowers/specs/2026-08-01-opencost-integration-design.md
+++ b/docs/superpowers/specs/2026-08-01-opencost-integration-design.md
@@ -1,0 +1,86 @@
+# OpenCost Integration — Design
+
+## Purpose
+
+Grafana から AWS cost を可視化できるようにする。 Cost Explorer を都度開く運用を減らし、 特に system-components node pool (ほぼ spot) のコストを既存の Grafana/Mimir パイプラインで見られるようにする。
+
+## Scope
+
+- [OpenCost](https://opencost.io/) (CNCF incubating, Apache 2.0) を production cluster に導入する
+- コスト算出は **AWS Pricing API モードのみ** (CUR/Athena は導入しない)
+- spot instance の価格精度確保のため **AWS Spot Instance Data Feed** を新規に有効化する
+- OpenCost 公式 Grafana dashboard を導入する
+
+## Out of Scope
+
+- **CUR + Athena によるコスト reconciliation**: 個人アカウントには negotiated discount / savings plan 等の値引きがなく、 CUR 導入の主な価値 (実請求額との突合) がほぼ得られない。 一方 S3+Athena の追加インフラと Athena query 課金というランニングコストだけが乗るため見送る
+- **Slack 等への通知パイプライン**: 既存の `aws/cost-management` (Cost Optimization Hub / Compute Optimizer) と同様、 まずは Grafana で見られる状態を作ることが目的。 通知は別途検討
+- **Cost Optimization Hub / Compute Optimizer との連携**: 既存 stack だが実際には有効化されているのみで消費されていない (design spec `2026-05-03-aws-cost-management-design.md` の scope 通り)。 本設計では触れない
+
+## Architecture
+
+```
+EC2 (spot) --hourly--> S3 (spot data feed, 新規 bucket)
+                              │
+AWS Pricing API <-------------┼------ OpenCost pod (Pod Identity 認証)
+                              │              │
+kube-state-metrics/           │              │ /metrics
+node-exporter/cAdvisor -------┘              ▼
+  (既存 kube-prometheus-stack が scrape)  ServiceMonitor
+                                             │
+                                    kube-prometheus-stack Prometheus
+                                             │ remote-write (既存 pipeline)
+                                             ▼
+                                           Mimir
+                                             │
+                                           Grafana (公式 OpenCost dashboard)
+```
+
+## Components
+
+### `kubernetes/components/opencost/production/`
+
+新規 component。 既存 component (mimir 等) と同じ helmfile hydrate pattern に従う。
+
+- namespace: `monitoring` (mimir/loki/tempo/prometheus-operator/beyla/opentelemetry-collector と同居、 既存 convention)
+- 認証: EKS Pod Identity (IRSA ではなく、 mimir/cilium-operator/aws-load-balancer-controller/karpenter と同じ既存 pattern)
+- ServiceMonitor: `release: kube-prometheus-stack` label を付与し既存 Prometheus に scrape させる (cilium の ServiceMonitor と同じ pattern)。 `trustCRDsExist: true` で offline hydrate 時の CRD 未登録エラーを回避
+
+### `aws/eks-cost/` (新規 stack)
+
+OpenCost 用 Pod Identity IAM role。 `aws/eks-metrics`/`eks-logs`/`eks-traces` と同じ「1 AWS 機能 = 1 stack」pattern に従う。 cluster と一蓮托生の resource のため `docs/runbooks/eks-production-recreate.md` の destroy/recreate cycle 対象に含める (= `scripts/eks-lifecycle/lib/30-destroy-stacks.sh` の STACKS 配列に追加)。
+
+- IAM role: Pod Identity Association で `monitoring:opencost` ServiceAccount にひも付け
+- 権限: AWS Pricing API (`pricing:GetProducts` 等) + EC2 read (instance/spot price history 参照用)。 具体的な最小権限 policy は実装時に実際の OpenCost 呼び出しログで検証しながら確定する
+
+### `aws/cost-management/` (既存 stack、 拡張)
+
+Spot Instance Data Feed 用の S3 bucket + `aws_spot_datafeed_subscription`。
+
+**なぜ既存 stack に足すか**: `aws_spot_datafeed_subscription` は **1 AWS account に1つしか作れない singleton resource** (今日の `AWSServiceRoleForEC2Spot` service-linked role と同種の制約)。 `aws/eks-cost` のような cluster 一蓮托生の stack に置くと、 cluster recreate の度に破棄・再作成を試みてしまう。 `aws/cost-management` は既に「account 単位の AWS cost 関連設定を置く場所」として teardown cycle 対象外で運用されており、 置き場所として適切
+
+### `kubernetes/components/dashboard/production/kustomization/grafana/`
+
+OpenCost 公式 Grafana dashboard JSON を追加。 既存の sidecar auto-discovery (`grafana_dashboard` label) にそのまま乗る。
+
+## Data Flow
+
+1. EC2 が spot instance 稼働時間分の価格情報を毎時 S3 (新規 bucket) に書き出す。 instance が稼働していない時間帯は data feed ファイルが生成されない
+2. OpenCost pod が Pod Identity で AWS 認証し、 S3 data feed (spot 価格) + AWS Pricing API (on-demand 価格) を読む
+3. 既存の kube-state-metrics / node-exporter / cAdvisor (既に kube-prometheus-stack が scrape 済み) の resource 使用量と突き合わせ、 pod/namespace/node/deployment 単位のコストを算出
+4. OpenCost 自身の `/metrics` を ServiceMonitor 経由で Prometheus が scrape → 既存の remote-write pipeline で Mimir へ
+5. Grafana (公式 dashboard、 datasource は Mimir) で可視化
+
+## Known Constraints
+
+- **S3 bucket の Object Ownership**: Spot Data Feed は AWS 側が bucket ACL に write 権限を付与する legacy 方式に依存する。 新規 bucket を `Bucket owner enforced` (ACL 無効、 現行 S3 のデフォルト) のままにすると data feed が書き込めない。 明示的に ACL を有効化する設定が必要
+- **データ遅延**: spot data feed は毎時到着、 かつ instance が稼働していない時間は生成されない。 bootstrap 直後や instance 起動直後はしばらく "no data" になりうる
+- **見積り精度の限界**: Pricing API モードは on-demand 料金表ベースで、 negotiated discount / savings plan は反映されない (本アカウントには該当なしのため実害なし)
+
+## Testing / Verification
+
+- deploy 後、 OpenCost pod のログで AWS 認証成功 + Pricing API 呼び出し成功を確認する (VERIFIED として記録)
+- `/metrics` (または Prometheus 経由の query) で cost metric に非ゼロ・妥当な値が出ることを確認する
+- 既知の node の spot 価格 (`aws ec2 describe-spot-price-history` で実測した値) と OpenCost の算出値を突き合わせて sanity check する
+- Grafana dashboard が "no data" にならず描画されることを確認する
+- `aws/eks-cost` と `aws/cost-management` それぞれで `terragrunt plan` が意図した差分のみになることを確認する

--- a/docs/superpowers/specs/2026-08-01-opencost-integration-design.md
+++ b/docs/superpowers/specs/2026-08-01-opencost-integration-design.md
@@ -22,18 +22,22 @@ Grafana から AWS cost を可視化できるようにする。 Cost Explorer �
 ```
 EC2 (spot) --hourly--> S3 (spot data feed, 新規 bucket)
                               │
-AWS Pricing API <-------------┼------ OpenCost pod (Pod Identity 認証)
-                              │              │
-kube-state-metrics/           │              │ /metrics
-node-exporter/cAdvisor -------┘              ▼
-  (既存 kube-prometheus-stack が scrape)  ServiceMonitor
-                                             │
-                                    kube-prometheus-stack Prometheus
-                                             │ remote-write (既存 pipeline)
-                                             ▼
-                                           Mimir
-                                             │
-                                           Grafana (公式 OpenCost dashboard)
+AWS 公開 pricing endpoint     │ (Pod Identity 認証: S3 read +
+  (認証不要、on-demand 価格)   │  ec2:DescribeSpotPriceHistory fallback)
+        │                    │
+        └──────────► OpenCost pod ◄──┘
+                              │ /metrics
+kube-state-metrics/           │
+node-exporter/cAdvisor -------┘  (既存 kube-prometheus-stack が scrape)
+                              │
+                        ServiceMonitor
+                              │
+                    kube-prometheus-stack Prometheus
+                              │ remote-write (既存 pipeline)
+                              ▼
+                            Mimir
+                              │
+                            Grafana (公式 OpenCost dashboard)
 ```
 
 ## Components
@@ -67,7 +71,7 @@ OpenCost 公式 Grafana dashboard JSON を追加。 既存の sidecar auto-disco
 ## Data Flow
 
 1. EC2 が spot instance 稼働時間分の価格情報を毎時 S3 (新規 bucket) に書き出す。 instance が稼働していない時間帯は data feed ファイルが生成されない
-2. OpenCost pod が Pod Identity で AWS 認証し、 S3 data feed (spot 価格) + AWS Pricing API (on-demand 価格) を読む
+2. OpenCost pod が S3 data feed (spot 価格) を Pod Identity 認証で読む (data feed に未反映の場合は `ec2:DescribeSpotPriceHistory` に fallback)。 on-demand 価格は AWS 公開 pricing endpoint から認証不要で読む
 3. 既存の kube-state-metrics / node-exporter / cAdvisor (既に kube-prometheus-stack が scrape 済み) の resource 使用量と突き合わせ、 pod/namespace/node/deployment 単位のコストを算出
 4. OpenCost 自身の `/metrics` を ServiceMonitor 経由で Prometheus が scrape → 既存の remote-write pipeline で Mimir へ
 5. Grafana (公式 dashboard、 datasource は Mimir) で可視化
@@ -80,7 +84,7 @@ OpenCost 公式 Grafana dashboard JSON を追加。 既存の sidecar auto-disco
 
 ## Testing / Verification
 
-- deploy 後、 OpenCost pod のログで AWS 認証成功 + Pricing API 呼び出し成功を確認する (VERIFIED として記録)
+- deploy 後、 OpenCost pod のログで Pod Identity 経由の AWS 認証成功 (S3 read) と on-demand pricing endpoint への到達成功を確認する (VERIFIED として記録)
 - `/metrics` (または Prometheus 経由の query) で cost metric に非ゼロ・妥当な値が出ることを確認する
 - 既知の node の spot 価格 (`aws ec2 describe-spot-price-history` で実測した値) と OpenCost の算出値を突き合わせて sanity check する
 - Grafana dashboard が "no data" にならず描画されることを確認する

--- a/docs/superpowers/specs/2026-08-01-opencost-integration-design.md
+++ b/docs/superpowers/specs/2026-08-01-opencost-integration-design.md
@@ -52,7 +52,7 @@ node-exporter/cAdvisor -------┘              ▼
 OpenCost 用 Pod Identity IAM role。 `aws/eks-metrics`/`eks-logs`/`eks-traces` と同じ「1 AWS 機能 = 1 stack」pattern に従う。 cluster と一蓮托生の resource のため `docs/runbooks/eks-production-recreate.md` の destroy/recreate cycle 対象に含める (= `scripts/eks-lifecycle/lib/30-destroy-stacks.sh` の STACKS 配列に追加)。
 
 - IAM role: Pod Identity Association で `monitoring:opencost` ServiceAccount にひも付け
-- 権限: AWS Pricing API (`pricing:GetProducts` 等) + EC2 read (instance/spot price history 参照用)。 具体的な最小権限 policy は実装時に実際の OpenCost 呼び出しログで検証しながら確定する
+- 権限: S3 read (Spot Data Feed bucket、 bucket-level + object-level) + `ec2:DescribeSpotPriceHistory` (`Resource: "*"`。 EC2 の `Describe*` 系 action は resource-level restriction 非対応のため)。 後者は spot node が S3 data feed にまだ反映されていない場合に OpenCost が呼ぶ fallback 用。 on-demand 価格は public unauthenticated HTTPS endpoint 経由のため AWS Pricing API 権限は不要
 
 ### `aws/cost-management/` (既存 stack、 拡張)
 

--- a/kubernetes/components/dashboard/production/kustomization/grafana/opencost-namespace.json
+++ b/kubernetes/components/dashboard/production/kustomization/grafana/opencost-namespace.json
@@ -1,0 +1,1180 @@
+{
+   "__inputs": [ ],
+   "__requires": [ ],
+   "annotations": {
+      "list": [ ]
+   },
+   "description": "A detailed namespace-level cost analysis dashboard that breaks down infrastructure spending by pods, containers, persistent volumes, and GPU usage within a selected namespace. Use this dashboard to understand which workloads are driving costs within a namespace, track monthly cost trends over time, and identify optimization opportunities at the pod and container level. This dashboard is ideal for application teams monitoring their own resource consumption and costs. The dashboards were generated using [opencost-mixin](https://github.com/adinhodovic/opencost-mixin). Open issues and create feature requests in the repository.",
+   "editable": false,
+   "links": [
+      {
+         "asDropdown": true,
+         "includeVars": false,
+         "keepTime": true,
+         "tags": [
+            "opencost",
+            "opencost-mixin"
+         ],
+         "targetBlank": true,
+         "title": "OpenCost",
+         "type": "dashboards"
+      }
+   ],
+   "panels": [
+      {
+         "collapsed": false,
+         "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 0
+         },
+         "id": 1,
+         "title": "Summary",
+         "type": "row"
+      },
+      {
+         "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+         },
+         "description": "Current hourly cost rate for the selected namespace, including CPU, RAM, and PV costs. This provides real-time visibility into namespace spending and helps track the immediate impact of workload changes on costs.",
+         "fieldConfig": {
+            "defaults": {
+               "decimals": 2,
+               "mappings": [ ],
+               "thresholds": {
+                  "steps": [
+                     {
+                        "color": "green",
+                        "value": 0
+                     }
+                  ]
+               },
+               "unit": "currencyUSD"
+            },
+            "overrides": [ ]
+         },
+         "gridPos": {
+            "h": 3,
+            "w": 4,
+            "x": 0,
+            "y": 1
+         },
+         "id": 2,
+         "options": {
+            "graphMode": "none",
+            "percentChangeColorMode": "inverted",
+            "showPercentChange": true
+         },
+         "pluginVersion": "v11.4.0",
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "$datasource"
+               },
+               "expr": "sum(\n  sum(\n    container_memory_allocation_bytes{\n      cluster=\"$cluster\",\njob=\"$job\"\n,\nnamespace=\"$namespace\"\n\n    }\n  )\n  by (namespace, instance)\n  * on(instance) group_left()\n  (\n    avg(\n      node_ram_hourly_cost{\n        cluster=\"$cluster\",\njob=\"$job\"\n\n      }\n    ) by (instance) / (1024 * 1024 * 1024) * 1\n  )\n)\n\n+\nsum(\n  sum(\n    container_cpu_allocation{\n      cluster=\"$cluster\",\njob=\"$job\"\n,\nnamespace=\"$namespace\"\n\n    }\n  )\n  by (namespace, instance)\n  * on(instance) group_left()\n  (\n    avg(\n      node_cpu_hourly_cost{\n        cluster=\"$cluster\",\njob=\"$job\"\n\n      }\n    ) by (instance) * 1\n  )\n)\n\n+\nsum(\n  sum(\n    container_gpu_allocation{\n      cluster=\"$cluster\",\njob=\"$job\"\n,\nnamespace=\"$namespace\"\n\n    }\n  )\n  by (namespace, instance)\n  * on(instance) group_left()\n  (\n    avg(\n      node_gpu_hourly_cost{\n        cluster=\"$cluster\",\njob=\"$job\"\n\n      }\n    ) by (instance) * 1\n  )\n)\n\n+\nsum(\n  sum(\n    kube_persistentvolume_capacity_bytes{\n      cluster=\"$cluster\",\njob=\"$job\"\n\n    }\n    / (1024 * 1024 * 1024)\n  ) by (persistentvolume)\n  *\n  sum(\n    pv_hourly_cost{\n      cluster=\"$cluster\",\njob=\"$job\"\n\n    }\n  ) by (persistentvolume)\n  * on(persistentvolume) group_left(cluster, namespace, persistentvolumeclaim) (\n    label_replace(\n      kube_persistentvolumeclaim_info{\n        cluster=\"$cluster\",\njob=\"$job\"\n,\nnamespace=\"$namespace\"\n\n      },\n      \"persistentvolume\", \"$1\",\n      \"volumename\", \"(.*)\"\n    )\n  ) or vector(0)\n) * 1\n\n",
+               "instant": false
+            }
+         ],
+         "title": "Hourly Cost",
+         "type": "stat"
+      },
+      {
+         "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+         },
+         "description": "Projected monthly cost for the selected namespace based on current hourly rates. This includes CPU, RAM, GPU, and PV costs so application teams can track their overall spend against budget.",
+         "fieldConfig": {
+            "defaults": {
+               "decimals": 2,
+               "mappings": [ ],
+               "thresholds": {
+                  "steps": [
+                     {
+                        "color": "green",
+                        "value": 0
+                     }
+                  ]
+               },
+               "unit": "currencyUSD"
+            },
+            "overrides": [ ]
+         },
+         "gridPos": {
+            "h": 3,
+            "w": 4,
+            "x": 4,
+            "y": 1
+         },
+         "id": 3,
+         "options": {
+            "graphMode": "none",
+            "percentChangeColorMode": "inverted",
+            "showPercentChange": true
+         },
+         "pluginVersion": "v11.4.0",
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "$datasource"
+               },
+               "expr": "sum(\n  sum(\n    container_memory_allocation_bytes{\n      cluster=\"$cluster\",\njob=\"$job\"\n,\nnamespace=\"$namespace\"\n\n    }\n  )\n  by (namespace, instance)\n  * on(instance) group_left()\n  (\n    avg(\n      node_ram_hourly_cost{\n        cluster=\"$cluster\",\njob=\"$job\"\n\n      }\n    ) by (instance) / (1024 * 1024 * 1024) * 730\n  )\n)\n\n+\nsum(\n  sum(\n    container_cpu_allocation{\n      cluster=\"$cluster\",\njob=\"$job\"\n,\nnamespace=\"$namespace\"\n\n    }\n  )\n  by (namespace, instance)\n  * on(instance) group_left()\n  (\n    avg(\n      node_cpu_hourly_cost{\n        cluster=\"$cluster\",\njob=\"$job\"\n\n      }\n    ) by (instance) * 730\n  )\n)\n\n+\nsum(\n  sum(\n    container_gpu_allocation{\n      cluster=\"$cluster\",\njob=\"$job\"\n,\nnamespace=\"$namespace\"\n\n    }\n  )\n  by (namespace, instance)\n  * on(instance) group_left()\n  (\n    avg(\n      node_gpu_hourly_cost{\n        cluster=\"$cluster\",\njob=\"$job\"\n\n      }\n    ) by (instance) * 730\n  )\n)\n\n+\nsum(\n  sum(\n    kube_persistentvolume_capacity_bytes{\n      cluster=\"$cluster\",\njob=\"$job\"\n\n    }\n    / (1024 * 1024 * 1024)\n  ) by (persistentvolume)\n  *\n  sum(\n    pv_hourly_cost{\n      cluster=\"$cluster\",\njob=\"$job\"\n\n    }\n  ) by (persistentvolume)\n  * on(persistentvolume) group_left(cluster, namespace, persistentvolumeclaim) (\n    label_replace(\n      kube_persistentvolumeclaim_info{\n        cluster=\"$cluster\",\njob=\"$job\"\n,\nnamespace=\"$namespace\"\n\n      },\n      \"persistentvolume\", \"$1\",\n      \"volumename\", \"(.*)\"\n    )\n  ) or vector(0)\n) * 730\n\n",
+               "instant": false
+            }
+         ],
+         "title": "Monthly Cost",
+         "type": "stat"
+      },
+      {
+         "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+         },
+         "description": "Projected monthly CPU cost for the selected namespace. Compare this with RAM costs to understand your namespace compute profile and identify if CPU requests are appropriately sized for your workloads.",
+         "fieldConfig": {
+            "defaults": {
+               "decimals": 2,
+               "mappings": [ ],
+               "thresholds": {
+                  "steps": [
+                     {
+                        "color": "green",
+                        "value": 0
+                     }
+                  ]
+               },
+               "unit": "currencyUSD"
+            },
+            "overrides": [ ]
+         },
+         "gridPos": {
+            "h": 3,
+            "w": 4,
+            "x": 8,
+            "y": 1
+         },
+         "id": 4,
+         "options": {
+            "graphMode": "none",
+            "percentChangeColorMode": "inverted",
+            "showPercentChange": true
+         },
+         "pluginVersion": "v11.4.0",
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "$datasource"
+               },
+               "expr": "sum(\n  sum(\n    container_cpu_allocation{\n      cluster=\"$cluster\",\njob=\"$job\"\n,\nnamespace=\"$namespace\"\n\n    }\n  )\n  by (namespace, instance)\n  * on(instance) group_left()\n  (\n    avg(\n      node_cpu_hourly_cost{\n        cluster=\"$cluster\",\njob=\"$job\"\n\n      }\n    ) by (instance) * 730\n  )\n)\n",
+               "instant": false
+            }
+         ],
+         "title": "Monthly CPU Cost",
+         "type": "stat"
+      },
+      {
+         "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+         },
+         "description": "Projected monthly RAM cost for the selected namespace. High memory costs may indicate opportunities to optimize container memory requests or identify memory-intensive workloads that could benefit from tuning.",
+         "fieldConfig": {
+            "defaults": {
+               "decimals": 2,
+               "mappings": [ ],
+               "thresholds": {
+                  "steps": [
+                     {
+                        "color": "green",
+                        "value": 0
+                     }
+                  ]
+               },
+               "unit": "currencyUSD"
+            },
+            "overrides": [ ]
+         },
+         "gridPos": {
+            "h": 3,
+            "w": 4,
+            "x": 12,
+            "y": 1
+         },
+         "id": 5,
+         "options": {
+            "graphMode": "none",
+            "percentChangeColorMode": "inverted",
+            "showPercentChange": true
+         },
+         "pluginVersion": "v11.4.0",
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "$datasource"
+               },
+               "expr": "sum(\n  sum(\n    container_memory_allocation_bytes{\n      cluster=\"$cluster\",\njob=\"$job\"\n,\nnamespace=\"$namespace\"\n\n    }\n  )\n  by (namespace, instance)\n  * on(instance) group_left()\n  (\n    avg(\n      node_ram_hourly_cost{\n        cluster=\"$cluster\",\njob=\"$job\"\n\n      }\n    ) by (instance) / (1024 * 1024 * 1024) * 730\n  )\n)\n",
+               "instant": false
+            }
+         ],
+         "title": "Monthly Ram Cost",
+         "type": "stat"
+      },
+      {
+         "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+         },
+         "description": "Projected monthly GPU cost for the selected namespace. This helps teams understand accelerator spend and spot namespaces where GPU-backed workloads dominate overall costs.",
+         "fieldConfig": {
+            "defaults": {
+               "decimals": 2,
+               "mappings": [ ],
+               "thresholds": {
+                  "steps": [
+                     {
+                        "color": "green",
+                        "value": 0
+                     }
+                  ]
+               },
+               "unit": "currencyUSD"
+            },
+            "overrides": [ ]
+         },
+         "gridPos": {
+            "h": 3,
+            "w": 4,
+            "x": 16,
+            "y": 1
+         },
+         "id": 6,
+         "options": {
+            "graphMode": "none",
+            "percentChangeColorMode": "inverted",
+            "showPercentChange": true
+         },
+         "pluginVersion": "v11.4.0",
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "$datasource"
+               },
+               "expr": "sum(\n  sum(\n    container_gpu_allocation{\n      cluster=\"$cluster\",\njob=\"$job\"\n,\nnamespace=\"$namespace\"\n\n    }\n  )\n  by (namespace, instance)\n  * on(instance) group_left()\n  (\n    avg(\n      node_gpu_hourly_cost{\n        cluster=\"$cluster\",\njob=\"$job\"\n\n      }\n    ) by (instance) * 730\n  )\n)\n",
+               "instant": false
+            }
+         ],
+         "title": "Monthly GPU Cost",
+         "type": "stat"
+      },
+      {
+         "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+         },
+         "description": "Projected monthly Persistent Volume cost for the selected namespace. Monitor this to identify unused PVCs or opportunities to migrate to cheaper storage classes without impacting application performance.",
+         "fieldConfig": {
+            "defaults": {
+               "decimals": 2,
+               "mappings": [ ],
+               "thresholds": {
+                  "steps": [
+                     {
+                        "color": "green",
+                        "value": 0
+                     }
+                  ]
+               },
+               "unit": "currencyUSD"
+            },
+            "overrides": [ ]
+         },
+         "gridPos": {
+            "h": 3,
+            "w": 4,
+            "x": 20,
+            "y": 1
+         },
+         "id": 7,
+         "options": {
+            "graphMode": "none",
+            "percentChangeColorMode": "inverted",
+            "showPercentChange": true
+         },
+         "pluginVersion": "v11.4.0",
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "$datasource"
+               },
+               "expr": "sum(\n  sum(\n    kube_persistentvolume_capacity_bytes{\n      cluster=\"$cluster\",\njob=\"$job\"\n\n    }\n    / (1024 * 1024 * 1024)\n  ) by (persistentvolume)\n  *\n  sum(\n    pv_hourly_cost{\n      cluster=\"$cluster\",\njob=\"$job\"\n\n    }\n  ) by (persistentvolume)\n  * on(persistentvolume) group_left(cluster, namespace, persistentvolumeclaim) (\n    label_replace(\n      kube_persistentvolumeclaim_info{\n        cluster=\"$cluster\",\njob=\"$job\"\n,\nnamespace=\"$namespace\"\n\n      },\n      \"persistentvolume\", \"$1\",\n      \"volumename\", \"(.*)\"\n    )\n  )\n) * 730\n",
+               "instant": false
+            }
+         ],
+         "title": "Monthly PV Cost",
+         "type": "stat"
+      },
+      {
+         "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+         },
+         "description": "Hourly cost trend for the selected namespace. Use this to see short-term cost changes from scaling, deployments, or workload churn without switching to the cluster overview.",
+         "fieldConfig": {
+            "defaults": {
+               "custom": {
+                  "fillOpacity": 10
+               },
+               "unit": "currencyUSD"
+            },
+            "overrides": [ ]
+         },
+         "gridPos": {
+            "h": 5,
+            "w": 12,
+            "x": 0,
+            "y": 4
+         },
+         "id": 8,
+         "options": {
+            "legend": {
+               "calcs": [
+                  "mean",
+                  "max"
+               ],
+               "displayMode": "table",
+               "placement": "right",
+               "showLegend": true,
+               "sortBy": "Mean",
+               "sortDesc": true
+            },
+            "tooltip": {
+               "mode": "multi",
+               "sort": "desc"
+            }
+         },
+         "pluginVersion": "v11.4.0",
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "$datasource"
+               },
+               "exemplar": false,
+               "expr": "sum(\n  sum(\n    container_memory_allocation_bytes{\n      cluster=\"$cluster\",\njob=\"$job\"\n,\nnamespace=\"$namespace\"\n\n    }\n  )\n  by (namespace, instance)\n  * on(instance) group_left()\n  (\n    avg(\n      node_ram_hourly_cost{\n        cluster=\"$cluster\",\njob=\"$job\"\n\n      }\n    ) by (instance) / (1024 * 1024 * 1024) * 1\n  )\n)\n\n+\nsum(\n  sum(\n    container_cpu_allocation{\n      cluster=\"$cluster\",\njob=\"$job\"\n,\nnamespace=\"$namespace\"\n\n    }\n  )\n  by (namespace, instance)\n  * on(instance) group_left()\n  (\n    avg(\n      node_cpu_hourly_cost{\n        cluster=\"$cluster\",\njob=\"$job\"\n\n      }\n    ) by (instance) * 1\n  )\n)\n\n+\nsum(\n  sum(\n    container_gpu_allocation{\n      cluster=\"$cluster\",\njob=\"$job\"\n,\nnamespace=\"$namespace\"\n\n    }\n  )\n  by (namespace, instance)\n  * on(instance) group_left()\n  (\n    avg(\n      node_gpu_hourly_cost{\n        cluster=\"$cluster\",\njob=\"$job\"\n\n      }\n    ) by (instance) * 1\n  )\n)\n\n+\nsum(\n  sum(\n    kube_persistentvolume_capacity_bytes{\n      cluster=\"$cluster\",\njob=\"$job\"\n\n    }\n    / (1024 * 1024 * 1024)\n  ) by (persistentvolume)\n  *\n  sum(\n    pv_hourly_cost{\n      cluster=\"$cluster\",\njob=\"$job\"\n\n    }\n  ) by (persistentvolume)\n  * on(persistentvolume) group_left(cluster, namespace, persistentvolumeclaim) (\n    label_replace(\n      kube_persistentvolumeclaim_info{\n        cluster=\"$cluster\",\njob=\"$job\"\n,\nnamespace=\"$namespace\"\n\n      },\n      \"persistentvolume\", \"$1\",\n      \"volumename\", \"(.*)\"\n    )\n  ) or vector(0)\n) * 1\n\n",
+               "interval": "30m",
+               "legendFormat": "Hourly Cost"
+            }
+         ],
+         "title": "Hourly Cost",
+         "type": "timeseries"
+      },
+      {
+         "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+         },
+         "description": "Monthly cost projection trend for the selected namespace. This helps application teams track their projected monthly spending and ensure they remain within their allocated budget throughout the billing period.",
+         "fieldConfig": {
+            "defaults": {
+               "custom": {
+                  "fillOpacity": 10
+               },
+               "unit": "currencyUSD"
+            },
+            "overrides": [ ]
+         },
+         "gridPos": {
+            "h": 5,
+            "w": 12,
+            "x": 12,
+            "y": 4
+         },
+         "id": 9,
+         "options": {
+            "legend": {
+               "calcs": [
+                  "mean",
+                  "max"
+               ],
+               "displayMode": "table",
+               "placement": "right",
+               "showLegend": true,
+               "sortBy": "Mean",
+               "sortDesc": true
+            },
+            "tooltip": {
+               "mode": "multi",
+               "sort": "desc"
+            }
+         },
+         "pluginVersion": "v11.4.0",
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "$datasource"
+               },
+               "exemplar": false,
+               "expr": "sum(\n  sum(\n    container_memory_allocation_bytes{\n      cluster=\"$cluster\",\njob=\"$job\"\n,\nnamespace=\"$namespace\"\n\n    }\n  )\n  by (namespace, instance)\n  * on(instance) group_left()\n  (\n    avg(\n      node_ram_hourly_cost{\n        cluster=\"$cluster\",\njob=\"$job\"\n\n      }\n    ) by (instance) / (1024 * 1024 * 1024) * 730\n  )\n)\n\n+\nsum(\n  sum(\n    container_cpu_allocation{\n      cluster=\"$cluster\",\njob=\"$job\"\n,\nnamespace=\"$namespace\"\n\n    }\n  )\n  by (namespace, instance)\n  * on(instance) group_left()\n  (\n    avg(\n      node_cpu_hourly_cost{\n        cluster=\"$cluster\",\njob=\"$job\"\n\n      }\n    ) by (instance) * 730\n  )\n)\n\n+\nsum(\n  sum(\n    container_gpu_allocation{\n      cluster=\"$cluster\",\njob=\"$job\"\n,\nnamespace=\"$namespace\"\n\n    }\n  )\n  by (namespace, instance)\n  * on(instance) group_left()\n  (\n    avg(\n      node_gpu_hourly_cost{\n        cluster=\"$cluster\",\njob=\"$job\"\n\n      }\n    ) by (instance) * 730\n  )\n)\n\n+\nsum(\n  sum(\n    kube_persistentvolume_capacity_bytes{\n      cluster=\"$cluster\",\njob=\"$job\"\n\n    }\n    / (1024 * 1024 * 1024)\n  ) by (persistentvolume)\n  *\n  sum(\n    pv_hourly_cost{\n      cluster=\"$cluster\",\njob=\"$job\"\n\n    }\n  ) by (persistentvolume)\n  * on(persistentvolume) group_left(cluster, namespace, persistentvolumeclaim) (\n    label_replace(\n      kube_persistentvolumeclaim_info{\n        cluster=\"$cluster\",\njob=\"$job\"\n,\nnamespace=\"$namespace\"\n\n      },\n      \"persistentvolume\", \"$1\",\n      \"volumename\", \"(.*)\"\n    )\n  ) or vector(0)\n) * 730\n\n",
+               "interval": "30m",
+               "legendFormat": "Monthly Cost"
+            }
+         ],
+         "title": "Monthly Cost",
+         "type": "timeseries"
+      },
+      {
+         "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+         },
+         "description": "Monthly cost distribution for the selected namespace across resource types (CPU, RAM, Persistent Volumes, and GPU). This shows which resource category is the primary cost driver for this namespace, helping teams prioritize their optimization efforts.",
+         "fieldConfig": {
+            "defaults": {
+               "unit": "currencyUSD"
+            },
+            "overrides": [ ]
+         },
+         "gridPos": {
+            "h": 7,
+            "w": 12,
+            "x": 0,
+            "y": 9
+         },
+         "id": 10,
+         "options": {
+            "displayLabels": [
+               "percent"
+            ],
+            "legend": {
+               "displayMode": "table",
+               "placement": "right",
+               "showLegend": true,
+               "values": [
+                  "percent",
+                  "value"
+               ]
+            },
+            "tooltip": {
+               "mode": "multi",
+               "sort": "desc"
+            }
+         },
+         "pluginVersion": "v11.4.0",
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "$datasource"
+               },
+               "expr": "sum(\n  sum(\n    container_cpu_allocation{\n      cluster=\"$cluster\",\njob=\"$job\"\n,\nnamespace=\"$namespace\"\n\n    }\n  )\n  by (namespace, instance)\n  * on(instance) group_left()\n  (\n    avg(\n      node_cpu_hourly_cost{\n        cluster=\"$cluster\",\njob=\"$job\"\n\n      }\n    ) by (instance) * 730\n  )\n)\n",
+               "instant": true,
+               "legendFormat": "CPU"
+            },
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "$datasource"
+               },
+               "expr": "sum(\n  sum(\n    container_memory_allocation_bytes{\n      cluster=\"$cluster\",\njob=\"$job\"\n,\nnamespace=\"$namespace\"\n\n    }\n  )\n  by (namespace, instance)\n  * on(instance) group_left()\n  (\n    avg(\n      node_ram_hourly_cost{\n        cluster=\"$cluster\",\njob=\"$job\"\n\n      }\n    ) by (instance) / (1024 * 1024 * 1024) * 730\n  )\n)\n",
+               "instant": true,
+               "legendFormat": "RAM"
+            },
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "$datasource"
+               },
+               "expr": "sum(\n  sum(\n    kube_persistentvolume_capacity_bytes{\n      cluster=\"$cluster\",\njob=\"$job\"\n\n    }\n    / (1024 * 1024 * 1024)\n  ) by (persistentvolume)\n  *\n  sum(\n    pv_hourly_cost{\n      cluster=\"$cluster\",\njob=\"$job\"\n\n    }\n  ) by (persistentvolume)\n  * on(persistentvolume) group_left(cluster, namespace, persistentvolumeclaim) (\n    label_replace(\n      kube_persistentvolumeclaim_info{\n        cluster=\"$cluster\",\njob=\"$job\"\n,\nnamespace=\"$namespace\"\n\n      },\n      \"persistentvolume\", \"$1\",\n      \"volumename\", \"(.*)\"\n    )\n  )\n) * 730\n",
+               "instant": true,
+               "legendFormat": "PV"
+            },
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "$datasource"
+               },
+               "expr": "sum(\n  sum(\n    container_gpu_allocation{\n      cluster=\"$cluster\",\njob=\"$job\"\n,\nnamespace=\"$namespace\"\n\n    }\n  )\n  by (namespace, instance)\n  * on(instance) group_left()\n  (\n    avg(\n      node_gpu_hourly_cost{\n        cluster=\"$cluster\",\njob=\"$job\"\n\n      }\n    ) by (instance) * 730\n  )\n)\n",
+               "instant": true,
+               "legendFormat": "GPU"
+            }
+         ],
+         "title": "Cost by Resource",
+         "type": "piechart"
+      },
+      {
+         "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+         },
+         "description": "Top 10 pods by monthly cost showing the distribution of spending across pods in the namespace. This visualization helps identify which pods consume the most resources and whether costs are evenly distributed or concentrated in a few workloads.",
+         "fieldConfig": {
+            "defaults": {
+               "unit": "currencyUSD"
+            },
+            "overrides": [ ]
+         },
+         "gridPos": {
+            "h": 7,
+            "w": 12,
+            "x": 12,
+            "y": 9
+         },
+         "id": 11,
+         "options": {
+            "displayLabels": [
+               "percent"
+            ],
+            "legend": {
+               "displayMode": "table",
+               "placement": "right",
+               "showLegend": true,
+               "values": [
+                  "percent",
+                  "value"
+               ]
+            },
+            "tooltip": {
+               "mode": "multi",
+               "sort": "desc"
+            }
+         },
+         "pluginVersion": "v11.4.0",
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "$datasource"
+               },
+               "expr": "topk(10,\n  sum(\n    (\n      sum(\n        container_memory_allocation_bytes{\n          cluster=\"$cluster\",\n          namespace=\"$namespace\",\n          job=\"$job\"}\n      )\n      by (instance, pod)\n      * on(instance) group_left()\n      (\n        avg(\n          node_ram_hourly_cost{\n            cluster=\"$cluster\",\n            job=\"$job\"}\n        ) by (instance) / (1024 * 1024 * 1024) * 730\n      )\n    )\n    +\n    (\n      sum(\n        container_cpu_allocation{\n          cluster=\"$cluster\",\n          namespace=\"$namespace\",\n          job=\"$job\"}\n      )\n      by (instance, pod)\n      * on(instance) group_left()\n      (\n        avg(\n          node_cpu_hourly_cost{\n            cluster=\"$cluster\",\n            job=\"$job\"}\n        ) by (instance) * 730)\n    )\n  ) by (pod)\n)\n",
+               "instant": true,
+               "legendFormat": "{{ pod }}"
+            }
+         ],
+         "title": "Cost by Pod",
+         "type": "piechart"
+      },
+      {
+         "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+         },
+         "description": "Top 10 containers by monthly cost showing the distribution of spending across containers in the namespace. This helps identify which container images or workload types are most expensive and whether sidecar containers are adding significant costs.",
+         "fieldConfig": {
+            "defaults": {
+               "unit": "currencyUSD"
+            },
+            "overrides": [ ]
+         },
+         "gridPos": {
+            "h": 7,
+            "w": 12,
+            "x": 0,
+            "y": 16
+         },
+         "id": 12,
+         "options": {
+            "displayLabels": [
+               "percent"
+            ],
+            "legend": {
+               "displayMode": "table",
+               "placement": "right",
+               "showLegend": true,
+               "values": [
+                  "percent",
+                  "value"
+               ]
+            },
+            "tooltip": {
+               "mode": "multi",
+               "sort": "desc"
+            }
+         },
+         "pluginVersion": "v11.4.0",
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "$datasource"
+               },
+               "expr": "topk(10,\n  sum(\n    (\n      sum(\n        container_memory_allocation_bytes{\n          cluster=\"$cluster\",\n          namespace=\"$namespace\",\n          job=\"$job\"}\n      )\n      by (instance, container)\n      * on(instance) group_left()\n      (\n        avg(\n          node_ram_hourly_cost{\n            cluster=\"$cluster\",\n            job=\"$job\"}\n        ) by (instance) / (1024 * 1024 * 1024) * 730\n      )\n    )\n    +\n    (\n      sum(\n        container_cpu_allocation{\n          cluster=\"$cluster\",\n          namespace=\"$namespace\",\n          job=\"$job\"}\n      )\n      by (instance, container)\n      * on(instance) group_left()\n      (\n        avg(\n          node_cpu_hourly_cost{\n            cluster=\"$cluster\",\n            job=\"$job\"}\n        ) by (instance) * 730\n      )\n    )\n  ) by (container)\n)\n",
+               "instant": true,
+               "legendFormat": "{{ container }}"
+            }
+         ],
+         "title": "Cost by Container",
+         "type": "piechart"
+      },
+      {
+         "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+         },
+         "description": "Distribution of monthly storage costs across Persistent Volume Claims in the namespace. This shows which claims consume the most storage budget and helps identify whether storage costs are concentrated in a few large claims or distributed across many smaller ones.",
+         "fieldConfig": {
+            "defaults": {
+               "unit": "currencyUSD"
+            },
+            "overrides": [ ]
+         },
+         "gridPos": {
+            "h": 7,
+            "w": 12,
+            "x": 12,
+            "y": 16
+         },
+         "id": 13,
+         "options": {
+            "displayLabels": [
+               "percent"
+            ],
+            "legend": {
+               "displayMode": "table",
+               "placement": "right",
+               "showLegend": true,
+               "values": [
+                  "percent",
+                  "value"
+               ]
+            },
+            "tooltip": {
+               "mode": "multi",
+               "sort": "desc"
+            }
+         },
+         "pluginVersion": "v11.4.0",
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "$datasource"
+               },
+               "expr": "sum(\n  sum(\n    kube_persistentvolume_capacity_bytes{\n      cluster=\"$cluster\",\njob=\"$job\"\n\n    }\n    / (1024 * 1024 * 1024)\n  ) by (persistentvolume)\n  *\n  sum(\n    pv_hourly_cost{\n      cluster=\"$cluster\",\njob=\"$job\"\n\n    }\n  ) by (persistentvolume)\n  * on(persistentvolume) group_left(cluster, namespace, persistentvolumeclaim) (\n    label_replace(\n      kube_persistentvolumeclaim_info{\n        cluster=\"$cluster\",\njob=\"$job\"\n,\nnamespace=\"$namespace\"\n\n      },\n      \"persistentvolume\", \"$1\",\n      \"volumename\", \"(.*)\"\n    )\n  )\n) by (persistentvolumeclaim) * 730\n",
+               "instant": true,
+               "legendFormat": "{{ persistentvolumeclaim }}"
+            }
+         ],
+         "title": "Cost by Persistent Volume Claim",
+         "type": "piechart"
+      },
+      {
+         "collapsed": false,
+         "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 23
+         },
+         "id": 14,
+         "title": "Pod Summary",
+         "type": "row"
+      },
+      {
+         "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+         },
+         "description": "Top 10 pods by projected monthly cost (based on current hourly rates) with percentage change compared to 7 days and 30 days ago. Positive percentages indicate cost increases (red), negative percentages indicate cost decreases (green). Use this to identify the most expensive pods in the namespace and track how pod costs change over time, especially after deployments or configuration changes.",
+         "fieldConfig": {
+            "defaults": {
+               "links": [ ],
+               "thresholds": {
+                  "steps": [
+                     {
+                        "color": "green",
+                        "value": 0
+                     },
+                     {
+                        "color": "yellow",
+                        "value": 5
+                     },
+                     {
+                        "color": "red",
+                        "value": 10
+                     }
+                  ]
+               },
+               "unit": "currencyUSD"
+            },
+            "overrides": [
+               {
+                  "matcher": {
+                     "id": "byName",
+                     "options": "Cost Change vs 7d Ago (%)"
+                  },
+                  "properties": [
+                     {
+                        "id": "color",
+                        "value": {
+                           "mode": "thresholds"
+                        }
+                     },
+                     {
+                        "id": "custom.cellOptions",
+                        "value": {
+                           "type": "color-background"
+                        }
+                     },
+                     {
+                        "id": "unit",
+                        "value": "percent"
+                     }
+                  ]
+               },
+               {
+                  "matcher": {
+                     "id": "byName",
+                     "options": "Cost Change vs 30d Ago (%)"
+                  },
+                  "properties": [
+                     {
+                        "id": "color",
+                        "value": {
+                           "mode": "thresholds"
+                        }
+                     },
+                     {
+                        "id": "custom.cellOptions",
+                        "value": {
+                           "type": "color-background"
+                        }
+                     },
+                     {
+                        "id": "unit",
+                        "value": "percent"
+                     }
+                  ]
+               }
+            ]
+         },
+         "gridPos": {
+            "h": 10,
+            "w": 24,
+            "x": 0,
+            "y": 24
+         },
+         "id": 15,
+         "options": {
+            "footer": {
+               "enablePagination": true
+            },
+            "sortBy": [
+               {
+                  "desc": true,
+                  "displayName": "Total Cost (Today)"
+               }
+            ]
+         },
+         "pluginVersion": "v11.4.0",
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "$datasource"
+               },
+               "expr": "topk(10,\n  sum(\n    (\n      sum(\n        container_memory_allocation_bytes{\n          cluster=\"$cluster\",\n          namespace=\"$namespace\",\n          job=\"$job\"}\n      )\n      by (instance, pod)\n      * on(instance) group_left()\n      (\n        avg(\n          node_ram_hourly_cost{\n            cluster=\"$cluster\",\n            job=\"$job\"}\n        ) by (instance) / (1024 * 1024 * 1024) * 730\n      )\n    )\n    +\n    (\n      sum(\n        container_cpu_allocation{\n          cluster=\"$cluster\",\n          namespace=\"$namespace\",\n          job=\"$job\"}\n      )\n      by (instance, pod)\n      * on(instance) group_left()\n      (\n        avg(\n          node_cpu_hourly_cost{\n            cluster=\"$cluster\",\n            job=\"$job\"}\n        ) by (instance) * 730)\n    )\n  ) by (pod)\n)\n",
+               "format": "table",
+               "instant": true
+            },
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "$datasource"
+               },
+               "expr": "topk(10,\n  sum(\n    (\n      sum(\n        container_memory_allocation_bytes{\n          cluster=\"$cluster\",\n          namespace=\"$namespace\",\n          job=\"$job\"}\n      )\n      by (instance, pod)\n      * on(instance) group_left()\n      (\n        avg(\n          node_ram_hourly_cost{\n            cluster=\"$cluster\",\n            job=\"$job\"}\n        ) by (instance) / (1024 * 1024 * 1024) * 730\n      )\n    )\n    +\n    (\n      sum(\n        container_cpu_allocation{\n          cluster=\"$cluster\",\n          namespace=\"$namespace\",\n          job=\"$job\"}\n      )\n      by (instance, pod)\n      * on(instance) group_left()\n      (\n        avg(\n          node_cpu_hourly_cost{\n            cluster=\"$cluster\",\n            job=\"$job\"}\n        ) by (instance) * 730)\n    )\n  ) by (pod)\n)\n\n/\ntopk(10,\n  sum(\n    (\n      sum(\n        container_memory_allocation_bytes{\n          cluster=\"$cluster\",\n          namespace=\"$namespace\",\n          job=\"$job\"} offset 7d\n      )\n      by (instance, pod)\n      * on(instance) group_left()\n      (\n        avg(\n          node_ram_hourly_cost{\n            cluster=\"$cluster\",\n            job=\"$job\"} offset 7d\n        ) by (instance) / (1024 * 1024 * 1024) * 730\n      )\n    )\n    +\n    (\n      sum(\n        container_cpu_allocation{\n          cluster=\"$cluster\",\n          namespace=\"$namespace\",\n          job=\"$job\"} offset 7d\n      )\n      by (instance, pod)\n      * on(instance) group_left()\n      (\n        avg(\n          node_cpu_hourly_cost{\n            cluster=\"$cluster\",\n            job=\"$job\"} offset 7d\n        ) by (instance) * 730)\n    )\n  ) by (pod)\n)\n\n* 100\n- 100\n",
+               "format": "table",
+               "instant": true
+            },
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "$datasource"
+               },
+               "expr": "topk(10,\n  sum(\n    (\n      sum(\n        container_memory_allocation_bytes{\n          cluster=\"$cluster\",\n          namespace=\"$namespace\",\n          job=\"$job\"}\n      )\n      by (instance, pod)\n      * on(instance) group_left()\n      (\n        avg(\n          node_ram_hourly_cost{\n            cluster=\"$cluster\",\n            job=\"$job\"}\n        ) by (instance) / (1024 * 1024 * 1024) * 730\n      )\n    )\n    +\n    (\n      sum(\n        container_cpu_allocation{\n          cluster=\"$cluster\",\n          namespace=\"$namespace\",\n          job=\"$job\"}\n      )\n      by (instance, pod)\n      * on(instance) group_left()\n      (\n        avg(\n          node_cpu_hourly_cost{\n            cluster=\"$cluster\",\n            job=\"$job\"}\n        ) by (instance) * 730)\n    )\n  ) by (pod)\n)\n\n/\ntopk(10,\n  sum(\n    (\n      sum(\n        container_memory_allocation_bytes{\n          cluster=\"$cluster\",\n          namespace=\"$namespace\",\n          job=\"$job\"} offset 30d\n      )\n      by (instance, pod)\n      * on(instance) group_left()\n      (\n        avg(\n          node_ram_hourly_cost{\n            cluster=\"$cluster\",\n            job=\"$job\"} offset 30d\n        ) by (instance) / (1024 * 1024 * 1024) * 730\n      )\n    )\n    +\n    (\n      sum(\n        container_cpu_allocation{\n          cluster=\"$cluster\",\n          namespace=\"$namespace\",\n          job=\"$job\"} offset 30d\n      )\n      by (instance, pod)\n      * on(instance) group_left()\n      (\n        avg(\n          node_cpu_hourly_cost{\n            cluster=\"$cluster\",\n            job=\"$job\"} offset 30d\n        ) by (instance) * 730)\n    )\n  ) by (pod)\n)\n\n* 100\n- 100\n",
+               "format": "table",
+               "instant": true
+            }
+         ],
+         "title": "Pod Monthly Cost",
+         "transformations": [
+            {
+               "id": "merge"
+            },
+            {
+               "id": "organize",
+               "options": {
+                  "excludeByName": {
+                     "Time": true,
+                     "job": true
+                  },
+                  "indexByName": {
+                     "Value #A": 1,
+                     "Value #B": 2,
+                     "Value #C": 3,
+                     "pod": 0
+                  },
+                  "renameByName": {
+                     "Value #A": "Monthly Cost",
+                     "Value #B": "Cost Change vs 7d Ago (%)",
+                     "Value #C": "Cost Change vs 30d Ago (%)",
+                     "pod": "Pod"
+                  }
+               }
+            }
+         ],
+         "type": "table"
+      },
+      {
+         "collapsed": false,
+         "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 34
+         },
+         "id": 16,
+         "title": "Container Summary",
+         "type": "row"
+      },
+      {
+         "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+         },
+         "description": "Top 10 containers by current monthly cost with percentage change compared to 7 days and 30 days ago. Positive percentages indicate cost increases (red), negative percentages indicate cost decreases (green). This granular view helps identify specific containers within pods that are driving costs, useful for optimizing multi-container pod configurations.",
+         "fieldConfig": {
+            "defaults": {
+               "links": [ ],
+               "thresholds": {
+                  "steps": [
+                     {
+                        "color": "green",
+                        "value": 0
+                     },
+                     {
+                        "color": "yellow",
+                        "value": 5
+                     },
+                     {
+                        "color": "red",
+                        "value": 10
+                     }
+                  ]
+               },
+               "unit": "currencyUSD"
+            },
+            "overrides": [
+               {
+                  "matcher": {
+                     "id": "byName",
+                     "options": "Cost Change vs 7d Ago (%)"
+                  },
+                  "properties": [
+                     {
+                        "id": "color",
+                        "value": {
+                           "mode": "thresholds"
+                        }
+                     },
+                     {
+                        "id": "custom.cellOptions",
+                        "value": {
+                           "type": "color-background"
+                        }
+                     },
+                     {
+                        "id": "unit",
+                        "value": "percent"
+                     }
+                  ]
+               },
+               {
+                  "matcher": {
+                     "id": "byName",
+                     "options": "Cost Change vs 30d Ago (%)"
+                  },
+                  "properties": [
+                     {
+                        "id": "color",
+                        "value": {
+                           "mode": "thresholds"
+                        }
+                     },
+                     {
+                        "id": "custom.cellOptions",
+                        "value": {
+                           "type": "color-background"
+                        }
+                     },
+                     {
+                        "id": "unit",
+                        "value": "percent"
+                     }
+                  ]
+               }
+            ]
+         },
+         "gridPos": {
+            "h": 10,
+            "w": 24,
+            "x": 0,
+            "y": 35
+         },
+         "id": 17,
+         "options": {
+            "footer": {
+               "enablePagination": true
+            },
+            "sortBy": [
+               {
+                  "desc": true,
+                  "displayName": "Monthly Cost"
+               }
+            ]
+         },
+         "pluginVersion": "v11.4.0",
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "$datasource"
+               },
+               "expr": "topk(10,\n  sum(\n    (\n      sum(\n        container_memory_allocation_bytes{\n          cluster=\"$cluster\",\n          namespace=\"$namespace\",\n          job=\"$job\"}\n      )\n      by (instance, container)\n      * on(instance) group_left()\n      (\n        avg(\n          node_ram_hourly_cost{\n            cluster=\"$cluster\",\n            job=\"$job\"}\n        ) by (instance) / (1024 * 1024 * 1024) * 730\n      )\n    )\n    +\n    (\n      sum(\n        container_cpu_allocation{\n          cluster=\"$cluster\",\n          namespace=\"$namespace\",\n          job=\"$job\"}\n      )\n      by (instance, container)\n      * on(instance) group_left()\n      (\n        avg(\n          node_cpu_hourly_cost{\n            cluster=\"$cluster\",\n            job=\"$job\"}\n        ) by (instance) * 730\n      )\n    )\n  ) by (container)\n)\n",
+               "format": "table",
+               "instant": true
+            },
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "$datasource"
+               },
+               "expr": "topk(10,\n  sum(\n    (\n      sum(\n        container_memory_allocation_bytes{\n          cluster=\"$cluster\",\n          namespace=\"$namespace\",\n          job=\"$job\"}\n      )\n      by (instance, container)\n      * on(instance) group_left()\n      (\n        avg(\n          node_ram_hourly_cost{\n            cluster=\"$cluster\",\n            job=\"$job\"}\n        ) by (instance) / (1024 * 1024 * 1024) * 730\n      )\n    )\n    +\n    (\n      sum(\n        container_cpu_allocation{\n          cluster=\"$cluster\",\n          namespace=\"$namespace\",\n          job=\"$job\"}\n      )\n      by (instance, container)\n      * on(instance) group_left()\n      (\n        avg(\n          node_cpu_hourly_cost{\n            cluster=\"$cluster\",\n            job=\"$job\"}\n        ) by (instance) * 730\n      )\n    )\n  ) by (container)\n)\n\n/\ntopk(10,\n  sum(\n    (\n      sum(\n        container_memory_allocation_bytes{\n          cluster=\"$cluster\",\n          namespace=\"$namespace\",\n          job=\"$job\"} offset 7d\n      )\n      by (instance, container)\n      * on(instance) group_left()\n      (\n        avg(\n          node_ram_hourly_cost{\n            cluster=\"$cluster\",\n            job=\"$job\"} offset 7d\n        ) by (instance) / (1024 * 1024 * 1024) * 730\n      )\n    )\n    +\n    (\n      sum(\n        container_cpu_allocation{\n          cluster=\"$cluster\",\n          namespace=\"$namespace\",\n          job=\"$job\"} offset 7d\n      )\n      by (instance, container)\n      * on(instance) group_left()\n      (\n        avg(\n          node_cpu_hourly_cost{\n            cluster=\"$cluster\",\n            job=\"$job\"} offset 7d\n        ) by (instance) * 730\n      )\n    )\n  ) by (container)\n)\n\n* 100\n- 100\n",
+               "format": "table",
+               "instant": true
+            },
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "$datasource"
+               },
+               "expr": "topk(10,\n  sum(\n    (\n      sum(\n        container_memory_allocation_bytes{\n          cluster=\"$cluster\",\n          namespace=\"$namespace\",\n          job=\"$job\"}\n      )\n      by (instance, container)\n      * on(instance) group_left()\n      (\n        avg(\n          node_ram_hourly_cost{\n            cluster=\"$cluster\",\n            job=\"$job\"}\n        ) by (instance) / (1024 * 1024 * 1024) * 730\n      )\n    )\n    +\n    (\n      sum(\n        container_cpu_allocation{\n          cluster=\"$cluster\",\n          namespace=\"$namespace\",\n          job=\"$job\"}\n      )\n      by (instance, container)\n      * on(instance) group_left()\n      (\n        avg(\n          node_cpu_hourly_cost{\n            cluster=\"$cluster\",\n            job=\"$job\"}\n        ) by (instance) * 730\n      )\n    )\n  ) by (container)\n)\n\n/\ntopk(10,\n  sum(\n    (\n      sum(\n        container_memory_allocation_bytes{\n          cluster=\"$cluster\",\n          namespace=\"$namespace\",\n          job=\"$job\"} offset 30d\n      )\n      by (instance, container)\n      * on(instance) group_left()\n      (\n        avg(\n          node_ram_hourly_cost{\n            cluster=\"$cluster\",\n            job=\"$job\"} offset 30d\n        ) by (instance) / (1024 * 1024 * 1024) * 730\n      )\n    )\n    +\n    (\n      sum(\n        container_cpu_allocation{\n          cluster=\"$cluster\",\n          namespace=\"$namespace\",\n          job=\"$job\"} offset 30d\n      )\n      by (instance, container)\n      * on(instance) group_left()\n      (\n        avg(\n          node_cpu_hourly_cost{\n            cluster=\"$cluster\",\n            job=\"$job\"} offset 30d\n        ) by (instance) * 730\n      )\n    )\n  ) by (container)\n)\n\n* 100\n- 100\n",
+               "format": "table",
+               "instant": true
+            }
+         ],
+         "title": "Container Monthly Cost",
+         "transformations": [
+            {
+               "id": "merge"
+            },
+            {
+               "id": "organize",
+               "options": {
+                  "excludeByName": {
+                     "Time": true,
+                     "job": true
+                  },
+                  "indexByName": {
+                     "Value #A": 1,
+                     "Value #B": 2,
+                     "Value #C": 3,
+                     "container": 0
+                  },
+                  "renameByName": {
+                     "Value #A": "Monthly Cost",
+                     "Value #B": "Cost Change vs 7d Ago (%)",
+                     "Value #C": "Cost Change vs 30d Ago (%)",
+                     "container": "Container"
+                  }
+               }
+            }
+         ],
+         "type": "table"
+      },
+      {
+         "collapsed": false,
+         "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 45
+         },
+         "id": 18,
+         "title": "PV Summary",
+         "type": "row"
+      },
+      {
+         "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+         },
+         "description": "List of Persistent Volume Claims used by the selected namespace with their capacity (in GiB) and monthly cost, sorted by total cost. Use this to identify large or expensive claims that may be candidates for cleanup, resizing, or migration to cheaper storage classes.",
+         "fieldConfig": {
+            "defaults": {
+               "links": [ ],
+               "thresholds": {
+                  "steps": [ ]
+               },
+               "unit": "decgbytes"
+            },
+            "overrides": [
+               {
+                  "matcher": {
+                     "id": "byName",
+                     "options": "Total Cost"
+                  },
+                  "properties": [
+                     {
+                        "id": "unit",
+                        "value": "currencyUSD"
+                     }
+                  ]
+               }
+            ]
+         },
+         "gridPos": {
+            "h": 10,
+            "w": 24,
+            "x": 0,
+            "y": 46
+         },
+         "id": 19,
+         "options": {
+            "footer": {
+               "enablePagination": true
+            },
+            "sortBy": [
+               {
+                  "desc": true,
+                  "displayName": "Monthly Cost"
+               }
+            ]
+         },
+         "pluginVersion": "v11.4.0",
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "$datasource"
+               },
+               "expr": "sum(\n  sum(\n    kube_persistentvolume_capacity_bytes{\n      cluster=\"$cluster\",\n      job=\"$job\"\n    } / (1024 * 1024 * 1024)\n  ) by (persistentvolume)\n  * on(persistentvolume) group_left(cluster, namespace, persistentvolumeclaim)\n    label_replace(\n      kube_persistentvolumeclaim_info{\n        cluster=\"$cluster\",\n        job=\"$job\",\n        namespace=\"$namespace\"\n      },\n      \"persistentvolume\", \"$1\",\n      \"volumename\", \"(.*)\"\n    )\n) by (persistentvolumeclaim)\n",
+               "format": "table",
+               "instant": true
+            },
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "$datasource"
+               },
+               "expr": "sum(\n  sum(\n    kube_persistentvolume_capacity_bytes{\n      cluster=\"$cluster\",\njob=\"$job\"\n\n    }\n    / (1024 * 1024 * 1024)\n  ) by (persistentvolume)\n  *\n  sum(\n    pv_hourly_cost{\n      cluster=\"$cluster\",\njob=\"$job\"\n\n    }\n  ) by (persistentvolume)\n  * on(persistentvolume) group_left(cluster, namespace, persistentvolumeclaim) (\n    label_replace(\n      kube_persistentvolumeclaim_info{\n        cluster=\"$cluster\",\njob=\"$job\"\n,\nnamespace=\"$namespace\"\n\n      },\n      \"persistentvolume\", \"$1\",\n      \"volumename\", \"(.*)\"\n    )\n  )\n) by (persistentvolumeclaim) * 730\n",
+               "format": "table",
+               "instant": true
+            }
+         ],
+         "title": "Persistent Volume Claims Monthly Cost",
+         "transformations": [
+            {
+               "id": "merge"
+            },
+            {
+               "id": "organize",
+               "options": {
+                  "excludeByName": {
+                     "Time": true,
+                     "job": true,
+                     "namespace": true
+                  },
+                  "indexByName": {
+                     "Value #A": 1,
+                     "Value #B": 2,
+                     "persistentvolumeclaim": 0
+                  },
+                  "renameByName": {
+                     "Value #A": "Total GiB",
+                     "Value #B": "Total Cost",
+                     "persistentvolumeclaim": "Persistent Volume Claim"
+                  }
+               }
+            }
+         ],
+         "type": "table"
+      }
+   ],
+   "schemaVersion": 39,
+   "tags": [
+      "opencost",
+      "opencost-mixin"
+   ],
+   "templating": {
+      "list": [
+         {
+            "current": {
+               "selected": true,
+               "text": "default",
+               "value": "default"
+            },
+            "label": "Data source",
+            "name": "datasource",
+            "query": "prometheus",
+            "type": "datasource"
+         },
+         {
+            "datasource": {
+               "type": "prometheus",
+               "uid": "${datasource}"
+            },
+            "hide": 2,
+            "label": "Cluster",
+            "name": "cluster",
+            "query": "label_values(opencost_build_info{}, cluster)",
+            "refresh": 2,
+            "sort": 1,
+            "type": "query"
+         },
+         {
+            "datasource": {
+               "type": "prometheus",
+               "uid": "${datasource}"
+            },
+            "includeAll": false,
+            "label": "Job",
+            "multi": false,
+            "name": "job",
+            "query": "label_values(opencost_build_info{cluster=\"$cluster\"}, job)",
+            "refresh": 2,
+            "sort": 1,
+            "type": "query"
+         },
+         {
+            "datasource": {
+               "type": "prometheus",
+               "uid": "${datasource}"
+            },
+            "includeAll": false,
+            "label": "Namespace",
+            "multi": false,
+            "name": "namespace",
+            "query": "label_values(kube_namespace_labels{cluster=\"$cluster\", job=\"$job\"}, namespace)",
+            "refresh": 2,
+            "sort": 1,
+            "type": "query"
+         }
+      ]
+   },
+   "time": {
+      "from": "now-2d",
+      "to": "now"
+   },
+   "timezone": "utc",
+   "title": "OpenCost / Namespace",
+   "uid": "opencost-mixin-namespace-jkwq"
+}

--- a/kubernetes/components/dashboard/production/kustomization/grafana/opencost-overview.json
+++ b/kubernetes/components/dashboard/production/kustomization/grafana/opencost-overview.json
@@ -1,0 +1,1201 @@
+{
+   "__inputs": [ ],
+   "__requires": [ ],
+   "annotations": {
+      "list": [ ]
+   },
+   "description": "A comprehensive overview dashboard for OpenCost that displays cluster-wide cost metrics including hourly and monthly costs broken down by resource type (CPU, RAM, PV, GPU), instance type, namespace, and individual nodes. Use this dashboard to monitor overall infrastructure spending, identify cost trends, and detect cost anomalies across your Kubernetes cluster. The dashboards were generated using [opencost-mixin](https://github.com/adinhodovic/opencost-mixin). Open issues and create feature requests in the repository.",
+   "editable": false,
+   "links": [
+      {
+         "asDropdown": true,
+         "includeVars": false,
+         "keepTime": true,
+         "tags": [
+            "opencost",
+            "opencost-mixin"
+         ],
+         "targetBlank": true,
+         "title": "OpenCost",
+         "type": "dashboards"
+      }
+   ],
+   "panels": [
+      {
+         "collapsed": false,
+         "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 0
+         },
+         "id": 1,
+         "title": "Cluster Summary",
+         "type": "row"
+      },
+      {
+         "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+         },
+         "description": "Current hourly infrastructure cost rate across the cluster. This metric provides real-time cost visibility and can be used to project daily and monthly spending. The percentage change helps track cost fluctuations over time.",
+         "fieldConfig": {
+            "defaults": {
+               "decimals": 2,
+               "mappings": [ ],
+               "thresholds": {
+                  "steps": [
+                     {
+                        "color": "green",
+                        "value": 0
+                     }
+                  ]
+               },
+               "unit": "currencyUSD"
+            },
+            "overrides": [ ]
+         },
+         "gridPos": {
+            "h": 3,
+            "w": 4,
+            "x": 0,
+            "y": 1
+         },
+         "id": 2,
+         "options": {
+            "graphMode": "none",
+            "percentChangeColorMode": "inverted",
+            "showPercentChange": true
+         },
+         "pluginVersion": "v11.4.0",
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "$datasource"
+               },
+               "expr": "sum(\n  node_total_hourly_cost{\n    cluster=\"$cluster\",\njob=\"$job\"\n\n  }\n)\n+\nsum(\n  sum(\n    kube_persistentvolume_capacity_bytes{\n      cluster=\"$cluster\",\njob=\"$job\"\n\n    } / (1024 * 1024 * 1024)\n  ) by (persistentvolume)\n  * on(persistentvolume) group_left()\n  sum(\n    pv_hourly_cost{\n      cluster=\"$cluster\",\njob=\"$job\"\n\n    }\n  ) by (persistentvolume)\n)\n",
+               "instant": false
+            }
+         ],
+         "title": "Hourly Cost",
+         "type": "stat"
+      },
+      {
+         "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+         },
+         "description": "Projected monthly infrastructure cost based on current hourly rates (730 hours per month). This projection helps with budget planning and cost forecasting. Compare this value against your budget to ensure spending stays within limits.",
+         "fieldConfig": {
+            "defaults": {
+               "decimals": 2,
+               "mappings": [ ],
+               "thresholds": {
+                  "steps": [
+                     {
+                        "color": "green",
+                        "value": 0
+                     }
+                  ]
+               },
+               "unit": "currencyUSD"
+            },
+            "overrides": [ ]
+         },
+         "gridPos": {
+            "h": 3,
+            "w": 4,
+            "x": 4,
+            "y": 1
+         },
+         "id": 3,
+         "options": {
+            "graphMode": "none",
+            "percentChangeColorMode": "inverted",
+            "showPercentChange": true
+         },
+         "pluginVersion": "v11.4.0",
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "$datasource"
+               },
+               "expr": "(sum(\n  node_total_hourly_cost{\n    cluster=\"$cluster\",\njob=\"$job\"\n\n  }\n)\n+\nsum(\n  sum(\n    kube_persistentvolume_capacity_bytes{\n      cluster=\"$cluster\",\njob=\"$job\"\n\n    } / (1024 * 1024 * 1024)\n  ) by (persistentvolume)\n  * on(persistentvolume) group_left()\n  sum(\n    pv_hourly_cost{\n      cluster=\"$cluster\",\njob=\"$job\"\n\n    }\n  ) by (persistentvolume)\n)\n) * 730",
+               "instant": false
+            }
+         ],
+         "title": "Monthly Cost",
+         "type": "stat"
+      },
+      {
+         "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+         },
+         "description": "Projected monthly cost for CPU (compute) resources across all cluster nodes. Compare this with RAM costs to understand your compute vs. memory cost ratio and optimize instance type selection accordingly.",
+         "fieldConfig": {
+            "defaults": {
+               "decimals": 2,
+               "mappings": [ ],
+               "thresholds": {
+                  "steps": [
+                     {
+                        "color": "green",
+                        "value": 0
+                     }
+                  ]
+               },
+               "unit": "currencyUSD"
+            },
+            "overrides": [ ]
+         },
+         "gridPos": {
+            "h": 3,
+            "w": 4,
+            "x": 8,
+            "y": 1
+         },
+         "id": 4,
+         "options": {
+            "graphMode": "none",
+            "percentChangeColorMode": "inverted",
+            "showPercentChange": true
+         },
+         "pluginVersion": "v11.4.0",
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "$datasource"
+               },
+               "expr": "sum(\n  sum(\n    kube_node_status_capacity{\n      cluster=\"$cluster\",\njob=\"$job\"\n,\n      resource=\"cpu\",\n      unit=\"core\"\n    }\n  ) by (node)\n  * on(node) group_left()\n    sum(\n      node_cpu_hourly_cost{\n        cluster=\"$cluster\",\njob=\"$job\"\n\n      }\n    ) by (node)\n  * 730\n)\n",
+               "instant": false
+            }
+         ],
+         "title": "Monthly CPU Cost",
+         "type": "stat"
+      },
+      {
+         "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+         },
+         "description": "Projected monthly cost for RAM (memory) resources across all cluster nodes. This metric helps identify if memory is a significant cost driver and can guide decisions about node sizing and memory allocation strategies.",
+         "fieldConfig": {
+            "defaults": {
+               "decimals": 2,
+               "mappings": [ ],
+               "thresholds": {
+                  "steps": [
+                     {
+                        "color": "green",
+                        "value": 0
+                     }
+                  ]
+               },
+               "unit": "currencyUSD"
+            },
+            "overrides": [ ]
+         },
+         "gridPos": {
+            "h": 3,
+            "w": 4,
+            "x": 12,
+            "y": 1
+         },
+         "id": 5,
+         "options": {
+            "graphMode": "none",
+            "percentChangeColorMode": "inverted",
+            "showPercentChange": true
+         },
+         "pluginVersion": "v11.4.0",
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "$datasource"
+               },
+               "expr": "sum(\n  sum(\n    kube_node_status_capacity{\n      cluster=\"$cluster\",\njob=\"$job\"\n,\n      resource=\"memory\",\n      unit=\"byte\"\n    }\n  ) by (node)\n  / (1024 * 1024 * 1024)\n  * on(node) group_left()\n    sum(\n      node_ram_hourly_cost{\n        cluster=\"$cluster\",\njob=\"$job\"\n\n      }\n    ) by (node)\n  * 730\n)\n",
+               "instant": false
+            }
+         ],
+         "title": "Monthly Ram Cost",
+         "type": "stat"
+      },
+      {
+         "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+         },
+         "description": "Projected monthly GPU cost across the cluster. Use this to understand whether accelerator usage is a major cost driver and to spot opportunities to right-size GPU-backed workloads.",
+         "fieldConfig": {
+            "defaults": {
+               "decimals": 2,
+               "mappings": [ ],
+               "thresholds": {
+                  "steps": [
+                     {
+                        "color": "green",
+                        "value": 0
+                     }
+                  ]
+               },
+               "unit": "currencyUSD"
+            },
+            "overrides": [ ]
+         },
+         "gridPos": {
+            "h": 3,
+            "w": 4,
+            "x": 16,
+            "y": 1
+         },
+         "id": 6,
+         "options": {
+            "graphMode": "none",
+            "percentChangeColorMode": "inverted",
+            "showPercentChange": true
+         },
+         "pluginVersion": "v11.4.0",
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "$datasource"
+               },
+               "expr": "sum(\n  node_gpu_hourly_cost{\n    cluster=\"$cluster\",\njob=\"$job\"\n\n  }\n) * 730\n",
+               "instant": false
+            }
+         ],
+         "title": "Monthly GPU Cost",
+         "type": "stat"
+      },
+      {
+         "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+         },
+         "description": "Projected monthly cost for Persistent Volume (storage) resources across the cluster. Monitor this metric to identify unused or oversized volumes that can be optimized to reduce storage costs.",
+         "fieldConfig": {
+            "defaults": {
+               "decimals": 2,
+               "mappings": [ ],
+               "thresholds": {
+                  "steps": [
+                     {
+                        "color": "green",
+                        "value": 0
+                     }
+                  ]
+               },
+               "unit": "currencyUSD"
+            },
+            "overrides": [ ]
+         },
+         "gridPos": {
+            "h": 3,
+            "w": 4,
+            "x": 20,
+            "y": 1
+         },
+         "id": 7,
+         "options": {
+            "graphMode": "none",
+            "percentChangeColorMode": "inverted",
+            "showPercentChange": true
+         },
+         "pluginVersion": "v11.4.0",
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "$datasource"
+               },
+               "expr": "sum(\n  sum(\n    kube_persistentvolume_capacity_bytes{\n      cluster=\"$cluster\",\njob=\"$job\"\n\n    } / (1024 * 1024 * 1024)\n  ) by (persistentvolume)\n  * on(persistentvolume) group_left()\n    sum(\n      pv_hourly_cost{\n        cluster=\"$cluster\",\njob=\"$job\"\n\n      }\n    ) by (persistentvolume)\n) * 730\n",
+               "instant": false
+            }
+         ],
+         "title": "Monthly PV Cost",
+         "type": "stat"
+      },
+      {
+         "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+         },
+         "description": "Monthly cost distribution across resource types (CPU, RAM, Persistent Volumes, and GPU). This breakdown shows which resource category consumes the most budget, helping prioritize optimization efforts.",
+         "fieldConfig": {
+            "defaults": {
+               "unit": "currencyUSD"
+            },
+            "overrides": [ ]
+         },
+         "gridPos": {
+            "h": 5,
+            "w": 8,
+            "x": 0,
+            "y": 5
+         },
+         "id": 8,
+         "options": {
+            "displayLabels": [
+               "percent"
+            ],
+            "legend": {
+               "displayMode": "table",
+               "placement": "right",
+               "showLegend": true,
+               "values": [
+                  "percent",
+                  "value"
+               ]
+            },
+            "tooltip": {
+               "mode": "multi",
+               "sort": "desc"
+            }
+         },
+         "pluginVersion": "v11.4.0",
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "$datasource"
+               },
+               "expr": "sum(\n  sum(\n    kube_node_status_capacity{\n      cluster=\"$cluster\",\njob=\"$job\"\n,\n      resource=\"cpu\",\n      unit=\"core\"\n    }\n  ) by (node)\n  * on(node) group_left()\n    sum(\n      node_cpu_hourly_cost{\n        cluster=\"$cluster\",\njob=\"$job\"\n\n      }\n    ) by (node)\n  * 730\n)\n",
+               "instant": true,
+               "legendFormat": "CPU"
+            },
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "$datasource"
+               },
+               "expr": "sum(\n  sum(\n    kube_node_status_capacity{\n      cluster=\"$cluster\",\njob=\"$job\"\n,\n      resource=\"memory\",\n      unit=\"byte\"\n    }\n  ) by (node)\n  / (1024 * 1024 * 1024)\n  * on(node) group_left()\n    sum(\n      node_ram_hourly_cost{\n        cluster=\"$cluster\",\njob=\"$job\"\n\n      }\n    ) by (node)\n  * 730\n)\n",
+               "instant": true,
+               "legendFormat": "RAM"
+            },
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "$datasource"
+               },
+               "expr": "sum(\n  sum(\n    kube_persistentvolume_capacity_bytes{\n      cluster=\"$cluster\",\njob=\"$job\"\n\n    } / (1024 * 1024 * 1024)\n  ) by (persistentvolume)\n  * on(persistentvolume) group_left()\n    sum(\n      pv_hourly_cost{\n        cluster=\"$cluster\",\njob=\"$job\"\n\n      }\n    ) by (persistentvolume)\n) * 730\n",
+               "instant": true,
+               "legendFormat": "PV"
+            },
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "$datasource"
+               },
+               "expr": "sum(\n  node_gpu_hourly_cost{\n    cluster=\"$cluster\",\njob=\"$job\"\n\n  }\n) * 730\n",
+               "instant": true,
+               "legendFormat": "GPU"
+            }
+         ],
+         "title": "Cost by Resource",
+         "type": "piechart"
+      },
+      {
+         "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+         },
+         "description": "Top 10 namespaces by monthly cost showing which teams, applications, or environments consume the most resources. Use this to allocate costs to teams, identify expensive applications, and ensure fair resource distribution across the organization.",
+         "fieldConfig": {
+            "defaults": {
+               "unit": "currencyUSD"
+            },
+            "overrides": [ ]
+         },
+         "gridPos": {
+            "h": 5,
+            "w": 8,
+            "x": 8,
+            "y": 5
+         },
+         "id": 9,
+         "options": {
+            "displayLabels": [
+               "percent"
+            ],
+            "legend": {
+               "displayMode": "table",
+               "placement": "right",
+               "showLegend": true,
+               "values": [
+                  "percent",
+                  "value"
+               ]
+            },
+            "tooltip": {
+               "mode": "multi",
+               "sort": "desc"
+            }
+         },
+         "pluginVersion": "v11.4.0",
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "$datasource"
+               },
+               "expr": "topk(10,\n  sum(\n    sum(\n      container_memory_allocation_bytes{\n        cluster=\"$cluster\",\n        job=\"$job\"}\n    ) by (cluster, namespace, instance)\n    * on(cluster, instance) group_left()\n      (\n        node_ram_hourly_cost{\n          cluster=\"$cluster\",\n          job=\"$job\"} / (1024 * 1024 * 1024) * 730\n      )\n    +\n    sum(\n      container_cpu_allocation{\n        cluster=\"$cluster\",\n        job=\"$job\"}\n    ) by (cluster, namespace, instance)\n    * on(cluster, instance) group_left()\n      (\n        node_cpu_hourly_cost{\n          cluster=\"$cluster\",\n          job=\"$job\"} * 730\n      )\n  ) by (cluster, namespace)\n)\n",
+               "instant": true,
+               "legendFormat": "{{ namespace }}"
+            }
+         ],
+         "title": "Cost by Namespace",
+         "type": "piechart"
+      },
+      {
+         "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+         },
+         "description": "Top 10 instance types by monthly cost showing which VM/node types contribute most to infrastructure spending. This helps evaluate whether your instance type selection is cost-effective and identify opportunities to switch to more economical instance families.",
+         "fieldConfig": {
+            "defaults": {
+               "unit": "currencyUSD"
+            },
+            "overrides": [ ]
+         },
+         "gridPos": {
+            "h": 5,
+            "w": 8,
+            "x": 16,
+            "y": 5
+         },
+         "id": 10,
+         "options": {
+            "displayLabels": [
+               "percent"
+            ],
+            "legend": {
+               "displayMode": "table",
+               "placement": "right",
+               "showLegend": true,
+               "values": [
+                  "percent",
+                  "value"
+               ]
+            },
+            "tooltip": {
+               "mode": "multi",
+               "sort": "desc"
+            }
+         },
+         "pluginVersion": "v11.4.0",
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "$datasource"
+               },
+               "expr": "topk(10,\n  sum(\n    node_total_hourly_cost{\n      cluster=\"$cluster\",\njob=\"$job\"\n\n    }\n  ) by (instance_type) * 730\n)\n",
+               "instant": true,
+               "legendFormat": "{{ instance_type }}"
+            }
+         ],
+         "title": "Cost by Instance Type",
+         "type": "piechart"
+      },
+      {
+         "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+         },
+         "description": "Hourly cost trend over time showing how infrastructure spending fluctuates throughout the day. Use this to identify cost spikes, correlate costs with workload patterns, and detect autoscaling behavior impact on spending.",
+         "fieldConfig": {
+            "defaults": {
+               "custom": {
+                  "fillOpacity": 10
+               },
+               "unit": "currencyUSD"
+            },
+            "overrides": [ ]
+         },
+         "gridPos": {
+            "h": 5,
+            "w": 12,
+            "x": 0,
+            "y": 10
+         },
+         "id": 11,
+         "options": {
+            "legend": {
+               "calcs": [
+                  "mean",
+                  "max"
+               ],
+               "displayMode": "table",
+               "placement": "right",
+               "showLegend": true,
+               "sortBy": "Mean",
+               "sortDesc": true
+            },
+            "tooltip": {
+               "mode": "multi",
+               "sort": "desc"
+            }
+         },
+         "pluginVersion": "v11.4.0",
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "$datasource"
+               },
+               "exemplar": false,
+               "expr": "sum(\n  node_total_hourly_cost{\n    cluster=\"$cluster\",\njob=\"$job\"\n\n  }\n)\n+\nsum(\n  sum(\n    kube_persistentvolume_capacity_bytes{\n      cluster=\"$cluster\",\njob=\"$job\"\n\n    } / (1024 * 1024 * 1024)\n  ) by (persistentvolume)\n  * on(persistentvolume) group_left()\n  sum(\n    pv_hourly_cost{\n      cluster=\"$cluster\",\njob=\"$job\"\n\n    }\n  ) by (persistentvolume)\n)\n",
+               "legendFormat": "Hourly Cost"
+            }
+         ],
+         "title": "Hourly Cost",
+         "type": "timeseries"
+      },
+      {
+         "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+         },
+         "description": "Monthly cost projection trend over time. This visualization helps track how your projected monthly spending evolves and whether you are staying within budget throughout the billing period.",
+         "fieldConfig": {
+            "defaults": {
+               "custom": {
+                  "fillOpacity": 10
+               },
+               "unit": "currencyUSD"
+            },
+            "overrides": [ ]
+         },
+         "gridPos": {
+            "h": 5,
+            "w": 12,
+            "x": 12,
+            "y": 10
+         },
+         "id": 12,
+         "options": {
+            "legend": {
+               "calcs": [
+                  "mean",
+                  "max"
+               ],
+               "displayMode": "table",
+               "placement": "right",
+               "showLegend": true,
+               "sortBy": "Mean",
+               "sortDesc": true
+            },
+            "tooltip": {
+               "mode": "multi",
+               "sort": "desc"
+            }
+         },
+         "pluginVersion": "v11.4.0",
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "$datasource"
+               },
+               "exemplar": false,
+               "expr": "(sum(\n  node_total_hourly_cost{\n    cluster=\"$cluster\",\njob=\"$job\"\n\n  }\n)\n+\nsum(\n  sum(\n    kube_persistentvolume_capacity_bytes{\n      cluster=\"$cluster\",\njob=\"$job\"\n\n    } / (1024 * 1024 * 1024)\n  ) by (persistentvolume)\n  * on(persistentvolume) group_left()\n  sum(\n    pv_hourly_cost{\n      cluster=\"$cluster\",\njob=\"$job\"\n\n    }\n  ) by (persistentvolume)\n)\n) * 730",
+               "interval": "30m",
+               "legendFormat": "Monthly Cost"
+            }
+         ],
+         "title": "Monthly Cost",
+         "type": "timeseries"
+      },
+      {
+         "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+         },
+         "description": "Cost variance comparing current hourly costs against 7-day and 30-day historical averages. Positive values indicate costs are higher than average, negative values indicate lower costs. Use this to detect cost anomalies and unusual spending patterns that may require investigation.",
+         "fieldConfig": {
+            "defaults": {
+               "custom": {
+                  "fillOpacity": 10
+               },
+               "unit": "percentunit"
+            },
+            "overrides": [ ]
+         },
+         "gridPos": {
+            "h": 5,
+            "w": 12,
+            "x": 0,
+            "y": 15
+         },
+         "id": 13,
+         "options": {
+            "legend": {
+               "calcs": [
+                  "mean",
+                  "max"
+               ],
+               "displayMode": "table",
+               "placement": "right",
+               "showLegend": true,
+               "sortBy": "Mean",
+               "sortDesc": true
+            },
+            "tooltip": {
+               "mode": "multi",
+               "sort": "desc"
+            }
+         },
+         "pluginVersion": "v11.4.0",
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "$datasource"
+               },
+               "exemplar": false,
+               "expr": "(\n  avg_over_time(\n    sum(\n      node_total_hourly_cost{\n        cluster=\"$cluster\",\njob=\"$job\"\n\n      }\n    ) [1d:1h]\n  )\n  -\n  avg_over_time(\n    sum(\n      node_total_hourly_cost{\n        cluster=\"$cluster\",\njob=\"$job\"\n\n      }\n    ) [7d:1h]\n  )\n)\n/\navg_over_time(\n  sum(\n    node_total_hourly_cost{\n      cluster=\"$cluster\",\njob=\"$job\"\n\n    }\n  ) [7d:1h]\n)\n",
+               "interval": "30m",
+               "legendFormat": "Current hourly cost vs. 7-day average"
+            },
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "$datasource"
+               },
+               "exemplar": false,
+               "expr": "(\n  avg_over_time(\n    sum(\n      node_total_hourly_cost{\n        cluster=\"$cluster\",\njob=\"$job\"\n\n      }\n    ) [1d:1h]\n  )\n  -\n  avg_over_time(\n    sum(\n      node_total_hourly_cost{\n        cluster=\"$cluster\",\njob=\"$job\"\n\n      }\n    ) [30d:1h]\n  )\n)\n/\navg_over_time(\n  sum(\n    node_total_hourly_cost{\n      cluster=\"$cluster\",\njob=\"$job\"\n\n    }\n  ) [30d:1h]\n)\n",
+               "interval": "30m",
+               "legendFormat": "Current hourly cost vs. 30-day average"
+            }
+         ],
+         "title": "Total Cost Variance",
+         "type": "timeseries"
+      },
+      {
+         "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+         },
+         "description": "Resource-specific cost variance comparing current CPU, RAM, and PV costs against their 30-day historical averages. This breakdown helps identify which resource type is driving cost changes - useful for pinpointing whether cost increases are due to compute scaling, memory usage, or storage growth.",
+         "fieldConfig": {
+            "defaults": {
+               "custom": {
+                  "fillOpacity": 10
+               },
+               "unit": "percentunit"
+            },
+            "overrides": [ ]
+         },
+         "gridPos": {
+            "h": 5,
+            "w": 12,
+            "x": 12,
+            "y": 15
+         },
+         "id": 14,
+         "options": {
+            "legend": {
+               "calcs": [
+                  "mean",
+                  "max"
+               ],
+               "displayMode": "table",
+               "placement": "right",
+               "showLegend": true,
+               "sortBy": "Mean",
+               "sortDesc": true
+            },
+            "tooltip": {
+               "mode": "multi",
+               "sort": "desc"
+            }
+         },
+         "pluginVersion": "v11.4.0",
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "$datasource"
+               },
+               "exemplar": false,
+               "expr": "(\n  avg_over_time(\n    sum(\n  sum(\n    kube_node_status_capacity{\n      cluster=\"$cluster\",\njob=\"$job\"\n,\n      resource=\"cpu\",\n      unit=\"core\"\n    }\n  ) by (node)\n  * on(node) group_left()\n    sum(\n      node_cpu_hourly_cost{\n        cluster=\"$cluster\",\njob=\"$job\"\n\n      }\n    ) by (node)\n  * 730\n)\n [1d:1h]\n  )\n  -\n  avg_over_time(\n    sum(\n  sum(\n    kube_node_status_capacity{\n      cluster=\"$cluster\",\njob=\"$job\"\n,\n      resource=\"cpu\",\n      unit=\"core\"\n    }\n  ) by (node)\n  * on(node) group_left()\n    sum(\n      node_cpu_hourly_cost{\n        cluster=\"$cluster\",\njob=\"$job\"\n\n      }\n    ) by (node)\n  * 730\n)\n [30d:1h]\n  )\n)\n/\navg_over_time(\n  sum(\n  sum(\n    kube_node_status_capacity{\n      cluster=\"$cluster\",\njob=\"$job\"\n,\n      resource=\"cpu\",\n      unit=\"core\"\n    }\n  ) by (node)\n  * on(node) group_left()\n    sum(\n      node_cpu_hourly_cost{\n        cluster=\"$cluster\",\njob=\"$job\"\n\n      }\n    ) by (node)\n  * 730\n)\n [30d:1h]\n)\n",
+               "interval": "30m",
+               "legendFormat": "CPU Cost vs. 30-day average"
+            },
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "$datasource"
+               },
+               "exemplar": false,
+               "expr": "(\n  avg_over_time(\n    sum(\n  sum(\n    kube_node_status_capacity{\n      cluster=\"$cluster\",\njob=\"$job\"\n,\n      resource=\"memory\",\n      unit=\"byte\"\n    }\n  ) by (node)\n  / (1024 * 1024 * 1024)\n  * on(node) group_left()\n    sum(\n      node_ram_hourly_cost{\n        cluster=\"$cluster\",\njob=\"$job\"\n\n      }\n    ) by (node)\n  * 730\n)\n [1d:1h]\n  )\n  -\n  avg_over_time(\n    sum(\n  sum(\n    kube_node_status_capacity{\n      cluster=\"$cluster\",\njob=\"$job\"\n,\n      resource=\"memory\",\n      unit=\"byte\"\n    }\n  ) by (node)\n  / (1024 * 1024 * 1024)\n  * on(node) group_left()\n    sum(\n      node_ram_hourly_cost{\n        cluster=\"$cluster\",\njob=\"$job\"\n\n      }\n    ) by (node)\n  * 730\n)\n [30d:1h]\n  )\n)\n/\navg_over_time(\n  sum(\n  sum(\n    kube_node_status_capacity{\n      cluster=\"$cluster\",\njob=\"$job\"\n,\n      resource=\"memory\",\n      unit=\"byte\"\n    }\n  ) by (node)\n  / (1024 * 1024 * 1024)\n  * on(node) group_left()\n    sum(\n      node_ram_hourly_cost{\n        cluster=\"$cluster\",\njob=\"$job\"\n\n      }\n    ) by (node)\n  * 730\n)\n [30d:1h]\n)\n",
+               "interval": "30m",
+               "legendFormat": "RAM Cost vs. 30-day average"
+            },
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "$datasource"
+               },
+               "exemplar": false,
+               "expr": "(\n  avg_over_time(\n    (sum(\n  sum(\n    kube_persistentvolume_capacity_bytes{\n      cluster=\"$cluster\",\njob=\"$job\"\n\n    } / (1024 * 1024 * 1024)\n  ) by (persistentvolume)\n  * on(persistentvolume) group_left()\n    sum(\n      pv_hourly_cost{\n        cluster=\"$cluster\",\njob=\"$job\"\n\n      }\n    ) by (persistentvolume)\n) * 730\n) [1d:1h]\n  )\n  -\n  avg_over_time(\n    (sum(\n  sum(\n    kube_persistentvolume_capacity_bytes{\n      cluster=\"$cluster\",\njob=\"$job\"\n\n    } / (1024 * 1024 * 1024)\n  ) by (persistentvolume)\n  * on(persistentvolume) group_left()\n    sum(\n      pv_hourly_cost{\n        cluster=\"$cluster\",\njob=\"$job\"\n\n      }\n    ) by (persistentvolume)\n) * 730\n) [30d:1h]\n  )\n)\n/\navg_over_time(\n  (sum(\n  sum(\n    kube_persistentvolume_capacity_bytes{\n      cluster=\"$cluster\",\njob=\"$job\"\n\n    } / (1024 * 1024 * 1024)\n  ) by (persistentvolume)\n  * on(persistentvolume) group_left()\n    sum(\n      pv_hourly_cost{\n        cluster=\"$cluster\",\njob=\"$job\"\n\n      }\n    ) by (persistentvolume)\n) * 730\n) [30d:1h]\n)\n",
+               "interval": "30m",
+               "legendFormat": "PV Cost vs. 30-day average"
+            }
+         ],
+         "title": "Resource Cost Variance",
+         "type": "timeseries"
+      },
+      {
+         "collapsed": false,
+         "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 20
+         },
+         "id": 15,
+         "title": "Cloud Resources",
+         "type": "row"
+      },
+      {
+         "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+         },
+         "description": "Detailed breakdown of monthly costs per node, showing CPU cost, RAM cost, and total cost for each node along with instance type and architecture. Sorted by total cost to highlight the most expensive nodes. Use this to identify underutilized expensive nodes that could be downsized or removed.",
+         "fieldConfig": {
+            "defaults": {
+               "links": [ ],
+               "thresholds": {
+                  "steps": [ ]
+               },
+               "unit": "currencyUSD"
+            },
+            "overrides": [ ]
+         },
+         "gridPos": {
+            "h": 10,
+            "w": 16,
+            "x": 0,
+            "y": 21
+         },
+         "id": 16,
+         "options": {
+            "footer": {
+               "enablePagination": true
+            },
+            "sortBy": [
+               {
+                  "desc": true,
+                  "displayName": "Total Cost"
+               }
+            ]
+         },
+         "pluginVersion": "v11.4.0",
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "$datasource"
+               },
+               "expr": "sum(\n  kube_node_status_capacity{\n    cluster=\"$cluster\",\njob=\"$job\"\n,\n    resource=\"cpu\",\n    unit=\"core\"\n  }\n) by (node)\n* on(node) group_left(cluster, instance_type, arch)\n  sum(\n    node_cpu_hourly_cost{\n      cluster=\"$cluster\",\njob=\"$job\"\n,\n    }\n  ) by (node, instance_type, arch)\n* 730\n",
+               "format": "table",
+               "instant": true
+            },
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "$datasource"
+               },
+               "expr": "sum(\n  kube_node_status_capacity{\n    cluster=\"$cluster\",\njob=\"$job\"\n,\n    resource=\"memory\",\n    unit=\"byte\"\n  }\n) by (node)\n/ (1024 * 1024 * 1024)\n* on(node) group_left(cluster, instance_type, arch)\n  sum(\n    node_ram_hourly_cost{\n      cluster=\"$cluster\",\njob=\"$job\"\n\n    }\n  ) by (node, instance_type, arch)\n* 730\n",
+               "format": "table",
+               "instant": true
+            },
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "$datasource"
+               },
+               "expr": "sum(\n  node_total_hourly_cost{\n    cluster=\"$cluster\",\njob=\"$job\"\n\n  }\n) by (node, instance_type, arch)\n* 730\n",
+               "format": "table",
+               "instant": true
+            }
+         ],
+         "title": "Nodes Monthly Cost",
+         "transformations": [
+            {
+               "id": "merge"
+            },
+            {
+               "id": "organize",
+               "options": {
+                  "excludeByName": {
+                     "Time": true,
+                     "job": true
+                  },
+                  "indexByName": {
+                     "Value #A": 3,
+                     "Value #B": 4,
+                     "Value #C": 5,
+                     "arch": 2,
+                     "instance_type": 1,
+                     "node": 0
+                  },
+                  "renameByName": {
+                     "Value #A": "CPU Cost",
+                     "Value #B": "RAM Cost",
+                     "Value #C": "Total Cost",
+                     "arch": "Architecture",
+                     "instance_type": "Instance Type",
+                     "node": "Node"
+                  }
+               }
+            }
+         ],
+         "type": "table"
+      },
+      {
+         "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+         },
+         "description": "List of all Persistent Volumes with their capacity (in GiB) and monthly cost, sorted by total cost. Use this to identify large or expensive volumes that may be candidates for cleanup, resizing, or migration to cheaper storage classes.",
+         "fieldConfig": {
+            "defaults": {
+               "links": [ ],
+               "thresholds": {
+                  "steps": [ ]
+               },
+               "unit": "decgbytes"
+            },
+            "overrides": [
+               {
+                  "matcher": {
+                     "id": "byName",
+                     "options": "Total Cost"
+                  },
+                  "properties": [
+                     {
+                        "id": "unit",
+                        "value": "currencyUSD"
+                     }
+                  ]
+               }
+            ]
+         },
+         "gridPos": {
+            "h": 10,
+            "w": 8,
+            "x": 16,
+            "y": 21
+         },
+         "id": 17,
+         "options": {
+            "footer": {
+               "enablePagination": true
+            },
+            "sortBy": [
+               {
+                  "desc": true,
+                  "displayName": "Total Cost"
+               }
+            ]
+         },
+         "pluginVersion": "v11.4.0",
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "$datasource"
+               },
+               "expr": "sum(\n  kube_persistentvolume_capacity_bytes{\n    cluster=\"$cluster\",\njob=\"$job\"\n\n  }\n  / 1024 / 1024 / 1024\n) by (persistentvolume)\n",
+               "format": "table",
+               "instant": true
+            },
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "$datasource"
+               },
+               "expr": "sum(\n  kube_persistentvolume_capacity_bytes{\n    cluster=\"$cluster\",\njob=\"$job\"\n\n  }\n  / 1024 / 1024 / 1024\n) by (persistentvolume)\n*\nsum(\n  pv_hourly_cost{\n    cluster=\"$cluster\",\njob=\"$job\"\n\n  }\n  * 730\n) by (persistentvolume)\n",
+               "format": "table",
+               "instant": true
+            }
+         ],
+         "title": "Persistent Volumes Monthly Cost",
+         "transformations": [
+            {
+               "id": "merge"
+            },
+            {
+               "id": "organize",
+               "options": {
+                  "excludeByName": {
+                     "Time": true,
+                     "job": true
+                  },
+                  "indexByName": {
+                     "Value #A": 1,
+                     "Value #B": 2,
+                     "persistentvolume": 0
+                  },
+                  "renameByName": {
+                     "Value #A": "Total GiB",
+                     "Value #B": "Total Cost",
+                     "persistentvolume": "Persistent Volume"
+                  }
+               }
+            }
+         ],
+         "type": "table"
+      },
+      {
+         "collapsed": false,
+         "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 31
+         },
+         "id": 18,
+         "title": "Namespace Summary",
+         "type": "row"
+      },
+      {
+         "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+         },
+         "description": "Top 10 namespaces by current monthly cost with percentage change compared to 7 days and 30 days ago. Positive percentages indicate cost increases (red), negative percentages indicate cost decreases (green). Click on a namespace name to drill down into detailed pod and container costs. Use this to track namespace-level spending trends and identify teams or applications with growing costs.",
+         "fieldConfig": {
+            "defaults": {
+               "links": [ ],
+               "thresholds": {
+                  "steps": [
+                     {
+                        "color": "green",
+                        "value": 0
+                     },
+                     {
+                        "color": "yellow",
+                        "value": 5
+                     },
+                     {
+                        "color": "red",
+                        "value": 10
+                     }
+                  ]
+               },
+               "unit": "currencyUSD"
+            },
+            "overrides": [
+               {
+                  "matcher": {
+                     "id": "byName",
+                     "options": "Cost Change vs 7d Ago (%)"
+                  },
+                  "properties": [
+                     {
+                        "id": "color",
+                        "value": {
+                           "mode": "thresholds"
+                        }
+                     },
+                     {
+                        "id": "custom.cellOptions",
+                        "value": {
+                           "type": "color-background"
+                        }
+                     },
+                     {
+                        "id": "unit",
+                        "value": "percent"
+                     }
+                  ]
+               },
+               {
+                  "matcher": {
+                     "id": "byName",
+                     "options": "Cost Change vs 30d Ago (%)"
+                  },
+                  "properties": [
+                     {
+                        "id": "color",
+                        "value": {
+                           "mode": "thresholds"
+                        }
+                     },
+                     {
+                        "id": "custom.cellOptions",
+                        "value": {
+                           "type": "color-background"
+                        }
+                     },
+                     {
+                        "id": "unit",
+                        "value": "percent"
+                     }
+                  ]
+               },
+               {
+                  "matcher": {
+                     "id": "byName",
+                     "options": "Namespace"
+                  },
+                  "properties": [
+                     {
+                        "id": "links",
+                        "value": [
+                           {
+                              "targetBlank": true,
+                              "title": "Go To Namespace",
+                              "type": "dashboard",
+                              "url": "/d/opencost-mixin-namespace-jkwq/opencost-namespace?var-cluster=${__data.fields.cluster}&var-job=$job&var-namespace=${__data.fields.Namespace}"
+                           }
+                        ]
+                     }
+                  ]
+               }
+            ]
+         },
+         "gridPos": {
+            "h": 12,
+            "w": 24,
+            "x": 0,
+            "y": 32
+         },
+         "id": 19,
+         "options": {
+            "footer": {
+               "enablePagination": true
+            },
+            "sortBy": [
+               {
+                  "desc": true,
+                  "displayName": "Monthly Cost"
+               }
+            ]
+         },
+         "pluginVersion": "v11.4.0",
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "$datasource"
+               },
+               "expr": "topk(10,\n  sum(\n    sum(\n      container_memory_allocation_bytes{\n        cluster=\"$cluster\",\n        job=\"$job\"}\n    ) by (cluster, namespace, instance)\n    * on(cluster, instance) group_left()\n      (\n        node_ram_hourly_cost{\n          cluster=\"$cluster\",\n          job=\"$job\"} / (1024 * 1024 * 1024) * 730\n      )\n    +\n    sum(\n      container_cpu_allocation{\n        cluster=\"$cluster\",\n        job=\"$job\"}\n    ) by (cluster, namespace, instance)\n    * on(cluster, instance) group_left()\n      (\n        node_cpu_hourly_cost{\n          cluster=\"$cluster\",\n          job=\"$job\"} * 730\n      )\n  ) by (cluster, namespace)\n)\n",
+               "format": "table",
+               "instant": true
+            },
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "$datasource"
+               },
+               "expr": "topk(10,\n  sum(\n    sum(\n      container_memory_allocation_bytes{\n        cluster=\"$cluster\",\n        job=\"$job\"}\n    ) by (cluster, namespace, instance)\n    * on(cluster, instance) group_left()\n      (\n        node_ram_hourly_cost{\n          cluster=\"$cluster\",\n          job=\"$job\"} / (1024 * 1024 * 1024) * 730\n      )\n    +\n    sum(\n      container_cpu_allocation{\n        cluster=\"$cluster\",\n        job=\"$job\"}\n    ) by (cluster, namespace, instance)\n    * on(cluster, instance) group_left()\n      (\n        node_cpu_hourly_cost{\n          cluster=\"$cluster\",\n          job=\"$job\"} * 730\n      )\n  ) by (cluster, namespace)\n)\n\n/\ntopk(10,\n  sum(\n    sum(\n      container_memory_allocation_bytes{\n        cluster=\"$cluster\",\n        job=\"$job\"} offset 7d\n    ) by (cluster, namespace, instance)\n    * on(cluster, instance) group_left()\n      (\n        node_ram_hourly_cost{\n          cluster=\"$cluster\",\n          job=\"$job\"} offset 7d / (1024 * 1024 * 1024) * 730\n      )\n    +\n    sum(\n      container_cpu_allocation{\n        cluster=\"$cluster\",\n        job=\"$job\"} offset 7d\n    ) by (cluster, namespace, instance)\n    * on(cluster, instance) group_left()\n      (\n        node_cpu_hourly_cost{\n          cluster=\"$cluster\",\n          job=\"$job\"} offset 7d * 730\n      )\n  ) by (cluster, namespace)\n)\n\n* 100\n- 100\n",
+               "format": "table",
+               "instant": true
+            },
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "$datasource"
+               },
+               "expr": "topk(10,\n  sum(\n    sum(\n      container_memory_allocation_bytes{\n        cluster=\"$cluster\",\n        job=\"$job\"}\n    ) by (cluster, namespace, instance)\n    * on(cluster, instance) group_left()\n      (\n        node_ram_hourly_cost{\n          cluster=\"$cluster\",\n          job=\"$job\"} / (1024 * 1024 * 1024) * 730\n      )\n    +\n    sum(\n      container_cpu_allocation{\n        cluster=\"$cluster\",\n        job=\"$job\"}\n    ) by (cluster, namespace, instance)\n    * on(cluster, instance) group_left()\n      (\n        node_cpu_hourly_cost{\n          cluster=\"$cluster\",\n          job=\"$job\"} * 730\n      )\n  ) by (cluster, namespace)\n)\n\n/\ntopk(10,\n  sum(\n    sum(\n      container_memory_allocation_bytes{\n        cluster=\"$cluster\",\n        job=\"$job\"} offset 30d\n    ) by (cluster, namespace, instance)\n    * on(cluster, instance) group_left()\n      (\n        node_ram_hourly_cost{\n          cluster=\"$cluster\",\n          job=\"$job\"} offset 30d / (1024 * 1024 * 1024) * 730\n      )\n    +\n    sum(\n      container_cpu_allocation{\n        cluster=\"$cluster\",\n        job=\"$job\"} offset 30d\n    ) by (cluster, namespace, instance)\n    * on(cluster, instance) group_left()\n      (\n        node_cpu_hourly_cost{\n          cluster=\"$cluster\",\n          job=\"$job\"} offset 30d * 730\n      )\n  ) by (cluster, namespace)\n)\n\n* 100\n- 100\n",
+               "format": "table",
+               "instant": true
+            }
+         ],
+         "title": "Namespace Monthly Cost",
+         "transformations": [
+            {
+               "id": "merge"
+            },
+            {
+               "id": "organize",
+               "options": {
+                  "excludeByName": {
+                     "Time": true,
+                     "job": true
+                  },
+                  "indexByName": {
+                     "Value #A": 1,
+                     "Value #B": 2,
+                     "Value #C": 3,
+                     "namespace": 0
+                  },
+                  "renameByName": {
+                     "Value #A": "Monthly Cost",
+                     "Value #B": "Cost Change vs 7d Ago (%)",
+                     "Value #C": "Cost Change vs 30d Ago (%)",
+                     "namespace": "Namespace"
+                  }
+               }
+            }
+         ],
+         "type": "table"
+      }
+   ],
+   "schemaVersion": 39,
+   "tags": [
+      "opencost",
+      "opencost-mixin"
+   ],
+   "templating": {
+      "list": [
+         {
+            "current": {
+               "selected": true,
+               "text": "default",
+               "value": "default"
+            },
+            "label": "Data source",
+            "name": "datasource",
+            "query": "prometheus",
+            "type": "datasource"
+         },
+         {
+            "datasource": {
+               "type": "prometheus",
+               "uid": "${datasource}"
+            },
+            "hide": 2,
+            "label": "Cluster",
+            "name": "cluster",
+            "query": "label_values(opencost_build_info{}, cluster)",
+            "refresh": 2,
+            "sort": 1,
+            "type": "query"
+         },
+         {
+            "datasource": {
+               "type": "prometheus",
+               "uid": "${datasource}"
+            },
+            "includeAll": false,
+            "label": "Job",
+            "multi": false,
+            "name": "job",
+            "query": "label_values(opencost_build_info{cluster=\"$cluster\"}, job)",
+            "refresh": 2,
+            "sort": 1,
+            "type": "query"
+         }
+      ]
+   },
+   "time": {
+      "from": "now-2d",
+      "to": "now"
+   },
+   "timezone": "utc",
+   "title": "OpenCost / Overview",
+   "uid": "opencost-mixin-kover-jkwq"
+}

--- a/kubernetes/components/dashboard/production/kustomization/grafana/opencost-workload.json
+++ b/kubernetes/components/dashboard/production/kustomization/grafana/opencost-workload.json
@@ -1,0 +1,969 @@
+{
+   "__inputs": [ ],
+   "__requires": [ ],
+   "annotations": {
+      "list": [ ]
+   },
+   "description": "A workload-focused OpenCost dashboard that breaks down cost inside a namespace using workload ownership labels. It mirrors the existing mixin style while adding workload_type and workload selectors so teams can inspect workload-level monthly, daily, and hourly cost drivers across RAM, CPU, persistent volume, and GPU usage. This dashboard depends on the workload recording rules shipped with the mixin on GitHub. Time-based workload cost views are smoothed with 1-hour averages sampled every 5 minutes (`[1h:5m]`). The dashboards were generated using [opencost-mixin](https://github.com/adinhodovic/opencost-mixin). Open issues and create feature requests in the repository.",
+   "editable": false,
+   "links": [
+      {
+         "asDropdown": true,
+         "includeVars": false,
+         "keepTime": true,
+         "tags": [
+            "opencost",
+            "opencost-mixin"
+         ],
+         "targetBlank": true,
+         "title": "OpenCost",
+         "type": "dashboards"
+      }
+   ],
+   "panels": [
+      {
+         "collapsed": false,
+         "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 0
+         },
+         "id": 1,
+         "title": "Workload Summary",
+         "type": "row"
+      },
+      {
+         "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+         },
+         "description": "Smoothed current hourly cost rate for the selected workload scope. The query averages the workload recording rules over the last hour using a 5-minute step (`[1h:5m]`) and combines RAM, CPU, persistent volume, and GPU costs for the selected `workload_type / workload` pairs.",
+         "fieldConfig": {
+            "defaults": {
+               "decimals": 2,
+               "mappings": [ ],
+               "thresholds": {
+                  "steps": [
+                     {
+                        "color": "green",
+                        "value": 0
+                     }
+                  ]
+               },
+               "unit": "currencyUSD"
+            },
+            "overrides": [ ]
+         },
+         "gridPos": {
+            "h": 3,
+            "w": 4,
+            "x": 0,
+            "y": 1
+         },
+         "id": 2,
+         "options": {
+            "graphMode": "none",
+            "percentChangeColorMode": "standard",
+            "showPercentChange": false
+         },
+         "pluginVersion": "v11.4.0",
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "$datasource"
+               },
+               "expr": "sum((\n  sum by (cluster, namespace, workload_type, workload) (\n  avg_over_time(workload:opencost_ram_cost:sum{cluster=\"$cluster\",\nnamespace=\"$namespace\",\nworkload_type=~\"$workload_type\",\nworkload=~\"$workload\"\n}[1h:5m])\n)\n\n  +\n  sum by (cluster, namespace, workload_type, workload) (\n  avg_over_time(workload:opencost_cpu_cost:sum{cluster=\"$cluster\",\nnamespace=\"$namespace\",\nworkload_type=~\"$workload_type\",\nworkload=~\"$workload\"\n}[1h:5m])\n)\n\n)\n+\n(\n  sum by (cluster, namespace, workload_type, workload) (\n  avg_over_time(workload:opencost_pvc_cost:sum{cluster=\"$cluster\",\nnamespace=\"$namespace\",\nworkload_type=~\"$workload_type\",\nworkload=~\"$workload\"\n}[1h:5m])\n)\n\n  or (sum by (cluster, namespace, workload_type, workload) (\n  avg_over_time(workload:opencost_ram_cost:sum{cluster=\"$cluster\",\nnamespace=\"$namespace\",\nworkload_type=~\"$workload_type\",\nworkload=~\"$workload\"\n}[1h:5m])\n)\n * 0)\n)\n+\n(\n  sum by (cluster, namespace, workload_type, workload) (\n  avg_over_time(workload:opencost_gpu_cost:sum{cluster=\"$cluster\",\nnamespace=\"$namespace\",\nworkload_type=~\"$workload_type\",\nworkload=~\"$workload\"\n}[1h:5m])\n)\n\n  or (sum by (cluster, namespace, workload_type, workload) (\n  avg_over_time(workload:opencost_ram_cost:sum{cluster=\"$cluster\",\nnamespace=\"$namespace\",\nworkload_type=~\"$workload_type\",\nworkload=~\"$workload\"\n}[1h:5m])\n)\n * 0)\n)\n) or vector(0)",
+               "instant": false
+            }
+         ],
+         "title": "Hourly Cost",
+         "type": "stat"
+      },
+      {
+         "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+         },
+         "description": "Projected monthly cost for the selected workload scope using the smoothed hourly rate multiplied across a 730-hour month. This is useful for estimating steady-state spend for the selected workloads.",
+         "fieldConfig": {
+            "defaults": {
+               "decimals": 2,
+               "mappings": [ ],
+               "thresholds": {
+                  "steps": [
+                     {
+                        "color": "green",
+                        "value": 0
+                     }
+                  ]
+               },
+               "unit": "currencyUSD"
+            },
+            "overrides": [ ]
+         },
+         "gridPos": {
+            "h": 3,
+            "w": 4,
+            "x": 4,
+            "y": 1
+         },
+         "id": 3,
+         "options": {
+            "graphMode": "none",
+            "percentChangeColorMode": "standard",
+            "showPercentChange": false
+         },
+         "pluginVersion": "v11.4.0",
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "$datasource"
+               },
+               "expr": "sum(((\n  sum by (cluster, namespace, workload_type, workload) (\n  avg_over_time(workload:opencost_ram_cost:sum{cluster=\"$cluster\",\nnamespace=\"$namespace\",\nworkload_type=~\"$workload_type\",\nworkload=~\"$workload\"\n}[1h:5m])\n)\n\n  +\n  sum by (cluster, namespace, workload_type, workload) (\n  avg_over_time(workload:opencost_cpu_cost:sum{cluster=\"$cluster\",\nnamespace=\"$namespace\",\nworkload_type=~\"$workload_type\",\nworkload=~\"$workload\"\n}[1h:5m])\n)\n\n)\n+\n(\n  sum by (cluster, namespace, workload_type, workload) (\n  avg_over_time(workload:opencost_pvc_cost:sum{cluster=\"$cluster\",\nnamespace=\"$namespace\",\nworkload_type=~\"$workload_type\",\nworkload=~\"$workload\"\n}[1h:5m])\n)\n\n  or (sum by (cluster, namespace, workload_type, workload) (\n  avg_over_time(workload:opencost_ram_cost:sum{cluster=\"$cluster\",\nnamespace=\"$namespace\",\nworkload_type=~\"$workload_type\",\nworkload=~\"$workload\"\n}[1h:5m])\n)\n * 0)\n)\n+\n(\n  sum by (cluster, namespace, workload_type, workload) (\n  avg_over_time(workload:opencost_gpu_cost:sum{cluster=\"$cluster\",\nnamespace=\"$namespace\",\nworkload_type=~\"$workload_type\",\nworkload=~\"$workload\"\n}[1h:5m])\n)\n\n  or (sum by (cluster, namespace, workload_type, workload) (\n  avg_over_time(workload:opencost_ram_cost:sum{cluster=\"$cluster\",\nnamespace=\"$namespace\",\nworkload_type=~\"$workload_type\",\nworkload=~\"$workload\"\n}[1h:5m])\n)\n * 0)\n)\n) * 730) or vector(0)",
+               "instant": false
+            }
+         ],
+         "title": "Monthly Cost",
+         "type": "stat"
+      },
+      {
+         "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+         },
+         "description": "Projected monthly CPU cost for the selected `workload_type / workload` selection, derived from the workload CPU cost recording rule and scaled to a 730-hour month.",
+         "fieldConfig": {
+            "defaults": {
+               "decimals": 2,
+               "mappings": [ ],
+               "thresholds": {
+                  "steps": [
+                     {
+                        "color": "green",
+                        "value": 0
+                     }
+                  ]
+               },
+               "unit": "currencyUSD"
+            },
+            "overrides": [ ]
+         },
+         "gridPos": {
+            "h": 3,
+            "w": 4,
+            "x": 8,
+            "y": 1
+         },
+         "id": 4,
+         "options": {
+            "graphMode": "none",
+            "percentChangeColorMode": "standard",
+            "showPercentChange": false
+         },
+         "pluginVersion": "v11.4.0",
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "$datasource"
+               },
+               "expr": "sum((sum by (cluster, namespace, workload_type, workload) (\n  avg_over_time(workload:opencost_cpu_cost:sum{cluster=\"$cluster\",\nnamespace=\"$namespace\",\nworkload_type=~\"$workload_type\",\nworkload=~\"$workload\"\n}[1h:5m])\n)\n) * 730) or vector(0)",
+               "instant": false
+            }
+         ],
+         "title": "Monthly CPU Cost",
+         "type": "stat"
+      },
+      {
+         "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+         },
+         "description": "Projected monthly memory cost for the selected `workload_type / workload` selection, derived from the workload RAM cost recording rule and scaled to a 730-hour month.",
+         "fieldConfig": {
+            "defaults": {
+               "decimals": 2,
+               "mappings": [ ],
+               "thresholds": {
+                  "steps": [
+                     {
+                        "color": "green",
+                        "value": 0
+                     }
+                  ]
+               },
+               "unit": "currencyUSD"
+            },
+            "overrides": [ ]
+         },
+         "gridPos": {
+            "h": 3,
+            "w": 4,
+            "x": 12,
+            "y": 1
+         },
+         "id": 5,
+         "options": {
+            "graphMode": "none",
+            "percentChangeColorMode": "standard",
+            "showPercentChange": false
+         },
+         "pluginVersion": "v11.4.0",
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "$datasource"
+               },
+               "expr": "sum((sum by (cluster, namespace, workload_type, workload) (\n  avg_over_time(workload:opencost_ram_cost:sum{cluster=\"$cluster\",\nnamespace=\"$namespace\",\nworkload_type=~\"$workload_type\",\nworkload=~\"$workload\"\n}[1h:5m])\n)\n) * 730) or vector(0)",
+               "instant": false
+            }
+         ],
+         "title": "Monthly Ram Cost",
+         "type": "stat"
+      },
+      {
+         "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+         },
+         "description": "Projected monthly GPU cost for the selected `workload_type / workload` selection, derived from the workload GPU cost recording rule and scaled to a 730-hour month.",
+         "fieldConfig": {
+            "defaults": {
+               "decimals": 2,
+               "mappings": [ ],
+               "thresholds": {
+                  "steps": [
+                     {
+                        "color": "green",
+                        "value": 0
+                     }
+                  ]
+               },
+               "unit": "currencyUSD"
+            },
+            "overrides": [ ]
+         },
+         "gridPos": {
+            "h": 3,
+            "w": 4,
+            "x": 16,
+            "y": 1
+         },
+         "id": 6,
+         "options": {
+            "graphMode": "none",
+            "percentChangeColorMode": "standard",
+            "showPercentChange": false
+         },
+         "pluginVersion": "v11.4.0",
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "$datasource"
+               },
+               "expr": "sum((sum by (cluster, namespace, workload_type, workload) (\n  avg_over_time(workload:opencost_gpu_cost:sum{cluster=\"$cluster\",\nnamespace=\"$namespace\",\nworkload_type=~\"$workload_type\",\nworkload=~\"$workload\"\n}[1h:5m])\n)\n) * 730) or vector(0)",
+               "instant": false
+            }
+         ],
+         "title": "Monthly GPU Cost",
+         "type": "stat"
+      },
+      {
+         "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+         },
+         "description": "Projected monthly persistent volume cost for the selected workload scope. PVC attribution is inferred from workload-owned pods that mount each claim, so shared claims can contribute cost to more than one workload.",
+         "fieldConfig": {
+            "defaults": {
+               "decimals": 2,
+               "mappings": [ ],
+               "thresholds": {
+                  "steps": [
+                     {
+                        "color": "green",
+                        "value": 0
+                     }
+                  ]
+               },
+               "unit": "currencyUSD"
+            },
+            "overrides": [ ]
+         },
+         "gridPos": {
+            "h": 3,
+            "w": 4,
+            "x": 20,
+            "y": 1
+         },
+         "id": 7,
+         "options": {
+            "graphMode": "none",
+            "percentChangeColorMode": "standard",
+            "showPercentChange": false
+         },
+         "pluginVersion": "v11.4.0",
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "$datasource"
+               },
+               "expr": "sum((sum by (cluster, namespace, workload_type, workload) (\n  avg_over_time(workload:opencost_pvc_cost:sum{cluster=\"$cluster\",\nnamespace=\"$namespace\",\nworkload_type=~\"$workload_type\",\nworkload=~\"$workload\"\n}[1h:5m])\n)\n) * 730) or vector(0)",
+               "instant": false
+            }
+         ],
+         "title": "Monthly PV Cost",
+         "type": "stat"
+      },
+      {
+         "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+         },
+         "description": "Top workloads by projected monthly cost in the current namespace and filter scope. Each slice is a `workload_type / workload` pair.",
+         "fieldConfig": {
+            "defaults": {
+               "unit": "currencyUSD"
+            },
+            "overrides": [ ]
+         },
+         "gridPos": {
+            "h": 5,
+            "w": 8,
+            "x": 0,
+            "y": 4
+         },
+         "id": 8,
+         "options": {
+            "displayLabels": [
+               "percent"
+            ],
+            "legend": {
+               "displayMode": "table",
+               "placement": "right",
+               "showLegend": true,
+               "values": [
+                  "percent",
+                  "value"
+               ]
+            },
+            "tooltip": {
+               "mode": "multi",
+               "sort": "desc"
+            }
+         },
+         "pluginVersion": "v11.4.0",
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "$datasource"
+               },
+               "expr": "topk(10, ((\n  sum by (cluster, namespace, workload_type, workload) (\n  avg_over_time(workload:opencost_ram_cost:sum{cluster=\"$cluster\",\nnamespace=\"$namespace\",\nworkload_type=~\"$workload_type\",\nworkload=~\"$workload\"\n}[1h:5m])\n)\n\n  +\n  sum by (cluster, namespace, workload_type, workload) (\n  avg_over_time(workload:opencost_cpu_cost:sum{cluster=\"$cluster\",\nnamespace=\"$namespace\",\nworkload_type=~\"$workload_type\",\nworkload=~\"$workload\"\n}[1h:5m])\n)\n\n)\n+\n(\n  sum by (cluster, namespace, workload_type, workload) (\n  avg_over_time(workload:opencost_pvc_cost:sum{cluster=\"$cluster\",\nnamespace=\"$namespace\",\nworkload_type=~\"$workload_type\",\nworkload=~\"$workload\"\n}[1h:5m])\n)\n\n  or (sum by (cluster, namespace, workload_type, workload) (\n  avg_over_time(workload:opencost_ram_cost:sum{cluster=\"$cluster\",\nnamespace=\"$namespace\",\nworkload_type=~\"$workload_type\",\nworkload=~\"$workload\"\n}[1h:5m])\n)\n * 0)\n)\n+\n(\n  sum by (cluster, namespace, workload_type, workload) (\n  avg_over_time(workload:opencost_gpu_cost:sum{cluster=\"$cluster\",\nnamespace=\"$namespace\",\nworkload_type=~\"$workload_type\",\nworkload=~\"$workload\"\n}[1h:5m])\n)\n\n  or (sum by (cluster, namespace, workload_type, workload) (\n  avg_over_time(workload:opencost_ram_cost:sum{cluster=\"$cluster\",\nnamespace=\"$namespace\",\nworkload_type=~\"$workload_type\",\nworkload=~\"$workload\"\n}[1h:5m])\n)\n * 0)\n)\n) * 730)",
+               "instant": true,
+               "legendFormat": "{{ workload_type }} / {{ workload }}"
+            }
+         ],
+         "title": "Cost by Workload",
+         "type": "piechart"
+      },
+      {
+         "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+         },
+         "description": "Projected monthly cost grouped by workload type for the current namespace and filter scope.",
+         "fieldConfig": {
+            "defaults": {
+               "unit": "currencyUSD"
+            },
+            "overrides": [ ]
+         },
+         "gridPos": {
+            "h": 5,
+            "w": 8,
+            "x": 8,
+            "y": 4
+         },
+         "id": 9,
+         "options": {
+            "displayLabels": [
+               "percent"
+            ],
+            "legend": {
+               "displayMode": "table",
+               "placement": "right",
+               "showLegend": true,
+               "values": [
+                  "percent",
+                  "value"
+               ]
+            },
+            "tooltip": {
+               "mode": "multi",
+               "sort": "desc"
+            }
+         },
+         "pluginVersion": "v11.4.0",
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "$datasource"
+               },
+               "expr": "sum by (workload_type) (\n  ((\n  sum by (cluster, namespace, workload_type, workload) (\n  avg_over_time(workload:opencost_ram_cost:sum{cluster=\"$cluster\",\nnamespace=\"$namespace\",\nworkload_type=~\"$workload_type\",\nworkload=~\"$workload\"\n}[1h:5m])\n)\n\n  +\n  sum by (cluster, namespace, workload_type, workload) (\n  avg_over_time(workload:opencost_cpu_cost:sum{cluster=\"$cluster\",\nnamespace=\"$namespace\",\nworkload_type=~\"$workload_type\",\nworkload=~\"$workload\"\n}[1h:5m])\n)\n\n)\n+\n(\n  sum by (cluster, namespace, workload_type, workload) (\n  avg_over_time(workload:opencost_pvc_cost:sum{cluster=\"$cluster\",\nnamespace=\"$namespace\",\nworkload_type=~\"$workload_type\",\nworkload=~\"$workload\"\n}[1h:5m])\n)\n\n  or (sum by (cluster, namespace, workload_type, workload) (\n  avg_over_time(workload:opencost_ram_cost:sum{cluster=\"$cluster\",\nnamespace=\"$namespace\",\nworkload_type=~\"$workload_type\",\nworkload=~\"$workload\"\n}[1h:5m])\n)\n * 0)\n)\n+\n(\n  sum by (cluster, namespace, workload_type, workload) (\n  avg_over_time(workload:opencost_gpu_cost:sum{cluster=\"$cluster\",\nnamespace=\"$namespace\",\nworkload_type=~\"$workload_type\",\nworkload=~\"$workload\"\n}[1h:5m])\n)\n\n  or (sum by (cluster, namespace, workload_type, workload) (\n  avg_over_time(workload:opencost_ram_cost:sum{cluster=\"$cluster\",\nnamespace=\"$namespace\",\nworkload_type=~\"$workload_type\",\nworkload=~\"$workload\"\n}[1h:5m])\n)\n * 0)\n)\n) * 730\n)\n",
+               "instant": true,
+               "legendFormat": "{{ workload_type }}"
+            }
+         ],
+         "title": "Cost by Workload Type",
+         "type": "piechart"
+      },
+      {
+         "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+         },
+         "description": "Monthly cost distribution for the selected workload scope across compute, memory, storage, and GPU. Use this to see which resource category is driving the projected monthly spend.",
+         "fieldConfig": {
+            "defaults": {
+               "unit": "currencyUSD"
+            },
+            "overrides": [ ]
+         },
+         "gridPos": {
+            "h": 5,
+            "w": 8,
+            "x": 16,
+            "y": 4
+         },
+         "id": 10,
+         "options": {
+            "displayLabels": [
+               "percent"
+            ],
+            "legend": {
+               "displayMode": "table",
+               "placement": "right",
+               "showLegend": true,
+               "values": [
+                  "percent",
+                  "value"
+               ]
+            },
+            "tooltip": {
+               "mode": "multi",
+               "sort": "desc"
+            }
+         },
+         "pluginVersion": "v11.4.0",
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "$datasource"
+               },
+               "expr": "sum((sum by (cluster, namespace, workload_type, workload) (\n  avg_over_time(workload:opencost_cpu_cost:sum{cluster=\"$cluster\",\nnamespace=\"$namespace\",\nworkload_type=~\"$workload_type\",\nworkload=~\"$workload\"\n}[1h:5m])\n)\n) * 730) or vector(0)",
+               "instant": true,
+               "legendFormat": "CPU"
+            },
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "$datasource"
+               },
+               "expr": "sum((sum by (cluster, namespace, workload_type, workload) (\n  avg_over_time(workload:opencost_ram_cost:sum{cluster=\"$cluster\",\nnamespace=\"$namespace\",\nworkload_type=~\"$workload_type\",\nworkload=~\"$workload\"\n}[1h:5m])\n)\n) * 730) or vector(0)",
+               "instant": true,
+               "legendFormat": "RAM"
+            },
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "$datasource"
+               },
+               "expr": "sum((sum by (cluster, namespace, workload_type, workload) (\n  avg_over_time(workload:opencost_pvc_cost:sum{cluster=\"$cluster\",\nnamespace=\"$namespace\",\nworkload_type=~\"$workload_type\",\nworkload=~\"$workload\"\n}[1h:5m])\n)\n) * 730) or vector(0)",
+               "instant": true,
+               "legendFormat": "PV"
+            },
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "$datasource"
+               },
+               "expr": "sum((sum by (cluster, namespace, workload_type, workload) (\n  avg_over_time(workload:opencost_gpu_cost:sum{cluster=\"$cluster\",\nnamespace=\"$namespace\",\nworkload_type=~\"$workload_type\",\nworkload=~\"$workload\"\n}[1h:5m])\n)\n) * 730) or vector(0)",
+               "instant": true,
+               "legendFormat": "GPU"
+            }
+         ],
+         "title": "Cost by Resource",
+         "type": "piechart"
+      },
+      {
+         "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+         },
+         "description": "Top workloads in the selected namespace by projected monthly cost. Each series represents a `workload_type / workload` pair, which is helpful when the dashboard is scoped to all workloads or all workloads of a given type.",
+         "fieldConfig": {
+            "defaults": {
+               "custom": {
+                  "axisSoftMin": 0,
+                  "fillOpacity": 100,
+                  "lineWidth": 1,
+                  "stacking": {
+                     "mode": "normal"
+                  }
+               },
+               "unit": "currencyUSD"
+            },
+            "overrides": [ ]
+         },
+         "gridPos": {
+            "h": 8,
+            "w": 24,
+            "x": 0,
+            "y": 10
+         },
+         "id": 11,
+         "options": {
+            "legend": {
+               "calcs": [
+                  "mean",
+                  "max"
+               ],
+               "displayMode": "table",
+               "placement": "right",
+               "showLegend": true,
+               "sortBy": "Mean",
+               "sortDesc": true
+            },
+            "tooltip": {
+               "mode": "multi",
+               "sort": "desc"
+            }
+         },
+         "pluginVersion": "v11.4.0",
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "$datasource"
+               },
+               "exemplar": false,
+               "expr": "topk(10, ((\n  sum by (cluster, namespace, workload_type, workload) (\n  avg_over_time(workload:opencost_ram_cost:sum{cluster=\"$cluster\",\nnamespace=\"$namespace\",\nworkload_type=~\"$workload_type\",\nworkload=~\"$workload\"\n}[1h:5m])\n)\n\n  +\n  sum by (cluster, namespace, workload_type, workload) (\n  avg_over_time(workload:opencost_cpu_cost:sum{cluster=\"$cluster\",\nnamespace=\"$namespace\",\nworkload_type=~\"$workload_type\",\nworkload=~\"$workload\"\n}[1h:5m])\n)\n\n)\n+\n(\n  sum by (cluster, namespace, workload_type, workload) (\n  avg_over_time(workload:opencost_pvc_cost:sum{cluster=\"$cluster\",\nnamespace=\"$namespace\",\nworkload_type=~\"$workload_type\",\nworkload=~\"$workload\"\n}[1h:5m])\n)\n\n  or (sum by (cluster, namespace, workload_type, workload) (\n  avg_over_time(workload:opencost_ram_cost:sum{cluster=\"$cluster\",\nnamespace=\"$namespace\",\nworkload_type=~\"$workload_type\",\nworkload=~\"$workload\"\n}[1h:5m])\n)\n * 0)\n)\n+\n(\n  sum by (cluster, namespace, workload_type, workload) (\n  avg_over_time(workload:opencost_gpu_cost:sum{cluster=\"$cluster\",\nnamespace=\"$namespace\",\nworkload_type=~\"$workload_type\",\nworkload=~\"$workload\"\n}[1h:5m])\n)\n\n  or (sum by (cluster, namespace, workload_type, workload) (\n  avg_over_time(workload:opencost_ram_cost:sum{cluster=\"$cluster\",\nnamespace=\"$namespace\",\nworkload_type=~\"$workload_type\",\nworkload=~\"$workload\"\n}[1h:5m])\n)\n * 0)\n)\n) * 730)",
+               "interval": "5m",
+               "legendFormat": "{{ workload_type }} / {{ workload }}"
+            }
+         ],
+         "title": "Monthly Cost by Workload",
+         "type": "timeseries"
+      },
+      {
+         "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+         },
+         "description": "Monthly cost trend for the selected workload scope split into RAM, CPU, persistent volume, and GPU components. These values are based on the smoothed hourly workload cost rules and then projected to a 730-hour month.",
+         "fieldConfig": {
+            "defaults": {
+               "custom": {
+                  "axisSoftMin": 0,
+                  "fillOpacity": 100,
+                  "lineWidth": 1,
+                  "stacking": {
+                     "mode": "normal"
+                  }
+               },
+               "unit": "currencyUSD"
+            },
+            "overrides": [ ]
+         },
+         "gridPos": {
+            "h": 8,
+            "w": 24,
+            "x": 0,
+            "y": 18
+         },
+         "id": 12,
+         "options": {
+            "legend": {
+               "calcs": [
+                  "mean",
+                  "max"
+               ],
+               "displayMode": "table",
+               "placement": "right",
+               "showLegend": true,
+               "sortBy": "Mean",
+               "sortDesc": true
+            },
+            "tooltip": {
+               "mode": "multi",
+               "sort": "desc"
+            }
+         },
+         "pluginVersion": "v11.4.0",
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "$datasource"
+               },
+               "exemplar": false,
+               "expr": "sum((sum by (cluster, namespace, workload_type, workload) (\n  avg_over_time(workload:opencost_ram_cost:sum{cluster=\"$cluster\",\nnamespace=\"$namespace\",\nworkload_type=~\"$workload_type\",\nworkload=~\"$workload\"\n}[1h:5m])\n)\n) * 730) or vector(0)",
+               "interval": "5m",
+               "legendFormat": "RAM"
+            },
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "$datasource"
+               },
+               "exemplar": false,
+               "expr": "sum((sum by (cluster, namespace, workload_type, workload) (\n  avg_over_time(workload:opencost_cpu_cost:sum{cluster=\"$cluster\",\nnamespace=\"$namespace\",\nworkload_type=~\"$workload_type\",\nworkload=~\"$workload\"\n}[1h:5m])\n)\n) * 730) or vector(0)",
+               "interval": "5m",
+               "legendFormat": "CPU"
+            },
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "$datasource"
+               },
+               "exemplar": false,
+               "expr": "sum((sum by (cluster, namespace, workload_type, workload) (\n  avg_over_time(workload:opencost_pvc_cost:sum{cluster=\"$cluster\",\nnamespace=\"$namespace\",\nworkload_type=~\"$workload_type\",\nworkload=~\"$workload\"\n}[1h:5m])\n)\n) * 730) or vector(0)",
+               "interval": "5m",
+               "legendFormat": "PV"
+            },
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "$datasource"
+               },
+               "exemplar": false,
+               "expr": "sum((sum by (cluster, namespace, workload_type, workload) (\n  avg_over_time(workload:opencost_gpu_cost:sum{cluster=\"$cluster\",\nnamespace=\"$namespace\",\nworkload_type=~\"$workload_type\",\nworkload=~\"$workload\"\n}[1h:5m])\n)\n) * 730) or vector(0)",
+               "interval": "5m",
+               "legendFormat": "GPU"
+            }
+         ],
+         "title": "Monthly Cost by Resource",
+         "type": "timeseries"
+      },
+      {
+         "collapsed": false,
+         "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 25
+         },
+         "id": 13,
+         "title": "Workload Breakdown",
+         "type": "row"
+      },
+      {
+         "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+         },
+         "description": "Monthly cost breakdown by workload, where each row is a `workload_type / workload` pair. The table shows RAM, CPU, persistent volume, GPU, and total projected monthly cost so you can compare the main cost drivers for each workload.",
+         "fieldConfig": {
+            "defaults": {
+               "links": [ ],
+               "thresholds": {
+                  "steps": [ ]
+               },
+               "unit": "currencyUSD"
+            },
+            "overrides": [ ]
+         },
+         "gridPos": {
+            "h": 10,
+            "w": 24,
+            "x": 0,
+            "y": 26
+         },
+         "id": 14,
+         "options": {
+            "footer": {
+               "enablePagination": true
+            },
+            "sortBy": [
+               {
+                  "desc": true,
+                  "displayName": "Total Cost"
+               }
+            ]
+         },
+         "pluginVersion": "v11.4.0",
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "$datasource"
+               },
+               "expr": "(sum by (cluster, namespace, workload_type, workload) (\n  avg_over_time(workload:opencost_ram_cost:sum{cluster=\"$cluster\",\nnamespace=\"$namespace\",\nworkload_type=~\"$workload_type\",\nworkload=~\"$workload\"\n}[1h:5m])\n)\n) * 730",
+               "format": "table",
+               "instant": true
+            },
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "$datasource"
+               },
+               "expr": "(sum by (cluster, namespace, workload_type, workload) (\n  avg_over_time(workload:opencost_cpu_cost:sum{cluster=\"$cluster\",\nnamespace=\"$namespace\",\nworkload_type=~\"$workload_type\",\nworkload=~\"$workload\"\n}[1h:5m])\n)\n) * 730",
+               "format": "table",
+               "instant": true
+            },
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "$datasource"
+               },
+               "expr": "(sum by (cluster, namespace, workload_type, workload) (\n  avg_over_time(workload:opencost_pvc_cost:sum{cluster=\"$cluster\",\nnamespace=\"$namespace\",\nworkload_type=~\"$workload_type\",\nworkload=~\"$workload\"\n}[1h:5m])\n)\n) * 730",
+               "format": "table",
+               "instant": true
+            },
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "$datasource"
+               },
+               "expr": "(sum by (cluster, namespace, workload_type, workload) (\n  avg_over_time(workload:opencost_gpu_cost:sum{cluster=\"$cluster\",\nnamespace=\"$namespace\",\nworkload_type=~\"$workload_type\",\nworkload=~\"$workload\"\n}[1h:5m])\n)\n) * 730",
+               "format": "table",
+               "instant": true
+            },
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "$datasource"
+               },
+               "expr": "((\n  sum by (cluster, namespace, workload_type, workload) (\n  avg_over_time(workload:opencost_ram_cost:sum{cluster=\"$cluster\",\nnamespace=\"$namespace\",\nworkload_type=~\"$workload_type\",\nworkload=~\"$workload\"\n}[1h:5m])\n)\n\n  +\n  sum by (cluster, namespace, workload_type, workload) (\n  avg_over_time(workload:opencost_cpu_cost:sum{cluster=\"$cluster\",\nnamespace=\"$namespace\",\nworkload_type=~\"$workload_type\",\nworkload=~\"$workload\"\n}[1h:5m])\n)\n\n)\n+\n(\n  sum by (cluster, namespace, workload_type, workload) (\n  avg_over_time(workload:opencost_pvc_cost:sum{cluster=\"$cluster\",\nnamespace=\"$namespace\",\nworkload_type=~\"$workload_type\",\nworkload=~\"$workload\"\n}[1h:5m])\n)\n\n  or (sum by (cluster, namespace, workload_type, workload) (\n  avg_over_time(workload:opencost_ram_cost:sum{cluster=\"$cluster\",\nnamespace=\"$namespace\",\nworkload_type=~\"$workload_type\",\nworkload=~\"$workload\"\n}[1h:5m])\n)\n * 0)\n)\n+\n(\n  sum by (cluster, namespace, workload_type, workload) (\n  avg_over_time(workload:opencost_gpu_cost:sum{cluster=\"$cluster\",\nnamespace=\"$namespace\",\nworkload_type=~\"$workload_type\",\nworkload=~\"$workload\"\n}[1h:5m])\n)\n\n  or (sum by (cluster, namespace, workload_type, workload) (\n  avg_over_time(workload:opencost_ram_cost:sum{cluster=\"$cluster\",\nnamespace=\"$namespace\",\nworkload_type=~\"$workload_type\",\nworkload=~\"$workload\"\n}[1h:5m])\n)\n * 0)\n)\n) * 730",
+               "format": "table",
+               "instant": true
+            }
+         ],
+         "title": "Workload Monthly Cost",
+         "transformations": [
+            {
+               "id": "merge"
+            },
+            {
+               "id": "organize",
+               "options": {
+                  "excludeByName": {
+                     "Time": true,
+                     "cluster": true,
+                     "namespace": true
+                  },
+                  "indexByName": {
+                     "Value #A": 2,
+                     "Value #B": 3,
+                     "Value #C": 4,
+                     "Value #D": 5,
+                     "Value #E": 6,
+                     "workload": 1,
+                     "workload_type": 0
+                  },
+                  "renameByName": {
+                     "Value #A": "RAM Cost",
+                     "Value #B": "CPU Cost",
+                     "Value #C": "PV Cost",
+                     "Value #D": "GPU Cost",
+                     "Value #E": "Total Cost",
+                     "workload": "Workload",
+                     "workload_type": "Workload Type"
+                  }
+               }
+            }
+         ],
+         "type": "table"
+      },
+      {
+         "collapsed": false,
+         "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 36
+         },
+         "id": 15,
+         "title": "Persistent Volume Claims",
+         "type": "row"
+      },
+      {
+         "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+         },
+         "description": "Projected monthly storage cost by persistent volume claim for the selected workload scope.",
+         "fieldConfig": {
+            "defaults": {
+               "links": [ ],
+               "thresholds": {
+                  "steps": [ ]
+               },
+               "unit": "currencyUSD"
+            },
+            "overrides": [ ]
+         },
+         "gridPos": {
+            "h": 8,
+            "w": 24,
+            "x": 0,
+            "y": 37
+         },
+         "id": 16,
+         "options": {
+            "footer": {
+               "enablePagination": true
+            },
+            "sortBy": [
+               {
+                  "desc": true,
+                  "displayName": "Total Cost"
+               }
+            ]
+         },
+         "pluginVersion": "v11.4.0",
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "$datasource"
+               },
+               "expr": "sum by (persistentvolumeclaim, workload_type, workload) (\n  avg_over_time(\n    workload:opencost_pvc_cost:sum{cluster=\"$cluster\",\nnamespace=\"$namespace\",\nworkload_type=~\"$workload_type\",\nworkload=~\"$workload\"\n}[1h:5m]\n  )\n) * 730\n",
+               "format": "table",
+               "instant": true
+            }
+         ],
+         "title": "Persistent Volume Claims Monthly Cost",
+         "transformations": [
+            {
+               "id": "organize",
+               "options": {
+                  "excludeByName": {
+                     "Time": true,
+                     "cluster": true,
+                     "namespace": true
+                  },
+                  "indexByName": {
+                     "Value": 3,
+                     "persistentvolumeclaim": 2,
+                     "workload": 1,
+                     "workload_type": 0
+                  },
+                  "renameByName": {
+                     "Value": "Total Cost",
+                     "persistentvolumeclaim": "Persistent Volume Claim",
+                     "workload": "Workload",
+                     "workload_type": "Workload Type"
+                  }
+               }
+            }
+         ],
+         "type": "table"
+      }
+   ],
+   "schemaVersion": 39,
+   "tags": [
+      "opencost",
+      "opencost-mixin"
+   ],
+   "templating": {
+      "list": [
+         {
+            "current": {
+               "selected": true,
+               "text": "default",
+               "value": "default"
+            },
+            "label": "Data source",
+            "name": "datasource",
+            "query": "prometheus",
+            "type": "datasource"
+         },
+         {
+            "datasource": {
+               "type": "prometheus",
+               "uid": "${datasource}"
+            },
+            "hide": 2,
+            "label": "Cluster",
+            "name": "cluster",
+            "query": "label_values(opencost_build_info{}, cluster)",
+            "refresh": 2,
+            "sort": 1,
+            "type": "query"
+         },
+         {
+            "datasource": {
+               "type": "prometheus",
+               "uid": "${datasource}"
+            },
+            "includeAll": false,
+            "label": "Job",
+            "multi": false,
+            "name": "job",
+            "query": "label_values(opencost_build_info{cluster=\"$cluster\"}, job)",
+            "refresh": 2,
+            "sort": 1,
+            "type": "query"
+         },
+         {
+            "datasource": {
+               "type": "prometheus",
+               "uid": "${datasource}"
+            },
+            "includeAll": false,
+            "label": "Namespace",
+            "multi": false,
+            "name": "namespace",
+            "query": "label_values(kube_namespace_labels{cluster=\"$cluster\", job=\"$job\"}, namespace)",
+            "refresh": 2,
+            "sort": 1,
+            "type": "query"
+         },
+         {
+            "datasource": {
+               "type": "prometheus",
+               "uid": "${datasource}"
+            },
+            "hide": 0,
+            "includeAll": true,
+            "label": "Workload Type",
+            "name": "workload_type",
+            "query": "label_values(namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\"}, workload_type)",
+            "refresh": 2,
+            "sort": 1,
+            "type": "query"
+         },
+         {
+            "datasource": {
+               "type": "prometheus",
+               "uid": "${datasource}"
+            },
+            "hide": 0,
+            "includeAll": true,
+            "label": "Workload",
+            "name": "workload",
+            "query": "label_values(namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload_type=~\"$workload_type\"}, workload)",
+            "refresh": 2,
+            "sort": 1,
+            "type": "query"
+         }
+      ]
+   },
+   "time": {
+      "from": "now-2d",
+      "to": "now"
+   },
+   "timezone": "utc",
+   "title": "OpenCost / Workload",
+   "uid": "opencost-mixin-workload-jkwq"
+}

--- a/kubernetes/components/dashboard/production/kustomization/kustomization.yaml
+++ b/kubernetes/components/dashboard/production/kustomization/kustomization.yaml
@@ -22,6 +22,24 @@ configMapGenerator:
     options:
       labels:
         grafana_dashboard: "1"
+  - name: grafana-dashboard-opencost-overview
+    files:
+      - grafana/opencost-overview.json
+    options:
+      labels:
+        grafana_dashboard: "1"
+  - name: grafana-dashboard-opencost-namespace
+    files:
+      - grafana/opencost-namespace.json
+    options:
+      labels:
+        grafana_dashboard: "1"
+  - name: grafana-dashboard-opencost-workload
+    files:
+      - grafana/opencost-workload.json
+    options:
+      labels:
+        grafana_dashboard: "1"
 
 generatorOptions:
   disableNameSuffixHash: true

--- a/kubernetes/components/opencost/production/helmfile.yaml
+++ b/kubernetes/components/opencost/production/helmfile.yaml
@@ -1,0 +1,30 @@
+# =============================================================================
+# OpenCost Helmfile for production
+# =============================================================================
+# Kubernetes cost allocation. On-demand pricing comes from a public,
+# unauthenticated AWS endpoint (no credentials involved). Spot pricing comes
+# from the AWS Spot Instance Data Feed (aws/cost-management) read via Pod
+# Identity (aws/eks-cost).
+# =============================================================================
+environments:
+  production:
+    values:
+      - opencost:
+          # Source: aws/cost-management/envs/develop terragrunt output spot_datafeed_bucket_name
+          spotDataBucket: opencost-spot-datafeed-559744160976
+          # Source: aws/cost-management/envs/develop terragrunt output spot_datafeed_region
+          spotDataRegion: ap-northeast-1
+          # STABLE: AWS account ID
+          awsAccountId: "559744160976"
+---
+repositories:
+  - name: opencost
+    url: https://opencost.github.io/opencost-helm-chart
+
+releases:
+  - name: opencost
+    namespace: monitoring
+    chart: opencost/opencost
+    version: "2.5.28"
+    values:
+      - values.yaml.gotmpl

--- a/kubernetes/components/opencost/production/values.yaml.gotmpl
+++ b/kubernetes/components/opencost/production/values.yaml.gotmpl
@@ -8,6 +8,7 @@ opencost:
   metrics:
     serviceMonitor:
       enabled: true
+      namespace: monitoring
       # kube-prometheus-stack の serviceMonitorSelector match (cilium の
       # ServiceMonitor と同じ pattern)
       additionalLabels:

--- a/kubernetes/components/opencost/production/values.yaml.gotmpl
+++ b/kubernetes/components/opencost/production/values.yaml.gotmpl
@@ -1,0 +1,51 @@
+# OpenCost values for production
+
+serviceAccount:
+  create: true
+  name: opencost
+
+opencost:
+  metrics:
+    serviceMonitor:
+      enabled: true
+      # kube-prometheus-stack の serviceMonitorSelector match (cilium の
+      # ServiceMonitor と同じ pattern)
+      additionalLabels:
+        release: kube-prometheus-stack
+
+  prometheus:
+    internal:
+      enabled: true
+      serviceName: kube-prometheus-stack-prometheus
+      namespaceName: monitoring
+      port: 9090
+
+  # awsSpotDataBucket/awsSpotDataRegion/projectID の3つを渡すためだけに
+  # customPricing を有効化する。 CPU/RAM/GPU 等の costModel フィールドは未指定
+  # のまま chart デフォルトにフォールバックさせる (= 動的取得 (Pricing API)
+  # が失敗した場合のみ使われる fallback 値であり、 常用の静的価格ではない。
+  # opencost.io/docs/configuration/aws のソース調査で確認済)。
+  customPricing:
+    enabled: true
+    provider: aws
+    costModel:
+      description: "AWS Spot Instance Data Feed location for spot price accuracy"
+      awsSpotDataBucket: {{ .Values.opencost.spotDataBucket }}
+      awsSpotDataRegion: {{ .Values.opencost.spotDataRegion }}
+      projectID: "{{ .Values.opencost.awsAccountId }}"
+
+  exporter:
+    resources:
+      requests:
+        cpu: 25m
+        memory: 55Mi
+      limits:
+        memory: 256Mi
+
+  ui:
+    resources:
+      requests:
+        cpu: 10m
+        memory: 55Mi
+      limits:
+        memory: 256Mi

--- a/kubernetes/manifests/production/dashboard/manifest.yaml
+++ b/kubernetes/manifests/production/dashboard/manifest.yaml
@@ -1877,6 +1877,3386 @@ metadata:
 ---
 apiVersion: v1
 data:
+  opencost-namespace.json: |
+    {
+       "__inputs": [ ],
+       "__requires": [ ],
+       "annotations": {
+          "list": [ ]
+       },
+       "description": "A detailed namespace-level cost analysis dashboard that breaks down infrastructure spending by pods, containers, persistent volumes, and GPU usage within a selected namespace. Use this dashboard to understand which workloads are driving costs within a namespace, track monthly cost trends over time, and identify optimization opportunities at the pod and container level. This dashboard is ideal for application teams monitoring their own resource consumption and costs. The dashboards were generated using [opencost-mixin](https://github.com/adinhodovic/opencost-mixin). Open issues and create feature requests in the repository.",
+       "editable": false,
+       "links": [
+          {
+             "asDropdown": true,
+             "includeVars": false,
+             "keepTime": true,
+             "tags": [
+                "opencost",
+                "opencost-mixin"
+             ],
+             "targetBlank": true,
+             "title": "OpenCost",
+             "type": "dashboards"
+          }
+       ],
+       "panels": [
+          {
+             "collapsed": false,
+             "gridPos": {
+                "h": 1,
+                "w": 24,
+                "x": 0,
+                "y": 0
+             },
+             "id": 1,
+             "title": "Summary",
+             "type": "row"
+          },
+          {
+             "datasource": {
+                "type": "prometheus",
+                "uid": "$datasource"
+             },
+             "description": "Current hourly cost rate for the selected namespace, including CPU, RAM, and PV costs. This provides real-time visibility into namespace spending and helps track the immediate impact of workload changes on costs.",
+             "fieldConfig": {
+                "defaults": {
+                   "decimals": 2,
+                   "mappings": [ ],
+                   "thresholds": {
+                      "steps": [
+                         {
+                            "color": "green",
+                            "value": 0
+                         }
+                      ]
+                   },
+                   "unit": "currencyUSD"
+                },
+                "overrides": [ ]
+             },
+             "gridPos": {
+                "h": 3,
+                "w": 4,
+                "x": 0,
+                "y": 1
+             },
+             "id": 2,
+             "options": {
+                "graphMode": "none",
+                "percentChangeColorMode": "inverted",
+                "showPercentChange": true
+             },
+             "pluginVersion": "v11.4.0",
+             "targets": [
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "$datasource"
+                   },
+                   "expr": "sum(\n  sum(\n    container_memory_allocation_bytes{\n      cluster=\"$cluster\",\njob=\"$job\"\n,\nnamespace=\"$namespace\"\n\n    }\n  )\n  by (namespace, instance)\n  * on(instance) group_left()\n  (\n    avg(\n      node_ram_hourly_cost{\n        cluster=\"$cluster\",\njob=\"$job\"\n\n      }\n    ) by (instance) / (1024 * 1024 * 1024) * 1\n  )\n)\n\n+\nsum(\n  sum(\n    container_cpu_allocation{\n      cluster=\"$cluster\",\njob=\"$job\"\n,\nnamespace=\"$namespace\"\n\n    }\n  )\n  by (namespace, instance)\n  * on(instance) group_left()\n  (\n    avg(\n      node_cpu_hourly_cost{\n        cluster=\"$cluster\",\njob=\"$job\"\n\n      }\n    ) by (instance) * 1\n  )\n)\n\n+\nsum(\n  sum(\n    container_gpu_allocation{\n      cluster=\"$cluster\",\njob=\"$job\"\n,\nnamespace=\"$namespace\"\n\n    }\n  )\n  by (namespace, instance)\n  * on(instance) group_left()\n  (\n    avg(\n      node_gpu_hourly_cost{\n        cluster=\"$cluster\",\njob=\"$job\"\n\n      }\n    ) by (instance) * 1\n  )\n)\n\n+\nsum(\n  sum(\n    kube_persistentvolume_capacity_bytes{\n      cluster=\"$cluster\",\njob=\"$job\"\n\n    }\n    / (1024 * 1024 * 1024)\n  ) by (persistentvolume)\n  *\n  sum(\n    pv_hourly_cost{\n      cluster=\"$cluster\",\njob=\"$job\"\n\n    }\n  ) by (persistentvolume)\n  * on(persistentvolume) group_left(cluster, namespace, persistentvolumeclaim) (\n    label_replace(\n      kube_persistentvolumeclaim_info{\n        cluster=\"$cluster\",\njob=\"$job\"\n,\nnamespace=\"$namespace\"\n\n      },\n      \"persistentvolume\", \"$1\",\n      \"volumename\", \"(.*)\"\n    )\n  ) or vector(0)\n) * 1\n\n",
+                   "instant": false
+                }
+             ],
+             "title": "Hourly Cost",
+             "type": "stat"
+          },
+          {
+             "datasource": {
+                "type": "prometheus",
+                "uid": "$datasource"
+             },
+             "description": "Projected monthly cost for the selected namespace based on current hourly rates. This includes CPU, RAM, GPU, and PV costs so application teams can track their overall spend against budget.",
+             "fieldConfig": {
+                "defaults": {
+                   "decimals": 2,
+                   "mappings": [ ],
+                   "thresholds": {
+                      "steps": [
+                         {
+                            "color": "green",
+                            "value": 0
+                         }
+                      ]
+                   },
+                   "unit": "currencyUSD"
+                },
+                "overrides": [ ]
+             },
+             "gridPos": {
+                "h": 3,
+                "w": 4,
+                "x": 4,
+                "y": 1
+             },
+             "id": 3,
+             "options": {
+                "graphMode": "none",
+                "percentChangeColorMode": "inverted",
+                "showPercentChange": true
+             },
+             "pluginVersion": "v11.4.0",
+             "targets": [
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "$datasource"
+                   },
+                   "expr": "sum(\n  sum(\n    container_memory_allocation_bytes{\n      cluster=\"$cluster\",\njob=\"$job\"\n,\nnamespace=\"$namespace\"\n\n    }\n  )\n  by (namespace, instance)\n  * on(instance) group_left()\n  (\n    avg(\n      node_ram_hourly_cost{\n        cluster=\"$cluster\",\njob=\"$job\"\n\n      }\n    ) by (instance) / (1024 * 1024 * 1024) * 730\n  )\n)\n\n+\nsum(\n  sum(\n    container_cpu_allocation{\n      cluster=\"$cluster\",\njob=\"$job\"\n,\nnamespace=\"$namespace\"\n\n    }\n  )\n  by (namespace, instance)\n  * on(instance) group_left()\n  (\n    avg(\n      node_cpu_hourly_cost{\n        cluster=\"$cluster\",\njob=\"$job\"\n\n      }\n    ) by (instance) * 730\n  )\n)\n\n+\nsum(\n  sum(\n    container_gpu_allocation{\n      cluster=\"$cluster\",\njob=\"$job\"\n,\nnamespace=\"$namespace\"\n\n    }\n  )\n  by (namespace, instance)\n  * on(instance) group_left()\n  (\n    avg(\n      node_gpu_hourly_cost{\n        cluster=\"$cluster\",\njob=\"$job\"\n\n      }\n    ) by (instance) * 730\n  )\n)\n\n+\nsum(\n  sum(\n    kube_persistentvolume_capacity_bytes{\n      cluster=\"$cluster\",\njob=\"$job\"\n\n    }\n    / (1024 * 1024 * 1024)\n  ) by (persistentvolume)\n  *\n  sum(\n    pv_hourly_cost{\n      cluster=\"$cluster\",\njob=\"$job\"\n\n    }\n  ) by (persistentvolume)\n  * on(persistentvolume) group_left(cluster, namespace, persistentvolumeclaim) (\n    label_replace(\n      kube_persistentvolumeclaim_info{\n        cluster=\"$cluster\",\njob=\"$job\"\n,\nnamespace=\"$namespace\"\n\n      },\n      \"persistentvolume\", \"$1\",\n      \"volumename\", \"(.*)\"\n    )\n  ) or vector(0)\n) * 730\n\n",
+                   "instant": false
+                }
+             ],
+             "title": "Monthly Cost",
+             "type": "stat"
+          },
+          {
+             "datasource": {
+                "type": "prometheus",
+                "uid": "$datasource"
+             },
+             "description": "Projected monthly CPU cost for the selected namespace. Compare this with RAM costs to understand your namespace compute profile and identify if CPU requests are appropriately sized for your workloads.",
+             "fieldConfig": {
+                "defaults": {
+                   "decimals": 2,
+                   "mappings": [ ],
+                   "thresholds": {
+                      "steps": [
+                         {
+                            "color": "green",
+                            "value": 0
+                         }
+                      ]
+                   },
+                   "unit": "currencyUSD"
+                },
+                "overrides": [ ]
+             },
+             "gridPos": {
+                "h": 3,
+                "w": 4,
+                "x": 8,
+                "y": 1
+             },
+             "id": 4,
+             "options": {
+                "graphMode": "none",
+                "percentChangeColorMode": "inverted",
+                "showPercentChange": true
+             },
+             "pluginVersion": "v11.4.0",
+             "targets": [
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "$datasource"
+                   },
+                   "expr": "sum(\n  sum(\n    container_cpu_allocation{\n      cluster=\"$cluster\",\njob=\"$job\"\n,\nnamespace=\"$namespace\"\n\n    }\n  )\n  by (namespace, instance)\n  * on(instance) group_left()\n  (\n    avg(\n      node_cpu_hourly_cost{\n        cluster=\"$cluster\",\njob=\"$job\"\n\n      }\n    ) by (instance) * 730\n  )\n)\n",
+                   "instant": false
+                }
+             ],
+             "title": "Monthly CPU Cost",
+             "type": "stat"
+          },
+          {
+             "datasource": {
+                "type": "prometheus",
+                "uid": "$datasource"
+             },
+             "description": "Projected monthly RAM cost for the selected namespace. High memory costs may indicate opportunities to optimize container memory requests or identify memory-intensive workloads that could benefit from tuning.",
+             "fieldConfig": {
+                "defaults": {
+                   "decimals": 2,
+                   "mappings": [ ],
+                   "thresholds": {
+                      "steps": [
+                         {
+                            "color": "green",
+                            "value": 0
+                         }
+                      ]
+                   },
+                   "unit": "currencyUSD"
+                },
+                "overrides": [ ]
+             },
+             "gridPos": {
+                "h": 3,
+                "w": 4,
+                "x": 12,
+                "y": 1
+             },
+             "id": 5,
+             "options": {
+                "graphMode": "none",
+                "percentChangeColorMode": "inverted",
+                "showPercentChange": true
+             },
+             "pluginVersion": "v11.4.0",
+             "targets": [
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "$datasource"
+                   },
+                   "expr": "sum(\n  sum(\n    container_memory_allocation_bytes{\n      cluster=\"$cluster\",\njob=\"$job\"\n,\nnamespace=\"$namespace\"\n\n    }\n  )\n  by (namespace, instance)\n  * on(instance) group_left()\n  (\n    avg(\n      node_ram_hourly_cost{\n        cluster=\"$cluster\",\njob=\"$job\"\n\n      }\n    ) by (instance) / (1024 * 1024 * 1024) * 730\n  )\n)\n",
+                   "instant": false
+                }
+             ],
+             "title": "Monthly Ram Cost",
+             "type": "stat"
+          },
+          {
+             "datasource": {
+                "type": "prometheus",
+                "uid": "$datasource"
+             },
+             "description": "Projected monthly GPU cost for the selected namespace. This helps teams understand accelerator spend and spot namespaces where GPU-backed workloads dominate overall costs.",
+             "fieldConfig": {
+                "defaults": {
+                   "decimals": 2,
+                   "mappings": [ ],
+                   "thresholds": {
+                      "steps": [
+                         {
+                            "color": "green",
+                            "value": 0
+                         }
+                      ]
+                   },
+                   "unit": "currencyUSD"
+                },
+                "overrides": [ ]
+             },
+             "gridPos": {
+                "h": 3,
+                "w": 4,
+                "x": 16,
+                "y": 1
+             },
+             "id": 6,
+             "options": {
+                "graphMode": "none",
+                "percentChangeColorMode": "inverted",
+                "showPercentChange": true
+             },
+             "pluginVersion": "v11.4.0",
+             "targets": [
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "$datasource"
+                   },
+                   "expr": "sum(\n  sum(\n    container_gpu_allocation{\n      cluster=\"$cluster\",\njob=\"$job\"\n,\nnamespace=\"$namespace\"\n\n    }\n  )\n  by (namespace, instance)\n  * on(instance) group_left()\n  (\n    avg(\n      node_gpu_hourly_cost{\n        cluster=\"$cluster\",\njob=\"$job\"\n\n      }\n    ) by (instance) * 730\n  )\n)\n",
+                   "instant": false
+                }
+             ],
+             "title": "Monthly GPU Cost",
+             "type": "stat"
+          },
+          {
+             "datasource": {
+                "type": "prometheus",
+                "uid": "$datasource"
+             },
+             "description": "Projected monthly Persistent Volume cost for the selected namespace. Monitor this to identify unused PVCs or opportunities to migrate to cheaper storage classes without impacting application performance.",
+             "fieldConfig": {
+                "defaults": {
+                   "decimals": 2,
+                   "mappings": [ ],
+                   "thresholds": {
+                      "steps": [
+                         {
+                            "color": "green",
+                            "value": 0
+                         }
+                      ]
+                   },
+                   "unit": "currencyUSD"
+                },
+                "overrides": [ ]
+             },
+             "gridPos": {
+                "h": 3,
+                "w": 4,
+                "x": 20,
+                "y": 1
+             },
+             "id": 7,
+             "options": {
+                "graphMode": "none",
+                "percentChangeColorMode": "inverted",
+                "showPercentChange": true
+             },
+             "pluginVersion": "v11.4.0",
+             "targets": [
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "$datasource"
+                   },
+                   "expr": "sum(\n  sum(\n    kube_persistentvolume_capacity_bytes{\n      cluster=\"$cluster\",\njob=\"$job\"\n\n    }\n    / (1024 * 1024 * 1024)\n  ) by (persistentvolume)\n  *\n  sum(\n    pv_hourly_cost{\n      cluster=\"$cluster\",\njob=\"$job\"\n\n    }\n  ) by (persistentvolume)\n  * on(persistentvolume) group_left(cluster, namespace, persistentvolumeclaim) (\n    label_replace(\n      kube_persistentvolumeclaim_info{\n        cluster=\"$cluster\",\njob=\"$job\"\n,\nnamespace=\"$namespace\"\n\n      },\n      \"persistentvolume\", \"$1\",\n      \"volumename\", \"(.*)\"\n    )\n  )\n) * 730\n",
+                   "instant": false
+                }
+             ],
+             "title": "Monthly PV Cost",
+             "type": "stat"
+          },
+          {
+             "datasource": {
+                "type": "prometheus",
+                "uid": "$datasource"
+             },
+             "description": "Hourly cost trend for the selected namespace. Use this to see short-term cost changes from scaling, deployments, or workload churn without switching to the cluster overview.",
+             "fieldConfig": {
+                "defaults": {
+                   "custom": {
+                      "fillOpacity": 10
+                   },
+                   "unit": "currencyUSD"
+                },
+                "overrides": [ ]
+             },
+             "gridPos": {
+                "h": 5,
+                "w": 12,
+                "x": 0,
+                "y": 4
+             },
+             "id": 8,
+             "options": {
+                "legend": {
+                   "calcs": [
+                      "mean",
+                      "max"
+                   ],
+                   "displayMode": "table",
+                   "placement": "right",
+                   "showLegend": true,
+                   "sortBy": "Mean",
+                   "sortDesc": true
+                },
+                "tooltip": {
+                   "mode": "multi",
+                   "sort": "desc"
+                }
+             },
+             "pluginVersion": "v11.4.0",
+             "targets": [
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "$datasource"
+                   },
+                   "exemplar": false,
+                   "expr": "sum(\n  sum(\n    container_memory_allocation_bytes{\n      cluster=\"$cluster\",\njob=\"$job\"\n,\nnamespace=\"$namespace\"\n\n    }\n  )\n  by (namespace, instance)\n  * on(instance) group_left()\n  (\n    avg(\n      node_ram_hourly_cost{\n        cluster=\"$cluster\",\njob=\"$job\"\n\n      }\n    ) by (instance) / (1024 * 1024 * 1024) * 1\n  )\n)\n\n+\nsum(\n  sum(\n    container_cpu_allocation{\n      cluster=\"$cluster\",\njob=\"$job\"\n,\nnamespace=\"$namespace\"\n\n    }\n  )\n  by (namespace, instance)\n  * on(instance) group_left()\n  (\n    avg(\n      node_cpu_hourly_cost{\n        cluster=\"$cluster\",\njob=\"$job\"\n\n      }\n    ) by (instance) * 1\n  )\n)\n\n+\nsum(\n  sum(\n    container_gpu_allocation{\n      cluster=\"$cluster\",\njob=\"$job\"\n,\nnamespace=\"$namespace\"\n\n    }\n  )\n  by (namespace, instance)\n  * on(instance) group_left()\n  (\n    avg(\n      node_gpu_hourly_cost{\n        cluster=\"$cluster\",\njob=\"$job\"\n\n      }\n    ) by (instance) * 1\n  )\n)\n\n+\nsum(\n  sum(\n    kube_persistentvolume_capacity_bytes{\n      cluster=\"$cluster\",\njob=\"$job\"\n\n    }\n    / (1024 * 1024 * 1024)\n  ) by (persistentvolume)\n  *\n  sum(\n    pv_hourly_cost{\n      cluster=\"$cluster\",\njob=\"$job\"\n\n    }\n  ) by (persistentvolume)\n  * on(persistentvolume) group_left(cluster, namespace, persistentvolumeclaim) (\n    label_replace(\n      kube_persistentvolumeclaim_info{\n        cluster=\"$cluster\",\njob=\"$job\"\n,\nnamespace=\"$namespace\"\n\n      },\n      \"persistentvolume\", \"$1\",\n      \"volumename\", \"(.*)\"\n    )\n  ) or vector(0)\n) * 1\n\n",
+                   "interval": "30m",
+                   "legendFormat": "Hourly Cost"
+                }
+             ],
+             "title": "Hourly Cost",
+             "type": "timeseries"
+          },
+          {
+             "datasource": {
+                "type": "prometheus",
+                "uid": "$datasource"
+             },
+             "description": "Monthly cost projection trend for the selected namespace. This helps application teams track their projected monthly spending and ensure they remain within their allocated budget throughout the billing period.",
+             "fieldConfig": {
+                "defaults": {
+                   "custom": {
+                      "fillOpacity": 10
+                   },
+                   "unit": "currencyUSD"
+                },
+                "overrides": [ ]
+             },
+             "gridPos": {
+                "h": 5,
+                "w": 12,
+                "x": 12,
+                "y": 4
+             },
+             "id": 9,
+             "options": {
+                "legend": {
+                   "calcs": [
+                      "mean",
+                      "max"
+                   ],
+                   "displayMode": "table",
+                   "placement": "right",
+                   "showLegend": true,
+                   "sortBy": "Mean",
+                   "sortDesc": true
+                },
+                "tooltip": {
+                   "mode": "multi",
+                   "sort": "desc"
+                }
+             },
+             "pluginVersion": "v11.4.0",
+             "targets": [
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "$datasource"
+                   },
+                   "exemplar": false,
+                   "expr": "sum(\n  sum(\n    container_memory_allocation_bytes{\n      cluster=\"$cluster\",\njob=\"$job\"\n,\nnamespace=\"$namespace\"\n\n    }\n  )\n  by (namespace, instance)\n  * on(instance) group_left()\n  (\n    avg(\n      node_ram_hourly_cost{\n        cluster=\"$cluster\",\njob=\"$job\"\n\n      }\n    ) by (instance) / (1024 * 1024 * 1024) * 730\n  )\n)\n\n+\nsum(\n  sum(\n    container_cpu_allocation{\n      cluster=\"$cluster\",\njob=\"$job\"\n,\nnamespace=\"$namespace\"\n\n    }\n  )\n  by (namespace, instance)\n  * on(instance) group_left()\n  (\n    avg(\n      node_cpu_hourly_cost{\n        cluster=\"$cluster\",\njob=\"$job\"\n\n      }\n    ) by (instance) * 730\n  )\n)\n\n+\nsum(\n  sum(\n    container_gpu_allocation{\n      cluster=\"$cluster\",\njob=\"$job\"\n,\nnamespace=\"$namespace\"\n\n    }\n  )\n  by (namespace, instance)\n  * on(instance) group_left()\n  (\n    avg(\n      node_gpu_hourly_cost{\n        cluster=\"$cluster\",\njob=\"$job\"\n\n      }\n    ) by (instance) * 730\n  )\n)\n\n+\nsum(\n  sum(\n    kube_persistentvolume_capacity_bytes{\n      cluster=\"$cluster\",\njob=\"$job\"\n\n    }\n    / (1024 * 1024 * 1024)\n  ) by (persistentvolume)\n  *\n  sum(\n    pv_hourly_cost{\n      cluster=\"$cluster\",\njob=\"$job\"\n\n    }\n  ) by (persistentvolume)\n  * on(persistentvolume) group_left(cluster, namespace, persistentvolumeclaim) (\n    label_replace(\n      kube_persistentvolumeclaim_info{\n        cluster=\"$cluster\",\njob=\"$job\"\n,\nnamespace=\"$namespace\"\n\n      },\n      \"persistentvolume\", \"$1\",\n      \"volumename\", \"(.*)\"\n    )\n  ) or vector(0)\n) * 730\n\n",
+                   "interval": "30m",
+                   "legendFormat": "Monthly Cost"
+                }
+             ],
+             "title": "Monthly Cost",
+             "type": "timeseries"
+          },
+          {
+             "datasource": {
+                "type": "prometheus",
+                "uid": "$datasource"
+             },
+             "description": "Monthly cost distribution for the selected namespace across resource types (CPU, RAM, Persistent Volumes, and GPU). This shows which resource category is the primary cost driver for this namespace, helping teams prioritize their optimization efforts.",
+             "fieldConfig": {
+                "defaults": {
+                   "unit": "currencyUSD"
+                },
+                "overrides": [ ]
+             },
+             "gridPos": {
+                "h": 7,
+                "w": 12,
+                "x": 0,
+                "y": 9
+             },
+             "id": 10,
+             "options": {
+                "displayLabels": [
+                   "percent"
+                ],
+                "legend": {
+                   "displayMode": "table",
+                   "placement": "right",
+                   "showLegend": true,
+                   "values": [
+                      "percent",
+                      "value"
+                   ]
+                },
+                "tooltip": {
+                   "mode": "multi",
+                   "sort": "desc"
+                }
+             },
+             "pluginVersion": "v11.4.0",
+             "targets": [
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "$datasource"
+                   },
+                   "expr": "sum(\n  sum(\n    container_cpu_allocation{\n      cluster=\"$cluster\",\njob=\"$job\"\n,\nnamespace=\"$namespace\"\n\n    }\n  )\n  by (namespace, instance)\n  * on(instance) group_left()\n  (\n    avg(\n      node_cpu_hourly_cost{\n        cluster=\"$cluster\",\njob=\"$job\"\n\n      }\n    ) by (instance) * 730\n  )\n)\n",
+                   "instant": true,
+                   "legendFormat": "CPU"
+                },
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "$datasource"
+                   },
+                   "expr": "sum(\n  sum(\n    container_memory_allocation_bytes{\n      cluster=\"$cluster\",\njob=\"$job\"\n,\nnamespace=\"$namespace\"\n\n    }\n  )\n  by (namespace, instance)\n  * on(instance) group_left()\n  (\n    avg(\n      node_ram_hourly_cost{\n        cluster=\"$cluster\",\njob=\"$job\"\n\n      }\n    ) by (instance) / (1024 * 1024 * 1024) * 730\n  )\n)\n",
+                   "instant": true,
+                   "legendFormat": "RAM"
+                },
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "$datasource"
+                   },
+                   "expr": "sum(\n  sum(\n    kube_persistentvolume_capacity_bytes{\n      cluster=\"$cluster\",\njob=\"$job\"\n\n    }\n    / (1024 * 1024 * 1024)\n  ) by (persistentvolume)\n  *\n  sum(\n    pv_hourly_cost{\n      cluster=\"$cluster\",\njob=\"$job\"\n\n    }\n  ) by (persistentvolume)\n  * on(persistentvolume) group_left(cluster, namespace, persistentvolumeclaim) (\n    label_replace(\n      kube_persistentvolumeclaim_info{\n        cluster=\"$cluster\",\njob=\"$job\"\n,\nnamespace=\"$namespace\"\n\n      },\n      \"persistentvolume\", \"$1\",\n      \"volumename\", \"(.*)\"\n    )\n  )\n) * 730\n",
+                   "instant": true,
+                   "legendFormat": "PV"
+                },
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "$datasource"
+                   },
+                   "expr": "sum(\n  sum(\n    container_gpu_allocation{\n      cluster=\"$cluster\",\njob=\"$job\"\n,\nnamespace=\"$namespace\"\n\n    }\n  )\n  by (namespace, instance)\n  * on(instance) group_left()\n  (\n    avg(\n      node_gpu_hourly_cost{\n        cluster=\"$cluster\",\njob=\"$job\"\n\n      }\n    ) by (instance) * 730\n  )\n)\n",
+                   "instant": true,
+                   "legendFormat": "GPU"
+                }
+             ],
+             "title": "Cost by Resource",
+             "type": "piechart"
+          },
+          {
+             "datasource": {
+                "type": "prometheus",
+                "uid": "$datasource"
+             },
+             "description": "Top 10 pods by monthly cost showing the distribution of spending across pods in the namespace. This visualization helps identify which pods consume the most resources and whether costs are evenly distributed or concentrated in a few workloads.",
+             "fieldConfig": {
+                "defaults": {
+                   "unit": "currencyUSD"
+                },
+                "overrides": [ ]
+             },
+             "gridPos": {
+                "h": 7,
+                "w": 12,
+                "x": 12,
+                "y": 9
+             },
+             "id": 11,
+             "options": {
+                "displayLabels": [
+                   "percent"
+                ],
+                "legend": {
+                   "displayMode": "table",
+                   "placement": "right",
+                   "showLegend": true,
+                   "values": [
+                      "percent",
+                      "value"
+                   ]
+                },
+                "tooltip": {
+                   "mode": "multi",
+                   "sort": "desc"
+                }
+             },
+             "pluginVersion": "v11.4.0",
+             "targets": [
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "$datasource"
+                   },
+                   "expr": "topk(10,\n  sum(\n    (\n      sum(\n        container_memory_allocation_bytes{\n          cluster=\"$cluster\",\n          namespace=\"$namespace\",\n          job=\"$job\"}\n      )\n      by (instance, pod)\n      * on(instance) group_left()\n      (\n        avg(\n          node_ram_hourly_cost{\n            cluster=\"$cluster\",\n            job=\"$job\"}\n        ) by (instance) / (1024 * 1024 * 1024) * 730\n      )\n    )\n    +\n    (\n      sum(\n        container_cpu_allocation{\n          cluster=\"$cluster\",\n          namespace=\"$namespace\",\n          job=\"$job\"}\n      )\n      by (instance, pod)\n      * on(instance) group_left()\n      (\n        avg(\n          node_cpu_hourly_cost{\n            cluster=\"$cluster\",\n            job=\"$job\"}\n        ) by (instance) * 730)\n    )\n  ) by (pod)\n)\n",
+                   "instant": true,
+                   "legendFormat": "{{ pod }}"
+                }
+             ],
+             "title": "Cost by Pod",
+             "type": "piechart"
+          },
+          {
+             "datasource": {
+                "type": "prometheus",
+                "uid": "$datasource"
+             },
+             "description": "Top 10 containers by monthly cost showing the distribution of spending across containers in the namespace. This helps identify which container images or workload types are most expensive and whether sidecar containers are adding significant costs.",
+             "fieldConfig": {
+                "defaults": {
+                   "unit": "currencyUSD"
+                },
+                "overrides": [ ]
+             },
+             "gridPos": {
+                "h": 7,
+                "w": 12,
+                "x": 0,
+                "y": 16
+             },
+             "id": 12,
+             "options": {
+                "displayLabels": [
+                   "percent"
+                ],
+                "legend": {
+                   "displayMode": "table",
+                   "placement": "right",
+                   "showLegend": true,
+                   "values": [
+                      "percent",
+                      "value"
+                   ]
+                },
+                "tooltip": {
+                   "mode": "multi",
+                   "sort": "desc"
+                }
+             },
+             "pluginVersion": "v11.4.0",
+             "targets": [
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "$datasource"
+                   },
+                   "expr": "topk(10,\n  sum(\n    (\n      sum(\n        container_memory_allocation_bytes{\n          cluster=\"$cluster\",\n          namespace=\"$namespace\",\n          job=\"$job\"}\n      )\n      by (instance, container)\n      * on(instance) group_left()\n      (\n        avg(\n          node_ram_hourly_cost{\n            cluster=\"$cluster\",\n            job=\"$job\"}\n        ) by (instance) / (1024 * 1024 * 1024) * 730\n      )\n    )\n    +\n    (\n      sum(\n        container_cpu_allocation{\n          cluster=\"$cluster\",\n          namespace=\"$namespace\",\n          job=\"$job\"}\n      )\n      by (instance, container)\n      * on(instance) group_left()\n      (\n        avg(\n          node_cpu_hourly_cost{\n            cluster=\"$cluster\",\n            job=\"$job\"}\n        ) by (instance) * 730\n      )\n    )\n  ) by (container)\n)\n",
+                   "instant": true,
+                   "legendFormat": "{{ container }}"
+                }
+             ],
+             "title": "Cost by Container",
+             "type": "piechart"
+          },
+          {
+             "datasource": {
+                "type": "prometheus",
+                "uid": "$datasource"
+             },
+             "description": "Distribution of monthly storage costs across Persistent Volume Claims in the namespace. This shows which claims consume the most storage budget and helps identify whether storage costs are concentrated in a few large claims or distributed across many smaller ones.",
+             "fieldConfig": {
+                "defaults": {
+                   "unit": "currencyUSD"
+                },
+                "overrides": [ ]
+             },
+             "gridPos": {
+                "h": 7,
+                "w": 12,
+                "x": 12,
+                "y": 16
+             },
+             "id": 13,
+             "options": {
+                "displayLabels": [
+                   "percent"
+                ],
+                "legend": {
+                   "displayMode": "table",
+                   "placement": "right",
+                   "showLegend": true,
+                   "values": [
+                      "percent",
+                      "value"
+                   ]
+                },
+                "tooltip": {
+                   "mode": "multi",
+                   "sort": "desc"
+                }
+             },
+             "pluginVersion": "v11.4.0",
+             "targets": [
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "$datasource"
+                   },
+                   "expr": "sum(\n  sum(\n    kube_persistentvolume_capacity_bytes{\n      cluster=\"$cluster\",\njob=\"$job\"\n\n    }\n    / (1024 * 1024 * 1024)\n  ) by (persistentvolume)\n  *\n  sum(\n    pv_hourly_cost{\n      cluster=\"$cluster\",\njob=\"$job\"\n\n    }\n  ) by (persistentvolume)\n  * on(persistentvolume) group_left(cluster, namespace, persistentvolumeclaim) (\n    label_replace(\n      kube_persistentvolumeclaim_info{\n        cluster=\"$cluster\",\njob=\"$job\"\n,\nnamespace=\"$namespace\"\n\n      },\n      \"persistentvolume\", \"$1\",\n      \"volumename\", \"(.*)\"\n    )\n  )\n) by (persistentvolumeclaim) * 730\n",
+                   "instant": true,
+                   "legendFormat": "{{ persistentvolumeclaim }}"
+                }
+             ],
+             "title": "Cost by Persistent Volume Claim",
+             "type": "piechart"
+          },
+          {
+             "collapsed": false,
+             "gridPos": {
+                "h": 1,
+                "w": 24,
+                "x": 0,
+                "y": 23
+             },
+             "id": 14,
+             "title": "Pod Summary",
+             "type": "row"
+          },
+          {
+             "datasource": {
+                "type": "prometheus",
+                "uid": "$datasource"
+             },
+             "description": "Top 10 pods by projected monthly cost (based on current hourly rates) with percentage change compared to 7 days and 30 days ago. Positive percentages indicate cost increases (red), negative percentages indicate cost decreases (green). Use this to identify the most expensive pods in the namespace and track how pod costs change over time, especially after deployments or configuration changes.",
+             "fieldConfig": {
+                "defaults": {
+                   "links": [ ],
+                   "thresholds": {
+                      "steps": [
+                         {
+                            "color": "green",
+                            "value": 0
+                         },
+                         {
+                            "color": "yellow",
+                            "value": 5
+                         },
+                         {
+                            "color": "red",
+                            "value": 10
+                         }
+                      ]
+                   },
+                   "unit": "currencyUSD"
+                },
+                "overrides": [
+                   {
+                      "matcher": {
+                         "id": "byName",
+                         "options": "Cost Change vs 7d Ago (%)"
+                      },
+                      "properties": [
+                         {
+                            "id": "color",
+                            "value": {
+                               "mode": "thresholds"
+                            }
+                         },
+                         {
+                            "id": "custom.cellOptions",
+                            "value": {
+                               "type": "color-background"
+                            }
+                         },
+                         {
+                            "id": "unit",
+                            "value": "percent"
+                         }
+                      ]
+                   },
+                   {
+                      "matcher": {
+                         "id": "byName",
+                         "options": "Cost Change vs 30d Ago (%)"
+                      },
+                      "properties": [
+                         {
+                            "id": "color",
+                            "value": {
+                               "mode": "thresholds"
+                            }
+                         },
+                         {
+                            "id": "custom.cellOptions",
+                            "value": {
+                               "type": "color-background"
+                            }
+                         },
+                         {
+                            "id": "unit",
+                            "value": "percent"
+                         }
+                      ]
+                   }
+                ]
+             },
+             "gridPos": {
+                "h": 10,
+                "w": 24,
+                "x": 0,
+                "y": 24
+             },
+             "id": 15,
+             "options": {
+                "footer": {
+                   "enablePagination": true
+                },
+                "sortBy": [
+                   {
+                      "desc": true,
+                      "displayName": "Total Cost (Today)"
+                   }
+                ]
+             },
+             "pluginVersion": "v11.4.0",
+             "targets": [
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "$datasource"
+                   },
+                   "expr": "topk(10,\n  sum(\n    (\n      sum(\n        container_memory_allocation_bytes{\n          cluster=\"$cluster\",\n          namespace=\"$namespace\",\n          job=\"$job\"}\n      )\n      by (instance, pod)\n      * on(instance) group_left()\n      (\n        avg(\n          node_ram_hourly_cost{\n            cluster=\"$cluster\",\n            job=\"$job\"}\n        ) by (instance) / (1024 * 1024 * 1024) * 730\n      )\n    )\n    +\n    (\n      sum(\n        container_cpu_allocation{\n          cluster=\"$cluster\",\n          namespace=\"$namespace\",\n          job=\"$job\"}\n      )\n      by (instance, pod)\n      * on(instance) group_left()\n      (\n        avg(\n          node_cpu_hourly_cost{\n            cluster=\"$cluster\",\n            job=\"$job\"}\n        ) by (instance) * 730)\n    )\n  ) by (pod)\n)\n",
+                   "format": "table",
+                   "instant": true
+                },
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "$datasource"
+                   },
+                   "expr": "topk(10,\n  sum(\n    (\n      sum(\n        container_memory_allocation_bytes{\n          cluster=\"$cluster\",\n          namespace=\"$namespace\",\n          job=\"$job\"}\n      )\n      by (instance, pod)\n      * on(instance) group_left()\n      (\n        avg(\n          node_ram_hourly_cost{\n            cluster=\"$cluster\",\n            job=\"$job\"}\n        ) by (instance) / (1024 * 1024 * 1024) * 730\n      )\n    )\n    +\n    (\n      sum(\n        container_cpu_allocation{\n          cluster=\"$cluster\",\n          namespace=\"$namespace\",\n          job=\"$job\"}\n      )\n      by (instance, pod)\n      * on(instance) group_left()\n      (\n        avg(\n          node_cpu_hourly_cost{\n            cluster=\"$cluster\",\n            job=\"$job\"}\n        ) by (instance) * 730)\n    )\n  ) by (pod)\n)\n\n/\ntopk(10,\n  sum(\n    (\n      sum(\n        container_memory_allocation_bytes{\n          cluster=\"$cluster\",\n          namespace=\"$namespace\",\n          job=\"$job\"} offset 7d\n      )\n      by (instance, pod)\n      * on(instance) group_left()\n      (\n        avg(\n          node_ram_hourly_cost{\n            cluster=\"$cluster\",\n            job=\"$job\"} offset 7d\n        ) by (instance) / (1024 * 1024 * 1024) * 730\n      )\n    )\n    +\n    (\n      sum(\n        container_cpu_allocation{\n          cluster=\"$cluster\",\n          namespace=\"$namespace\",\n          job=\"$job\"} offset 7d\n      )\n      by (instance, pod)\n      * on(instance) group_left()\n      (\n        avg(\n          node_cpu_hourly_cost{\n            cluster=\"$cluster\",\n            job=\"$job\"} offset 7d\n        ) by (instance) * 730)\n    )\n  ) by (pod)\n)\n\n* 100\n- 100\n",
+                   "format": "table",
+                   "instant": true
+                },
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "$datasource"
+                   },
+                   "expr": "topk(10,\n  sum(\n    (\n      sum(\n        container_memory_allocation_bytes{\n          cluster=\"$cluster\",\n          namespace=\"$namespace\",\n          job=\"$job\"}\n      )\n      by (instance, pod)\n      * on(instance) group_left()\n      (\n        avg(\n          node_ram_hourly_cost{\n            cluster=\"$cluster\",\n            job=\"$job\"}\n        ) by (instance) / (1024 * 1024 * 1024) * 730\n      )\n    )\n    +\n    (\n      sum(\n        container_cpu_allocation{\n          cluster=\"$cluster\",\n          namespace=\"$namespace\",\n          job=\"$job\"}\n      )\n      by (instance, pod)\n      * on(instance) group_left()\n      (\n        avg(\n          node_cpu_hourly_cost{\n            cluster=\"$cluster\",\n            job=\"$job\"}\n        ) by (instance) * 730)\n    )\n  ) by (pod)\n)\n\n/\ntopk(10,\n  sum(\n    (\n      sum(\n        container_memory_allocation_bytes{\n          cluster=\"$cluster\",\n          namespace=\"$namespace\",\n          job=\"$job\"} offset 30d\n      )\n      by (instance, pod)\n      * on(instance) group_left()\n      (\n        avg(\n          node_ram_hourly_cost{\n            cluster=\"$cluster\",\n            job=\"$job\"} offset 30d\n        ) by (instance) / (1024 * 1024 * 1024) * 730\n      )\n    )\n    +\n    (\n      sum(\n        container_cpu_allocation{\n          cluster=\"$cluster\",\n          namespace=\"$namespace\",\n          job=\"$job\"} offset 30d\n      )\n      by (instance, pod)\n      * on(instance) group_left()\n      (\n        avg(\n          node_cpu_hourly_cost{\n            cluster=\"$cluster\",\n            job=\"$job\"} offset 30d\n        ) by (instance) * 730)\n    )\n  ) by (pod)\n)\n\n* 100\n- 100\n",
+                   "format": "table",
+                   "instant": true
+                }
+             ],
+             "title": "Pod Monthly Cost",
+             "transformations": [
+                {
+                   "id": "merge"
+                },
+                {
+                   "id": "organize",
+                   "options": {
+                      "excludeByName": {
+                         "Time": true,
+                         "job": true
+                      },
+                      "indexByName": {
+                         "Value #A": 1,
+                         "Value #B": 2,
+                         "Value #C": 3,
+                         "pod": 0
+                      },
+                      "renameByName": {
+                         "Value #A": "Monthly Cost",
+                         "Value #B": "Cost Change vs 7d Ago (%)",
+                         "Value #C": "Cost Change vs 30d Ago (%)",
+                         "pod": "Pod"
+                      }
+                   }
+                }
+             ],
+             "type": "table"
+          },
+          {
+             "collapsed": false,
+             "gridPos": {
+                "h": 1,
+                "w": 24,
+                "x": 0,
+                "y": 34
+             },
+             "id": 16,
+             "title": "Container Summary",
+             "type": "row"
+          },
+          {
+             "datasource": {
+                "type": "prometheus",
+                "uid": "$datasource"
+             },
+             "description": "Top 10 containers by current monthly cost with percentage change compared to 7 days and 30 days ago. Positive percentages indicate cost increases (red), negative percentages indicate cost decreases (green). This granular view helps identify specific containers within pods that are driving costs, useful for optimizing multi-container pod configurations.",
+             "fieldConfig": {
+                "defaults": {
+                   "links": [ ],
+                   "thresholds": {
+                      "steps": [
+                         {
+                            "color": "green",
+                            "value": 0
+                         },
+                         {
+                            "color": "yellow",
+                            "value": 5
+                         },
+                         {
+                            "color": "red",
+                            "value": 10
+                         }
+                      ]
+                   },
+                   "unit": "currencyUSD"
+                },
+                "overrides": [
+                   {
+                      "matcher": {
+                         "id": "byName",
+                         "options": "Cost Change vs 7d Ago (%)"
+                      },
+                      "properties": [
+                         {
+                            "id": "color",
+                            "value": {
+                               "mode": "thresholds"
+                            }
+                         },
+                         {
+                            "id": "custom.cellOptions",
+                            "value": {
+                               "type": "color-background"
+                            }
+                         },
+                         {
+                            "id": "unit",
+                            "value": "percent"
+                         }
+                      ]
+                   },
+                   {
+                      "matcher": {
+                         "id": "byName",
+                         "options": "Cost Change vs 30d Ago (%)"
+                      },
+                      "properties": [
+                         {
+                            "id": "color",
+                            "value": {
+                               "mode": "thresholds"
+                            }
+                         },
+                         {
+                            "id": "custom.cellOptions",
+                            "value": {
+                               "type": "color-background"
+                            }
+                         },
+                         {
+                            "id": "unit",
+                            "value": "percent"
+                         }
+                      ]
+                   }
+                ]
+             },
+             "gridPos": {
+                "h": 10,
+                "w": 24,
+                "x": 0,
+                "y": 35
+             },
+             "id": 17,
+             "options": {
+                "footer": {
+                   "enablePagination": true
+                },
+                "sortBy": [
+                   {
+                      "desc": true,
+                      "displayName": "Monthly Cost"
+                   }
+                ]
+             },
+             "pluginVersion": "v11.4.0",
+             "targets": [
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "$datasource"
+                   },
+                   "expr": "topk(10,\n  sum(\n    (\n      sum(\n        container_memory_allocation_bytes{\n          cluster=\"$cluster\",\n          namespace=\"$namespace\",\n          job=\"$job\"}\n      )\n      by (instance, container)\n      * on(instance) group_left()\n      (\n        avg(\n          node_ram_hourly_cost{\n            cluster=\"$cluster\",\n            job=\"$job\"}\n        ) by (instance) / (1024 * 1024 * 1024) * 730\n      )\n    )\n    +\n    (\n      sum(\n        container_cpu_allocation{\n          cluster=\"$cluster\",\n          namespace=\"$namespace\",\n          job=\"$job\"}\n      )\n      by (instance, container)\n      * on(instance) group_left()\n      (\n        avg(\n          node_cpu_hourly_cost{\n            cluster=\"$cluster\",\n            job=\"$job\"}\n        ) by (instance) * 730\n      )\n    )\n  ) by (container)\n)\n",
+                   "format": "table",
+                   "instant": true
+                },
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "$datasource"
+                   },
+                   "expr": "topk(10,\n  sum(\n    (\n      sum(\n        container_memory_allocation_bytes{\n          cluster=\"$cluster\",\n          namespace=\"$namespace\",\n          job=\"$job\"}\n      )\n      by (instance, container)\n      * on(instance) group_left()\n      (\n        avg(\n          node_ram_hourly_cost{\n            cluster=\"$cluster\",\n            job=\"$job\"}\n        ) by (instance) / (1024 * 1024 * 1024) * 730\n      )\n    )\n    +\n    (\n      sum(\n        container_cpu_allocation{\n          cluster=\"$cluster\",\n          namespace=\"$namespace\",\n          job=\"$job\"}\n      )\n      by (instance, container)\n      * on(instance) group_left()\n      (\n        avg(\n          node_cpu_hourly_cost{\n            cluster=\"$cluster\",\n            job=\"$job\"}\n        ) by (instance) * 730\n      )\n    )\n  ) by (container)\n)\n\n/\ntopk(10,\n  sum(\n    (\n      sum(\n        container_memory_allocation_bytes{\n          cluster=\"$cluster\",\n          namespace=\"$namespace\",\n          job=\"$job\"} offset 7d\n      )\n      by (instance, container)\n      * on(instance) group_left()\n      (\n        avg(\n          node_ram_hourly_cost{\n            cluster=\"$cluster\",\n            job=\"$job\"} offset 7d\n        ) by (instance) / (1024 * 1024 * 1024) * 730\n      )\n    )\n    +\n    (\n      sum(\n        container_cpu_allocation{\n          cluster=\"$cluster\",\n          namespace=\"$namespace\",\n          job=\"$job\"} offset 7d\n      )\n      by (instance, container)\n      * on(instance) group_left()\n      (\n        avg(\n          node_cpu_hourly_cost{\n            cluster=\"$cluster\",\n            job=\"$job\"} offset 7d\n        ) by (instance) * 730\n      )\n    )\n  ) by (container)\n)\n\n* 100\n- 100\n",
+                   "format": "table",
+                   "instant": true
+                },
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "$datasource"
+                   },
+                   "expr": "topk(10,\n  sum(\n    (\n      sum(\n        container_memory_allocation_bytes{\n          cluster=\"$cluster\",\n          namespace=\"$namespace\",\n          job=\"$job\"}\n      )\n      by (instance, container)\n      * on(instance) group_left()\n      (\n        avg(\n          node_ram_hourly_cost{\n            cluster=\"$cluster\",\n            job=\"$job\"}\n        ) by (instance) / (1024 * 1024 * 1024) * 730\n      )\n    )\n    +\n    (\n      sum(\n        container_cpu_allocation{\n          cluster=\"$cluster\",\n          namespace=\"$namespace\",\n          job=\"$job\"}\n      )\n      by (instance, container)\n      * on(instance) group_left()\n      (\n        avg(\n          node_cpu_hourly_cost{\n            cluster=\"$cluster\",\n            job=\"$job\"}\n        ) by (instance) * 730\n      )\n    )\n  ) by (container)\n)\n\n/\ntopk(10,\n  sum(\n    (\n      sum(\n        container_memory_allocation_bytes{\n          cluster=\"$cluster\",\n          namespace=\"$namespace\",\n          job=\"$job\"} offset 30d\n      )\n      by (instance, container)\n      * on(instance) group_left()\n      (\n        avg(\n          node_ram_hourly_cost{\n            cluster=\"$cluster\",\n            job=\"$job\"} offset 30d\n        ) by (instance) / (1024 * 1024 * 1024) * 730\n      )\n    )\n    +\n    (\n      sum(\n        container_cpu_allocation{\n          cluster=\"$cluster\",\n          namespace=\"$namespace\",\n          job=\"$job\"} offset 30d\n      )\n      by (instance, container)\n      * on(instance) group_left()\n      (\n        avg(\n          node_cpu_hourly_cost{\n            cluster=\"$cluster\",\n            job=\"$job\"} offset 30d\n        ) by (instance) * 730\n      )\n    )\n  ) by (container)\n)\n\n* 100\n- 100\n",
+                   "format": "table",
+                   "instant": true
+                }
+             ],
+             "title": "Container Monthly Cost",
+             "transformations": [
+                {
+                   "id": "merge"
+                },
+                {
+                   "id": "organize",
+                   "options": {
+                      "excludeByName": {
+                         "Time": true,
+                         "job": true
+                      },
+                      "indexByName": {
+                         "Value #A": 1,
+                         "Value #B": 2,
+                         "Value #C": 3,
+                         "container": 0
+                      },
+                      "renameByName": {
+                         "Value #A": "Monthly Cost",
+                         "Value #B": "Cost Change vs 7d Ago (%)",
+                         "Value #C": "Cost Change vs 30d Ago (%)",
+                         "container": "Container"
+                      }
+                   }
+                }
+             ],
+             "type": "table"
+          },
+          {
+             "collapsed": false,
+             "gridPos": {
+                "h": 1,
+                "w": 24,
+                "x": 0,
+                "y": 45
+             },
+             "id": 18,
+             "title": "PV Summary",
+             "type": "row"
+          },
+          {
+             "datasource": {
+                "type": "prometheus",
+                "uid": "$datasource"
+             },
+             "description": "List of Persistent Volume Claims used by the selected namespace with their capacity (in GiB) and monthly cost, sorted by total cost. Use this to identify large or expensive claims that may be candidates for cleanup, resizing, or migration to cheaper storage classes.",
+             "fieldConfig": {
+                "defaults": {
+                   "links": [ ],
+                   "thresholds": {
+                      "steps": [ ]
+                   },
+                   "unit": "decgbytes"
+                },
+                "overrides": [
+                   {
+                      "matcher": {
+                         "id": "byName",
+                         "options": "Total Cost"
+                      },
+                      "properties": [
+                         {
+                            "id": "unit",
+                            "value": "currencyUSD"
+                         }
+                      ]
+                   }
+                ]
+             },
+             "gridPos": {
+                "h": 10,
+                "w": 24,
+                "x": 0,
+                "y": 46
+             },
+             "id": 19,
+             "options": {
+                "footer": {
+                   "enablePagination": true
+                },
+                "sortBy": [
+                   {
+                      "desc": true,
+                      "displayName": "Monthly Cost"
+                   }
+                ]
+             },
+             "pluginVersion": "v11.4.0",
+             "targets": [
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "$datasource"
+                   },
+                   "expr": "sum(\n  sum(\n    kube_persistentvolume_capacity_bytes{\n      cluster=\"$cluster\",\n      job=\"$job\"\n    } / (1024 * 1024 * 1024)\n  ) by (persistentvolume)\n  * on(persistentvolume) group_left(cluster, namespace, persistentvolumeclaim)\n    label_replace(\n      kube_persistentvolumeclaim_info{\n        cluster=\"$cluster\",\n        job=\"$job\",\n        namespace=\"$namespace\"\n      },\n      \"persistentvolume\", \"$1\",\n      \"volumename\", \"(.*)\"\n    )\n) by (persistentvolumeclaim)\n",
+                   "format": "table",
+                   "instant": true
+                },
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "$datasource"
+                   },
+                   "expr": "sum(\n  sum(\n    kube_persistentvolume_capacity_bytes{\n      cluster=\"$cluster\",\njob=\"$job\"\n\n    }\n    / (1024 * 1024 * 1024)\n  ) by (persistentvolume)\n  *\n  sum(\n    pv_hourly_cost{\n      cluster=\"$cluster\",\njob=\"$job\"\n\n    }\n  ) by (persistentvolume)\n  * on(persistentvolume) group_left(cluster, namespace, persistentvolumeclaim) (\n    label_replace(\n      kube_persistentvolumeclaim_info{\n        cluster=\"$cluster\",\njob=\"$job\"\n,\nnamespace=\"$namespace\"\n\n      },\n      \"persistentvolume\", \"$1\",\n      \"volumename\", \"(.*)\"\n    )\n  )\n) by (persistentvolumeclaim) * 730\n",
+                   "format": "table",
+                   "instant": true
+                }
+             ],
+             "title": "Persistent Volume Claims Monthly Cost",
+             "transformations": [
+                {
+                   "id": "merge"
+                },
+                {
+                   "id": "organize",
+                   "options": {
+                      "excludeByName": {
+                         "Time": true,
+                         "job": true,
+                         "namespace": true
+                      },
+                      "indexByName": {
+                         "Value #A": 1,
+                         "Value #B": 2,
+                         "persistentvolumeclaim": 0
+                      },
+                      "renameByName": {
+                         "Value #A": "Total GiB",
+                         "Value #B": "Total Cost",
+                         "persistentvolumeclaim": "Persistent Volume Claim"
+                      }
+                   }
+                }
+             ],
+             "type": "table"
+          }
+       ],
+       "schemaVersion": 39,
+       "tags": [
+          "opencost",
+          "opencost-mixin"
+       ],
+       "templating": {
+          "list": [
+             {
+                "current": {
+                   "selected": true,
+                   "text": "default",
+                   "value": "default"
+                },
+                "label": "Data source",
+                "name": "datasource",
+                "query": "prometheus",
+                "type": "datasource"
+             },
+             {
+                "datasource": {
+                   "type": "prometheus",
+                   "uid": "${datasource}"
+                },
+                "hide": 2,
+                "label": "Cluster",
+                "name": "cluster",
+                "query": "label_values(opencost_build_info{}, cluster)",
+                "refresh": 2,
+                "sort": 1,
+                "type": "query"
+             },
+             {
+                "datasource": {
+                   "type": "prometheus",
+                   "uid": "${datasource}"
+                },
+                "includeAll": false,
+                "label": "Job",
+                "multi": false,
+                "name": "job",
+                "query": "label_values(opencost_build_info{cluster=\"$cluster\"}, job)",
+                "refresh": 2,
+                "sort": 1,
+                "type": "query"
+             },
+             {
+                "datasource": {
+                   "type": "prometheus",
+                   "uid": "${datasource}"
+                },
+                "includeAll": false,
+                "label": "Namespace",
+                "multi": false,
+                "name": "namespace",
+                "query": "label_values(kube_namespace_labels{cluster=\"$cluster\", job=\"$job\"}, namespace)",
+                "refresh": 2,
+                "sort": 1,
+                "type": "query"
+             }
+          ]
+       },
+       "time": {
+          "from": "now-2d",
+          "to": "now"
+       },
+       "timezone": "utc",
+       "title": "OpenCost / Namespace",
+       "uid": "opencost-mixin-namespace-jkwq"
+    }
+kind: ConfigMap
+metadata:
+  labels:
+    grafana_dashboard: "1"
+  name: grafana-dashboard-opencost-namespace
+  namespace: monitoring
+---
+apiVersion: v1
+data:
+  opencost-overview.json: |
+    {
+       "__inputs": [ ],
+       "__requires": [ ],
+       "annotations": {
+          "list": [ ]
+       },
+       "description": "A comprehensive overview dashboard for OpenCost that displays cluster-wide cost metrics including hourly and monthly costs broken down by resource type (CPU, RAM, PV, GPU), instance type, namespace, and individual nodes. Use this dashboard to monitor overall infrastructure spending, identify cost trends, and detect cost anomalies across your Kubernetes cluster. The dashboards were generated using [opencost-mixin](https://github.com/adinhodovic/opencost-mixin). Open issues and create feature requests in the repository.",
+       "editable": false,
+       "links": [
+          {
+             "asDropdown": true,
+             "includeVars": false,
+             "keepTime": true,
+             "tags": [
+                "opencost",
+                "opencost-mixin"
+             ],
+             "targetBlank": true,
+             "title": "OpenCost",
+             "type": "dashboards"
+          }
+       ],
+       "panels": [
+          {
+             "collapsed": false,
+             "gridPos": {
+                "h": 1,
+                "w": 24,
+                "x": 0,
+                "y": 0
+             },
+             "id": 1,
+             "title": "Cluster Summary",
+             "type": "row"
+          },
+          {
+             "datasource": {
+                "type": "prometheus",
+                "uid": "$datasource"
+             },
+             "description": "Current hourly infrastructure cost rate across the cluster. This metric provides real-time cost visibility and can be used to project daily and monthly spending. The percentage change helps track cost fluctuations over time.",
+             "fieldConfig": {
+                "defaults": {
+                   "decimals": 2,
+                   "mappings": [ ],
+                   "thresholds": {
+                      "steps": [
+                         {
+                            "color": "green",
+                            "value": 0
+                         }
+                      ]
+                   },
+                   "unit": "currencyUSD"
+                },
+                "overrides": [ ]
+             },
+             "gridPos": {
+                "h": 3,
+                "w": 4,
+                "x": 0,
+                "y": 1
+             },
+             "id": 2,
+             "options": {
+                "graphMode": "none",
+                "percentChangeColorMode": "inverted",
+                "showPercentChange": true
+             },
+             "pluginVersion": "v11.4.0",
+             "targets": [
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "$datasource"
+                   },
+                   "expr": "sum(\n  node_total_hourly_cost{\n    cluster=\"$cluster\",\njob=\"$job\"\n\n  }\n)\n+\nsum(\n  sum(\n    kube_persistentvolume_capacity_bytes{\n      cluster=\"$cluster\",\njob=\"$job\"\n\n    } / (1024 * 1024 * 1024)\n  ) by (persistentvolume)\n  * on(persistentvolume) group_left()\n  sum(\n    pv_hourly_cost{\n      cluster=\"$cluster\",\njob=\"$job\"\n\n    }\n  ) by (persistentvolume)\n)\n",
+                   "instant": false
+                }
+             ],
+             "title": "Hourly Cost",
+             "type": "stat"
+          },
+          {
+             "datasource": {
+                "type": "prometheus",
+                "uid": "$datasource"
+             },
+             "description": "Projected monthly infrastructure cost based on current hourly rates (730 hours per month). This projection helps with budget planning and cost forecasting. Compare this value against your budget to ensure spending stays within limits.",
+             "fieldConfig": {
+                "defaults": {
+                   "decimals": 2,
+                   "mappings": [ ],
+                   "thresholds": {
+                      "steps": [
+                         {
+                            "color": "green",
+                            "value": 0
+                         }
+                      ]
+                   },
+                   "unit": "currencyUSD"
+                },
+                "overrides": [ ]
+             },
+             "gridPos": {
+                "h": 3,
+                "w": 4,
+                "x": 4,
+                "y": 1
+             },
+             "id": 3,
+             "options": {
+                "graphMode": "none",
+                "percentChangeColorMode": "inverted",
+                "showPercentChange": true
+             },
+             "pluginVersion": "v11.4.0",
+             "targets": [
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "$datasource"
+                   },
+                   "expr": "(sum(\n  node_total_hourly_cost{\n    cluster=\"$cluster\",\njob=\"$job\"\n\n  }\n)\n+\nsum(\n  sum(\n    kube_persistentvolume_capacity_bytes{\n      cluster=\"$cluster\",\njob=\"$job\"\n\n    } / (1024 * 1024 * 1024)\n  ) by (persistentvolume)\n  * on(persistentvolume) group_left()\n  sum(\n    pv_hourly_cost{\n      cluster=\"$cluster\",\njob=\"$job\"\n\n    }\n  ) by (persistentvolume)\n)\n) * 730",
+                   "instant": false
+                }
+             ],
+             "title": "Monthly Cost",
+             "type": "stat"
+          },
+          {
+             "datasource": {
+                "type": "prometheus",
+                "uid": "$datasource"
+             },
+             "description": "Projected monthly cost for CPU (compute) resources across all cluster nodes. Compare this with RAM costs to understand your compute vs. memory cost ratio and optimize instance type selection accordingly.",
+             "fieldConfig": {
+                "defaults": {
+                   "decimals": 2,
+                   "mappings": [ ],
+                   "thresholds": {
+                      "steps": [
+                         {
+                            "color": "green",
+                            "value": 0
+                         }
+                      ]
+                   },
+                   "unit": "currencyUSD"
+                },
+                "overrides": [ ]
+             },
+             "gridPos": {
+                "h": 3,
+                "w": 4,
+                "x": 8,
+                "y": 1
+             },
+             "id": 4,
+             "options": {
+                "graphMode": "none",
+                "percentChangeColorMode": "inverted",
+                "showPercentChange": true
+             },
+             "pluginVersion": "v11.4.0",
+             "targets": [
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "$datasource"
+                   },
+                   "expr": "sum(\n  sum(\n    kube_node_status_capacity{\n      cluster=\"$cluster\",\njob=\"$job\"\n,\n      resource=\"cpu\",\n      unit=\"core\"\n    }\n  ) by (node)\n  * on(node) group_left()\n    sum(\n      node_cpu_hourly_cost{\n        cluster=\"$cluster\",\njob=\"$job\"\n\n      }\n    ) by (node)\n  * 730\n)\n",
+                   "instant": false
+                }
+             ],
+             "title": "Monthly CPU Cost",
+             "type": "stat"
+          },
+          {
+             "datasource": {
+                "type": "prometheus",
+                "uid": "$datasource"
+             },
+             "description": "Projected monthly cost for RAM (memory) resources across all cluster nodes. This metric helps identify if memory is a significant cost driver and can guide decisions about node sizing and memory allocation strategies.",
+             "fieldConfig": {
+                "defaults": {
+                   "decimals": 2,
+                   "mappings": [ ],
+                   "thresholds": {
+                      "steps": [
+                         {
+                            "color": "green",
+                            "value": 0
+                         }
+                      ]
+                   },
+                   "unit": "currencyUSD"
+                },
+                "overrides": [ ]
+             },
+             "gridPos": {
+                "h": 3,
+                "w": 4,
+                "x": 12,
+                "y": 1
+             },
+             "id": 5,
+             "options": {
+                "graphMode": "none",
+                "percentChangeColorMode": "inverted",
+                "showPercentChange": true
+             },
+             "pluginVersion": "v11.4.0",
+             "targets": [
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "$datasource"
+                   },
+                   "expr": "sum(\n  sum(\n    kube_node_status_capacity{\n      cluster=\"$cluster\",\njob=\"$job\"\n,\n      resource=\"memory\",\n      unit=\"byte\"\n    }\n  ) by (node)\n  / (1024 * 1024 * 1024)\n  * on(node) group_left()\n    sum(\n      node_ram_hourly_cost{\n        cluster=\"$cluster\",\njob=\"$job\"\n\n      }\n    ) by (node)\n  * 730\n)\n",
+                   "instant": false
+                }
+             ],
+             "title": "Monthly Ram Cost",
+             "type": "stat"
+          },
+          {
+             "datasource": {
+                "type": "prometheus",
+                "uid": "$datasource"
+             },
+             "description": "Projected monthly GPU cost across the cluster. Use this to understand whether accelerator usage is a major cost driver and to spot opportunities to right-size GPU-backed workloads.",
+             "fieldConfig": {
+                "defaults": {
+                   "decimals": 2,
+                   "mappings": [ ],
+                   "thresholds": {
+                      "steps": [
+                         {
+                            "color": "green",
+                            "value": 0
+                         }
+                      ]
+                   },
+                   "unit": "currencyUSD"
+                },
+                "overrides": [ ]
+             },
+             "gridPos": {
+                "h": 3,
+                "w": 4,
+                "x": 16,
+                "y": 1
+             },
+             "id": 6,
+             "options": {
+                "graphMode": "none",
+                "percentChangeColorMode": "inverted",
+                "showPercentChange": true
+             },
+             "pluginVersion": "v11.4.0",
+             "targets": [
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "$datasource"
+                   },
+                   "expr": "sum(\n  node_gpu_hourly_cost{\n    cluster=\"$cluster\",\njob=\"$job\"\n\n  }\n) * 730\n",
+                   "instant": false
+                }
+             ],
+             "title": "Monthly GPU Cost",
+             "type": "stat"
+          },
+          {
+             "datasource": {
+                "type": "prometheus",
+                "uid": "$datasource"
+             },
+             "description": "Projected monthly cost for Persistent Volume (storage) resources across the cluster. Monitor this metric to identify unused or oversized volumes that can be optimized to reduce storage costs.",
+             "fieldConfig": {
+                "defaults": {
+                   "decimals": 2,
+                   "mappings": [ ],
+                   "thresholds": {
+                      "steps": [
+                         {
+                            "color": "green",
+                            "value": 0
+                         }
+                      ]
+                   },
+                   "unit": "currencyUSD"
+                },
+                "overrides": [ ]
+             },
+             "gridPos": {
+                "h": 3,
+                "w": 4,
+                "x": 20,
+                "y": 1
+             },
+             "id": 7,
+             "options": {
+                "graphMode": "none",
+                "percentChangeColorMode": "inverted",
+                "showPercentChange": true
+             },
+             "pluginVersion": "v11.4.0",
+             "targets": [
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "$datasource"
+                   },
+                   "expr": "sum(\n  sum(\n    kube_persistentvolume_capacity_bytes{\n      cluster=\"$cluster\",\njob=\"$job\"\n\n    } / (1024 * 1024 * 1024)\n  ) by (persistentvolume)\n  * on(persistentvolume) group_left()\n    sum(\n      pv_hourly_cost{\n        cluster=\"$cluster\",\njob=\"$job\"\n\n      }\n    ) by (persistentvolume)\n) * 730\n",
+                   "instant": false
+                }
+             ],
+             "title": "Monthly PV Cost",
+             "type": "stat"
+          },
+          {
+             "datasource": {
+                "type": "prometheus",
+                "uid": "$datasource"
+             },
+             "description": "Monthly cost distribution across resource types (CPU, RAM, Persistent Volumes, and GPU). This breakdown shows which resource category consumes the most budget, helping prioritize optimization efforts.",
+             "fieldConfig": {
+                "defaults": {
+                   "unit": "currencyUSD"
+                },
+                "overrides": [ ]
+             },
+             "gridPos": {
+                "h": 5,
+                "w": 8,
+                "x": 0,
+                "y": 5
+             },
+             "id": 8,
+             "options": {
+                "displayLabels": [
+                   "percent"
+                ],
+                "legend": {
+                   "displayMode": "table",
+                   "placement": "right",
+                   "showLegend": true,
+                   "values": [
+                      "percent",
+                      "value"
+                   ]
+                },
+                "tooltip": {
+                   "mode": "multi",
+                   "sort": "desc"
+                }
+             },
+             "pluginVersion": "v11.4.0",
+             "targets": [
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "$datasource"
+                   },
+                   "expr": "sum(\n  sum(\n    kube_node_status_capacity{\n      cluster=\"$cluster\",\njob=\"$job\"\n,\n      resource=\"cpu\",\n      unit=\"core\"\n    }\n  ) by (node)\n  * on(node) group_left()\n    sum(\n      node_cpu_hourly_cost{\n        cluster=\"$cluster\",\njob=\"$job\"\n\n      }\n    ) by (node)\n  * 730\n)\n",
+                   "instant": true,
+                   "legendFormat": "CPU"
+                },
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "$datasource"
+                   },
+                   "expr": "sum(\n  sum(\n    kube_node_status_capacity{\n      cluster=\"$cluster\",\njob=\"$job\"\n,\n      resource=\"memory\",\n      unit=\"byte\"\n    }\n  ) by (node)\n  / (1024 * 1024 * 1024)\n  * on(node) group_left()\n    sum(\n      node_ram_hourly_cost{\n        cluster=\"$cluster\",\njob=\"$job\"\n\n      }\n    ) by (node)\n  * 730\n)\n",
+                   "instant": true,
+                   "legendFormat": "RAM"
+                },
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "$datasource"
+                   },
+                   "expr": "sum(\n  sum(\n    kube_persistentvolume_capacity_bytes{\n      cluster=\"$cluster\",\njob=\"$job\"\n\n    } / (1024 * 1024 * 1024)\n  ) by (persistentvolume)\n  * on(persistentvolume) group_left()\n    sum(\n      pv_hourly_cost{\n        cluster=\"$cluster\",\njob=\"$job\"\n\n      }\n    ) by (persistentvolume)\n) * 730\n",
+                   "instant": true,
+                   "legendFormat": "PV"
+                },
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "$datasource"
+                   },
+                   "expr": "sum(\n  node_gpu_hourly_cost{\n    cluster=\"$cluster\",\njob=\"$job\"\n\n  }\n) * 730\n",
+                   "instant": true,
+                   "legendFormat": "GPU"
+                }
+             ],
+             "title": "Cost by Resource",
+             "type": "piechart"
+          },
+          {
+             "datasource": {
+                "type": "prometheus",
+                "uid": "$datasource"
+             },
+             "description": "Top 10 namespaces by monthly cost showing which teams, applications, or environments consume the most resources. Use this to allocate costs to teams, identify expensive applications, and ensure fair resource distribution across the organization.",
+             "fieldConfig": {
+                "defaults": {
+                   "unit": "currencyUSD"
+                },
+                "overrides": [ ]
+             },
+             "gridPos": {
+                "h": 5,
+                "w": 8,
+                "x": 8,
+                "y": 5
+             },
+             "id": 9,
+             "options": {
+                "displayLabels": [
+                   "percent"
+                ],
+                "legend": {
+                   "displayMode": "table",
+                   "placement": "right",
+                   "showLegend": true,
+                   "values": [
+                      "percent",
+                      "value"
+                   ]
+                },
+                "tooltip": {
+                   "mode": "multi",
+                   "sort": "desc"
+                }
+             },
+             "pluginVersion": "v11.4.0",
+             "targets": [
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "$datasource"
+                   },
+                   "expr": "topk(10,\n  sum(\n    sum(\n      container_memory_allocation_bytes{\n        cluster=\"$cluster\",\n        job=\"$job\"}\n    ) by (cluster, namespace, instance)\n    * on(cluster, instance) group_left()\n      (\n        node_ram_hourly_cost{\n          cluster=\"$cluster\",\n          job=\"$job\"} / (1024 * 1024 * 1024) * 730\n      )\n    +\n    sum(\n      container_cpu_allocation{\n        cluster=\"$cluster\",\n        job=\"$job\"}\n    ) by (cluster, namespace, instance)\n    * on(cluster, instance) group_left()\n      (\n        node_cpu_hourly_cost{\n          cluster=\"$cluster\",\n          job=\"$job\"} * 730\n      )\n  ) by (cluster, namespace)\n)\n",
+                   "instant": true,
+                   "legendFormat": "{{ namespace }}"
+                }
+             ],
+             "title": "Cost by Namespace",
+             "type": "piechart"
+          },
+          {
+             "datasource": {
+                "type": "prometheus",
+                "uid": "$datasource"
+             },
+             "description": "Top 10 instance types by monthly cost showing which VM/node types contribute most to infrastructure spending. This helps evaluate whether your instance type selection is cost-effective and identify opportunities to switch to more economical instance families.",
+             "fieldConfig": {
+                "defaults": {
+                   "unit": "currencyUSD"
+                },
+                "overrides": [ ]
+             },
+             "gridPos": {
+                "h": 5,
+                "w": 8,
+                "x": 16,
+                "y": 5
+             },
+             "id": 10,
+             "options": {
+                "displayLabels": [
+                   "percent"
+                ],
+                "legend": {
+                   "displayMode": "table",
+                   "placement": "right",
+                   "showLegend": true,
+                   "values": [
+                      "percent",
+                      "value"
+                   ]
+                },
+                "tooltip": {
+                   "mode": "multi",
+                   "sort": "desc"
+                }
+             },
+             "pluginVersion": "v11.4.0",
+             "targets": [
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "$datasource"
+                   },
+                   "expr": "topk(10,\n  sum(\n    node_total_hourly_cost{\n      cluster=\"$cluster\",\njob=\"$job\"\n\n    }\n  ) by (instance_type) * 730\n)\n",
+                   "instant": true,
+                   "legendFormat": "{{ instance_type }}"
+                }
+             ],
+             "title": "Cost by Instance Type",
+             "type": "piechart"
+          },
+          {
+             "datasource": {
+                "type": "prometheus",
+                "uid": "$datasource"
+             },
+             "description": "Hourly cost trend over time showing how infrastructure spending fluctuates throughout the day. Use this to identify cost spikes, correlate costs with workload patterns, and detect autoscaling behavior impact on spending.",
+             "fieldConfig": {
+                "defaults": {
+                   "custom": {
+                      "fillOpacity": 10
+                   },
+                   "unit": "currencyUSD"
+                },
+                "overrides": [ ]
+             },
+             "gridPos": {
+                "h": 5,
+                "w": 12,
+                "x": 0,
+                "y": 10
+             },
+             "id": 11,
+             "options": {
+                "legend": {
+                   "calcs": [
+                      "mean",
+                      "max"
+                   ],
+                   "displayMode": "table",
+                   "placement": "right",
+                   "showLegend": true,
+                   "sortBy": "Mean",
+                   "sortDesc": true
+                },
+                "tooltip": {
+                   "mode": "multi",
+                   "sort": "desc"
+                }
+             },
+             "pluginVersion": "v11.4.0",
+             "targets": [
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "$datasource"
+                   },
+                   "exemplar": false,
+                   "expr": "sum(\n  node_total_hourly_cost{\n    cluster=\"$cluster\",\njob=\"$job\"\n\n  }\n)\n+\nsum(\n  sum(\n    kube_persistentvolume_capacity_bytes{\n      cluster=\"$cluster\",\njob=\"$job\"\n\n    } / (1024 * 1024 * 1024)\n  ) by (persistentvolume)\n  * on(persistentvolume) group_left()\n  sum(\n    pv_hourly_cost{\n      cluster=\"$cluster\",\njob=\"$job\"\n\n    }\n  ) by (persistentvolume)\n)\n",
+                   "legendFormat": "Hourly Cost"
+                }
+             ],
+             "title": "Hourly Cost",
+             "type": "timeseries"
+          },
+          {
+             "datasource": {
+                "type": "prometheus",
+                "uid": "$datasource"
+             },
+             "description": "Monthly cost projection trend over time. This visualization helps track how your projected monthly spending evolves and whether you are staying within budget throughout the billing period.",
+             "fieldConfig": {
+                "defaults": {
+                   "custom": {
+                      "fillOpacity": 10
+                   },
+                   "unit": "currencyUSD"
+                },
+                "overrides": [ ]
+             },
+             "gridPos": {
+                "h": 5,
+                "w": 12,
+                "x": 12,
+                "y": 10
+             },
+             "id": 12,
+             "options": {
+                "legend": {
+                   "calcs": [
+                      "mean",
+                      "max"
+                   ],
+                   "displayMode": "table",
+                   "placement": "right",
+                   "showLegend": true,
+                   "sortBy": "Mean",
+                   "sortDesc": true
+                },
+                "tooltip": {
+                   "mode": "multi",
+                   "sort": "desc"
+                }
+             },
+             "pluginVersion": "v11.4.0",
+             "targets": [
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "$datasource"
+                   },
+                   "exemplar": false,
+                   "expr": "(sum(\n  node_total_hourly_cost{\n    cluster=\"$cluster\",\njob=\"$job\"\n\n  }\n)\n+\nsum(\n  sum(\n    kube_persistentvolume_capacity_bytes{\n      cluster=\"$cluster\",\njob=\"$job\"\n\n    } / (1024 * 1024 * 1024)\n  ) by (persistentvolume)\n  * on(persistentvolume) group_left()\n  sum(\n    pv_hourly_cost{\n      cluster=\"$cluster\",\njob=\"$job\"\n\n    }\n  ) by (persistentvolume)\n)\n) * 730",
+                   "interval": "30m",
+                   "legendFormat": "Monthly Cost"
+                }
+             ],
+             "title": "Monthly Cost",
+             "type": "timeseries"
+          },
+          {
+             "datasource": {
+                "type": "prometheus",
+                "uid": "$datasource"
+             },
+             "description": "Cost variance comparing current hourly costs against 7-day and 30-day historical averages. Positive values indicate costs are higher than average, negative values indicate lower costs. Use this to detect cost anomalies and unusual spending patterns that may require investigation.",
+             "fieldConfig": {
+                "defaults": {
+                   "custom": {
+                      "fillOpacity": 10
+                   },
+                   "unit": "percentunit"
+                },
+                "overrides": [ ]
+             },
+             "gridPos": {
+                "h": 5,
+                "w": 12,
+                "x": 0,
+                "y": 15
+             },
+             "id": 13,
+             "options": {
+                "legend": {
+                   "calcs": [
+                      "mean",
+                      "max"
+                   ],
+                   "displayMode": "table",
+                   "placement": "right",
+                   "showLegend": true,
+                   "sortBy": "Mean",
+                   "sortDesc": true
+                },
+                "tooltip": {
+                   "mode": "multi",
+                   "sort": "desc"
+                }
+             },
+             "pluginVersion": "v11.4.0",
+             "targets": [
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "$datasource"
+                   },
+                   "exemplar": false,
+                   "expr": "(\n  avg_over_time(\n    sum(\n      node_total_hourly_cost{\n        cluster=\"$cluster\",\njob=\"$job\"\n\n      }\n    ) [1d:1h]\n  )\n  -\n  avg_over_time(\n    sum(\n      node_total_hourly_cost{\n        cluster=\"$cluster\",\njob=\"$job\"\n\n      }\n    ) [7d:1h]\n  )\n)\n/\navg_over_time(\n  sum(\n    node_total_hourly_cost{\n      cluster=\"$cluster\",\njob=\"$job\"\n\n    }\n  ) [7d:1h]\n)\n",
+                   "interval": "30m",
+                   "legendFormat": "Current hourly cost vs. 7-day average"
+                },
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "$datasource"
+                   },
+                   "exemplar": false,
+                   "expr": "(\n  avg_over_time(\n    sum(\n      node_total_hourly_cost{\n        cluster=\"$cluster\",\njob=\"$job\"\n\n      }\n    ) [1d:1h]\n  )\n  -\n  avg_over_time(\n    sum(\n      node_total_hourly_cost{\n        cluster=\"$cluster\",\njob=\"$job\"\n\n      }\n    ) [30d:1h]\n  )\n)\n/\navg_over_time(\n  sum(\n    node_total_hourly_cost{\n      cluster=\"$cluster\",\njob=\"$job\"\n\n    }\n  ) [30d:1h]\n)\n",
+                   "interval": "30m",
+                   "legendFormat": "Current hourly cost vs. 30-day average"
+                }
+             ],
+             "title": "Total Cost Variance",
+             "type": "timeseries"
+          },
+          {
+             "datasource": {
+                "type": "prometheus",
+                "uid": "$datasource"
+             },
+             "description": "Resource-specific cost variance comparing current CPU, RAM, and PV costs against their 30-day historical averages. This breakdown helps identify which resource type is driving cost changes - useful for pinpointing whether cost increases are due to compute scaling, memory usage, or storage growth.",
+             "fieldConfig": {
+                "defaults": {
+                   "custom": {
+                      "fillOpacity": 10
+                   },
+                   "unit": "percentunit"
+                },
+                "overrides": [ ]
+             },
+             "gridPos": {
+                "h": 5,
+                "w": 12,
+                "x": 12,
+                "y": 15
+             },
+             "id": 14,
+             "options": {
+                "legend": {
+                   "calcs": [
+                      "mean",
+                      "max"
+                   ],
+                   "displayMode": "table",
+                   "placement": "right",
+                   "showLegend": true,
+                   "sortBy": "Mean",
+                   "sortDesc": true
+                },
+                "tooltip": {
+                   "mode": "multi",
+                   "sort": "desc"
+                }
+             },
+             "pluginVersion": "v11.4.0",
+             "targets": [
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "$datasource"
+                   },
+                   "exemplar": false,
+                   "expr": "(\n  avg_over_time(\n    sum(\n  sum(\n    kube_node_status_capacity{\n      cluster=\"$cluster\",\njob=\"$job\"\n,\n      resource=\"cpu\",\n      unit=\"core\"\n    }\n  ) by (node)\n  * on(node) group_left()\n    sum(\n      node_cpu_hourly_cost{\n        cluster=\"$cluster\",\njob=\"$job\"\n\n      }\n    ) by (node)\n  * 730\n)\n [1d:1h]\n  )\n  -\n  avg_over_time(\n    sum(\n  sum(\n    kube_node_status_capacity{\n      cluster=\"$cluster\",\njob=\"$job\"\n,\n      resource=\"cpu\",\n      unit=\"core\"\n    }\n  ) by (node)\n  * on(node) group_left()\n    sum(\n      node_cpu_hourly_cost{\n        cluster=\"$cluster\",\njob=\"$job\"\n\n      }\n    ) by (node)\n  * 730\n)\n [30d:1h]\n  )\n)\n/\navg_over_time(\n  sum(\n  sum(\n    kube_node_status_capacity{\n      cluster=\"$cluster\",\njob=\"$job\"\n,\n      resource=\"cpu\",\n      unit=\"core\"\n    }\n  ) by (node)\n  * on(node) group_left()\n    sum(\n      node_cpu_hourly_cost{\n        cluster=\"$cluster\",\njob=\"$job\"\n\n      }\n    ) by (node)\n  * 730\n)\n [30d:1h]\n)\n",
+                   "interval": "30m",
+                   "legendFormat": "CPU Cost vs. 30-day average"
+                },
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "$datasource"
+                   },
+                   "exemplar": false,
+                   "expr": "(\n  avg_over_time(\n    sum(\n  sum(\n    kube_node_status_capacity{\n      cluster=\"$cluster\",\njob=\"$job\"\n,\n      resource=\"memory\",\n      unit=\"byte\"\n    }\n  ) by (node)\n  / (1024 * 1024 * 1024)\n  * on(node) group_left()\n    sum(\n      node_ram_hourly_cost{\n        cluster=\"$cluster\",\njob=\"$job\"\n\n      }\n    ) by (node)\n  * 730\n)\n [1d:1h]\n  )\n  -\n  avg_over_time(\n    sum(\n  sum(\n    kube_node_status_capacity{\n      cluster=\"$cluster\",\njob=\"$job\"\n,\n      resource=\"memory\",\n      unit=\"byte\"\n    }\n  ) by (node)\n  / (1024 * 1024 * 1024)\n  * on(node) group_left()\n    sum(\n      node_ram_hourly_cost{\n        cluster=\"$cluster\",\njob=\"$job\"\n\n      }\n    ) by (node)\n  * 730\n)\n [30d:1h]\n  )\n)\n/\navg_over_time(\n  sum(\n  sum(\n    kube_node_status_capacity{\n      cluster=\"$cluster\",\njob=\"$job\"\n,\n      resource=\"memory\",\n      unit=\"byte\"\n    }\n  ) by (node)\n  / (1024 * 1024 * 1024)\n  * on(node) group_left()\n    sum(\n      node_ram_hourly_cost{\n        cluster=\"$cluster\",\njob=\"$job\"\n\n      }\n    ) by (node)\n  * 730\n)\n [30d:1h]\n)\n",
+                   "interval": "30m",
+                   "legendFormat": "RAM Cost vs. 30-day average"
+                },
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "$datasource"
+                   },
+                   "exemplar": false,
+                   "expr": "(\n  avg_over_time(\n    (sum(\n  sum(\n    kube_persistentvolume_capacity_bytes{\n      cluster=\"$cluster\",\njob=\"$job\"\n\n    } / (1024 * 1024 * 1024)\n  ) by (persistentvolume)\n  * on(persistentvolume) group_left()\n    sum(\n      pv_hourly_cost{\n        cluster=\"$cluster\",\njob=\"$job\"\n\n      }\n    ) by (persistentvolume)\n) * 730\n) [1d:1h]\n  )\n  -\n  avg_over_time(\n    (sum(\n  sum(\n    kube_persistentvolume_capacity_bytes{\n      cluster=\"$cluster\",\njob=\"$job\"\n\n    } / (1024 * 1024 * 1024)\n  ) by (persistentvolume)\n  * on(persistentvolume) group_left()\n    sum(\n      pv_hourly_cost{\n        cluster=\"$cluster\",\njob=\"$job\"\n\n      }\n    ) by (persistentvolume)\n) * 730\n) [30d:1h]\n  )\n)\n/\navg_over_time(\n  (sum(\n  sum(\n    kube_persistentvolume_capacity_bytes{\n      cluster=\"$cluster\",\njob=\"$job\"\n\n    } / (1024 * 1024 * 1024)\n  ) by (persistentvolume)\n  * on(persistentvolume) group_left()\n    sum(\n      pv_hourly_cost{\n        cluster=\"$cluster\",\njob=\"$job\"\n\n      }\n    ) by (persistentvolume)\n) * 730\n) [30d:1h]\n)\n",
+                   "interval": "30m",
+                   "legendFormat": "PV Cost vs. 30-day average"
+                }
+             ],
+             "title": "Resource Cost Variance",
+             "type": "timeseries"
+          },
+          {
+             "collapsed": false,
+             "gridPos": {
+                "h": 1,
+                "w": 24,
+                "x": 0,
+                "y": 20
+             },
+             "id": 15,
+             "title": "Cloud Resources",
+             "type": "row"
+          },
+          {
+             "datasource": {
+                "type": "prometheus",
+                "uid": "$datasource"
+             },
+             "description": "Detailed breakdown of monthly costs per node, showing CPU cost, RAM cost, and total cost for each node along with instance type and architecture. Sorted by total cost to highlight the most expensive nodes. Use this to identify underutilized expensive nodes that could be downsized or removed.",
+             "fieldConfig": {
+                "defaults": {
+                   "links": [ ],
+                   "thresholds": {
+                      "steps": [ ]
+                   },
+                   "unit": "currencyUSD"
+                },
+                "overrides": [ ]
+             },
+             "gridPos": {
+                "h": 10,
+                "w": 16,
+                "x": 0,
+                "y": 21
+             },
+             "id": 16,
+             "options": {
+                "footer": {
+                   "enablePagination": true
+                },
+                "sortBy": [
+                   {
+                      "desc": true,
+                      "displayName": "Total Cost"
+                   }
+                ]
+             },
+             "pluginVersion": "v11.4.0",
+             "targets": [
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "$datasource"
+                   },
+                   "expr": "sum(\n  kube_node_status_capacity{\n    cluster=\"$cluster\",\njob=\"$job\"\n,\n    resource=\"cpu\",\n    unit=\"core\"\n  }\n) by (node)\n* on(node) group_left(cluster, instance_type, arch)\n  sum(\n    node_cpu_hourly_cost{\n      cluster=\"$cluster\",\njob=\"$job\"\n,\n    }\n  ) by (node, instance_type, arch)\n* 730\n",
+                   "format": "table",
+                   "instant": true
+                },
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "$datasource"
+                   },
+                   "expr": "sum(\n  kube_node_status_capacity{\n    cluster=\"$cluster\",\njob=\"$job\"\n,\n    resource=\"memory\",\n    unit=\"byte\"\n  }\n) by (node)\n/ (1024 * 1024 * 1024)\n* on(node) group_left(cluster, instance_type, arch)\n  sum(\n    node_ram_hourly_cost{\n      cluster=\"$cluster\",\njob=\"$job\"\n\n    }\n  ) by (node, instance_type, arch)\n* 730\n",
+                   "format": "table",
+                   "instant": true
+                },
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "$datasource"
+                   },
+                   "expr": "sum(\n  node_total_hourly_cost{\n    cluster=\"$cluster\",\njob=\"$job\"\n\n  }\n) by (node, instance_type, arch)\n* 730\n",
+                   "format": "table",
+                   "instant": true
+                }
+             ],
+             "title": "Nodes Monthly Cost",
+             "transformations": [
+                {
+                   "id": "merge"
+                },
+                {
+                   "id": "organize",
+                   "options": {
+                      "excludeByName": {
+                         "Time": true,
+                         "job": true
+                      },
+                      "indexByName": {
+                         "Value #A": 3,
+                         "Value #B": 4,
+                         "Value #C": 5,
+                         "arch": 2,
+                         "instance_type": 1,
+                         "node": 0
+                      },
+                      "renameByName": {
+                         "Value #A": "CPU Cost",
+                         "Value #B": "RAM Cost",
+                         "Value #C": "Total Cost",
+                         "arch": "Architecture",
+                         "instance_type": "Instance Type",
+                         "node": "Node"
+                      }
+                   }
+                }
+             ],
+             "type": "table"
+          },
+          {
+             "datasource": {
+                "type": "prometheus",
+                "uid": "$datasource"
+             },
+             "description": "List of all Persistent Volumes with their capacity (in GiB) and monthly cost, sorted by total cost. Use this to identify large or expensive volumes that may be candidates for cleanup, resizing, or migration to cheaper storage classes.",
+             "fieldConfig": {
+                "defaults": {
+                   "links": [ ],
+                   "thresholds": {
+                      "steps": [ ]
+                   },
+                   "unit": "decgbytes"
+                },
+                "overrides": [
+                   {
+                      "matcher": {
+                         "id": "byName",
+                         "options": "Total Cost"
+                      },
+                      "properties": [
+                         {
+                            "id": "unit",
+                            "value": "currencyUSD"
+                         }
+                      ]
+                   }
+                ]
+             },
+             "gridPos": {
+                "h": 10,
+                "w": 8,
+                "x": 16,
+                "y": 21
+             },
+             "id": 17,
+             "options": {
+                "footer": {
+                   "enablePagination": true
+                },
+                "sortBy": [
+                   {
+                      "desc": true,
+                      "displayName": "Total Cost"
+                   }
+                ]
+             },
+             "pluginVersion": "v11.4.0",
+             "targets": [
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "$datasource"
+                   },
+                   "expr": "sum(\n  kube_persistentvolume_capacity_bytes{\n    cluster=\"$cluster\",\njob=\"$job\"\n\n  }\n  / 1024 / 1024 / 1024\n) by (persistentvolume)\n",
+                   "format": "table",
+                   "instant": true
+                },
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "$datasource"
+                   },
+                   "expr": "sum(\n  kube_persistentvolume_capacity_bytes{\n    cluster=\"$cluster\",\njob=\"$job\"\n\n  }\n  / 1024 / 1024 / 1024\n) by (persistentvolume)\n*\nsum(\n  pv_hourly_cost{\n    cluster=\"$cluster\",\njob=\"$job\"\n\n  }\n  * 730\n) by (persistentvolume)\n",
+                   "format": "table",
+                   "instant": true
+                }
+             ],
+             "title": "Persistent Volumes Monthly Cost",
+             "transformations": [
+                {
+                   "id": "merge"
+                },
+                {
+                   "id": "organize",
+                   "options": {
+                      "excludeByName": {
+                         "Time": true,
+                         "job": true
+                      },
+                      "indexByName": {
+                         "Value #A": 1,
+                         "Value #B": 2,
+                         "persistentvolume": 0
+                      },
+                      "renameByName": {
+                         "Value #A": "Total GiB",
+                         "Value #B": "Total Cost",
+                         "persistentvolume": "Persistent Volume"
+                      }
+                   }
+                }
+             ],
+             "type": "table"
+          },
+          {
+             "collapsed": false,
+             "gridPos": {
+                "h": 1,
+                "w": 24,
+                "x": 0,
+                "y": 31
+             },
+             "id": 18,
+             "title": "Namespace Summary",
+             "type": "row"
+          },
+          {
+             "datasource": {
+                "type": "prometheus",
+                "uid": "$datasource"
+             },
+             "description": "Top 10 namespaces by current monthly cost with percentage change compared to 7 days and 30 days ago. Positive percentages indicate cost increases (red), negative percentages indicate cost decreases (green). Click on a namespace name to drill down into detailed pod and container costs. Use this to track namespace-level spending trends and identify teams or applications with growing costs.",
+             "fieldConfig": {
+                "defaults": {
+                   "links": [ ],
+                   "thresholds": {
+                      "steps": [
+                         {
+                            "color": "green",
+                            "value": 0
+                         },
+                         {
+                            "color": "yellow",
+                            "value": 5
+                         },
+                         {
+                            "color": "red",
+                            "value": 10
+                         }
+                      ]
+                   },
+                   "unit": "currencyUSD"
+                },
+                "overrides": [
+                   {
+                      "matcher": {
+                         "id": "byName",
+                         "options": "Cost Change vs 7d Ago (%)"
+                      },
+                      "properties": [
+                         {
+                            "id": "color",
+                            "value": {
+                               "mode": "thresholds"
+                            }
+                         },
+                         {
+                            "id": "custom.cellOptions",
+                            "value": {
+                               "type": "color-background"
+                            }
+                         },
+                         {
+                            "id": "unit",
+                            "value": "percent"
+                         }
+                      ]
+                   },
+                   {
+                      "matcher": {
+                         "id": "byName",
+                         "options": "Cost Change vs 30d Ago (%)"
+                      },
+                      "properties": [
+                         {
+                            "id": "color",
+                            "value": {
+                               "mode": "thresholds"
+                            }
+                         },
+                         {
+                            "id": "custom.cellOptions",
+                            "value": {
+                               "type": "color-background"
+                            }
+                         },
+                         {
+                            "id": "unit",
+                            "value": "percent"
+                         }
+                      ]
+                   },
+                   {
+                      "matcher": {
+                         "id": "byName",
+                         "options": "Namespace"
+                      },
+                      "properties": [
+                         {
+                            "id": "links",
+                            "value": [
+                               {
+                                  "targetBlank": true,
+                                  "title": "Go To Namespace",
+                                  "type": "dashboard",
+                                  "url": "/d/opencost-mixin-namespace-jkwq/opencost-namespace?var-cluster=${__data.fields.cluster}&var-job=$job&var-namespace=${__data.fields.Namespace}"
+                               }
+                            ]
+                         }
+                      ]
+                   }
+                ]
+             },
+             "gridPos": {
+                "h": 12,
+                "w": 24,
+                "x": 0,
+                "y": 32
+             },
+             "id": 19,
+             "options": {
+                "footer": {
+                   "enablePagination": true
+                },
+                "sortBy": [
+                   {
+                      "desc": true,
+                      "displayName": "Monthly Cost"
+                   }
+                ]
+             },
+             "pluginVersion": "v11.4.0",
+             "targets": [
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "$datasource"
+                   },
+                   "expr": "topk(10,\n  sum(\n    sum(\n      container_memory_allocation_bytes{\n        cluster=\"$cluster\",\n        job=\"$job\"}\n    ) by (cluster, namespace, instance)\n    * on(cluster, instance) group_left()\n      (\n        node_ram_hourly_cost{\n          cluster=\"$cluster\",\n          job=\"$job\"} / (1024 * 1024 * 1024) * 730\n      )\n    +\n    sum(\n      container_cpu_allocation{\n        cluster=\"$cluster\",\n        job=\"$job\"}\n    ) by (cluster, namespace, instance)\n    * on(cluster, instance) group_left()\n      (\n        node_cpu_hourly_cost{\n          cluster=\"$cluster\",\n          job=\"$job\"} * 730\n      )\n  ) by (cluster, namespace)\n)\n",
+                   "format": "table",
+                   "instant": true
+                },
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "$datasource"
+                   },
+                   "expr": "topk(10,\n  sum(\n    sum(\n      container_memory_allocation_bytes{\n        cluster=\"$cluster\",\n        job=\"$job\"}\n    ) by (cluster, namespace, instance)\n    * on(cluster, instance) group_left()\n      (\n        node_ram_hourly_cost{\n          cluster=\"$cluster\",\n          job=\"$job\"} / (1024 * 1024 * 1024) * 730\n      )\n    +\n    sum(\n      container_cpu_allocation{\n        cluster=\"$cluster\",\n        job=\"$job\"}\n    ) by (cluster, namespace, instance)\n    * on(cluster, instance) group_left()\n      (\n        node_cpu_hourly_cost{\n          cluster=\"$cluster\",\n          job=\"$job\"} * 730\n      )\n  ) by (cluster, namespace)\n)\n\n/\ntopk(10,\n  sum(\n    sum(\n      container_memory_allocation_bytes{\n        cluster=\"$cluster\",\n        job=\"$job\"} offset 7d\n    ) by (cluster, namespace, instance)\n    * on(cluster, instance) group_left()\n      (\n        node_ram_hourly_cost{\n          cluster=\"$cluster\",\n          job=\"$job\"} offset 7d / (1024 * 1024 * 1024) * 730\n      )\n    +\n    sum(\n      container_cpu_allocation{\n        cluster=\"$cluster\",\n        job=\"$job\"} offset 7d\n    ) by (cluster, namespace, instance)\n    * on(cluster, instance) group_left()\n      (\n        node_cpu_hourly_cost{\n          cluster=\"$cluster\",\n          job=\"$job\"} offset 7d * 730\n      )\n  ) by (cluster, namespace)\n)\n\n* 100\n- 100\n",
+                   "format": "table",
+                   "instant": true
+                },
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "$datasource"
+                   },
+                   "expr": "topk(10,\n  sum(\n    sum(\n      container_memory_allocation_bytes{\n        cluster=\"$cluster\",\n        job=\"$job\"}\n    ) by (cluster, namespace, instance)\n    * on(cluster, instance) group_left()\n      (\n        node_ram_hourly_cost{\n          cluster=\"$cluster\",\n          job=\"$job\"} / (1024 * 1024 * 1024) * 730\n      )\n    +\n    sum(\n      container_cpu_allocation{\n        cluster=\"$cluster\",\n        job=\"$job\"}\n    ) by (cluster, namespace, instance)\n    * on(cluster, instance) group_left()\n      (\n        node_cpu_hourly_cost{\n          cluster=\"$cluster\",\n          job=\"$job\"} * 730\n      )\n  ) by (cluster, namespace)\n)\n\n/\ntopk(10,\n  sum(\n    sum(\n      container_memory_allocation_bytes{\n        cluster=\"$cluster\",\n        job=\"$job\"} offset 30d\n    ) by (cluster, namespace, instance)\n    * on(cluster, instance) group_left()\n      (\n        node_ram_hourly_cost{\n          cluster=\"$cluster\",\n          job=\"$job\"} offset 30d / (1024 * 1024 * 1024) * 730\n      )\n    +\n    sum(\n      container_cpu_allocation{\n        cluster=\"$cluster\",\n        job=\"$job\"} offset 30d\n    ) by (cluster, namespace, instance)\n    * on(cluster, instance) group_left()\n      (\n        node_cpu_hourly_cost{\n          cluster=\"$cluster\",\n          job=\"$job\"} offset 30d * 730\n      )\n  ) by (cluster, namespace)\n)\n\n* 100\n- 100\n",
+                   "format": "table",
+                   "instant": true
+                }
+             ],
+             "title": "Namespace Monthly Cost",
+             "transformations": [
+                {
+                   "id": "merge"
+                },
+                {
+                   "id": "organize",
+                   "options": {
+                      "excludeByName": {
+                         "Time": true,
+                         "job": true
+                      },
+                      "indexByName": {
+                         "Value #A": 1,
+                         "Value #B": 2,
+                         "Value #C": 3,
+                         "namespace": 0
+                      },
+                      "renameByName": {
+                         "Value #A": "Monthly Cost",
+                         "Value #B": "Cost Change vs 7d Ago (%)",
+                         "Value #C": "Cost Change vs 30d Ago (%)",
+                         "namespace": "Namespace"
+                      }
+                   }
+                }
+             ],
+             "type": "table"
+          }
+       ],
+       "schemaVersion": 39,
+       "tags": [
+          "opencost",
+          "opencost-mixin"
+       ],
+       "templating": {
+          "list": [
+             {
+                "current": {
+                   "selected": true,
+                   "text": "default",
+                   "value": "default"
+                },
+                "label": "Data source",
+                "name": "datasource",
+                "query": "prometheus",
+                "type": "datasource"
+             },
+             {
+                "datasource": {
+                   "type": "prometheus",
+                   "uid": "${datasource}"
+                },
+                "hide": 2,
+                "label": "Cluster",
+                "name": "cluster",
+                "query": "label_values(opencost_build_info{}, cluster)",
+                "refresh": 2,
+                "sort": 1,
+                "type": "query"
+             },
+             {
+                "datasource": {
+                   "type": "prometheus",
+                   "uid": "${datasource}"
+                },
+                "includeAll": false,
+                "label": "Job",
+                "multi": false,
+                "name": "job",
+                "query": "label_values(opencost_build_info{cluster=\"$cluster\"}, job)",
+                "refresh": 2,
+                "sort": 1,
+                "type": "query"
+             }
+          ]
+       },
+       "time": {
+          "from": "now-2d",
+          "to": "now"
+       },
+       "timezone": "utc",
+       "title": "OpenCost / Overview",
+       "uid": "opencost-mixin-kover-jkwq"
+    }
+kind: ConfigMap
+metadata:
+  labels:
+    grafana_dashboard: "1"
+  name: grafana-dashboard-opencost-overview
+  namespace: monitoring
+---
+apiVersion: v1
+data:
+  opencost-workload.json: |
+    {
+       "__inputs": [ ],
+       "__requires": [ ],
+       "annotations": {
+          "list": [ ]
+       },
+       "description": "A workload-focused OpenCost dashboard that breaks down cost inside a namespace using workload ownership labels. It mirrors the existing mixin style while adding workload_type and workload selectors so teams can inspect workload-level monthly, daily, and hourly cost drivers across RAM, CPU, persistent volume, and GPU usage. This dashboard depends on the workload recording rules shipped with the mixin on GitHub. Time-based workload cost views are smoothed with 1-hour averages sampled every 5 minutes (`[1h:5m]`). The dashboards were generated using [opencost-mixin](https://github.com/adinhodovic/opencost-mixin). Open issues and create feature requests in the repository.",
+       "editable": false,
+       "links": [
+          {
+             "asDropdown": true,
+             "includeVars": false,
+             "keepTime": true,
+             "tags": [
+                "opencost",
+                "opencost-mixin"
+             ],
+             "targetBlank": true,
+             "title": "OpenCost",
+             "type": "dashboards"
+          }
+       ],
+       "panels": [
+          {
+             "collapsed": false,
+             "gridPos": {
+                "h": 1,
+                "w": 24,
+                "x": 0,
+                "y": 0
+             },
+             "id": 1,
+             "title": "Workload Summary",
+             "type": "row"
+          },
+          {
+             "datasource": {
+                "type": "prometheus",
+                "uid": "$datasource"
+             },
+             "description": "Smoothed current hourly cost rate for the selected workload scope. The query averages the workload recording rules over the last hour using a 5-minute step (`[1h:5m]`) and combines RAM, CPU, persistent volume, and GPU costs for the selected `workload_type / workload` pairs.",
+             "fieldConfig": {
+                "defaults": {
+                   "decimals": 2,
+                   "mappings": [ ],
+                   "thresholds": {
+                      "steps": [
+                         {
+                            "color": "green",
+                            "value": 0
+                         }
+                      ]
+                   },
+                   "unit": "currencyUSD"
+                },
+                "overrides": [ ]
+             },
+             "gridPos": {
+                "h": 3,
+                "w": 4,
+                "x": 0,
+                "y": 1
+             },
+             "id": 2,
+             "options": {
+                "graphMode": "none",
+                "percentChangeColorMode": "standard",
+                "showPercentChange": false
+             },
+             "pluginVersion": "v11.4.0",
+             "targets": [
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "$datasource"
+                   },
+                   "expr": "sum((\n  sum by (cluster, namespace, workload_type, workload) (\n  avg_over_time(workload:opencost_ram_cost:sum{cluster=\"$cluster\",\nnamespace=\"$namespace\",\nworkload_type=~\"$workload_type\",\nworkload=~\"$workload\"\n}[1h:5m])\n)\n\n  +\n  sum by (cluster, namespace, workload_type, workload) (\n  avg_over_time(workload:opencost_cpu_cost:sum{cluster=\"$cluster\",\nnamespace=\"$namespace\",\nworkload_type=~\"$workload_type\",\nworkload=~\"$workload\"\n}[1h:5m])\n)\n\n)\n+\n(\n  sum by (cluster, namespace, workload_type, workload) (\n  avg_over_time(workload:opencost_pvc_cost:sum{cluster=\"$cluster\",\nnamespace=\"$namespace\",\nworkload_type=~\"$workload_type\",\nworkload=~\"$workload\"\n}[1h:5m])\n)\n\n  or (sum by (cluster, namespace, workload_type, workload) (\n  avg_over_time(workload:opencost_ram_cost:sum{cluster=\"$cluster\",\nnamespace=\"$namespace\",\nworkload_type=~\"$workload_type\",\nworkload=~\"$workload\"\n}[1h:5m])\n)\n * 0)\n)\n+\n(\n  sum by (cluster, namespace, workload_type, workload) (\n  avg_over_time(workload:opencost_gpu_cost:sum{cluster=\"$cluster\",\nnamespace=\"$namespace\",\nworkload_type=~\"$workload_type\",\nworkload=~\"$workload\"\n}[1h:5m])\n)\n\n  or (sum by (cluster, namespace, workload_type, workload) (\n  avg_over_time(workload:opencost_ram_cost:sum{cluster=\"$cluster\",\nnamespace=\"$namespace\",\nworkload_type=~\"$workload_type\",\nworkload=~\"$workload\"\n}[1h:5m])\n)\n * 0)\n)\n) or vector(0)",
+                   "instant": false
+                }
+             ],
+             "title": "Hourly Cost",
+             "type": "stat"
+          },
+          {
+             "datasource": {
+                "type": "prometheus",
+                "uid": "$datasource"
+             },
+             "description": "Projected monthly cost for the selected workload scope using the smoothed hourly rate multiplied across a 730-hour month. This is useful for estimating steady-state spend for the selected workloads.",
+             "fieldConfig": {
+                "defaults": {
+                   "decimals": 2,
+                   "mappings": [ ],
+                   "thresholds": {
+                      "steps": [
+                         {
+                            "color": "green",
+                            "value": 0
+                         }
+                      ]
+                   },
+                   "unit": "currencyUSD"
+                },
+                "overrides": [ ]
+             },
+             "gridPos": {
+                "h": 3,
+                "w": 4,
+                "x": 4,
+                "y": 1
+             },
+             "id": 3,
+             "options": {
+                "graphMode": "none",
+                "percentChangeColorMode": "standard",
+                "showPercentChange": false
+             },
+             "pluginVersion": "v11.4.0",
+             "targets": [
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "$datasource"
+                   },
+                   "expr": "sum(((\n  sum by (cluster, namespace, workload_type, workload) (\n  avg_over_time(workload:opencost_ram_cost:sum{cluster=\"$cluster\",\nnamespace=\"$namespace\",\nworkload_type=~\"$workload_type\",\nworkload=~\"$workload\"\n}[1h:5m])\n)\n\n  +\n  sum by (cluster, namespace, workload_type, workload) (\n  avg_over_time(workload:opencost_cpu_cost:sum{cluster=\"$cluster\",\nnamespace=\"$namespace\",\nworkload_type=~\"$workload_type\",\nworkload=~\"$workload\"\n}[1h:5m])\n)\n\n)\n+\n(\n  sum by (cluster, namespace, workload_type, workload) (\n  avg_over_time(workload:opencost_pvc_cost:sum{cluster=\"$cluster\",\nnamespace=\"$namespace\",\nworkload_type=~\"$workload_type\",\nworkload=~\"$workload\"\n}[1h:5m])\n)\n\n  or (sum by (cluster, namespace, workload_type, workload) (\n  avg_over_time(workload:opencost_ram_cost:sum{cluster=\"$cluster\",\nnamespace=\"$namespace\",\nworkload_type=~\"$workload_type\",\nworkload=~\"$workload\"\n}[1h:5m])\n)\n * 0)\n)\n+\n(\n  sum by (cluster, namespace, workload_type, workload) (\n  avg_over_time(workload:opencost_gpu_cost:sum{cluster=\"$cluster\",\nnamespace=\"$namespace\",\nworkload_type=~\"$workload_type\",\nworkload=~\"$workload\"\n}[1h:5m])\n)\n\n  or (sum by (cluster, namespace, workload_type, workload) (\n  avg_over_time(workload:opencost_ram_cost:sum{cluster=\"$cluster\",\nnamespace=\"$namespace\",\nworkload_type=~\"$workload_type\",\nworkload=~\"$workload\"\n}[1h:5m])\n)\n * 0)\n)\n) * 730) or vector(0)",
+                   "instant": false
+                }
+             ],
+             "title": "Monthly Cost",
+             "type": "stat"
+          },
+          {
+             "datasource": {
+                "type": "prometheus",
+                "uid": "$datasource"
+             },
+             "description": "Projected monthly CPU cost for the selected `workload_type / workload` selection, derived from the workload CPU cost recording rule and scaled to a 730-hour month.",
+             "fieldConfig": {
+                "defaults": {
+                   "decimals": 2,
+                   "mappings": [ ],
+                   "thresholds": {
+                      "steps": [
+                         {
+                            "color": "green",
+                            "value": 0
+                         }
+                      ]
+                   },
+                   "unit": "currencyUSD"
+                },
+                "overrides": [ ]
+             },
+             "gridPos": {
+                "h": 3,
+                "w": 4,
+                "x": 8,
+                "y": 1
+             },
+             "id": 4,
+             "options": {
+                "graphMode": "none",
+                "percentChangeColorMode": "standard",
+                "showPercentChange": false
+             },
+             "pluginVersion": "v11.4.0",
+             "targets": [
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "$datasource"
+                   },
+                   "expr": "sum((sum by (cluster, namespace, workload_type, workload) (\n  avg_over_time(workload:opencost_cpu_cost:sum{cluster=\"$cluster\",\nnamespace=\"$namespace\",\nworkload_type=~\"$workload_type\",\nworkload=~\"$workload\"\n}[1h:5m])\n)\n) * 730) or vector(0)",
+                   "instant": false
+                }
+             ],
+             "title": "Monthly CPU Cost",
+             "type": "stat"
+          },
+          {
+             "datasource": {
+                "type": "prometheus",
+                "uid": "$datasource"
+             },
+             "description": "Projected monthly memory cost for the selected `workload_type / workload` selection, derived from the workload RAM cost recording rule and scaled to a 730-hour month.",
+             "fieldConfig": {
+                "defaults": {
+                   "decimals": 2,
+                   "mappings": [ ],
+                   "thresholds": {
+                      "steps": [
+                         {
+                            "color": "green",
+                            "value": 0
+                         }
+                      ]
+                   },
+                   "unit": "currencyUSD"
+                },
+                "overrides": [ ]
+             },
+             "gridPos": {
+                "h": 3,
+                "w": 4,
+                "x": 12,
+                "y": 1
+             },
+             "id": 5,
+             "options": {
+                "graphMode": "none",
+                "percentChangeColorMode": "standard",
+                "showPercentChange": false
+             },
+             "pluginVersion": "v11.4.0",
+             "targets": [
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "$datasource"
+                   },
+                   "expr": "sum((sum by (cluster, namespace, workload_type, workload) (\n  avg_over_time(workload:opencost_ram_cost:sum{cluster=\"$cluster\",\nnamespace=\"$namespace\",\nworkload_type=~\"$workload_type\",\nworkload=~\"$workload\"\n}[1h:5m])\n)\n) * 730) or vector(0)",
+                   "instant": false
+                }
+             ],
+             "title": "Monthly Ram Cost",
+             "type": "stat"
+          },
+          {
+             "datasource": {
+                "type": "prometheus",
+                "uid": "$datasource"
+             },
+             "description": "Projected monthly GPU cost for the selected `workload_type / workload` selection, derived from the workload GPU cost recording rule and scaled to a 730-hour month.",
+             "fieldConfig": {
+                "defaults": {
+                   "decimals": 2,
+                   "mappings": [ ],
+                   "thresholds": {
+                      "steps": [
+                         {
+                            "color": "green",
+                            "value": 0
+                         }
+                      ]
+                   },
+                   "unit": "currencyUSD"
+                },
+                "overrides": [ ]
+             },
+             "gridPos": {
+                "h": 3,
+                "w": 4,
+                "x": 16,
+                "y": 1
+             },
+             "id": 6,
+             "options": {
+                "graphMode": "none",
+                "percentChangeColorMode": "standard",
+                "showPercentChange": false
+             },
+             "pluginVersion": "v11.4.0",
+             "targets": [
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "$datasource"
+                   },
+                   "expr": "sum((sum by (cluster, namespace, workload_type, workload) (\n  avg_over_time(workload:opencost_gpu_cost:sum{cluster=\"$cluster\",\nnamespace=\"$namespace\",\nworkload_type=~\"$workload_type\",\nworkload=~\"$workload\"\n}[1h:5m])\n)\n) * 730) or vector(0)",
+                   "instant": false
+                }
+             ],
+             "title": "Monthly GPU Cost",
+             "type": "stat"
+          },
+          {
+             "datasource": {
+                "type": "prometheus",
+                "uid": "$datasource"
+             },
+             "description": "Projected monthly persistent volume cost for the selected workload scope. PVC attribution is inferred from workload-owned pods that mount each claim, so shared claims can contribute cost to more than one workload.",
+             "fieldConfig": {
+                "defaults": {
+                   "decimals": 2,
+                   "mappings": [ ],
+                   "thresholds": {
+                      "steps": [
+                         {
+                            "color": "green",
+                            "value": 0
+                         }
+                      ]
+                   },
+                   "unit": "currencyUSD"
+                },
+                "overrides": [ ]
+             },
+             "gridPos": {
+                "h": 3,
+                "w": 4,
+                "x": 20,
+                "y": 1
+             },
+             "id": 7,
+             "options": {
+                "graphMode": "none",
+                "percentChangeColorMode": "standard",
+                "showPercentChange": false
+             },
+             "pluginVersion": "v11.4.0",
+             "targets": [
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "$datasource"
+                   },
+                   "expr": "sum((sum by (cluster, namespace, workload_type, workload) (\n  avg_over_time(workload:opencost_pvc_cost:sum{cluster=\"$cluster\",\nnamespace=\"$namespace\",\nworkload_type=~\"$workload_type\",\nworkload=~\"$workload\"\n}[1h:5m])\n)\n) * 730) or vector(0)",
+                   "instant": false
+                }
+             ],
+             "title": "Monthly PV Cost",
+             "type": "stat"
+          },
+          {
+             "datasource": {
+                "type": "prometheus",
+                "uid": "$datasource"
+             },
+             "description": "Top workloads by projected monthly cost in the current namespace and filter scope. Each slice is a `workload_type / workload` pair.",
+             "fieldConfig": {
+                "defaults": {
+                   "unit": "currencyUSD"
+                },
+                "overrides": [ ]
+             },
+             "gridPos": {
+                "h": 5,
+                "w": 8,
+                "x": 0,
+                "y": 4
+             },
+             "id": 8,
+             "options": {
+                "displayLabels": [
+                   "percent"
+                ],
+                "legend": {
+                   "displayMode": "table",
+                   "placement": "right",
+                   "showLegend": true,
+                   "values": [
+                      "percent",
+                      "value"
+                   ]
+                },
+                "tooltip": {
+                   "mode": "multi",
+                   "sort": "desc"
+                }
+             },
+             "pluginVersion": "v11.4.0",
+             "targets": [
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "$datasource"
+                   },
+                   "expr": "topk(10, ((\n  sum by (cluster, namespace, workload_type, workload) (\n  avg_over_time(workload:opencost_ram_cost:sum{cluster=\"$cluster\",\nnamespace=\"$namespace\",\nworkload_type=~\"$workload_type\",\nworkload=~\"$workload\"\n}[1h:5m])\n)\n\n  +\n  sum by (cluster, namespace, workload_type, workload) (\n  avg_over_time(workload:opencost_cpu_cost:sum{cluster=\"$cluster\",\nnamespace=\"$namespace\",\nworkload_type=~\"$workload_type\",\nworkload=~\"$workload\"\n}[1h:5m])\n)\n\n)\n+\n(\n  sum by (cluster, namespace, workload_type, workload) (\n  avg_over_time(workload:opencost_pvc_cost:sum{cluster=\"$cluster\",\nnamespace=\"$namespace\",\nworkload_type=~\"$workload_type\",\nworkload=~\"$workload\"\n}[1h:5m])\n)\n\n  or (sum by (cluster, namespace, workload_type, workload) (\n  avg_over_time(workload:opencost_ram_cost:sum{cluster=\"$cluster\",\nnamespace=\"$namespace\",\nworkload_type=~\"$workload_type\",\nworkload=~\"$workload\"\n}[1h:5m])\n)\n * 0)\n)\n+\n(\n  sum by (cluster, namespace, workload_type, workload) (\n  avg_over_time(workload:opencost_gpu_cost:sum{cluster=\"$cluster\",\nnamespace=\"$namespace\",\nworkload_type=~\"$workload_type\",\nworkload=~\"$workload\"\n}[1h:5m])\n)\n\n  or (sum by (cluster, namespace, workload_type, workload) (\n  avg_over_time(workload:opencost_ram_cost:sum{cluster=\"$cluster\",\nnamespace=\"$namespace\",\nworkload_type=~\"$workload_type\",\nworkload=~\"$workload\"\n}[1h:5m])\n)\n * 0)\n)\n) * 730)",
+                   "instant": true,
+                   "legendFormat": "{{ workload_type }} / {{ workload }}"
+                }
+             ],
+             "title": "Cost by Workload",
+             "type": "piechart"
+          },
+          {
+             "datasource": {
+                "type": "prometheus",
+                "uid": "$datasource"
+             },
+             "description": "Projected monthly cost grouped by workload type for the current namespace and filter scope.",
+             "fieldConfig": {
+                "defaults": {
+                   "unit": "currencyUSD"
+                },
+                "overrides": [ ]
+             },
+             "gridPos": {
+                "h": 5,
+                "w": 8,
+                "x": 8,
+                "y": 4
+             },
+             "id": 9,
+             "options": {
+                "displayLabels": [
+                   "percent"
+                ],
+                "legend": {
+                   "displayMode": "table",
+                   "placement": "right",
+                   "showLegend": true,
+                   "values": [
+                      "percent",
+                      "value"
+                   ]
+                },
+                "tooltip": {
+                   "mode": "multi",
+                   "sort": "desc"
+                }
+             },
+             "pluginVersion": "v11.4.0",
+             "targets": [
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "$datasource"
+                   },
+                   "expr": "sum by (workload_type) (\n  ((\n  sum by (cluster, namespace, workload_type, workload) (\n  avg_over_time(workload:opencost_ram_cost:sum{cluster=\"$cluster\",\nnamespace=\"$namespace\",\nworkload_type=~\"$workload_type\",\nworkload=~\"$workload\"\n}[1h:5m])\n)\n\n  +\n  sum by (cluster, namespace, workload_type, workload) (\n  avg_over_time(workload:opencost_cpu_cost:sum{cluster=\"$cluster\",\nnamespace=\"$namespace\",\nworkload_type=~\"$workload_type\",\nworkload=~\"$workload\"\n}[1h:5m])\n)\n\n)\n+\n(\n  sum by (cluster, namespace, workload_type, workload) (\n  avg_over_time(workload:opencost_pvc_cost:sum{cluster=\"$cluster\",\nnamespace=\"$namespace\",\nworkload_type=~\"$workload_type\",\nworkload=~\"$workload\"\n}[1h:5m])\n)\n\n  or (sum by (cluster, namespace, workload_type, workload) (\n  avg_over_time(workload:opencost_ram_cost:sum{cluster=\"$cluster\",\nnamespace=\"$namespace\",\nworkload_type=~\"$workload_type\",\nworkload=~\"$workload\"\n}[1h:5m])\n)\n * 0)\n)\n+\n(\n  sum by (cluster, namespace, workload_type, workload) (\n  avg_over_time(workload:opencost_gpu_cost:sum{cluster=\"$cluster\",\nnamespace=\"$namespace\",\nworkload_type=~\"$workload_type\",\nworkload=~\"$workload\"\n}[1h:5m])\n)\n\n  or (sum by (cluster, namespace, workload_type, workload) (\n  avg_over_time(workload:opencost_ram_cost:sum{cluster=\"$cluster\",\nnamespace=\"$namespace\",\nworkload_type=~\"$workload_type\",\nworkload=~\"$workload\"\n}[1h:5m])\n)\n * 0)\n)\n) * 730\n)\n",
+                   "instant": true,
+                   "legendFormat": "{{ workload_type }}"
+                }
+             ],
+             "title": "Cost by Workload Type",
+             "type": "piechart"
+          },
+          {
+             "datasource": {
+                "type": "prometheus",
+                "uid": "$datasource"
+             },
+             "description": "Monthly cost distribution for the selected workload scope across compute, memory, storage, and GPU. Use this to see which resource category is driving the projected monthly spend.",
+             "fieldConfig": {
+                "defaults": {
+                   "unit": "currencyUSD"
+                },
+                "overrides": [ ]
+             },
+             "gridPos": {
+                "h": 5,
+                "w": 8,
+                "x": 16,
+                "y": 4
+             },
+             "id": 10,
+             "options": {
+                "displayLabels": [
+                   "percent"
+                ],
+                "legend": {
+                   "displayMode": "table",
+                   "placement": "right",
+                   "showLegend": true,
+                   "values": [
+                      "percent",
+                      "value"
+                   ]
+                },
+                "tooltip": {
+                   "mode": "multi",
+                   "sort": "desc"
+                }
+             },
+             "pluginVersion": "v11.4.0",
+             "targets": [
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "$datasource"
+                   },
+                   "expr": "sum((sum by (cluster, namespace, workload_type, workload) (\n  avg_over_time(workload:opencost_cpu_cost:sum{cluster=\"$cluster\",\nnamespace=\"$namespace\",\nworkload_type=~\"$workload_type\",\nworkload=~\"$workload\"\n}[1h:5m])\n)\n) * 730) or vector(0)",
+                   "instant": true,
+                   "legendFormat": "CPU"
+                },
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "$datasource"
+                   },
+                   "expr": "sum((sum by (cluster, namespace, workload_type, workload) (\n  avg_over_time(workload:opencost_ram_cost:sum{cluster=\"$cluster\",\nnamespace=\"$namespace\",\nworkload_type=~\"$workload_type\",\nworkload=~\"$workload\"\n}[1h:5m])\n)\n) * 730) or vector(0)",
+                   "instant": true,
+                   "legendFormat": "RAM"
+                },
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "$datasource"
+                   },
+                   "expr": "sum((sum by (cluster, namespace, workload_type, workload) (\n  avg_over_time(workload:opencost_pvc_cost:sum{cluster=\"$cluster\",\nnamespace=\"$namespace\",\nworkload_type=~\"$workload_type\",\nworkload=~\"$workload\"\n}[1h:5m])\n)\n) * 730) or vector(0)",
+                   "instant": true,
+                   "legendFormat": "PV"
+                },
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "$datasource"
+                   },
+                   "expr": "sum((sum by (cluster, namespace, workload_type, workload) (\n  avg_over_time(workload:opencost_gpu_cost:sum{cluster=\"$cluster\",\nnamespace=\"$namespace\",\nworkload_type=~\"$workload_type\",\nworkload=~\"$workload\"\n}[1h:5m])\n)\n) * 730) or vector(0)",
+                   "instant": true,
+                   "legendFormat": "GPU"
+                }
+             ],
+             "title": "Cost by Resource",
+             "type": "piechart"
+          },
+          {
+             "datasource": {
+                "type": "prometheus",
+                "uid": "$datasource"
+             },
+             "description": "Top workloads in the selected namespace by projected monthly cost. Each series represents a `workload_type / workload` pair, which is helpful when the dashboard is scoped to all workloads or all workloads of a given type.",
+             "fieldConfig": {
+                "defaults": {
+                   "custom": {
+                      "axisSoftMin": 0,
+                      "fillOpacity": 100,
+                      "lineWidth": 1,
+                      "stacking": {
+                         "mode": "normal"
+                      }
+                   },
+                   "unit": "currencyUSD"
+                },
+                "overrides": [ ]
+             },
+             "gridPos": {
+                "h": 8,
+                "w": 24,
+                "x": 0,
+                "y": 10
+             },
+             "id": 11,
+             "options": {
+                "legend": {
+                   "calcs": [
+                      "mean",
+                      "max"
+                   ],
+                   "displayMode": "table",
+                   "placement": "right",
+                   "showLegend": true,
+                   "sortBy": "Mean",
+                   "sortDesc": true
+                },
+                "tooltip": {
+                   "mode": "multi",
+                   "sort": "desc"
+                }
+             },
+             "pluginVersion": "v11.4.0",
+             "targets": [
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "$datasource"
+                   },
+                   "exemplar": false,
+                   "expr": "topk(10, ((\n  sum by (cluster, namespace, workload_type, workload) (\n  avg_over_time(workload:opencost_ram_cost:sum{cluster=\"$cluster\",\nnamespace=\"$namespace\",\nworkload_type=~\"$workload_type\",\nworkload=~\"$workload\"\n}[1h:5m])\n)\n\n  +\n  sum by (cluster, namespace, workload_type, workload) (\n  avg_over_time(workload:opencost_cpu_cost:sum{cluster=\"$cluster\",\nnamespace=\"$namespace\",\nworkload_type=~\"$workload_type\",\nworkload=~\"$workload\"\n}[1h:5m])\n)\n\n)\n+\n(\n  sum by (cluster, namespace, workload_type, workload) (\n  avg_over_time(workload:opencost_pvc_cost:sum{cluster=\"$cluster\",\nnamespace=\"$namespace\",\nworkload_type=~\"$workload_type\",\nworkload=~\"$workload\"\n}[1h:5m])\n)\n\n  or (sum by (cluster, namespace, workload_type, workload) (\n  avg_over_time(workload:opencost_ram_cost:sum{cluster=\"$cluster\",\nnamespace=\"$namespace\",\nworkload_type=~\"$workload_type\",\nworkload=~\"$workload\"\n}[1h:5m])\n)\n * 0)\n)\n+\n(\n  sum by (cluster, namespace, workload_type, workload) (\n  avg_over_time(workload:opencost_gpu_cost:sum{cluster=\"$cluster\",\nnamespace=\"$namespace\",\nworkload_type=~\"$workload_type\",\nworkload=~\"$workload\"\n}[1h:5m])\n)\n\n  or (sum by (cluster, namespace, workload_type, workload) (\n  avg_over_time(workload:opencost_ram_cost:sum{cluster=\"$cluster\",\nnamespace=\"$namespace\",\nworkload_type=~\"$workload_type\",\nworkload=~\"$workload\"\n}[1h:5m])\n)\n * 0)\n)\n) * 730)",
+                   "interval": "5m",
+                   "legendFormat": "{{ workload_type }} / {{ workload }}"
+                }
+             ],
+             "title": "Monthly Cost by Workload",
+             "type": "timeseries"
+          },
+          {
+             "datasource": {
+                "type": "prometheus",
+                "uid": "$datasource"
+             },
+             "description": "Monthly cost trend for the selected workload scope split into RAM, CPU, persistent volume, and GPU components. These values are based on the smoothed hourly workload cost rules and then projected to a 730-hour month.",
+             "fieldConfig": {
+                "defaults": {
+                   "custom": {
+                      "axisSoftMin": 0,
+                      "fillOpacity": 100,
+                      "lineWidth": 1,
+                      "stacking": {
+                         "mode": "normal"
+                      }
+                   },
+                   "unit": "currencyUSD"
+                },
+                "overrides": [ ]
+             },
+             "gridPos": {
+                "h": 8,
+                "w": 24,
+                "x": 0,
+                "y": 18
+             },
+             "id": 12,
+             "options": {
+                "legend": {
+                   "calcs": [
+                      "mean",
+                      "max"
+                   ],
+                   "displayMode": "table",
+                   "placement": "right",
+                   "showLegend": true,
+                   "sortBy": "Mean",
+                   "sortDesc": true
+                },
+                "tooltip": {
+                   "mode": "multi",
+                   "sort": "desc"
+                }
+             },
+             "pluginVersion": "v11.4.0",
+             "targets": [
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "$datasource"
+                   },
+                   "exemplar": false,
+                   "expr": "sum((sum by (cluster, namespace, workload_type, workload) (\n  avg_over_time(workload:opencost_ram_cost:sum{cluster=\"$cluster\",\nnamespace=\"$namespace\",\nworkload_type=~\"$workload_type\",\nworkload=~\"$workload\"\n}[1h:5m])\n)\n) * 730) or vector(0)",
+                   "interval": "5m",
+                   "legendFormat": "RAM"
+                },
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "$datasource"
+                   },
+                   "exemplar": false,
+                   "expr": "sum((sum by (cluster, namespace, workload_type, workload) (\n  avg_over_time(workload:opencost_cpu_cost:sum{cluster=\"$cluster\",\nnamespace=\"$namespace\",\nworkload_type=~\"$workload_type\",\nworkload=~\"$workload\"\n}[1h:5m])\n)\n) * 730) or vector(0)",
+                   "interval": "5m",
+                   "legendFormat": "CPU"
+                },
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "$datasource"
+                   },
+                   "exemplar": false,
+                   "expr": "sum((sum by (cluster, namespace, workload_type, workload) (\n  avg_over_time(workload:opencost_pvc_cost:sum{cluster=\"$cluster\",\nnamespace=\"$namespace\",\nworkload_type=~\"$workload_type\",\nworkload=~\"$workload\"\n}[1h:5m])\n)\n) * 730) or vector(0)",
+                   "interval": "5m",
+                   "legendFormat": "PV"
+                },
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "$datasource"
+                   },
+                   "exemplar": false,
+                   "expr": "sum((sum by (cluster, namespace, workload_type, workload) (\n  avg_over_time(workload:opencost_gpu_cost:sum{cluster=\"$cluster\",\nnamespace=\"$namespace\",\nworkload_type=~\"$workload_type\",\nworkload=~\"$workload\"\n}[1h:5m])\n)\n) * 730) or vector(0)",
+                   "interval": "5m",
+                   "legendFormat": "GPU"
+                }
+             ],
+             "title": "Monthly Cost by Resource",
+             "type": "timeseries"
+          },
+          {
+             "collapsed": false,
+             "gridPos": {
+                "h": 1,
+                "w": 24,
+                "x": 0,
+                "y": 25
+             },
+             "id": 13,
+             "title": "Workload Breakdown",
+             "type": "row"
+          },
+          {
+             "datasource": {
+                "type": "prometheus",
+                "uid": "$datasource"
+             },
+             "description": "Monthly cost breakdown by workload, where each row is a `workload_type / workload` pair. The table shows RAM, CPU, persistent volume, GPU, and total projected monthly cost so you can compare the main cost drivers for each workload.",
+             "fieldConfig": {
+                "defaults": {
+                   "links": [ ],
+                   "thresholds": {
+                      "steps": [ ]
+                   },
+                   "unit": "currencyUSD"
+                },
+                "overrides": [ ]
+             },
+             "gridPos": {
+                "h": 10,
+                "w": 24,
+                "x": 0,
+                "y": 26
+             },
+             "id": 14,
+             "options": {
+                "footer": {
+                   "enablePagination": true
+                },
+                "sortBy": [
+                   {
+                      "desc": true,
+                      "displayName": "Total Cost"
+                   }
+                ]
+             },
+             "pluginVersion": "v11.4.0",
+             "targets": [
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "$datasource"
+                   },
+                   "expr": "(sum by (cluster, namespace, workload_type, workload) (\n  avg_over_time(workload:opencost_ram_cost:sum{cluster=\"$cluster\",\nnamespace=\"$namespace\",\nworkload_type=~\"$workload_type\",\nworkload=~\"$workload\"\n}[1h:5m])\n)\n) * 730",
+                   "format": "table",
+                   "instant": true
+                },
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "$datasource"
+                   },
+                   "expr": "(sum by (cluster, namespace, workload_type, workload) (\n  avg_over_time(workload:opencost_cpu_cost:sum{cluster=\"$cluster\",\nnamespace=\"$namespace\",\nworkload_type=~\"$workload_type\",\nworkload=~\"$workload\"\n}[1h:5m])\n)\n) * 730",
+                   "format": "table",
+                   "instant": true
+                },
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "$datasource"
+                   },
+                   "expr": "(sum by (cluster, namespace, workload_type, workload) (\n  avg_over_time(workload:opencost_pvc_cost:sum{cluster=\"$cluster\",\nnamespace=\"$namespace\",\nworkload_type=~\"$workload_type\",\nworkload=~\"$workload\"\n}[1h:5m])\n)\n) * 730",
+                   "format": "table",
+                   "instant": true
+                },
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "$datasource"
+                   },
+                   "expr": "(sum by (cluster, namespace, workload_type, workload) (\n  avg_over_time(workload:opencost_gpu_cost:sum{cluster=\"$cluster\",\nnamespace=\"$namespace\",\nworkload_type=~\"$workload_type\",\nworkload=~\"$workload\"\n}[1h:5m])\n)\n) * 730",
+                   "format": "table",
+                   "instant": true
+                },
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "$datasource"
+                   },
+                   "expr": "((\n  sum by (cluster, namespace, workload_type, workload) (\n  avg_over_time(workload:opencost_ram_cost:sum{cluster=\"$cluster\",\nnamespace=\"$namespace\",\nworkload_type=~\"$workload_type\",\nworkload=~\"$workload\"\n}[1h:5m])\n)\n\n  +\n  sum by (cluster, namespace, workload_type, workload) (\n  avg_over_time(workload:opencost_cpu_cost:sum{cluster=\"$cluster\",\nnamespace=\"$namespace\",\nworkload_type=~\"$workload_type\",\nworkload=~\"$workload\"\n}[1h:5m])\n)\n\n)\n+\n(\n  sum by (cluster, namespace, workload_type, workload) (\n  avg_over_time(workload:opencost_pvc_cost:sum{cluster=\"$cluster\",\nnamespace=\"$namespace\",\nworkload_type=~\"$workload_type\",\nworkload=~\"$workload\"\n}[1h:5m])\n)\n\n  or (sum by (cluster, namespace, workload_type, workload) (\n  avg_over_time(workload:opencost_ram_cost:sum{cluster=\"$cluster\",\nnamespace=\"$namespace\",\nworkload_type=~\"$workload_type\",\nworkload=~\"$workload\"\n}[1h:5m])\n)\n * 0)\n)\n+\n(\n  sum by (cluster, namespace, workload_type, workload) (\n  avg_over_time(workload:opencost_gpu_cost:sum{cluster=\"$cluster\",\nnamespace=\"$namespace\",\nworkload_type=~\"$workload_type\",\nworkload=~\"$workload\"\n}[1h:5m])\n)\n\n  or (sum by (cluster, namespace, workload_type, workload) (\n  avg_over_time(workload:opencost_ram_cost:sum{cluster=\"$cluster\",\nnamespace=\"$namespace\",\nworkload_type=~\"$workload_type\",\nworkload=~\"$workload\"\n}[1h:5m])\n)\n * 0)\n)\n) * 730",
+                   "format": "table",
+                   "instant": true
+                }
+             ],
+             "title": "Workload Monthly Cost",
+             "transformations": [
+                {
+                   "id": "merge"
+                },
+                {
+                   "id": "organize",
+                   "options": {
+                      "excludeByName": {
+                         "Time": true,
+                         "cluster": true,
+                         "namespace": true
+                      },
+                      "indexByName": {
+                         "Value #A": 2,
+                         "Value #B": 3,
+                         "Value #C": 4,
+                         "Value #D": 5,
+                         "Value #E": 6,
+                         "workload": 1,
+                         "workload_type": 0
+                      },
+                      "renameByName": {
+                         "Value #A": "RAM Cost",
+                         "Value #B": "CPU Cost",
+                         "Value #C": "PV Cost",
+                         "Value #D": "GPU Cost",
+                         "Value #E": "Total Cost",
+                         "workload": "Workload",
+                         "workload_type": "Workload Type"
+                      }
+                   }
+                }
+             ],
+             "type": "table"
+          },
+          {
+             "collapsed": false,
+             "gridPos": {
+                "h": 1,
+                "w": 24,
+                "x": 0,
+                "y": 36
+             },
+             "id": 15,
+             "title": "Persistent Volume Claims",
+             "type": "row"
+          },
+          {
+             "datasource": {
+                "type": "prometheus",
+                "uid": "$datasource"
+             },
+             "description": "Projected monthly storage cost by persistent volume claim for the selected workload scope.",
+             "fieldConfig": {
+                "defaults": {
+                   "links": [ ],
+                   "thresholds": {
+                      "steps": [ ]
+                   },
+                   "unit": "currencyUSD"
+                },
+                "overrides": [ ]
+             },
+             "gridPos": {
+                "h": 8,
+                "w": 24,
+                "x": 0,
+                "y": 37
+             },
+             "id": 16,
+             "options": {
+                "footer": {
+                   "enablePagination": true
+                },
+                "sortBy": [
+                   {
+                      "desc": true,
+                      "displayName": "Total Cost"
+                   }
+                ]
+             },
+             "pluginVersion": "v11.4.0",
+             "targets": [
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "$datasource"
+                   },
+                   "expr": "sum by (persistentvolumeclaim, workload_type, workload) (\n  avg_over_time(\n    workload:opencost_pvc_cost:sum{cluster=\"$cluster\",\nnamespace=\"$namespace\",\nworkload_type=~\"$workload_type\",\nworkload=~\"$workload\"\n}[1h:5m]\n  )\n) * 730\n",
+                   "format": "table",
+                   "instant": true
+                }
+             ],
+             "title": "Persistent Volume Claims Monthly Cost",
+             "transformations": [
+                {
+                   "id": "organize",
+                   "options": {
+                      "excludeByName": {
+                         "Time": true,
+                         "cluster": true,
+                         "namespace": true
+                      },
+                      "indexByName": {
+                         "Value": 3,
+                         "persistentvolumeclaim": 2,
+                         "workload": 1,
+                         "workload_type": 0
+                      },
+                      "renameByName": {
+                         "Value": "Total Cost",
+                         "persistentvolumeclaim": "Persistent Volume Claim",
+                         "workload": "Workload",
+                         "workload_type": "Workload Type"
+                      }
+                   }
+                }
+             ],
+             "type": "table"
+          }
+       ],
+       "schemaVersion": 39,
+       "tags": [
+          "opencost",
+          "opencost-mixin"
+       ],
+       "templating": {
+          "list": [
+             {
+                "current": {
+                   "selected": true,
+                   "text": "default",
+                   "value": "default"
+                },
+                "label": "Data source",
+                "name": "datasource",
+                "query": "prometheus",
+                "type": "datasource"
+             },
+             {
+                "datasource": {
+                   "type": "prometheus",
+                   "uid": "${datasource}"
+                },
+                "hide": 2,
+                "label": "Cluster",
+                "name": "cluster",
+                "query": "label_values(opencost_build_info{}, cluster)",
+                "refresh": 2,
+                "sort": 1,
+                "type": "query"
+             },
+             {
+                "datasource": {
+                   "type": "prometheus",
+                   "uid": "${datasource}"
+                },
+                "includeAll": false,
+                "label": "Job",
+                "multi": false,
+                "name": "job",
+                "query": "label_values(opencost_build_info{cluster=\"$cluster\"}, job)",
+                "refresh": 2,
+                "sort": 1,
+                "type": "query"
+             },
+             {
+                "datasource": {
+                   "type": "prometheus",
+                   "uid": "${datasource}"
+                },
+                "includeAll": false,
+                "label": "Namespace",
+                "multi": false,
+                "name": "namespace",
+                "query": "label_values(kube_namespace_labels{cluster=\"$cluster\", job=\"$job\"}, namespace)",
+                "refresh": 2,
+                "sort": 1,
+                "type": "query"
+             },
+             {
+                "datasource": {
+                   "type": "prometheus",
+                   "uid": "${datasource}"
+                },
+                "hide": 0,
+                "includeAll": true,
+                "label": "Workload Type",
+                "name": "workload_type",
+                "query": "label_values(namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\"}, workload_type)",
+                "refresh": 2,
+                "sort": 1,
+                "type": "query"
+             },
+             {
+                "datasource": {
+                   "type": "prometheus",
+                   "uid": "${datasource}"
+                },
+                "hide": 0,
+                "includeAll": true,
+                "label": "Workload",
+                "name": "workload",
+                "query": "label_values(namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload_type=~\"$workload_type\"}, workload)",
+                "refresh": 2,
+                "sort": 1,
+                "type": "query"
+             }
+          ]
+       },
+       "time": {
+          "from": "now-2d",
+          "to": "now"
+       },
+       "timezone": "utc",
+       "title": "OpenCost / Workload",
+       "uid": "opencost-mixin-workload-jkwq"
+    }
+kind: ConfigMap
+metadata:
+  labels:
+    grafana_dashboard: "1"
+  name: grafana-dashboard-opencost-workload
+  namespace: monitoring
+---
+apiVersion: v1
+data:
   unified-monitoring.json: |
     {
       "annotations": {

--- a/kubernetes/manifests/production/kustomization.yaml
+++ b/kubernetes/manifests/production/kustomization.yaml
@@ -14,6 +14,7 @@ resources:
   - ./metrics-server
   - ./mimir
   - ./oauth2-proxy
+  - ./opencost
   - ./opentelemetry-collector
   - ./opentelemetry
   - ./prometheus-operator

--- a/kubernetes/manifests/production/opencost/kustomization.yaml
+++ b/kubernetes/manifests/production/opencost/kustomization.yaml
@@ -1,0 +1,2 @@
+resources:
+  - manifest.yaml

--- a/kubernetes/manifests/production/opencost/manifest.yaml
+++ b/kubernetes/manifests/production/opencost/manifest.yaml
@@ -435,6 +435,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: opencost
+  namespace: "monitoring"
   labels:
     helm.sh/chart: opencost-2.5.28
     app.kubernetes.io/name: opencost

--- a/kubernetes/manifests/production/opencost/manifest.yaml
+++ b/kubernetes/manifests/production/opencost/manifest.yaml
@@ -1,0 +1,461 @@
+---
+# Source: opencost/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: opencost
+  namespace: monitoring
+  labels:
+    helm.sh/chart: opencost-2.5.28
+    app.kubernetes.io/name: opencost
+    app.kubernetes.io/instance: opencost
+    app.kubernetes.io/version: "1.121.0"
+    app.kubernetes.io/part-of: opencost
+    app.kubernetes.io/managed-by: Helm
+automountServiceAccountToken: true
+
+---
+# Source: opencost/templates/configmap-custom-pricing.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: custom-pricing-model
+  namespace: monitoring
+data:
+    {
+      "CPU": "1.25",
+      "GPU": "0.95",
+      "RAM": "0.5",
+      "awsSpotDataBucket": "opencost-spot-datafeed-559744160976",
+      "awsSpotDataRegion": "ap-northeast-1",
+      "description": "AWS Spot Instance Data Feed location for spot price accuracy",
+      "internetNetworkEgress": "0.12",
+      "projectID": "559744160976",
+      "regionNetworkEgress": "0.01",
+      "spotCPU": "0.006655",
+      "spotRAM": "0.000892",
+      "storage": "0.25",
+      "zoneNetworkEgress": "0.01",
+      "provider" : "aws"
+    }
+
+---
+# Source: opencost/templates/configmap-frontend.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: opencost-ui-nginx-config
+  namespace: monitoring
+data:
+  nginx.conf: |
+    gzip_static  on;
+    gzip on;
+    gzip_min_length 50000;
+    gzip_proxied expired no-cache no-store private auth;
+    gzip_types
+        application/atom+xml
+        application/geo+json
+        application/javascript
+        application/x-javascript
+        application/json
+        application/ld+json
+        application/manifest+json
+        application/rdf+xml
+        application/rss+xml
+        application/vnd.ms-fontobject
+        application/wasm
+        application/x-web-app-manifest+json
+        application/xhtml+xml
+        application/xml
+        font/eot
+        font/otf
+        font/ttf
+        image/bmp
+        image/svg+xml
+        text/cache-manifest
+        text/calendar
+        text/css
+        text/javascript
+        text/markdown
+        text/plain
+        text/xml
+        text/x-component
+        text/x-cross-domain-policy;
+
+    upstream model {
+            server opencost.monitoring:9003;
+    }
+
+    server {
+        server_name _;
+        root /var/www;
+        index index.html;
+        large_client_header_buffers 4 32k;
+        add_header Cache-Control "must-revalidate";
+
+        error_page 504 /custom_504.html;
+        location = /custom_504.html {
+            internal;
+        }
+
+        add_header Cache-Control "max-age=300";
+        location / {
+            alias /var/www/;
+            try_files $uri /index.html;
+        }
+
+        add_header ETag "1.96.0";
+        listen 9090;
+        listen [::]:9090;
+        resolver 127.0.0.1 valid=5s;
+        location /healthz {
+            access_log /dev/null;
+            return 200 'OK';
+        }
+        location /model/ {
+            proxy_connect_timeout       180;
+            proxy_send_timeout          180;
+            proxy_read_timeout          180;
+            proxy_pass http://model/;
+            proxy_redirect off;
+            proxy_http_version 1.1;
+            proxy_set_header Connection "";
+            proxy_set_header  X-Real-IP  $remote_addr;
+            proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
+        }
+    }
+
+---
+# Source: opencost/templates/clusterrole.yaml
+# Cluster role giving opencost to get, list, watch required resources
+# No write permissions are required
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: opencost
+  labels:
+    helm.sh/chart: opencost-2.5.28
+    app.kubernetes.io/name: opencost
+    app.kubernetes.io/instance: opencost
+    app.kubernetes.io/version: "1.121.0"
+    app.kubernetes.io/part-of: opencost
+    app.kubernetes.io/managed-by: Helm
+rules:
+  - apiGroups: [""]
+    resources:
+      - configmaps
+      - deployments
+      - nodes
+      - pods
+      - services
+      - resourcequotas
+      - replicationcontrollers
+      - limitranges
+      - persistentvolumeclaims
+      - persistentvolumes
+      - namespaces
+      - endpoints
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - extensions
+    resources:
+      - daemonsets
+      - deployments
+      - replicasets
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - apps
+    resources:
+      - statefulsets
+      - deployments
+      - daemonsets
+      - replicasets
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - batch
+    resources:
+      - cronjobs
+      - jobs
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - autoscaling
+    resources:
+      - horizontalpodautoscalers
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - policy
+    resources:
+      - poddisruptionbudgets
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - storage.k8s.io
+    resources:
+      - storageclasses
+    verbs:
+      - get
+      - list
+      - watch
+
+---
+# Source: opencost/templates/clusterrolebinding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: opencost
+  labels:
+    helm.sh/chart: opencost-2.5.28
+    app.kubernetes.io/name: opencost
+    app.kubernetes.io/instance: opencost
+    app.kubernetes.io/version: "1.121.0"
+    app.kubernetes.io/part-of: opencost
+    app.kubernetes.io/managed-by: Helm
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: opencost
+subjects:
+  - kind: ServiceAccount
+    name: opencost
+    namespace: monitoring
+---
+# Source: opencost/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: opencost
+  namespace: monitoring
+  labels:
+    helm.sh/chart: opencost-2.5.28
+    app.kubernetes.io/name: opencost
+    app.kubernetes.io/instance: opencost
+    app.kubernetes.io/version: "1.121.0"
+    app.kubernetes.io/part-of: opencost
+    app.kubernetes.io/managed-by: Helm
+spec:
+  selector:
+    app.kubernetes.io/name: opencost
+    app.kubernetes.io/instance: opencost
+  type: "ClusterIP"
+  ports:
+    - name: http
+      port: 9003
+      targetPort: 9003
+    - name: mcp-server
+      port: 8081
+      targetPort: 8081
+    - name: http-ui
+      port: 9090
+      targetPort: 9090
+---
+# Source: opencost/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: opencost
+  namespace: monitoring
+  labels:
+    helm.sh/chart: opencost-2.5.28
+    app.kubernetes.io/name: opencost
+    app.kubernetes.io/instance: opencost
+    app.kubernetes.io/version: "1.121.0"
+    app.kubernetes.io/part-of: opencost
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    checksum/configs: ee84c3cbbe371c30560d72a903b62772402159bd2300a6b5aa99024fb2c730d9
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: opencost
+      app.kubernetes.io/instance: opencost
+  strategy: 
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 1
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: opencost
+        app.kubernetes.io/instance: opencost
+    spec:
+      serviceAccountName: opencost
+      automountServiceAccountToken: true
+      initContainers:
+      containers:
+        - name: opencost
+          image: ghcr.io/opencost/opencost:1.121.0@sha256:2b0def286f343891b2cb2f10309d92bd614aab2f886e363cdc817dfd8595e472
+          imagePullPolicy: IfNotPresent
+          args:
+          ports:
+            - containerPort: 9003
+              name: http
+            - containerPort: 8081
+              name: mcp-server
+          resources:
+            limits:
+              memory: 256Mi
+            requests:
+              cpu: 25m
+              memory: 55Mi
+          startupProbe:
+            httpGet:
+              path: /healthz
+              port: 9003
+            initialDelaySeconds: 10
+            periodSeconds: 5
+            failureThreshold: 30
+            timeoutSeconds: 1
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 9003
+            initialDelaySeconds: 10
+            periodSeconds: 20
+            failureThreshold: 3
+            timeoutSeconds: 1
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: 9003
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            failureThreshold: 3
+            timeoutSeconds: 1
+            successThreshold: 1
+          env:
+            - name: LOG_LEVEL
+              value: info
+            - name: CUSTOM_COST_ENABLED
+              value: "false"
+            - name: INSTALL_NAMESPACE
+              value: monitoring
+            - name: PROMETHEUS_QUERY_RESOLUTION_SECONDS
+              value: "300"
+            - name: API_PORT
+              value: "9003"
+            - name: PROMETHEUS_SERVER_ENDPOINT
+              value: "http://kube-prometheus-stack-prometheus.monitoring.svc.cluster.local:9090"
+            - name: INSECURE_SKIP_VERIFY
+              value: "false"
+            - name: CLUSTER_ID
+              value: "default-cluster"
+            - name: CONFIG_PATH
+              value: "/tmp/custom-config"
+            - name: PRICING_CONFIGMAP_NAME
+              value: "custom-pricing-model"
+            - name: RESOLUTION_1D_RETENTION
+              value: "15"
+            - name: RESOLUTION_1H_RETENTION
+              value: "49"
+            - name: CLOUD_COST_ENABLED
+              value: "false"
+            - name: CLOUD_COST_MONTH_TO_DATE_INTERVAL
+              value: "6"
+            - name: CLOUD_COST_REFRESH_RATE_HOURS
+              value: "6"
+            - name: CLOUD_COST_QUERY_WINDOW_DAYS
+              value: "7"
+            - name: CLOUD_COST_RUN_WINDOW_DAYS
+              value: "3"
+            # Add any additional provided variables
+            # MCP Server Configuration
+            - name: MCP_SERVER_ENABLED
+              value: "true"
+            - name: MCP_HTTP_PORT
+              value: "8081"
+          volumeMounts:
+            - mountPath: /tmp/custom-config
+              name: custom-configs
+        - name: opencost-ui
+          image: ghcr.io/opencost/opencost-ui:1.121.0@sha256:cdaa04a66a17963393627040ddaec4faa6caf5174fa7b4be590c852f2fd839c7
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 9090
+              name: http-ui
+          env:
+            - name: API_PORT
+              value: "9003"
+            - name: UI_PORT
+              value: "9090"
+          resources:
+            limits:
+              memory: 256Mi
+            requests:
+              cpu: 10m
+              memory: 55Mi
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 9090
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: 9090
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            failureThreshold: 3
+          volumeMounts:
+            - name: opencost-ui-nginx-config-volume
+              mountPath: /etc/nginx/conf.d/default.nginx.conf
+              subPath: default.nginx.conf
+      volumes:
+        - name: custom-configs
+          emptyDir: {}
+        - name: opencost-ui-nginx-config-volume
+          configMap:
+            name: opencost-ui-nginx-config
+            items:
+              - key: nginx.conf
+                path: default.nginx.conf
+
+---
+# Source: opencost/templates/servicemonitor.yaml
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: opencost
+  labels:
+    helm.sh/chart: opencost-2.5.28
+    app.kubernetes.io/name: opencost
+    app.kubernetes.io/instance: opencost
+    app.kubernetes.io/version: "1.121.0"
+    app.kubernetes.io/part-of: opencost
+    app.kubernetes.io/managed-by: Helm
+    release: kube-prometheus-stack
+spec:
+  endpoints:
+    - port: http
+      scheme: http
+      path: /metrics
+      interval: 30s
+      scrapeTimeout: 10s
+      honorLabels: true
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: opencost
+      app.kubernetes.io/instance: opencost
+  namespaceSelector:
+    matchNames:
+      - monitoring
+

--- a/kubernetes/manifests/production/opencost/manifest.yaml
+++ b/kubernetes/manifests/production/opencost/manifest.yaml
@@ -13,7 +13,6 @@ metadata:
     app.kubernetes.io/part-of: opencost
     app.kubernetes.io/managed-by: Helm
 automountServiceAccountToken: true
-
 ---
 # Source: opencost/templates/configmap-custom-pricing.yaml
 apiVersion: v1
@@ -38,7 +37,6 @@ data:
       "zoneNetworkEgress": "0.01",
       "provider" : "aws"
     }
-
 ---
 # Source: opencost/templates/configmap-frontend.yaml
 apiVersion: v1
@@ -124,7 +122,6 @@ data:
             proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
         }
     }
-
 ---
 # Source: opencost/templates/clusterrole.yaml
 # Cluster role giving opencost to get, list, watch required resources
@@ -212,7 +209,6 @@ rules:
       - get
       - list
       - watch
-
 ---
 # Source: opencost/templates/clusterrolebinding.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -428,7 +424,6 @@ spec:
             items:
               - key: nginx.conf
                 path: default.nginx.conf
-
 ---
 # Source: opencost/templates/servicemonitor.yaml
 apiVersion: monitoring.coreos.com/v1

--- a/scripts/eks-lifecycle/lib/30-destroy-stacks.sh
+++ b/scripts/eks-lifecycle/lib/30-destroy-stacks.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
-# 30-destroy-stacks.sh - Destroy 8 EKS-related stacks in fixed order.
+# 30-destroy-stacks.sh - Destroy 9 EKS-related stacks in fixed order.
 #
 # Order:
-#   karpenter -> eks-secrets -> eks-logs -> eks-metrics -> eks-traces
+#   karpenter -> eks-secrets -> eks-logs -> eks-metrics -> eks-traces -> eks-cost
 #   -> eks -> alb -> vpc
 #
 # Each stack runs `terragrunt destroy -auto-approve`. On failure, fail
@@ -24,12 +24,13 @@ STACKS=(
   "eks-logs"
   "eks-metrics"
   "eks-traces"
+  "eks-cost"
   "eks"
   "alb"
   "vpc"
 )
 
-confirm "About to DESTROY 8 stacks for ENV=${ENV}. Continue?"
+confirm "About to DESTROY 9 stacks for ENV=${ENV}. Continue?"
 
 for stack in "${STACKS[@]}"; do
   info "Step 30.${stack}: terragrunt destroy aws/${stack}/envs/${ENV}"
@@ -57,4 +58,4 @@ After resolving, re-run: make eks-teardown-aws ENV=${ENV}"
   fi
 done
 
-ok "All 8 stacks destroyed"
+ok "All 9 stacks destroyed"


### PR DESCRIPTION
## Summary
- OpenCost (CNCF incubating) を production cluster に導入し、 Grafana から AWS cost (特に spot instance) を可視化する
- `aws/cost-management` に AWS Spot Instance Data Feed (S3 bucket + subscription) を追加
- 新規 `aws/eks-cost` stack で OpenCost 用 Pod Identity IAM role を provision
- `kubernetes/components/opencost/production/` で OpenCost chart を deploy (既存 kube-prometheus-stack/Mimir パイプラインに統合)
- OpenCost / Overview・Namespace・Workload の Grafana dashboard を追加
- `aws/eks-cost` を EKS cluster destroy/recreate lifecycle に登録

## Details
- design spec: `docs/superpowers/specs/2026-08-01-opencost-integration-design.md`
- implementation plan: `docs/superpowers/plans/2026-08-02-opencost-integration.md`

## Test plan
- [x] 各 AWS stack で `terragrunt validate` / `terragrunt plan` (additive diff のみ) を確認
- [x] `helmfile template` / `kustomize build` による manifest render を確認
- [ ] `eks-production` cluster 復旧後: server-side dry-run、`terragrunt apply`、OpenCost pod 起動確認、cost metric 非ゼロ確認、spot 価格 sanity check、Grafana dashboard 描画確認 (plan の Task 6 Step 2/5-8 参照)

## Note
- `eks-production` cluster は現在 AWS 上に存在しない (意図的な状態、本 PR の作業とは無関係)。 そのため live cluster を要する検証はクラスタ復旧後に別途実施が必要

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added OpenCost cost monitoring for production EKS clusters, including AWS pricing and Spot Instance data.
  * Added Grafana dashboards for cluster, namespace, and workload cost analysis.
  * Added cost infrastructure, access configuration, metrics integration, and monthly cost projections.
  * Added operational commands for managing the EKS cost stack.

* **Documentation**
  * Added OpenCost integration design, implementation, validation, and production recreation guidance.

* **Chores**
  * Updated EKS lifecycle workflows to include the cost stack during deployment and teardown.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->