### PR TITLE
chore(aws): Add new inference profiles for Claude models

### DIFF
--- a/aws/eks/modules/iam_holmesgpt.tf
+++ b/aws/eks/modules/iam_holmesgpt.tf
@@ -32,14 +32,14 @@ resource "aws_iam_policy" "holmesgpt_bedrock" {
           "bedrock:InvokeModelWithResponseStream",
         ]
         Resource = [
-          "arn:aws:bedrock:us-east-1:${data.aws_caller_identity.current.account_id}:inference-profile/us.anthropic.claude-sonnet-5",
-          "arn:aws:bedrock:us-east-1:${data.aws_caller_identity.current.account_id}:inference-profile/us.anthropic.claude-opus-5",
-          "arn:aws:bedrock:us-east-1::foundation-model/anthropic.claude-sonnet-5",
-          "arn:aws:bedrock:us-east-2::foundation-model/anthropic.claude-sonnet-5",
-          "arn:aws:bedrock:us-west-2::foundation-model/anthropic.claude-sonnet-5",
-          "arn:aws:bedrock:us-east-1::foundation-model/anthropic.claude-opus-5",
-          "arn:aws:bedrock:us-east-2::foundation-model/anthropic.claude-opus-5",
-          "arn:aws:bedrock:us-west-2::foundation-model/anthropic.claude-opus-5",
+          "arn:aws:bedrock:us-east-1:${data.aws_caller_identity.current.account_id}:inference-profile/us.anthropic.claude-sonnet-4-6",
+          "arn:aws:bedrock:us-east-1:${data.aws_caller_identity.current.account_id}:inference-profile/us.anthropic.claude-opus-4-6",
+          "arn:aws:bedrock:us-east-1::foundation-model/anthropic.claude-sonnet-4-6",
+          "arn:aws:bedrock:us-east-2::foundation-model/anthropic.claude-sonnet-4-6",
+          "arn:aws:bedrock:us-west-2::foundation-model/anthropic.claude-sonnet-4-6",
+          "arn:aws:bedrock:us-east-1::foundation-model/anthropic.claude-opus-4-6",
+          "arn:aws:bedrock:us-east-2::foundation-model/anthropic.claude-opus-4-6",
+          "arn:aws:bedrock:us-west-2::foundation-model/anthropic.claude-opus-4-6",
         ]
       }
     ]


### PR DESCRIPTION
Updated IAM policy to include new inference profiles for Claude models.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated supported AI model configurations to use Sonnet 4.6 and Opus 4.6 inference profiles.
  * Added regional model access for the updated AI model versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->