### PR TITLE
chore(aws): Update IAM policy to remove obsolete model ARNs

### DIFF
--- a/aws/eks/modules/iam_holmesgpt.tf
+++ b/aws/eks/modules/iam_holmesgpt.tf
@@ -32,12 +32,8 @@ resource "aws_iam_policy" "holmesgpt_bedrock" {
           "bedrock:InvokeModelWithResponseStream",
         ]
         Resource = [
-          "arn:aws:bedrock:us-east-1:${data.aws_caller_identity.current.account_id}:inference-profile/us.anthropic.claude-sonnet-4-6",
           "arn:aws:bedrock:us-east-1:${data.aws_caller_identity.current.account_id}:inference-profile/us.anthropic.claude-sonnet-5",
           "arn:aws:bedrock:us-east-1:${data.aws_caller_identity.current.account_id}:inference-profile/us.anthropic.claude-opus-5",
-          "arn:aws:bedrock:us-east-1::foundation-model/anthropic.claude-sonnet-4-6",
-          "arn:aws:bedrock:us-east-2::foundation-model/anthropic.claude-sonnet-4-6",
-          "arn:aws:bedrock:us-west-2::foundation-model/anthropic.claude-sonnet-4-6",
           "arn:aws:bedrock:us-east-1::foundation-model/anthropic.claude-sonnet-5",
           "arn:aws:bedrock:us-east-2::foundation-model/anthropic.claude-sonnet-5",
           "arn:aws:bedrock:us-west-2::foundation-model/anthropic.claude-sonnet-5",


### PR DESCRIPTION
Removed references to 'anthropic.claude-sonnet-4-6' from IAM policy.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated AI service permissions to remove access to deprecated Claude Sonnet 4.6 models.
  * Continued support for Claude Sonnet 5 and Opus 5 models across supported regions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->