### PR TITLE
chore(kubernetes): track Falco ruleset updates and right-size requests

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -111,6 +111,16 @@
         "#\\s*renovate:\\s*datasource=(?<datasource>\\S+)\\s+depName=(?<depName>\\S+)(?:\\s+versioning=(?<versioning>\\S+))?\\s*\\n\\s*cluster_version\\s*=\\s*\"(?<currentValue>[^\"]+)\""
       ],
       "extractVersionTemplate": "^(?<version>\\d+\\.\\d+)"
+    },
+    {
+      "customType": "regex",
+      "description": "Falco ruleset OCI artifact pinned in values (helmfile manager does not see OCI refs)",
+      "managerFilePatterns": [
+        "/^kubernetes/components/falco/.+/values\\.yaml\\.gotmpl$/"
+      ],
+      "matchStrings": [
+        "#\\s*renovate:\\s*datasource=(?<datasource>\\S+)\\s+depName=(?<depName>\\S+)\\s*\\n\\s*-\\s*falco-rules:(?<currentValue>\\S+)"
+      ]
     }
   ]
 }

--- a/kubernetes/components/falco/production/values.yaml.gotmpl
+++ b/kubernetes/components/falco/production/values.yaml.gotmpl
@@ -47,6 +47,17 @@ falcoctl:
     artifact:
       install:
         refs:
+          # NOTE: falcoctl は index 経由の短縮名で解決するため ref に registry を
+          # 書かない。Renovate は短縮名から artifact を特定できないので、下の
+          # renovate コメントで完全な OCI 参照を depName として与える。
+          # renovate: datasource=docker depName=ghcr.io/falcosecurity/rules/falco-rules
+          - falco-rules:5.1.0
+      # NOTE: follow container は無効なのでこの値は誰も consume しない。それでも
+      # chart default の floating tag (falco-rules:5) を残さないのは、将来 follow を
+      # 有効化した人が floating 参照を引き継ぎ、「ルールが Git 外で変わらない」という
+      # 本 component の前提を無言で壊すのを防ぐため。
+      follow:
+        refs:
           - falco-rules:5.1.0
 
 # =============================================================================
@@ -93,3 +104,36 @@ serviceMonitor:
   create: true
   labels:
     release: kube-prometheus-stack
+
+# =============================================================================
+# Resources (= requests のみ下げる)
+# =============================================================================
+# deploy 後の実測は cpu 7-13m / memory 54-78Mi で、chart default の requests
+# (cpu 100m / memory 512Mi) は過大。Karpenter は requests を見て instance を
+# 選ぶため、使わない予約が node サイズと台数に直結する。
+# NOTE: limits は chart default (cpu 1000m / memory 1024Mi) のまま据え置く。
+# helm の deep merge で requests だけ上書きしても limits は残る (= 実際に render
+# して確認済)。security agent を CPU throttling や OOM に晒すと検知を取り逃すため、
+# 削るのは予約 (requests) だけにして上限は広く保つ。
+# eBPF ring buffer は kernel 側の確保で container の memory limit に計上されない。
+resources:
+  requests:
+    cpu: 50m
+    memory: 128Mi
+
+# =============================================================================
+# Custom rules (= 既知の正常動作を除外)
+# =============================================================================
+# Beyla は eBPF で network を捕捉するため AF_PACKET socket を開く。これは正常
+# 動作だが `Packet socket created in container` に該当し続ける。恒常的な誤検知は
+# 「このルールは無視するもの」という運用習慣を作り、本物の ARP spoofing /
+# CVE-2020-14386 を見逃す下地になるため除外する。
+# NOTE: 除外機構は macro ではなく list (= ルール本文が
+# `not proc.name in (user_known_packet_socket_binaries)` で参照)。
+# override.items: append で上流のリストに追記する (= 上流が要素を足しても衝突しない)。
+customRules:
+  beyla-packet-socket.yaml: |-
+    - list: user_known_packet_socket_binaries
+      items: [beyla]
+      override:
+        items: append

--- a/kubernetes/manifests/production/falco/manifest.yaml
+++ b/kubernetes/manifests/production/falco/manifest.yaml
@@ -197,7 +197,7 @@ data:
         falcoversions: http://localhost:8765/versions
         pluginsDir: /plugins
         refs:
-        - falco-rules:5
+        - falco-rules:5.1.0
         rulesfilesDir: /rulesfiles
         stateDir: /artifactstate
       install:
@@ -211,6 +211,25 @@ data:
     indexes:
     - name: falcosecurity
       url: https://falcosecurity.github.io/falcoctl/index.yaml
+---
+# Source: falco/templates/rules-configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: falco-rules
+  namespace: falco
+  labels:
+    helm.sh/chart: falco-9.1.0
+    app.kubernetes.io/name: falco
+    app.kubernetes.io/instance: falco
+    app.kubernetes.io/version: "0.44.1"
+    app.kubernetes.io/managed-by: Helm
+data:
+  beyla-packet-socket.yaml: |-
+    - list: user_known_packet_socket_binaries
+      items: [beyla]
+      override:
+        items: append
 ---
 # Source: falco/templates/service.yaml
 apiVersion: v1
