### PR TITLE
fix(scripts/eks-lifecycle): sweep orphan ALB controller LB/SG before vpc destroy

### DIFF
--- a/scripts/eks-lifecycle/README.md
+++ b/scripts/eks-lifecycle/README.md
@@ -74,13 +74,14 @@ make eks-teardown-verify ENV=production    # orphan verify only
 - `40-orphan-verify.sh` は read-only verify で auto-delete しない (= false-positive 含み得る出力を operator が目視精査し、必要なら提示された AWS CLI コマンドで個別削除)。検出時の exit code は live run = 1 (= operator 注意喚起 + make chain 停止)、DRY_RUN=1 = 0 (= live cluster の現役 resource を warn として列挙、make chain は継続)
 - `terragrunt destroy` で `Module version requirements have changed` (= 既存 `.terragrunt-cache/` の module version と現行 main.tf の constraint が乖離) のエラーが出たら、対象 stack を `terragrunt init -upgrade` で更新してから再開する。 8 stack 一括は以下:
   ```bash
-  for stack in karpenter eks-secrets eks-logs eks-metrics eks-traces eks alb vpc; do
+  for stack in eks-karpenter eks-secrets eks-logs eks-metrics eks-traces eks alb vpc; do
     echo "=== init: $stack ==="
     ( cd aws/$stack/envs/production && TG_TF_PATH=tofu terragrunt init -upgrade )
   done
   make eks-teardown-aws ENV=production   # 中断地点から再開、 fail fast 後の再 run は idempotent
   ```
   発生例: Renovate PR で `terraform-aws-modules/eks/aws` を `~> 21.20` に更新済みだが、 操作者の `.terragrunt-cache/` には v21.19.0 がキャッシュされているケース
+- `terragrunt destroy` (alb / vpc stack) が `DependencyViolation: ... has some mapped public address(es)` (IGW detach) や `has dependencies and cannot be deleted` (subnet/VPC) で fail する → AWS Load Balancer Controller が管理する ALB/NLB (+ 自動作成 security group) が terraform 管理外のまま残っている。 shared IngressGroup を `kubectl delete ingress --all` で 1 件ずつ消す際、 controller が同名 ALB を再作成するレースが原因 (= Step 10.4 の一度きりの tag sweep はこれを捕捉できない)。 `30-destroy-stacks.sh` は `eks` stack destroy 直後 (= controller 消滅後の安全なタイミング) に `elbv2.k8s.aws/cluster` タグで再 sweep するため通常は自動解消するが、 万一残る場合は `aws resourcegroupstaggingapi get-resources --resource-type-filters elasticloadbalancing:loadbalancer --tag-filters Key=elbv2.k8s.aws/cluster,Values=eks-production` で ALB を、 `aws ec2 describe-security-groups --filters Name=tag:elbv2.k8s.aws/cluster,Values=eks-production` で security group を特定し手動削除する
 
 ## What is preserved through teardown
 

--- a/scripts/eks-lifecycle/lib/30-destroy-stacks.sh
+++ b/scripts/eks-lifecycle/lib/30-destroy-stacks.sh
@@ -18,6 +18,57 @@ LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 require_env
 require_cmd terragrunt tofu
 
