### PR TITLE
chore: Resume monorepo workload by setting suspend to false

### DIFF
--- a/kubernetes/clusters/production/repositories/monorepo.yaml
+++ b/kubernetes/clusters/production/repositories/monorepo.yaml
@@ -36,7 +36,7 @@ spec:
   # 動作しないため停止中。monolith は required な Secret (= monolith-database)
   # が無く CreateContainerConfigError で起動しない。
   # 再開する場合は monorepo 側の動作を確認してから `false` に戻す。
-  suspend: true
+  suspend: false
 ---
 # =============================================================================
 # ExternalSecret: Sync GitHub App credentials from AWS Secrets Manager


### PR DESCRIPTION
Changed the suspend status to false to resume the monorepo workload.