@@ -261,7 +280,7 @@ spec:
         app.kubernetes.io/instance: falco
       annotations:
         checksum/config: 16eeedd1b83ae65c870be4322c6ea79b1f12516d302c676d052ddcd0fc022d2d
-        checksum/rules: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+        checksum/rules: 1c386d3cd218be185236929c557cd6702ab3ecfe9f4a68c063d74d31e7613013
         checksum/certs: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
         container.apparmor.security.beta.kubernetes.io/falco: unconfined
     spec:
@@ -281,8 +300,8 @@ spec:
               cpu: 1000m
               memory: 1024Mi
             requests:
-              cpu: 100m
-              memory: 512Mi
+              cpu: 50m
+              memory: 128Mi
           securityContext:
             capabilities:
               add:
@@ -362,6 +381,8 @@ spec:
             - mountPath: /etc/falco/falco.yaml
               name: falco-yaml
               subPath: falco.yaml
+            - mountPath: /etc/falco/rules.d
+              name: rules-volume
       initContainers:
         - name: falcoctl-artifact-install
           image: docker.io/falcosecurity/falcoctl:0.13.0
@@ -437,6 +458,9 @@ spec:
             items:
             - key: falco.yaml
               path: falco.yaml
+        - name: rules-volume
+          configMap:
+            name: falco-rules
   updateStrategy:
     type: RollingUpdate
 ---


### PR DESCRIPTION
Falco 導入直後の実測と最終レビューで見つかった 3 点をまとめて解消する。同じ `values.yaml.gotmpl` を触るため 1 PR にまとめた（deploy 影響も rolling restart 1 回で同じ）。

## 1. ルールセットの追従（放置すると静かに劣化する）

ルールを `falco-rules:5.1.0` に exact pin したが、**Renovate の helmfile manager は OCI artifact を見ない**。放置するとルールが導入時点で凍結し、上流が追加する新しい攻撃手法の検知が永久に届かない。「runtime security 導入済み」と思ったまま中身だけ古くなるという壊れ方をする。

custom manager を追加した。falcoctl は index 経由の短縮名で解決するため ref に registry を書けないので、comment 側で完全な OCI 参照を `depName` として渡している。

**検証**: node（Renovate と同じ JS 正規表現エンジン）で実際にマッチさせ、`datasource=docker` / `depName=ghcr.io/falcosecurity/rules/falco-rules` / `currentValue=5.1.0` がキャプチャされることを確認。既存の EKS custom manager が壊れていないことも同時に確認済み。

## 2. requests の right-size（放置するとコストが出続ける）

| | requests |
|---|---|
| chart default | cpu 100m / memory 512Mi |
| 実測 | cpu 7-13m / memory 54-78Mi |
| 本 PR | cpu 50m / memory 128Mi |

Karpenter は requests を見て instance を選ぶため、使わない予約が node のサイズと台数に直結する。4 Pod 合計で 2048Mi → 512Mi。

**limits は chart default (cpu 1000m / memory 1024Mi) のまま据え置く。** helm の deep merge で requests だけ上書きしても limits が残ることを render して確認済み。security agent を CPU throttling や OOM に晒すと検知を取り逃すため、削るのは予約だけにして上限は広く保つ。

## 3. `follow.refs` の floating tag（放置すると罠になる）

follow container が無効なので現状は誰も consume しない。ただし chart default の `falco-rules:5` を残すと、**将来 follow を有効化した人が floating 参照を引き継ぎ**、「ルールが Git の外で変わらない」という本 component の前提を無言で壊す。

## 4. Beyla の恒常ノイズ除外

Beyla は eBPF で network を捕捉するため AF_PACKET socket を開く。正常動作だが `Packet socket created in container` に該当し続ける（実測で 1 時間に 1 件）。恒常的な誤検知は「このルールは無視するもの」という運用習慣を作り、本物の ARP spoofing / CVE-2020-14386 を見逃す下地になる。

除外機構は macro ではなく **list**（ルール本文が `not proc.name in (user_known_packet_socket_binaries)` を参照）。`override.items: append` で上流のリストに追記している。

**検証**: 稼働中の Falco Pod で実際に `falco --validate` を実行した。なお**単体ファイルだけを validate すると偽の失敗になる**（ベースのリストが未ロードのため `no list by that name already exists`）。ロード順どおり `falco_rules.yaml` → custom の順で渡すと `errors: []` / `schema_valid: true` / `successful: true`。

## Render 検証

hydrate 後の manifest に対し 11 項目を機械チェック済み。requests 引き下げ / limits 維持 / install・follow 両方の pin / floating tag 消滅 / customRules ConfigMap 生成 / `rules.d` が読み込み対象 / securityContext・capabilities・priorityClass・engine が不変。

Spec: `docs/superpowers/specs/2026-08-08-eks-production-falco-runtime-security-design.md`