### PR TITLE
chore(aws): relocate HolmesGPT IAM into its own eks-holmesgpt stack

### DIFF
--- a/aws/eks-holmesgpt/envs/production/env.hcl
+++ b/aws/eks-holmesgpt/envs/production/env.hcl
@@ -1,0 +1,12 @@
+# env.hcl - Environment-specific configuration for production
+
+locals {
+  environment = "production"
+  aws_region  = "ap-northeast-1"
+
+  environment_tags = {
+    Environment = local.environment
+    Component   = "eks-holmesgpt"
+    Owner       = "panicboat"
+  }
+}

--- a/aws/eks-holmesgpt/envs/production/terragrunt.hcl
+++ b/aws/eks-holmesgpt/envs/production/terragrunt.hcl
@@ -1,0 +1,32 @@
+# terragrunt.hcl - Terragrunt configuration for production environment
+
+include "root" {
+  path = find_in_parent_folders("root.hcl")
+}
+
+include "env" {
+  path   = "env.hcl"
+  expose = true
+}
+
+# Reference to Terraform modules.
+# Use go-getter `//` subdir notation so the entire `aws/` tree is copied to
+# the Terragrunt cache. This lets `module "eks"` in modules/lookups.tf
+# resolve `../../eks/lookup` from within the cache.
+terraform {
+  source = "../../..//eks-holmesgpt/modules"
+}
+
+inputs = {
+  environment = include.env.locals.environment
+  aws_region  = include.env.locals.aws_region
+
+  common_tags = merge(
+    include.env.locals.environment_tags,
+    {
+      Project    = "eks-holmesgpt"
+      ManagedBy  = "terraform"
+      Repository = "panicboat/platform"
+    }
+  )
+}

--- a/aws/eks-holmesgpt/modules/lookups.tf
+++ b/aws/eks-holmesgpt/modules/lookups.tf
@@ -1,0 +1,7 @@
+# lookups.tf - External stack lookups.
+
+# EKS cluster info (for Pod Identity Association cluster_name)
+module "eks" {
+  source      = "../../eks/lookup"
+  environment = var.environment
+}

--- a/aws/eks-holmesgpt/modules/main.tf
+++ b/aws/eks-holmesgpt/modules/main.tf
@@ -1,4 +1,4 @@
-# iam_holmesgpt.tf - IRSA role for the HolmesGPT evaluation (Bedrock inference only).
+# main.tf - HolmesGPT AWS-side infrastructure (IAM role + Pod Identity for Bedrock invoke).
 #
 # HolmesGPT runs in-cluster and reads the cluster through the Kubernetes API.
 # That access comes from the chart's own read-only ClusterRole, not from this
@@ -17,10 +17,33 @@
 # this account: the IAM grant is independent of Bedrock model-access enablement,
 # so having it in place avoids a second apply once propagation completes.
 
