### PR TITLE
feat(aws/route53): manage panicboat.net apex TXT/MX via Terraform

### DIFF
--- a/aws/route53/Makefile
+++ b/aws/route53/Makefile
@@ -1,0 +1,79 @@
+# Makefile for Route53
+
+# Default values
+ENV ?= production
+
+# Colors for output
+RED := \033[0;31m
+GREEN := \033[0;32m
+YELLOW := \033[0;33m
+BLUE := \033[0;34m
+NC := \033[0m # No Color
+
+.PHONY: help init plan apply destroy validate fmt check clean
+
+help: ## Show this help message
+	@echo "Route53 - Terragrunt Commands"
+	@echo ""
+	@echo "Usage: make <target> [ENV=<environment>]"
+	@echo ""
+	@echo "Available targets:"
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "  $(BLUE)%-15s$(NC) %s\n", $$1, $$2}'
+	@echo ""
+	@echo "Available environments:"
+	@echo "  - production"
+	@echo ""
+	@echo "Examples:"
+	@echo "  make plan ENV=production"
+	@echo "  make apply ENV=production"
+
+init: ## Initialize Terragrunt
+	@printf "$(YELLOW)Initializing Terragrunt for $(ENV)...$(NC)\n"
+	cd envs/$(ENV) && terragrunt init
+
+plan: ## Plan Terragrunt changes
+	@printf "$(YELLOW)Planning Terragrunt changes for $(ENV)...$(NC)\n"
+	cd envs/$(ENV) && terragrunt plan
+
+apply: ## Apply Terragrunt changes
+	@printf "$(YELLOW)Applying Terragrunt changes for $(ENV)...$(NC)\n"
+	cd envs/$(ENV) && terragrunt apply -auto-approve
+
+destroy: ## Destroy Terragrunt resources
+	@printf "$(RED)Destroying Terragrunt resources for $(ENV)...$(NC)\n"
+	@printf "$(RED)WARNING: This will destroy all resources!$(NC)\n"
+	@read -p "Are you sure? [y/N] " -n 1 -r; \
+	echo; \
+	if [[ $$REPLY =~ ^[Yy]$$ ]]; then \
+		cd envs/$(ENV) && terragrunt destroy; \
+	else \
+		printf "$(YELLOW)Cancelled.$(NC)\n"; \
+	fi
+
+validate: ## Validate Terragrunt configuration
+	@printf "$(YELLOW)Validating Terragrunt configuration for $(ENV)...$(NC)\n"
+	cd envs/$(ENV) && terragrunt validate
+
+fmt: ## Format Terraform files
+	@printf "$(YELLOW)Formatting Terraform files...$(NC)\n"
+	terraform fmt -recursive .
+
+check: validate fmt ## Run validation and formatting checks
+	@printf "$(GREEN)All checks completed for $(ENV)$(NC)\n"
+
+clean: ## Clean Terragrunt cache
+	@printf "$(YELLOW)Cleaning Terragrunt cache...$(NC)\n"
+	find . -type d -name ".terragrunt-cache" -exec rm -rf {} + 2>/dev/null || true
+	find . -name "*.tfplan" -delete 2>/dev/null || true
+
+show: ## Show current Terragrunt state
+	@printf "$(YELLOW)Showing current state for $(ENV)...$(NC)\n"
+	cd envs/$(ENV) && terragrunt show
+
+output: ## Show Terragrunt outputs
+	@printf "$(YELLOW)Showing outputs for $(ENV)...$(NC)\n"
+	cd envs/$(ENV) && terragrunt output
+
+refresh: ## Refresh Terragrunt state
+	@printf "$(YELLOW)Refreshing state for $(ENV)...$(NC)\n"
+	cd envs/$(ENV) && terragrunt refresh

--- a/aws/route53/envs/production/env.hcl
+++ b/aws/route53/envs/production/env.hcl
@@ -1,0 +1,16 @@
+# env.hcl - Environment-specific configuration for production
+
+locals {
+  # Environment-specific settings
+  environment = "production"
+
+  # AWS configuration
+  aws_region = "ap-northeast-1"
+
+  # Environment-specific tags
+  environment_tags = {
+    Environment = local.environment
+    Component   = "route53"
+    Owner       = "panicboat"
+  }
+}

--- a/aws/route53/envs/production/terragrunt.hcl
+++ b/aws/route53/envs/production/terragrunt.hcl
@@ -1,0 +1,35 @@
+# terragrunt.hcl - Terragrunt configuration for production environment
+
+# Include root configuration
+include "root" {
+  path = find_in_parent_folders("root.hcl")
+}
+
+# Include environment-specific configuration
+include "env" {
+  path   = "env.hcl"
+  expose = true
+}
+
+# Reference to Terraform modules.
+# Use go-getter `//` subdir notation so the entire `aws/` tree is copied to
+# the Terragrunt cache. This lets `module "route53"` in modules/lookups.tf
+# resolve `../lookup` from within the cache.
+terraform {
+  source = "../../..//route53/modules"
+}
+
+# Input variables for the module
+inputs = {
+  environment = include.env.locals.environment
+  aws_region  = include.env.locals.aws_region
+
+  common_tags = merge(
+    include.env.locals.environment_tags,
+    {
+      Project    = "route53"
+      ManagedBy  = "terraform"
+      Repository = "panicboat/platform"
+    }
+  )
+}

--- a/aws/route53/modules/lookups.tf
+++ b/aws/route53/modules/lookups.tf
@@ -1,0 +1,5 @@
+# lookups.tf - External stack lookups.
+
+module "route53" {
+  source = "../lookup"
+}

--- a/aws/route53/modules/main.tf
+++ b/aws/route53/modules/main.tf
@@ -1,0 +1,29 @@
+# main.tf - Zone-apex DNS records for panicboat.net.
+#
+# Route53 allows only one resource per (name, type) pair; multiple TXT values
+# must live in `records` on a single aws_route53_record. Colocate all
+# apex-level TXT entries (domain verification, SPF, etc.) here so a single
+# resource owns the apex TXT set.
+
+resource "aws_route53_record" "panicboat_net_apex_txt" {
+  zone_id = module.route53.zones.panicboat_net.id
+  name    = "panicboat.net"
+  type    = "TXT"
+  ttl     = 300
+  records = [
+    "google-site-verification=Pn_YBgisFYxUKSrVSNuaeVQaCpe63WT8tsd9lA-k9A8",
+  ]
+}
+
+# Google Workspace single-record MX setup. `smtp.google.com` fans out to
+# Google's MX cluster internally, so no ALT* records are needed.
+# https://support.google.com/a/answer/140034
+resource "aws_route53_record" "panicboat_net_apex_mx" {
+  zone_id = module.route53.zones.panicboat_net.id
+  name    = "panicboat.net"
+  type    = "MX"
+  ttl     = 3600
+  records = [
+    "1 smtp.google.com.",
+  ]
+}

--- a/aws/route53/modules/terraform.tf
+++ b/aws/route53/modules/terraform.tf
@@ -1,0 +1,20 @@
+# terraform.tf - OpenTofu and provider configuration
+
+terraform {
+  required_version = "1.12.5"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "6.57.1"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.aws_region
+
+  default_tags {
+    tags = var.common_tags
+  }
+}

--- a/aws/route53/modules/variables.tf
+++ b/aws/route53/modules/variables.tf
@@ -1,0 +1,16 @@
+# variables.tf - Inputs for the route53 module.
+
+variable "environment" {
+  description = "Environment name (e.g., production)"
+  type        = string
+}
+
+variable "aws_region" {
+  description = "AWS region"
+  type        = string
+}
+
+variable "common_tags" {
+  description = "Common tags applied to all resources"
+  type        = map(string)
+}

--- a/aws/route53/root.hcl
+++ b/aws/route53/root.hcl
@@ -1,0 +1,52 @@
+# root.hcl - Root Terragrunt configuration for Route53
+# This file contains common settings shared across all environments
+
+locals {
+  # Project metadata
+  project_name = "route53"
+
+  # Parse environment from the directory path
+  # This assumes environments are in envs/<environment>/ directories
+  path_parts  = split("/", path_relative_to_include())
+  environment = element(local.path_parts, length(local.path_parts) - 1)
+
+  # Common tags applied to all resources
+  common_tags = {
+    Project     = local.project_name
+    Environment = local.environment
+    ManagedBy   = "terragrunt"
+    Repository  = "monorepo"
+    Component   = "route53"
+    Team        = "panicboat"
+  }
+}
+
+# Remote state configuration using shared S3 bucket
+remote_state {
+  backend = "s3"
+  generate = {
+    path      = "backend.tf"
+    if_exists = "overwrite_terragrunt"
+  }
+  config = {
+    # Shared bucket for all monorepo services
+    bucket = "terragrunt-state-${get_aws_account_id()}"
+
+    # Service-specific path: route53/<environment>/terraform.tfstate
+    key    = "platform/route53/${local.environment}/terraform.tfstate"
+    region = "ap-northeast-1"
+
+    # Shared DynamoDB table for state locking across all services
+    dynamodb_table = "terragrunt-state-locks"
+
+    # Enable server-side encryption
+    encrypt = true
+  }
+}
+
+# Common inputs passed to all Terraform modules
+inputs = {
+  environment = local.environment
+  common_tags = local.common_tags
+  aws_region  = "ap-northeast-1"
+}


### PR DESCRIPTION
## Summary
- Bootstrap a Terragrunt stack for the `route53` component (`root.hcl`, `Makefile`, `envs/production`, `modules/`) mirroring `aws/alb` so zone-level DNS records can live under Terraform.
- Add the Google Search Console verification TXT record on the `panicboat.net` apex.
- Add a single-record Google Workspace MX (`1 smtp.google.com.`) on the `panicboat.net` apex.

## Notes
Route53 allows only one `aws_route53_record` per `(name, type)` pair. Future apex TXT values (SPF, DMARC, additional verifications) should be appended to the `records` list of `aws_route53_record.panicboat_net_apex_txt` rather than added as a new resource.

## Test plan
- [x] `terragrunt plan` clean before apply.
- [x] `terragrunt apply` succeeded — TXT + MX visible via `aws route53 list-resource-record-sets` and `dig @8.8.8.8`.
- [ ] Google Search Console verification succeeds against the new TXT record.
- [ ] Google Workspace inbound mail delivery to `panicboat.net` works end-to-end.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Route53 DNS management for the `panicboat.net` domain.
  * Added Google site verification and Google Workspace mail-routing records.
  * Added production environment configuration with AWS region and standardized resource tagging.
  * Added commands for initializing, validating, planning, applying, refreshing, and inspecting infrastructure changes.
  * Added encrypted remote state storage and state locking for safer infrastructure management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->