+REGION="$(resolve_aws_region)"
+
+# Step 10.4 (10-k8s-cleanup.sh) sweeps ALB/NLB tagged elbv2.k8s.aws/cluster
+# once, early in the pipeline. When multiple Ingresses share one ALB via
+# IngressGroup, `kubectl delete ingress --all` deleting them one-by-one can
+# race the controller into recreating the shared ALB (+ its auto-created
+# security groups) after that sweep already ran, leaving it orphaned once
+# the controller itself is gone. The recreate window closes for good once
+# the `eks` stack is destroyed (no controller left to reconcile), so that
+# is the last safe point to sweep before it blocks `alb`/`vpc` destroy with
+# IGW-detach / subnet-delete DependencyViolation errors.
+sweep_lb_controller_orphans() {
+  if [ "${DRY_RUN:-0}" = "1" ]; then
+    return 0
+  fi
+
+  use_apply_creds  # = need elbv2 / ec2 API permissions (= operator's chain)
+
+  local lb_arns sg_ids
+  lb_arns=$(aws resourcegroupstaggingapi get-resources --region "$REGION" \
+    --resource-type-filters "elasticloadbalancing:loadbalancer" \
+    --tag-filters "Key=elbv2.k8s.aws/cluster,Values=eks-${ENV}" \
+    --query 'ResourceTagMappingList[].ResourceARN' --output text)
+  if [ -n "$lb_arns" ]; then
+    warn "Found leftover load balancers (post-cluster-destroy): $lb_arns — force-deleting."
+    for arn in $lb_arns; do
+      aws elbv2 delete-load-balancer --region "$REGION" --load-balancer-arn "$arn" >/dev/null
+    done
+    for arn in $lb_arns; do
+      while aws elbv2 describe-load-balancers --region "$REGION" --load-balancer-arns "$arn" >/dev/null 2>&1; do
+        sleep 5
+      done
+    done
+    ok "Leftover load balancers deleted."
+  fi
+
+  # AWS Load Balancer Controller tags its auto-created security groups
+  # (frontend + backend/traffic) with the same elbv2.k8s.aws/cluster key;
+  # these are not terraform-managed so `terragrunt destroy` never sees them.
+  sg_ids=$(aws ec2 describe-security-groups --region "$REGION" \
+    --filters "Name=tag:elbv2.k8s.aws/cluster,Values=eks-${ENV}" \
+    --query 'SecurityGroups[].GroupId' --output text)
+  if [ -n "$sg_ids" ]; then
+    warn "Found leftover ALB controller security groups: $sg_ids — deleting."
+    for sg in $sg_ids; do
+      aws ec2 delete-security-group --region "$REGION" --group-id "$sg"
+    done
+    ok "Leftover ALB controller security groups deleted."
+  fi
+}
+
 STACKS=(
   "eks-karpenter"
   "eks-secrets"
@@ -50,6 +101,10 @@ After resolving, re-run: make eks-teardown-aws ENV=${ENV}"
   fi
 
   ok "${stack} destroyed"
+
+  if [ "$stack" = "eks" ]; then
+    sweep_lb_controller_orphans
+  fi
 
   if [ "${DRY_RUN:-0}" != "1" ]; then
     info "Sleeping 30s for AWS API eventual consistency..."


### PR DESCRIPTION
## Summary
- eks-production の live teardown 中に発見した `scripts/eks-lifecycle` のギャップを修正
- shared IngressGroup を `kubectl delete ingress --all` で1件ずつ削除する際、AWS Load Balancer Controller が Step 10.4 の一度きりの tag sweep 後に同名 ALB（+ 自動作成 security group）を再作成するレースがあり、`eks`/`alb`/`vpc` stack destroy 後にも orphan として残っていた
- orphan ALB の ENI が VPC の IGW detach / subnet 削除をブロックし、`terragrunt destroy` (vpc stack) が `DependencyViolation` で fail する実害を確認
- `30-destroy-stacks.sh` に、`eks` stack destroy 直後（controller が確実に消滅した安全なタイミング）に `elbv2.k8s.aws/cluster` タグで ALB/NLB + security group を再 sweep する処理を追加
- 併せて README 内の stale な `karpenter` stack 名（PR #798 の `eks-karpenter` rename 後に取り残されていた）を修正

## Context
本日の live teardown で以下の順に手動対処した内容を、恒久対応としてスクリプトに反映:
1. `terragrunt init -upgrade`（8 stack、Module version drift）
2. SIGTERM 中断からの `force-unlock` 再開
3. **orphan ALB (`k8s-application-92fded7941`) + 2 security group の手動削除**（本PRの対象）
4. orphan target group 7個の手動削除（既存の `40-orphan-verify.sh` Step 40.3 が正しく検出、対応不要と判断）

## Test plan
- [x] `shellcheck -x lib/30-destroy-stacks.sh` エラーなし
- [ ] 次回 teardown 実行時に sweep が正常動作することを確認（現在 eks-production は destroy 済のため今回は未検証）