### PR TITLE
fix(kubernetes/components/tempo/production): drop the chart-default opencensus receiver

### DIFF
--- a/kubernetes/components/tempo/production/values.yaml.gotmpl
+++ b/kubernetes/components/tempo/production/values.yaml.gotmpl
@@ -37,9 +37,16 @@ tempo:
         # Pod Identity 経由のため access_key / secret_key 不要
 
   # -------------------------------------------------------------------------
-  # Receivers (= 4b で OTel Collector からの OTLP 受信用、4a では未接続)
+  # Receivers (= OTel Collector からの OTLP 受信用)
   # -------------------------------------------------------------------------
+  # chart default の receivers に jaeger / opencensus が含まれ、values の map は
+  # deep-merge されるため otlp だけ書いても両者は残る。opencensus は null を置いて
+  # キーごと削除する。jaeger に同じ手は使えない: chart の _ports.tpl が
+  # .Values.tempo.receivers.jaeger.protocols.thrift_compact を無条件に参照しており、
+  # 削除すると Service の描画が nil pointer で失敗する。結果として jaeger の
+  # 4 protocol は開いたままになる (= chart が deprecated で修正の見込みがない)。
   receivers:
+    opencensus: null
     otlp:
       protocols:
         grpc:

--- a/kubernetes/manifests/production/tempo/manifest.yaml
+++ b/kubernetes/manifests/production/tempo/manifest.yaml
@@ -50,7 +50,6 @@ data:
                   endpoint: 0.0.0.0:6831
                 thrift_http:
                   endpoint: 0.0.0.0:14268
-            opencensus: null
             otlp:
               protocols:
                 grpc:
@@ -188,7 +187,7 @@ spec:
         app.kubernetes.io/name: tempo
         app.kubernetes.io/instance: tempo
       annotations:
-        checksum/config: dcf1e4227dbd17c2c3acd77d5e30210491073428338e8b0db39748c2ecdbbced
+        checksum/config: 8e3806583c07c406ea25dc3bbed8cc04a735cc117230003e1551207a9c449289
     spec:
       serviceAccountName: tempo
       automountServiceAccountToken: true


### PR DESCRIPTION
## Why

`values.yaml.gotmpl` は `receivers` に `otlp` しか宣言していないが、chart default の `receivers` に `jaeger` と `opencensus` が含まれ、Helm が map を deep-merge するため両者も有効になっていた。コメントは「OTel Collector からの OTLP 受信用」と読めるので、実態と食い違っている。

`opencensus` は #740（hydrate の決定性修正）で表面化した。helm 3 は chart default の値なしキーを `opencensus: null` として描画し、helm 4 は落とす。#740 で toolchain を pin した結果 helm 3 の挙動に固定され、Tempo が 55678 を bind するようになっていた。

## What

- `values` に `opencensus: null` を置いてキーごと削除する。#740 適用前と同じ設定に戻る（`checksum/config` が `8e380658…` に一致）
- コメントを実態に合わせ、jaeger を消せない理由を残す

## なぜ OTLP 単独にできないか

`jaeger: null` は chart を壊す。`_ports.tpl` が Service のポート生成で `.Values.tempo.receivers.jaeger.protocols.thrift_compact` を無条件に参照しているため、キーを削除すると描画が nil pointer で失敗する。

```
Error: template: tempo/templates/service.yaml:47:8: executing "tempo/templates/service.yaml"
at <include "tempo.udp" .>: error calling include: template: tempo/templates/_ports.tpl:5:24:
executing "tempo.udp" at <.Values.tempo.receivers.jaeger.protocols.thrift_compact>:
nil pointer evaluating interface {}.protocols
```

到達できるのは jaeger + otlp まで。jaeger 4 protocol（6831/UDP, 6832/UDP, 14268, 14250）は開いたままになる。ClusterIP のみで外部露出はない。

## Note

`grafana/tempo` chart 1.24.4 は `deprecated: true`。上記の制約が上流で直る見込みはなく、後継の `tempo-distributed` への移行は別途検討が要る。

## Verification

- `opencensus: null` で描画成功（exit 0）、rendered receivers が `jaeger` + `otlp` のみになることを確認
- hydrate 後の manifest 差分は `opencensus: null` の削除と `checksum/config` の追随のみ
