### PR TITLE
feat: wire holmes into production (DNS + Alertmanager route)

### DIFF
--- a/docs/superpowers/plans/2026-08-14-holmes-relay-alertmanager-route.md
+++ b/docs/superpowers/plans/2026-08-14-holmes-relay-alertmanager-route.md
@@ -1,0 +1,289 @@
+# holmes-relay Alertmanager Route Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Route `severity: critical` alerts from the existing Alertmanager to the `holmes-relay` service (built separately in `panicboat/monorepo`, see `services/holmes-relay/`), authenticated with a shared bearer token, without touching any other existing routing.
+
+**Architecture:** Extend `kubernetes/components/prometheus-operator/production/values.yaml.gotmpl`'s `alertmanager.config` (currently entirely default — everything routes to the `null` receiver) with one additional route matching `severity="critical"` and a `holmes-relay` webhook receiver. The receiver's bearer token comes from a file mounted via `alertmanagerSpec.secrets`, synced from AWS Secrets Manager by a new ExternalSecret in the `monitoring` namespace — the same underlying secret (`panicboat/holmes-relay/alertmanager`) that `services/holmes-relay`'s own ExternalSecret (in monorepo) already syncs for the relay's own token verification.
+
+**Tech Stack:** Helmfile (kube-prometheus-stack chart), Kustomize, External Secrets Operator.
+
+## Global Constraints
+
+- Do not touch any other `alertmanager.config` routing — this repo currently has zero configured receivers other than the chart's default `null` receiver (per the existing `# NOTE: receiver 設定 ... は未設定` comment); this plan is additive only.
+- The `holmes-relay` endpoint URL and Slack channel are **not know until `services/holmes-relay` is deployed** (separate plan: `panicboat/monorepo`'s `docs/superpowers/plans/2026-08-14-holmes-relay-service.md`). This plan uses a placeholder-free but explicitly-flagged value that must be confirmed against the real deployed hostname before merging — see Task 2 Step 1.
+- Design doc: `docs/superpowers/specs/2026-08-14-holmes-relay-design.md`.
+
+---
+
+## Task 1: ExternalSecret for the Alertmanager shared token
+
+**Files:**
+- Create: `kubernetes/components/prometheus-operator/production/kustomization/holmes-relay-alertmanager-external-secret.yaml`
+- Modify: `kubernetes/components/prometheus-operator/production/kustomization/kustomization.yaml`
+
+**Interfaces:**
+- Produces: K8s Secret `holmes-relay-alertmanager` in the `monitoring` namespace with key `ALERTMANAGER_SHARED_TOKEN`, consumed by Task 2's `alertmanagerSpec.secrets` mount.
+
+- [ ] **Step 1: Write the ExternalSecret**
+
+`kubernetes/components/prometheus-operator/production/kustomization/holmes-relay-alertmanager-external-secret.yaml`:
+
+```yaml
+# =============================================================================
+# ExternalSecret: holmes-relay shared token (Alertmanager side)
+# =============================================================================
+# AWS Secrets Manager の panicboat/holmes-relay/alertmanager (property:
+# shared_token) を K8s Secret holmes-relay-alertmanager に sync。
+# alertmanagerSpec.secrets 経由で Alertmanager pod にファイルとしてマウントされ、
+# webhook_configs の http_config.authorization.credentials_file から参照される。
+#
+# 同じ AWS Secrets Manager path を、holmes-relay 自身(panicboat/monorepo,
+# services/holmes-relay)側の ExternalSecret も別途 sync している(受信側の
+# トークン検証用)。値の作成元は1箇所(このシークレット)、sync 先は2箇所という
+# 構成。
+# =============================================================================
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: holmes-relay-alertmanager
+  namespace: monitoring
+spec:
+  secretStoreRef:
+    name: aws-secrets-manager
+    kind: ClusterSecretStore
+  refreshInterval: 1h
+  target:
+    name: holmes-relay-alertmanager
+    creationPolicy: Owner
+  data:
+    - secretKey: ALERTMANAGER_SHARED_TOKEN
+      remoteRef:
+        key: panicboat/holmes-relay/alertmanager
+        property: shared_token
+```
+
+- [ ] **Step 2: Register it in the kustomization**
+
+Modify `kubernetes/components/prometheus-operator/production/kustomization/kustomization.yaml`:
+
+```yaml
+# =============================================================================
+# prometheus-operator production kustomization
+# =============================================================================
+# chart 範囲外 resource (= Grafana admin ExternalSecret, holmes-relay 用
+# Alertmanager token ExternalSecret) を helmfile output に上乗せする overlay。
+# =============================================================================
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - grafana-admin-external-secret.yaml
+  - holmes-relay-alertmanager-external-secret.yaml
+```
+
+- [ ] **Step 3: Hydrate and inspect the diff**
+
+Run: `./scripts/kubernetes-hydrate/hydrate-component.sh prometheus-operator production && git diff kubernetes/manifests/production/prometheus-operator`
+Expected: diff shows exactly one new `ExternalSecret` resource named `holmes-relay-alertmanager` in the `monitoring` namespace added to the rendered manifest. No other resources change.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add kubernetes/components/prometheus-operator/production/kustomization/holmes-relay-alertmanager-external-secret.yaml kubernetes/components/prometheus-operator/production/kustomization/kustomization.yaml kubernetes/manifests/production/prometheus-operator
+git commit -s -m "feat(prometheus-operator): sync holmes-relay Alertmanager token"
+```
+
+---
+
+## Task 2: Alertmanager route and receiver
+
+**Files:**
+- Modify: `kubernetes/components/prometheus-operator/production/values.yaml.gotmpl:221-242`
+
+**Interfaces:**
+- Consumes: `holmes-relay-alertmanager` Secret (Task 1), the deployed `holmes-relay` service's public hostname and the Slack channel it should post to (both owned by the `panicboat/monorepo` `services/holmes-relay` plan — confirm the real values before Step 1 below).
+
+- [ ] **Step 1: Confirm the real holmes-relay URL and target Slack channel**
+
+Before editing, verify against the actually-deployed `panicboat/monorepo` `services/holmes-relay`:
+- The HTTPRoute hostname (design/plan default: `holmes-relay.dystopia.city` — confirm the DNS record actually resolves and TLS is issued via `kubectl -n default get httproute holmes-relay` and `kubectl -n default get certificate`).
+- The Slack channel name to post critical-alert investigations to (per the design spec: "既存の運用・incident チャンネルを使う" — get the exact channel name from whoever owns that channel before writing the URL below).
+
+Substitute both into Step 2 in place of `<holmes-relay-host>` and `<slack-channel>`.
+
+- [ ] **Step 2: Replace the Alertmanager Configuration section**
+
+In `kubernetes/components/prometheus-operator/production/values.yaml.gotmpl`, replace:
+
+```yaml
+# =============================================================================
+# Alertmanager Configuration
+# =============================================================================
+# NOTE: receiver 設定 (Slack / SNS / PagerDuty) は未設定
+alertmanager:
+  enabled: true
+  alertmanagerSpec:
+    # cpu: 実測平均 0m (ほぼ idle) に対し 100m は過大。right-size。
+    resources:
+      requests:
+        cpu: 25m
+        memory: 128Mi
+      limits:
+        cpu: 500m
+        memory: 512Mi
+    storage:
+      volumeClaimTemplate:
+        spec:
+          storageClassName: gp3
+          resources:
+            requests:
+              storage: 2Gi
+```
+
+with:
+
+```yaml
+# =============================================================================
+# Alertmanager Configuration
+# =============================================================================
+# severity: critical のアラートのみ holmes-relay (panicboat/monorepo,
+# services/holmes-relay) に webhook 転送し、HolmesGPT の調査結果を Slack に
+# 投稿させる。severity ラベルは kube-prometheus-stack の default rule に
+# 既に付与されているため、新たなラベル付け作業は不要 (2026-08-14 実測: firing
+# 中 6 件中 critical 3 件)。route の見つけ方は "最初にマッチした sibling
+# route を上から順に評価" なので、既存の Watchdog->null を残したまま追加する。
+alertmanager:
+  enabled: true
+  alertmanagerSpec:
+    # cpu: 実測平均 0m (ほぼ idle) に対し 100m は過大。right-size。
+    resources:
+      requests:
+        cpu: 25m
+        memory: 128Mi
+      limits:
+        cpu: 500m
+        memory: 512Mi
+    storage:
+      volumeClaimTemplate:
+        spec:
+          storageClassName: gp3
+          resources:
+            requests:
+              storage: 2Gi
+    # holmes-relay の Alertmanager shared token を file mount (Task 1 の
+    # ExternalSecret が作る Secret)。alertmanagerSpec.secrets は Alertmanager
+    # と同一 namespace の Secret のみ参照可能なため、monitoring namespace 側に
+    # 専用の ExternalSecret を用意している (services/holmes-relay 側の
+    # ExternalSecret とは sync 先が別、値の出どころは同じ)。
+    secrets:
+      - holmes-relay-alertmanager
+  config:
+    global:
+      resolve_timeout: 5m
+    inhibit_rules:
+      - source_matchers:
+          - 'severity = critical'
+        target_matchers:
+          - 'severity =~ warning|info'
+        equal:
+          - 'namespace'
+          - 'alertname'
+      - source_matchers:
+          - 'severity = warning'
+        target_matchers:
+          - 'severity = info'
+        equal:
+          - 'namespace'
+          - 'alertname'
+      - source_matchers:
+          - 'alertname = InfoInhibitor'
+        target_matchers:
+          - 'severity = info'
+        equal:
+          - 'namespace'
+      - target_matchers:
+          - 'alertname = InfoInhibitor'
+    route:
+      group_by: ['namespace']
+      group_wait: 30s
+      group_interval: 5m
+      repeat_interval: 12h
+      receiver: 'null'
+      routes:
+        - receiver: 'null'
+          matchers:
+            - alertname = "Watchdog"
+        - receiver: 'holmes-relay'
+          matchers:
+            - severity = "critical"
+          continue: true
+    receivers:
+      - name: 'null'
+      - name: 'holmes-relay'
+        webhook_configs:
+          - url: 'https://<holmes-relay-host>/alertmanager/webhook?channel=<slack-channel>'
+            http_config:
+              authorization:
+                credentials_file: /etc/alertmanager/secrets/holmes-relay-alertmanager/ALERTMANAGER_SHARED_TOKEN
+    templates:
+      - '/etc/alertmanager/config/*.tmpl'
+```
+
+Note: this replaces the chart's implicit default `alertmanager.config` (previously unset, so the chart's own default applied — the `global`/`inhibit_rules`/`templates` values above are copied from that chart default so behavior is unchanged for everything except the new `holmes-relay` route/receiver — verified via `helm show values prometheus-community/kube-prometheus-stack`). `continue: true` on the new route means the alert still falls through and gets evaluated by later sibling routes too (there are none here, but this keeps future additions safe — an alert matching `severity="critical"` triggers holmes-relay AND is still available for group_by/inhibition against the top-level default).
+
+- [ ] **Step 3: Hydrate and inspect the diff**
+
+Run: `./scripts/kubernetes-hydrate/hydrate-component.sh prometheus-operator production && git diff kubernetes/manifests/production/prometheus-operator`
+Expected: diff shows the Alertmanager config Secret's rendered content changed to include the new `route.routes` entry and `receivers` entry for `holmes-relay`, and the Alertmanager StatefulSet gained a volume mount for the `holmes-relay-alertmanager` secret. No unrelated resources change (confirm by scanning the full diff for anything other than Alertmanager-owned resources).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add kubernetes/components/prometheus-operator/production/values.yaml.gotmpl kubernetes/manifests/production/prometheus-operator
+git commit -s -m "feat(prometheus-operator): route severity=critical alerts to holmes-relay"
+```
+
+---
+
+## Task 3: Open Draft PR
+
+**Files:** none (git/GitHub operations only)
+
+- [ ] **Step 1: Push the branch**
+
+```bash
+git push -u origin feat/holmes-relay-design
+```
+
+(Branch already exists and is tracked — this pushes the commits from Task 1 and Task 2, plus the earlier spec commits, in one PR.)
+
+- [ ] **Step 2: Open a Draft PR**
+
+```bash
+gh pr create --draft --title "feat(prometheus-operator): route critical alerts to holmes-relay" --body "$(cat <<'EOF'
+## Summary
+- Add an ExternalSecret in the monitoring namespace syncing the holmes-relay Alertmanager shared token.
+- Route severity=critical alerts to a new holmes-relay webhook receiver, leaving all existing (default) routing untouched.
+
+## Dependencies
+- Requires services/holmes-relay (panicboat/monorepo) to be deployed first for the webhook URL to have anywhere to send to; the ExternalSecret and route can merge independently but won't have effect until then.
+- Requires the AWS Secrets Manager secret panicboat/holmes-relay/alertmanager to have a shared_token value provisioned (see the monorepo plan's Task 8).
+
+## Test plan
+- [ ] `hydrate-component.sh prometheus-operator production` diff reviewed — only the intended resources changed
+- [ ] After merge and holmes-relay deployment: fire a test critical alert (`amtool alert add ... severity=critical`) and confirm holmes-relay receives the webhook and posts to Slack
+
+Design: docs/superpowers/specs/2026-08-14-holmes-relay-design.md
+EOF
+)"
+```
+
+- [ ] **Step 3: Report the PR URL back to the user.**
+
+---
+
+## Self-Review Notes
+
+- **Spec coverage**: `severity: critical` route-side filtering (Task 2), channel-via-query-param on the webhook URL (Task 2 Step 2, `?channel=<slack-channel>`), shared Bearer token auth (Task 1 + Task 2's `credentials_file`) are all covered. The design's "channel routing lives entirely in Alertmanager config" principle is honored — `holmes-relay` itself does not hardcode a channel.
+- **Placeholder scan**: `<holmes-relay-host>` and `<slack-channel>` in Task 2 are intentionally-flagged fill-ins, not plan placeholders — Task 2 Step 1 makes verifying and substituting the real values an explicit, required step before editing, because those values are owned by the separate monorepo plan and are not yet known at plan-writing time.
+- **Cross-repo dependency**: this plan has no code dependency on `services/holmes-relay` existing yet (it can be merged independently), but the receiver has no effect until the service is deployed and its real hostname/channel substituted. Noted in the Draft PR body.

--- a/docs/superpowers/specs/2026-08-14-holmes-relay-design.md
+++ b/docs/superpowers/specs/2026-08-14-holmes-relay-design.md
@@ -51,14 +51,17 @@ Alertmanager (severity=critical) ──POST /alertmanager/webhook──┘      
   - `url_verification` challenge に応答（初回セットアップ時の Slack 側ハンドシェイク）。
   - `event_callback` / `event.type == "app_mention"` を処理。mention 部分を取り除いたテキストを調査依頼文として使う。
   - `X-Slack-Signature` / `X-Slack-Request-Timestamp` を signing secret で HMAC-SHA256 検証（Slack 公式の署名検証手順に従う）。
-- **非同期処理**: Slack Events API は 3 秒以内の ACK を要求するが、調査には数十秒かかる（評価時実測 43 秒程度）。リクエストを受けたら即座に 200 を返し、`chat.postMessage` で「🔍 調査中です」を即時投稿した上で、goroutine で Holmes 呼び出し→結果投稿を行う。
+- **スレッドコンテキストの考慮**: mention イベントに `thread_ts` が含まれる場合（= 既存スレッド内での mention）、`conversations.replies` でスレッド内の過去メッセージを取得し、Holmes への調査依頼文の前段に会話履歴として付与する。トップレベルの mention（`thread_ts` 無し）はメンション文のみを使い、その mention の `ts` を新規スレッドのルートとして返信する。
+  - holmes-relay 自身の過去の返信もスレッド履歴に含まれるため、同じスレッドで追加の質問をした場合は自然に前回の調査結果を踏まえた文脈で再調査できる。
+  - メッセージ内の `<@U12345>` 形式の生ユーザー ID はそのまま Holmes に渡す（表示名への解決はしない。可読性より実装の単純さを優先する初期実装の判断）。
+- **非同期処理**: Slack Events API は 3 秒以内の ACK を要求するが、調査には数十秒かかる（評価時実測 43 秒程度）。リクエストを受けたら即座に 200 を返し、`chat.postMessage` で「🔍 調査中です」を即時投稿した上で、goroutine でスレッド履歴取得→Holmes 呼び出し→結果投稿を行う。
 - **投稿先**: mention されたチャンネル・スレッド。
 
 ### Slack app の手動セットアップ (コードでは自動化できない)
 
 1. api.slack.com で新規 Slack app を作成
 2. Event Subscriptions を有効化し、Request URL に holmes-relay の公開エンドポイント (`https://<holmes-relay-host>/slack/events`) を設定
-3. Bot Token Scopes: `app_mentions:read`, `chat:write`
+3. Bot Token Scopes: `app_mentions:read`, `chat:write`, `channels:history`, `groups:history`（スレッド履歴取得のため。後者は private channel での利用に備える）
 4. Subscribe to bot events: `app_mention`
 5. ワークスペースにインストールし、signing secret と bot token を取得
 

--- a/docs/superpowers/specs/2026-08-14-holmes-relay-design.md
+++ b/docs/superpowers/specs/2026-08-14-holmes-relay-design.md
@@ -1,0 +1,98 @@
+# holmes-relay Design
+
+## Background
+
+HolmesGPT は本番導入済み（`docs/superpowers/specs/2026-08-13-holmesgpt-evaluation-design.md`）だが、実際にインシデント発生時どう調査依頼を出すかの導線が無い。当初4つの経路を検討した:
+
+- **A. k9s plugin**（手動、pod 選択から調査）
+- **B. ScheduledHealthCheck**（operator CRD による定期チェック）
+- **C. Alertmanager 起点の自動調査**
+- **D. Slack からの on-demand 調査依頼**（"Ask Holmes" 的な UX）
+
+検討の結果、A・B は利用頻度が見込めないためスコープ外とした。C と D は実装すると「外部イベントを受けて Holmes の `/api/chat` を呼び、結果を Slack に返す」という同一の中継サービスに帰着することが分かったため、1つのサービス **holmes-relay** として統合設計する。
+
+## Goal
+
+Slack からのメンションと、Alertmanager の critical アラートの両方を起点に HolmesGPT の調査を実行し、結果を Slack に届ける中継サービスを設計する。
+
+## Scope
+
+### 対象 (このドキュメントでカバーする)
+
+- `holmes-relay`: Slack Events API と Alertmanager webhook を受け、HolmesGPT `/api/chat` を呼び出し、結果を Slack に投稿する新規サービス
+- Alertmanager 側のルーティング設定（`platform` repo, `prometheus-operator` component）
+- Slack app の必要スコープ・設定値（手動セットアップ手順として明記。実施はコードでは自動化できない）
+
+### 対象外
+
+- **A (k9s plugin)**: 利用頻度が低い見込みのため見送り。将来必要になれば別途 spec を起こす。
+- **B (ScheduledHealthCheck)**: 既存の Prometheus/Alertmanager による監視と役割が重複するため見送り。
+- Holmes 本体の toolset/model 構成変更（既存の `kubernetes/components/holmesgpt/` 設定を前提とし、変更しない）
+
+## Architecture
+
+```
+Slack (app_mention) ──POST /slack/events──┐
+                                            ├──> holmes-relay ──POST /api/chat──> HolmesGPT (holmesgpt-holmes.holmesgpt.svc.cluster.local)
+Alertmanager (severity=critical) ──POST /alertmanager/webhook──┘         │
+                                                                          └──chat.postMessage──> Slack
+```
+
+- **配置場所**: `panicboat/monorepo` の `services/holmes-relay/`（`workspace/` にアプリ本体、`kubernetes/` に Deployment/Service/HTTPRoute）。既存の `frontend`/`monolith` と同じ構成・CI（`reusable--container-builder.yaml`）・Flux デプロイパターンをそのまま使う。新規のインフラパターンは持ち込まない。
+- **実装言語**: Go。フレームワーク無し、`net/http` 標準ライブラリのみで実装する単一バイナリ。
+- **Holmes API 呼び出し**: `holmesgpt-holmes.holmesgpt.svc.cluster.local`（ClusterIP、クラスタ内到達のため追加公開不要）に `POST /api/chat`、`model: sonnet-4-6` 固定。
+  - sonnet-5 は Bedrock 側の service quota が 0 のまま self-service では解消しないため使わない（詳細: 別途トラッキング）。
+- **公開エンドポイント**: monorepo 既存の Gateway API + ALB IngressGroup パターンで公開（Slack・Alertmanager 双方とも外部からの到達が必要なため）。TLS は cert-manager、DNS は external-dns、既存 component をそのまま利用。
+
+## Slack Integration (D)
+
+- **UX**: メンション方式。任意チャンネルで `@holmes <調査内容>` と mention すると、同じスレッドで返信する。
+- **エンドポイント**: `POST /slack/events`（Slack Events API）。
+  - `url_verification` challenge に応答（初回セットアップ時の Slack 側ハンドシェイク）。
+  - `event_callback` / `event.type == "app_mention"` を処理。mention 部分を取り除いたテキストを調査依頼文として使う。
+  - `X-Slack-Signature` / `X-Slack-Request-Timestamp` を signing secret で HMAC-SHA256 検証（Slack 公式の署名検証手順に従う）。
+- **非同期処理**: Slack Events API は 3 秒以内の ACK を要求するが、調査には数十秒かかる（評価時実測 43 秒程度）。リクエストを受けたら即座に 200 を返し、`chat.postMessage` で「🔍 調査中です」を即時投稿した上で、goroutine で Holmes 呼び出し→結果投稿を行う。
+- **投稿先**: mention されたチャンネル・スレッド。
+
+### Slack app の手動セットアップ (コードでは自動化できない)
+
+1. api.slack.com で新規 Slack app を作成
+2. Event Subscriptions を有効化し、Request URL に holmes-relay の公開エンドポイント (`https://<holmes-relay-host>/slack/events`) を設定
+3. Bot Token Scopes: `app_mentions:read`, `chat:write`
+4. Subscribe to bot events: `app_mention`
+5. ワークスペースにインストールし、signing secret と bot token を取得
+
+## Alertmanager Integration (C)
+
+- **エンドポイント**: `POST /alertmanager/webhook`（Alertmanager 標準の webhook payload 形式を受ける）。
+- **対象アラート**: `severity: critical` のみ。この絞り込みは **Alertmanager の route 側**で行う（holmes-relay 側では絞り込まない）。理由: kube-prometheus-stack の default rule は既に `severity` ラベルを付与済み（VERIFIED: 2026-08-14 時点で firing 中の 6 アラート中、critical 3 / warning 1 / info 1 / ラベル無し 1）。新たなラベル付け作業が不要で、運用負担がゼロ。
+- **チャンネル振り分け**: holmes-relay 自体はチャンネルをハードコードしない。Alertmanager の receiver ごとに webhook URL のクエリパラメータでチャンネルを渡す（例: `.../alertmanager/webhook?channel=team-x-incidents`）。holmes-relay は受け取った `channel` にそのまま投稿する汎用実装とする。これにより、チーム/サービスごとのチャンネル分離は Alertmanager の route 定義側だけで完結し、holmes-relay のコード変更を必要としない。
+- **`platform` repo 側の変更**: `kubernetes/components/prometheus-operator/production/values.yaml.gotmpl` に `severity: critical` にマッチする route と、holmes-relay を指す `webhook_configs` を持つ receiver を追加する。
+
+## Secrets & Auth
+
+| 経路 | 認証方式 | 保存場所 |
+|---|---|---|
+| Slack → holmes-relay | Slack 署名検証 (HMAC-SHA256) | AWS Secrets Manager `panicboat/holmes-relay/slack`（`signing_secret`, `bot_token`）を ExternalSecret で sync |
+| Alertmanager → holmes-relay | 共有 Bearer トークン | AWS Secrets Manager `panicboat/holmes-relay/alertmanager`（`shared_token`）を ExternalSecret で sync |
+| holmes-relay → HolmesGPT `/api/chat` | 認証なし | Holmes API 自体が現状無認証設計のため踏襲。ClusterIP はクラスタ内到達可能。将来的に NetworkPolicy で holmes-relay の pod からのみ許可する多層防御を検討事項として残す |
+| holmes-relay → Slack API | Bot token (Bearer) | 上記と同じ Secret から取得 |
+
+ExternalSecret は oauth2-proxy の既存パターン（`aws-secrets-manager` ClusterSecretStore、`refreshInterval: 1h`）を踏襲する。
+
+## Error Handling
+
+- Holmes API 呼び出し失敗・タイムアウト時: Slack には「調査に失敗しました」の旨をエラー概要とともに投稿する（隠さない）。Alertmanager 側には常に 200 を返す（Alertmanager 側でリトライされても holmes-relay 側の処理自体は冪等ではないため、リトライさせない）。
+- Slack 署名検証失敗: 401 を返しログに記録。
+- Alertmanager の共有トークン不一致: 401 を返しログに記録。
+
+## Testing
+
+- holmes-relay 単体: 署名検証・Alertmanager トークン検証のユニットテスト、Holmes API / Slack API 呼び出し部分はモックで検証。
+- 結合テスト: 開発環境相当で実際に Slack app mention → holmes-relay → HolmesGPT（sandbox 相当環境があれば）→ Slack 投稿、が一連で通ることを手動確認。
+- Alertmanager 側: `amtool` 等で `severity: critical` のテストアラートを送り、holmes-relay の `/alertmanager/webhook` に届き Slack に投稿されることを確認。
+
+## Open Items (この spec では解決しない)
+
+- sonnet-5 の Bedrock service quota が 0 のまま解消しない件（`bedrock-5gen-quota-blocker` として別トラッキング）。解消次第 `model` を差し替えるだけで holmes-relay 側の変更は不要。
+- Holmes API (`/api/chat`) を無認証のまま新しい呼び出し元 (holmes-relay) に開放することの妥当性。NetworkPolicy 等の多層防御は本 spec のスコープ外とし、実装後の運用状況を見て判断する。

--- a/kubernetes/components/external-dns/production/values.yaml.gotmpl
+++ b/kubernetes/components/external-dns/production/values.yaml.gotmpl
@@ -9,6 +9,7 @@ provider:
 sources:
   - service
   - ingress
+  - gateway-httproute
 
 # =============================================================================
 # Domain filtering

--- a/kubernetes/manifests/production/external-dns/manifest.yaml
+++ b/kubernetes/manifests/production/external-dns/manifest.yaml
@@ -141,6 +141,15 @@ rules:
   - apiGroups: ["extensions","networking.k8s.io"]
     resources: ["ingresses"]
     verbs: ["get","watch","list"]
+  - apiGroups: ["gateway.networking.k8s.io"]
+    resources: ["gateways"]
+    verbs: ["get","watch","list"]
+  - apiGroups: [""]
+    resources: ["namespaces"]
+    verbs: ["get","watch","list"]
+  - apiGroups: ["gateway.networking.k8s.io"]
+    resources: ["httproutes"]
+    verbs: ["get","watch","list"]
 ---
 # Source: external-dns/templates/clusterrolebinding.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -238,6 +247,7 @@ spec:
             - --interval=1m
             - --source=service
             - --source=ingress
+            - --source=gateway-httproute
             - --policy=sync
             - --registry=txt
             - --txt-owner-id=eks-production


### PR DESCRIPTION
## Summary
- external-dns: add `gateway-httproute` source so it discovers `HTTPRoute` resources (holmes is the first HTTPRoute-based service in this cluster; existing services all use Ingress)
- holmes-relay design spec + Alertmanager route plan (plan not yet executed — still references old `holmes-relay` naming, pending rename to `holmes`)

## Context
`panicboat/monorepo`'s `system-components/holmes` service was deployed but unreachable at `holmes.dystopia.city` because external-dns never created the DNS record — it only watches `service`/`ingress` sources.

## Test plan
- [x] `holmes` pod confirmed Running/Ready after secret provisioning
- [ ] confirm `holmes.dystopia.city` resolves after this merges and Flux reconciles external-dns
- [ ] Alertmanager route plan still needs execution (naming rename + implementation)