-resource "aws_iam_policy" "holmesgpt_bedrock" {
-  name        = "eks-${var.environment}-holmesgpt-bedrock"
-  description = "Bedrock invoke permissions for the HolmesGPT evaluation"
-  tags        = var.common_tags
+data "aws_caller_identity" "current" {}
+
+locals {
+  service_name = "holmesgpt" # K8s ServiceAccount name
+}
+
+# IAM role for Pod Identity Association
+resource "aws_iam_role" "pod_identity" {
+  name = "eks-${var.environment}-holmesgpt"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect = "Allow"
+      Principal = {
+        Service = "pods.eks.amazonaws.com"
+      }
+      Action = ["sts:AssumeRole", "sts:TagSession"]
+    }]
+  })
+
+  tags = var.common_tags
+}
+
+resource "aws_iam_role_policy" "bedrock_invoke" {
+  name = "bedrock-invoke"
+  role = aws_iam_role.pod_identity.id
 
   policy = jsonencode({
     Version = "2012-10-17"
@@ -46,26 +69,12 @@ resource "aws_iam_policy" "holmesgpt_bedrock" {
   })
 }
 
-module "holmesgpt_irsa" {
-  source  = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts"
-  version = "~> 6.8"
-
-  name            = "eks-${var.environment}-holmesgpt"
-  use_name_prefix = false
-
-  policies = {
-    bedrock = aws_iam_policy.holmesgpt_bedrock.arn
-  }
-
-  # chart の既定 SA 名は release 名から導出されて変わりうるため、values 側で
-  # customServiceAccountName: holmesgpt を指定して固定する。trust policy が
-  # 参照する namespace:serviceaccount はそれと一致させる。
-  oidc_providers = {
-    main = {
-      provider_arn               = module.eks.oidc_provider_arn
-      namespace_service_accounts = ["holmesgpt:holmesgpt"]
-    }
-  }
+# Pod Identity Association binding K8s SA → IAM role
+resource "aws_eks_pod_identity_association" "this" {
+  cluster_name    = module.eks.cluster.name
+  namespace       = local.service_name
+  service_account = local.service_name
+  role_arn        = aws_iam_role.pod_identity.arn
 
   tags = var.common_tags
 }

--- a/aws/eks-holmesgpt/modules/outputs.tf
+++ b/aws/eks-holmesgpt/modules/outputs.tf
@@ -1,0 +1,21 @@
+# outputs.tf - Outputs for the eks-holmesgpt module.
+
+output "pod_identity_role_name" {
+  description = "IAM role name bound to holmesgpt:holmesgpt SA via Pod Identity Association. Used for verification."
+  value       = aws_iam_role.pod_identity.name
+}
+
+output "pod_identity_role_arn" {
+  description = "IAM role ARN for holmesgpt:holmesgpt SA Pod Identity binding."
+  value       = aws_iam_role.pod_identity.arn
+}
+
+output "pod_identity_association_id" {
+  description = "Pod Identity Association ID. Used for verification (aws eks describe-pod-identity-association)."
+  value       = aws_eks_pod_identity_association.this.association_id
+}
+
+output "pod_identity_association_arn" {
+  description = "Pod Identity Association ARN."
+  value       = aws_eks_pod_identity_association.this.association_arn
+}

--- a/aws/eks-holmesgpt/modules/terraform.tf
+++ b/aws/eks-holmesgpt/modules/terraform.tf
@@ -1,0 +1,20 @@
+# terraform.tf - OpenTofu and provider configuration
+
+terraform {
+  required_version = "1.12.5"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "6.58.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.aws_region
+
+  default_tags {
+    tags = var.common_tags
+  }
+}

--- a/aws/eks-holmesgpt/modules/variables.tf
+++ b/aws/eks-holmesgpt/modules/variables.tf
@@ -1,0 +1,17 @@
+# variables.tf - Inputs for the eks-holmesgpt module
+
+variable "environment" {
+  description = "Environment name (e.g., production). Used in IAM role name."
+  type        = string
+}
+
+variable "aws_region" {
+  description = "AWS region"
+  type        = string
+}
+
+variable "common_tags" {
+  description = "Common tags applied to all resources"
+  type        = map(string)
+  default     = {}
+}

--- a/aws/eks-holmesgpt/root.hcl
+++ b/aws/eks-holmesgpt/root.hcl
@@ -1,0 +1,39 @@
+# root.hcl - Root Terragrunt configuration for EKS HolmesGPT
+# This file contains common settings shared across all environments
+
+locals {
+  project_name = "eks-holmesgpt"
+
+  path_parts  = split("/", path_relative_to_include())
+  environment = element(local.path_parts, length(local.path_parts) - 1)
+
+  common_tags = {
+    Project     = local.project_name
+    Environment = local.environment
+    ManagedBy   = "terragrunt"
+    Repository  = "monorepo"
+    Component   = "eks-holmesgpt"
+    Team        = "panicboat"
+  }
+}
+
+remote_state {
+  backend = "s3"
+  generate = {
+    path      = "backend.tf"
+    if_exists = "overwrite_terragrunt"
+  }
+  config = {
+    bucket         = "terragrunt-state-${get_aws_account_id()}"
+    key            = "platform/eks-holmesgpt/${local.environment}/terraform.tfstate"
+    region         = "ap-northeast-1"
+    dynamodb_table = "terragrunt-state-locks"
+    encrypt        = true
+  }
+}
+
+inputs = {
+  environment = local.environment
+  common_tags = local.common_tags
+  aws_region  = "ap-northeast-1"
+}

--- a/kubernetes/components/holmesgpt/production/helmfile.yaml
+++ b/kubernetes/components/holmesgpt/production/helmfile.yaml
@@ -3,17 +3,13 @@
 # =============================================================================
 # HolmesGPT (CNCF Sandbox) の deploy。chart が read-only ClusterRole と
 # ServiceAccount を自前で作るため、RBAC をこちらで定義しない。
+#
+# Authentication: Pod Identity (provisioned by aws/eks-holmesgpt/ stack の
+# Pod Identity Association)。Helm chart の serviceAccount.annotations は
+# 不要 (Pod Identity Association が SA-to-role mapping を直接管理)。
 # =============================================================================
 environments:
   production:
-    # NOTE: helmfile v1.4 は親 helmfile.yaml.gotmpl の environments values を
-    # 子 helmfile に auto-inherit しないため、ここで再定義する。RECREATE marker
-    # convention は kubernetes/helmfile.yaml.gotmpl 参照。値は親 helmfile と同期。
-    values:
-      - cluster:
-          # STABLE: aws/eks/modules/iam_holmesgpt.tf で deterministic 化済
-          # (= use_name_prefix = false)
-          holmesgptRoleArn: arn:aws:iam::559744160976:role/eks-production-holmesgpt
 ---
 repositories:
   - name: robusta

--- a/kubernetes/components/holmesgpt/production/values.yaml.gotmpl
+++ b/kubernetes/components/holmesgpt/production/values.yaml.gotmpl
@@ -3,10 +3,10 @@
 # =============================================================================
 
 # -----------------------------------------------------------------------------
-# ServiceAccount / IRSA
+# ServiceAccount
 # -----------------------------------------------------------------------------
 # chart 既定の SA 名は release 名から導出されて変わりうる (= release holmesgpt
-# なら holmesgpt-holmes-service-account)。IRSA の trust policy は
+# なら holmesgpt-holmes-service-account)。Pod Identity Association は
 # namespace:serviceaccount を固定で参照するため、名前を固定する。
 createServiceAccount: true
 customServiceAccountName: holmesgpt
@@ -18,10 +18,6 @@ customServiceAccountName: holmesgpt
 #   holmesgpt-rbac-service-account.yaml: if and createServiceAccount k8sRBAC
 # chart の read-only ClusterRole をそのまま使うため既定の false を明示する。
 k8sRBAC: false
-
-serviceAccount:
-  annotations:
-    eks.amazonaws.com/role-arn: {{ .Values.cluster.holmesgptRoleArn }}
 
 # -----------------------------------------------------------------------------
 # LLM (Amazon Bedrock)

--- a/kubernetes/manifests/production/holmesgpt/manifest.yaml
+++ b/kubernetes/manifests/production/holmesgpt/manifest.yaml
@@ -597,8 +597,6 @@ kind: ServiceAccount
 metadata:
   name: holmesgpt
   namespace: holmesgpt
-  annotations:
-    eks.amazonaws.com/role-arn: arn:aws:iam::559744160976:role/eks-production-holmesgpt
 ---
 # Source: holmes/templates/toolset-config.yaml
 apiVersion: v1


### PR DESCRIPTION
## Summary
- `iam_holmesgpt.tf` lived inside the core `eks` stack's `modules/`, mixing an evaluation-status add-on's IAM into the cluster's bootstrap-critical state.
- Every other non-bootstrap-critical eks add-on (`eks-secrets`, `eks-metrics`, `eks-logs`, `eks-traces`) already gets its own top-level Terragrunt stack referencing `eks/lookup`, using Pod Identity rather than IRSA. The original placement cited mimir as an IRSA precedent, but mimir's own resources live in those Pod-Identity-based sibling stacks, not in `eks/modules` — the precedent was wrong.
- Moves the IAM role + Bedrock invoke policy into `aws/eks-holmesgpt/`, switches from IRSA to Pod Identity to match the sibling stacks, and drops the now-unneeded `serviceAccount.annotations` from the HolmesGPT Helm values.

## Production cutover (already done)
CI does not auto-apply `aws/` Terragrunt stacks (see `workflow-config.yaml` — the convention is still a TODO), so the AWS-side cutover was done manually ahead of this PR to avoid a window where the Kubernetes-side change (merged via this PR) ships before the replacement IAM exists:
1. Destroyed the old IRSA role/policy in the `eks` stack (targeted apply, no unrelated resources touched).
2. Applied the new `eks-holmesgpt` Pod Identity stack.
3. Restarted the HolmesGPT pod; confirmed Pod Identity credentials are injected (`AWS_CONTAINER_CREDENTIALS_FULL_URI` present, credentials endpoint returns 200) and the pod logs show a clean startup.

## Test plan
- [x] `tofu fmt -check` / `tofu validate` on the new stack
- [x] `terragrunt plan` on `eks-holmesgpt` (3 to add only) and `eks` (destroy-only for HolmesGPT resources, plus known steady churn: node SG tag + `terraform_data` replacement)
- [x] `terragrunt apply` executed for both stacks in production; `aws eks describe-pod-identity-association` confirms the association
- [x] `scripts/kubernetes-hydrate/hydrate-component.sh holmesgpt production` regenerated the rendered manifest; diff is the SA annotation removal only
- [x] HolmesGPT pod restarted; Pod Identity credential endpoint verified from inside the pod; logs clean
- [ ] Merge this PR so the Kubernetes-side manifest (SA without the stale annotation) lands via Flux