### PR TITLE
fix(kubernetes/components/oauth2-proxy/production): pass email as the upstream username

### DIFF
--- a/kubernetes/components/oauth2-proxy/production/values.yaml.gotmpl
+++ b/kubernetes/components/oauth2-proxy/production/values.yaml.gotmpl
@@ -66,6 +66,11 @@ resources:
 # 守るのは GWS テナント境界 (= テナントが複数ドメインを持てばその全部を通す)、
 # email_domains が守るのは monitoring UIs の利用者境界 (= panicboat.net のみ)。
 # テナントに追加ドメインが生えても本 UI の利用者が広がらないようにするのが後者。
+#
+# prefer_email_to_user は X-Forwarded-User に email を入れる (= default false だと
+# Google provider は sub claim の 21 桁数値を入れる)。Grafana は auth.proxy で
+# 同 header を user 名に使うため、これが無いと user 一覧が不透明な数値の羅列に
+# なり、誰の操作か判別できない。
 config:
   existingSecret: oauth2-proxy-google
   configFile: |-
@@ -83,6 +88,7 @@ config:
     set_xauthrequest = true
     skip_provider_button = true
     reverse_proxy = true
+    prefer_email_to_user = true
 
 # =============================================================================
 # Deployment Annotations (= Reloader watch)

--- a/kubernetes/manifests/production/oauth2-proxy/manifest.yaml
+++ b/kubernetes/manifests/production/oauth2-proxy/manifest.yaml
@@ -70,6 +70,7 @@ data:
     set_xauthrequest = true
     skip_provider_button = true
     reverse_proxy = true
+    prefer_email_to_user = true
 ---
 # Source: oauth2-proxy/templates/service.yaml
 apiVersion: v1
@@ -130,7 +131,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 7d327cf9e94d98cb39ab0fa0a88d236dc7f1e36b45d987471d1e347b2de2d696
+        checksum/config: 9ae8ded8d9c01822a431788234a76e6256ecfcb19d53a2606aab54d2b21d6db1
         checksum/secret: 9eb46bbdefd5cf844a2c4965b1241a7177addaa7c07789e7873ccda6b0104111
         checksum/google-secret: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
         checksum/redis-secret: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
@@ -328,6 +329,7 @@ data:
     set_xauthrequest = true
     skip_provider_button = true
     reverse_proxy = true
+    prefer_email_to_user = true
 ---
 # Source: oauth2-proxy/templates/service.yaml
 apiVersion: v1
@@ -388,7 +390,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: de503bb819e863770e3fa1f911bb0055cf1437b85e38c0590f417eb46eec765c
+        checksum/config: 496340958431cc033a4be129f33e2cb2638b8e8c65da639cf614f82a91f63617
         checksum/secret: 9eb46bbdefd5cf844a2c4965b1241a7177addaa7c07789e7873ccda6b0104111
         checksum/google-secret: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
         checksum/redis-secret: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
@@ -586,6 +588,7 @@ data:
     set_xauthrequest = true
     skip_provider_button = true
     reverse_proxy = true
+    prefer_email_to_user = true
 ---
 # Source: oauth2-proxy/templates/service.yaml
 apiVersion: v1
@@ -646,7 +649,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: e2074abdd7b150b9b1ef0daf4220696c7d006db1e8913ad44353b789b2519078
+        checksum/config: 15a0e0ae0791bd002ad8779ff6f54ccc919981511ac5af09f88adbde2e6df17b
         checksum/secret: 9eb46bbdefd5cf844a2c4965b1241a7177addaa7c07789e7873ccda6b0104111
         checksum/google-secret: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
         checksum/redis-secret: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
@@ -844,6 +847,7 @@ data:
     set_xauthrequest = true
     skip_provider_button = true
     reverse_proxy = true
+    prefer_email_to_user = true
 ---
 # Source: oauth2-proxy/templates/service.yaml
 apiVersion: v1
@@ -904,7 +908,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 3cc97e5ec01fe5f79d6734ce131d8387859e66e3a2cc8d08d445dc258380c96c
+        checksum/config: c527d7411b9580deb62a748b03142678929cdc5a392f3850052916a471139b7e
         checksum/secret: 9eb46bbdefd5cf844a2c4965b1241a7177addaa7c07789e7873ccda6b0104111
         checksum/google-secret: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
         checksum/redis-secret: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b


### PR DESCRIPTION
## Why

Grafana の user 一覧に `112912480064110192125` という 21 桁の数値が並んでいた。Google の `sub` クレームで、誰の操作か判別できない。

oauth2-proxy の `prefer_email_to_user` は default `false`。この状態で Google provider は `X-Forwarded-User` に `sub` を入れる。Grafana は `auth.proxy` で同 header をそのまま user 名として使うため、そのまま user 一覧に出る。

メンバーが 1 人の間は実害が無いが、GWS のユーザー管理を認可の単位に据えた以上、追加した人を識別できないのは目的に反する。

## What

`config.configFile` に `prefer_email_to_user = true` を追加する。4 release (grafana / hubble / alertmanager / prometheus) が同じ values を共有するため、1 行で全 instance に効く。

## Impact

適用後、Grafana は email をキーに**新しい user を作る**。既存の数値 ID の user (id=3) は取り残されるので、ログインを確認してから別途削除する。

dashboard は sidecar provisioning で org 単位のため、失われるものは無い。組み込みの `admin` (= `grafana-admin` secret) は break-glass 用として無関係に残る。

## Verification

hydrate 後の manifest で `prefer_email_to_user = true` が 4 release 分すべてに入ることを確認済み。他の差分は 4 件の `checksum/config` 追随のみ。
