### PR TITLE
fix(kubernetes): use xforwarded proxy headers for Keycloak behind ALB

### DIFF
--- a/kubernetes/components/keycloak/production/values.yaml.gotmpl
+++ b/kubernetes/components/keycloak/production/values.yaml.gotmpl
@@ -20,6 +20,15 @@ args:
 http:
   relativePath: "/"
 
+# chart default の proxy.mode "forwarded" は RFC7239 Forwarded ヘッダーを
+# 期待するが、ALB は X-Forwarded-For/Proto/Port しか送らない (Keycloak 公式
+# ドキュメントも ALB 配下では xforwarded を使うよう明記)。ミスマッチのまま
+# だと Keycloak が元リクエストの scheme (https) を認識できず issuer URL が
+# http:// になり、Admin Console の 3rd-party cookie check iframe がタイム
+# アウトする不具合を確認したため上書きする。
+proxy:
+  mode: xforwarded
+
 database:
   vendor: postgres
   hostname: keycloak-db-rw.keycloak.svc.cluster.local

--- a/kubernetes/manifests/production/keycloak/manifest.yaml
+++ b/kubernetes/manifests/production/keycloak/manifest.yaml
@@ -119,7 +119,7 @@ spec:
             - name: KC_CACHE_STACK
               value: "jdbc-ping"
             - name: KC_PROXY_HEADERS
-              value: forwarded
+              value: xforwarded
             - name: KC_HTTP_ENABLED
               value: "true"
             - name: KC_DB


### PR DESCRIPTION
## Summary
- Keycloak (`auth.dystopia.city`) admin console showed "Timeout when waiting for 3rd party check iframe message" after Phase 1 deploy (#735)
- Root cause: `codecentric/keycloakx` chart default `proxy.mode: forwarded` sets `KC_PROXY_HEADERS=forwarded`, which parses the RFC7239 `Forwarded` header — but AWS ALB sends the classic `X-Forwarded-For/Proto/Port` headers instead (confirmed against both AWS's and Keycloak's own docs). Keycloak couldn't detect the original request was HTTPS, so `issuer` URLs rendered as `http://` and the Admin Console's same-origin iframe check timed out.
- Fix: override `proxy.mode: xforwarded` in `kubernetes/components/keycloak/production/values.yaml.gotmpl`, matching Keycloak's documented guidance for AWS ALB.

## Test plan
- [x] Verified before the fix: `curl -s https://auth.dystopia.city/realms/master/.well-known/openid-configuration | grep issuer` returned `"issuer":"http://auth.dystopia.city/realms/master"`
- [x] `helmfile template` locally confirms `KC_PROXY_HEADERS=xforwarded` after the fix
- [x] Hydrated `kubernetes/manifests/production/keycloak/manifest.yaml` locally — single-line diff, matches the source change
- [ ] After merge: re-run the same curl check and confirm `issuer` is `https://...`
- [ ] After merge: confirm the Admin Console loads without the iframe timeout

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved HTTPS URL detection for Keycloak when accessed through the production load balancer.
  * Updated proxy header handling to ensure secure links and redirects are generated correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->