### PR TITLE
chore(docs): Migrate production to a dedicated AWS account

### DIFF
--- a/docs/superpowers/plans/2026-08-18-production-account-migration.md
+++ b/docs/superpowers/plans/2026-08-18-production-account-migration.md
@@ -64,6 +64,14 @@
 
 新アカウントを作る前に、管理アカウント側のドリフトと孤児を解消し、失うと復旧できない値を退避する。全て `559744160976` で完結する。
 
+> **実行記録（2026-08-19 完了）**
+>
+> 記載順（0.1 → 0.5）ではなく、**失うと復旧できない退避を先に**した（0.4 → 0.5 → 0.1 → 0.2 → 0.3）。
+>
+> - Task 0.1: Step 5 の destroy が `-refresh=false` 無しでは通らなかった。手順を修正済。スクリプト側の修正は #802
+> - Task 0.5: `panicboat` は Organization ではなく User アカウントだった（`gh api users/panicboat` が `"type":"User"`）。org レベルの secret / variable は存在し得ないことが確定し、未確認項目が 1 つ解消
+> - Task 0.3 の後に `aws/route53/envs/production` で `terragrunt plan` を実行し `No changes.` を確認（stale レコード削除が Terraform 管理レコードに影響していないこと）
+
 ### Task 0.1: `eks-holmesgpt` を teardown 対象に追加して destroy
 
 `scripts/eks-lifecycle/lib/30-destroy-stacks.sh` の `STACKS` 配列は 8 スタックだが `eks-holmesgpt` が抜けている（#795 の追加漏れ）。そのため `eks-production-holmesgpt` ロールが残存し、state 内の `data.aws_eks_cluster.this` が存在しないクラスタ `eks-production` を参照している。
@@ -74,7 +82,7 @@
 **Interfaces:**
 - Produces: `platform/eks-holmesgpt/production` state が resources=0 になる。Task 9.2 の削除対象に含められる
 
-- [ ] **Step 1: 現状のドリフトを確認**
+- [x] **Step 1: 現状のドリフトを確認**
 
 ```bash
 cd aws/eks-holmesgpt/envs/production && TG_TF_PATH=tofu terragrunt plan
@@ -82,7 +90,7 @@ cd aws/eks-holmesgpt/envs/production && TG_TF_PATH=tofu terragrunt plan
 
 Expected: `data.aws_eks_cluster.this` の解決に失敗する（`No cluster found for name: eks-production`）
 
-- [ ] **Step 2: `STACKS` 配列に `eks-holmesgpt` を追加**
+- [x] **Step 2: `STACKS` 配列に `eks-holmesgpt` を追加**
 
 `scripts/eks-lifecycle/lib/30-destroy-stacks.sh` の `STACKS=(` ブロックを以下に置き換える。`eks-holmesgpt` は EKS クラスタの Pod Identity Association を持つため `eks` より前に置く。
 
@@ -100,7 +108,7 @@ STACKS=(
 )
 ```
 
-- [ ] **Step 3: 件数の記述を更新**
+- [x] **Step 3: 件数の記述を更新**
 
 同ファイル冒頭のコメントを以下に置き換える。
 
@@ -114,7 +122,7 @@ STACKS=(
 
 さらに `confirm "About to DESTROY 8 stacks for ENV=${ENV}. Continue?"` と `ok "All 8 stacks destroyed"` の `8` を `9` に変更する。
 
-- [ ] **Step 4: 存在しないリソースを state から外す**
+- [x] **Step 4: 存在しないリソースを state から外す**
 
 クラスタが無いため Pod Identity Association は AWS 上に存在しない。
 
@@ -125,15 +133,17 @@ TG_TF_PATH=tofu terragrunt state rm aws_eks_pod_identity_association.this
 
 Expected: `Successfully removed 1 resource instance(s).`
 
-- [ ] **Step 5: 残りを destroy**
+- [x] **Step 5: 残りを destroy**
+
+`-refresh=false` が必須。クラスタが既に無いため、通常の destroy は plan 生成時に `module.eks.data.aws_eks_cluster.this` の解決で落ちる（Step 4 で `state rm` してもこの data source は config 上に残るため結果は同じ）。
 
 ```bash
-cd aws/eks-holmesgpt/envs/production && TG_TF_PATH=tofu terragrunt destroy -auto-approve
+cd aws/eks-holmesgpt/envs/production && TG_TF_PATH=tofu terragrunt destroy -auto-approve -refresh=false
 ```
 
-Expected: `aws_iam_role.pod_identity` と `aws_iam_role_policy.bedrock_invoke` が destroy される
+Expected: `Plan: 0 to add, 0 to change, 2 to destroy.` に続いて `aws_iam_role_policy.bedrock_invoke` と `aws_iam_role.pod_identity` が destroy される
 
-- [ ] **Step 6: ロールが消えたことを確認**
+- [x] **Step 6: ロールが消えたことを確認**
 
 ```bash
 aws iam get-role --role-name eks-production-holmesgpt
@@ -141,7 +151,7 @@ aws iam get-role --role-name eks-production-holmesgpt
 
 Expected: `NoSuchEntity` エラー
 
-- [ ] **Step 7: コミット**
+- [x] **Step 7: コミット**
 
 ```bash
 git add scripts/eks-lifecycle/lib/30-destroy-stacks.sh
@@ -152,7 +162,7 @@ git commit -s -m "fix(scripts/eks-lifecycle): include eks-holmesgpt in destroy o
 
 **Files:** なし（AWS API 操作のみ）
 
-- [ ] **Step 1: 孤児 instance profile を確認**
+- [x] **Step 1: 孤児 instance profile を確認**
 
 ```bash
 aws iam list-instance-profiles \
@@ -161,13 +171,13 @@ aws iam list-instance-profiles \
 
 Expected: `eks-production_513473553642647435` が `Roles: []` で 1 件返る
 
-- [ ] **Step 2: instance profile を削除**
+- [x] **Step 2: instance profile を削除**
 
 ```bash
 aws iam delete-instance-profile --instance-profile-name eks-production_513473553642647435
 ```
 
-- [ ] **Step 3: レガシーログ グループを削除**
+- [x] **Step 3: レガシーログ グループを削除**
 
 state に対応の無い 3 本のみ。`/github-repository/{ansible,deploy-actions,dotfiles,monorepo,panicboat-actions,platform}` は `platform/repository/develop` state が管理しているため残す。
 
@@ -177,7 +187,7 @@ aws logs delete-log-group --region ap-northeast-1 --log-group-name /github-repos
 aws logs delete-log-group --region us-east-1   --log-group-name /github-actions/claude-code-action-monorepo
 ```
 
-- [ ] **Step 4: 削除を確認**
+- [x] **Step 4: 削除を確認**
 
 ```bash
 aws iam list-instance-profiles --query 'InstanceProfiles[].InstanceProfileName' --output text
@@ -193,7 +203,7 @@ Expected: instance profile が空、`ap-northeast-1` が 8 本、`us-east-1` が
 
 **Files:** なし（Route53 API 操作のみ）
 
-- [ ] **Step 1: 対象レコードを確認**
+- [x] **Step 1: 対象レコードを確認**
 
 ```bash
 aws route53 list-resource-record-sets --hosted-zone-id Z03420722KS9MTSCUSIQZ \
@@ -202,7 +212,7 @@ aws route53 list-resource-record-sets --hosted-zone-id Z03420722KS9MTSCUSIQZ \
 
 Expected: 6 件。ALIAS の向き先が `k8s-application-92fded7941-*` であること
 
-- [ ] **Step 2: 削除用 change batch を生成**
+- [x] **Step 2: 削除用 change batch を生成**
 
 値を手で書き写すと ALIAS の `HostedZoneId` を取り違えるため、必ず API 出力から生成する。
 
@@ -218,7 +228,7 @@ cat /tmp/dystopia-stale-delete.json
 
 Expected: `Changes` が 6 要素
 
-- [ ] **Step 3: 削除を実行**
+- [x] **Step 3: 削除を実行**
 
 ```bash
 aws route53 change-resource-record-sets \
@@ -226,7 +236,7 @@ aws route53 change-resource-record-sets \
   --change-batch file:///tmp/dystopia-stale-delete.json
 ```
 
-- [ ] **Step 4: 残存レコードを確認**
+- [x] **Step 4: 残存レコードを確認**
 
 ```bash
 aws route53 list-resource-record-sets --hosted-zone-id Z03420722KS9MTSCUSIQZ \
@@ -244,7 +254,7 @@ Expected: 5 件（`dystopia.city.` の SOA / NS / MX / TXT、`google._domainkey.
 **Interfaces:**
 - Produces: `$HOME/.secrets-backup-559744160976.json`。Task 6.1 と Task 8.1 が読む
 
-- [ ] **Step 1: 全 secret 名を列挙**
+- [x] **Step 1: 全 secret 名を列挙**
 
 ```bash
 aws secretsmanager list-secrets --region ap-northeast-1 --query 'SecretList[].Name' --output text | tr '\t' '\n'
@@ -252,7 +262,7 @@ aws secretsmanager list-secrets --region ap-northeast-1 --query 'SecretList[].Na
 
 Expected: 8 件（`panicboat/oauth2-proxy/google`, `panicboat/grafana/admin`, `panicboat/github-app/panicboat`, `panicboat/keycloak/admin`, `panicboat/holmes/slack`, `panicboat/holmes/alertmanager`, `panicboat/holmes/github`, `panicboat/alertmanager/slack-notify`）
 
-- [ ] **Step 2: 値を退避**
+- [x] **Step 2: 値を退避**
 
 出力には認証情報が含まれるため、リポジトリ外かつパーミッション 0600 のファイルに書く。
 
@@ -270,7 +280,7 @@ ls -l "$OUT"
 
 Expected: パーミッションが `-rw-------`
 
-- [ ] **Step 3: 退避件数を確認**
+- [x] **Step 3: 退避件数を確認**
 
 ```bash
 grep -c '"name"' "$HOME/.secrets-backup-559744160976.json"
@@ -284,18 +294,17 @@ Expected: `8`
 
 **Files:** なし
 
-- [ ] **Step 1: org 管理権限のあるトークンで org レベルの設定を確認**
+- [x] **Step 1: `panicboat` が Organization かどうかを確認**
 
-`gh auth token` の既定トークンでは `admin:org` スコープが無く 404 になる。必要なら `gh auth refresh -s admin:org` でスコープを足す。
+org レベルの secret / variable は Organization アカウント専用の機能。所有者が User アカウントなら概念ごと存在しない。
 
 ```bash
-gh api orgs/panicboat/actions/secrets --jq '.secrets[].name' 2>&1
-gh api orgs/panicboat/actions/variables --jq '.variables[].name' 2>&1
+gh api users/panicboat --jq '{login, type}'
 ```
 
-Expected: 一覧が返る。AWS アカウント ID を含む値があれば Phase 4 の差し替え対象に加える。404 が続く場合は「スコープ不足のため未確認」として記録し、GitHub Web UI（Settings → Secrets and variables → Actions）で目視確認する
+Expected: `{"login":"panicboat","type":"User"}` — **User なので org レベルの secret / variable は存在し得ない**。`gh api orgs/panicboat/actions/secrets` が 404 を返すのはスコープ不足ではなくこれが理由。`"type":"Organization"` が返った場合のみ、`gh auth refresh -s admin:org` でスコープを足して一覧を取得し、AWS アカウント ID を含む値があれば Phase 4 の差し替え対象に加える
 
-- [ ] **Step 2: リポジトリレベルの設定が AWS アカウントに依存しないことを確認**
+- [x] **Step 2: リポジトリレベルの設定が AWS アカウントに依存しないことを確認**
 
 ```bash
 for r in platform monorepo; do
@@ -307,7 +316,7 @@ done
 
 Expected: `platform` は `APP_PRIVATE_KEY` / `APP_ID`（`1371999`）、`monorepo` は加えて `SLACK_BOT_TOKEN`。いずれも GitHub App とSlack の資格情報で AWS アカウント ID を含まない
 
-- [ ] **Step 3: GitHub Environments の有無を確認**
+- [x] **Step 3: GitHub Environments の有無を確認**
 
 `aws/github-oidc-auth` の trust policy が `repo:panicboat/*:environment:{master,develop,production}` を許可条件に含むが、Environment が存在しなければこの条件は使われない。
 
@@ -320,7 +329,7 @@ done
 
 Expected: 両方とも出力なし（0 件）。もし存在する場合は、移行後も同名で残っていることを Phase 9 で再確認する
 
-- [ ] **Step 4: ruleset の現状を記録**
+- [x] **Step 4: ruleset の現状を記録**
 
 Phase 3 の `github/branch` re-home 前後で変化していないことを比較するための基準値。
 

--- a/docs/superpowers/plans/2026-08-18-production-account-migration.md
+++ b/docs/superpowers/plans/2026-08-18-production-account-migration.md
@@ -14,7 +14,7 @@
 
 - 管理アカウント ID: `559744160976`（Organization `o-es9qoj85gw`、Identity Center `ssoins-7758e2d4fb37f3a7`、permission set `ps-77583734ef962d6b`、ユーザー `e7146ab8-20b1-70eb-a63d-b9887df5d7a6`）
 - 新アカウントのルートメール: production = `aws+production@panicboat.net`、develop = `aws+develop@panicboat.net`
-- `<PROD_ACCOUNT_ID>` / `<DEV_ACCOUNT_ID>` は Task 1.1 で確定する。以降のタスクではこの実値に置換すること
+- `337169763788` / `270242382571` は Task 1.1 で確定する。以降のタスクではこの実値に置換すること
 - hosted zone: `panicboat.net` = `Z07598371GKBU0WMF89MD`、`dystopia.city` = `Z03420722KS9MTSCUSIQZ`
 - クロスアカウントロール: `arn:aws:iam::559744160976:role/route53-zone-access`
 - region: `master` = `ap-northeast-1`、`develop` = `us-east-1`、`production` = `ap-northeast-1`
@@ -347,14 +347,27 @@ Expected: 3 本とも `active`（`15519991 monorepo-main` / `15519990 platform-m
 
 手動 AWS 操作のみ。コード変更もコミットも無い。
 
+> **実行記録（2026-08-20 完了）**
+>
+> | env | Account ID | root email |
+> |---|---|---|
+> | production | `337169763788` | `aws+production@panicboat.net` |
+> | develop | `270242382571` | `aws+develop@panicboat.net` |
+>
+> - 両アカウントとも `SUCCEEDED`。プラスアドレスの衝突は起きなかった
+> - `OrganizationAccountAccessRole` の assume を両方で確認済
+> - Identity Center の `AdministratorAccess` を 3 アカウント全てに割当済
+> - Task 1.2 Step 2 の実測値は On-Demand / Spot ともに **5.0**（設計の予測どおり AWS デフォルト）。増枠 2 件を申請し `PENDING`
+> - **Task 1.2 Step 5 のコンソール操作は不要だった。** Bedrock のモデルアクセスは新アカウントで既に有効（`authorizationStatus: AUTHORIZED` / `entitlementAvailability: AVAILABLE` / `agreementAvailability: NOT_AVAILABLE` = 同意取得不要）。手順を修正済
+
 ### Task 1.1: メンバーアカウント 2 つを作成
 
 **Files:** なし
 
 **Interfaces:**
-- Produces: `<PROD_ACCOUNT_ID>` と `<DEV_ACCOUNT_ID>`。以降の全タスクが依存する
+- Produces: `337169763788` と `270242382571`。以降の全タスクが依存する
 
-- [ ] **Step 1: 既存アカウント一覧を確認**
+- [x] **Step 1: 既存アカウント一覧を確認**
 
 ```bash
 aws organizations list-accounts --query 'Accounts[].{Id:Id,Name:Name,Email:Email,State:State}' --output table
@@ -362,7 +375,7 @@ aws organizations list-accounts --query 'Accounts[].{Id:Id,Name:Name,Email:Email
 
 Expected: `583677814390`（CLOSED）、`504150922582`（CLOSED）、`559744160976`（ACTIVE）
 
-- [ ] **Step 2: `aws@panicboat.net` が受信できることを確認**
+- [x] **Step 2: `aws@panicboat.net` が受信できることを確認**
 
 `panicboat.net` は Google Workspace（MX = `smtp.google.com`）で、プラスアドレスはベースのメールボックスへ配送される。`aws@panicboat.net` がユーザーまたはエイリアスとして存在しないと、ルートアカウントの検証メールとパスワードリセットが届かずアカウントを復旧できなくなる。
 
@@ -374,7 +387,7 @@ Expected: `1 smtp.google.com.`
 
 Google Workspace 管理コンソール（Directory → Users、または該当ユーザーの Alternate email addresses）で `aws@panicboat.net` の存在を確認する。無ければエイリアスを作成し、外部から `aws+production@panicboat.net` 宛にテストメールを送って受信できることを確かめてから次へ進む。
 
-- [ ] **Step 3: production アカウントを作成**
+- [x] **Step 3: production アカウントを作成**
 
 クローズ済みアカウントが保持しているのは `admin@panicboat.net` と `aws@dystopia.city` で、いずれも下記とは別アドレス。
 
@@ -387,7 +400,7 @@ aws organizations create-account \
 
 Expected: `CreateAccountStatus.State` が `IN_PROGRESS`
 
-- [ ] **Step 4: develop アカウントを作成**
+- [x] **Step 4: develop アカウントを作成**
 
 ```bash
 aws organizations create-account \
@@ -396,7 +409,7 @@ aws organizations create-account \
   --iam-user-access-to-billing DENY
 ```
 
-- [ ] **Step 5: 両方の完了とアカウント ID を確認**
+- [x] **Step 5: 両方の完了とアカウント ID を確認**
 
 ```bash
 aws organizations list-create-account-status --states SUCCEEDED FAILED \
@@ -404,12 +417,12 @@ aws organizations list-create-account-status --states SUCCEEDED FAILED \
   --output table
 ```
 
-Expected: 両方 `SUCCEEDED` で `AccountId` が返る。この 2 値を `<PROD_ACCOUNT_ID>` / `<DEV_ACCOUNT_ID>` として記録する。`EMAIL_ALREADY_EXISTS` で失敗した場合は別のプラスアドレス（例: `aws+prod2@panicboat.net`）で再試行する
+Expected: 両方 `SUCCEEDED` で `AccountId` が返る。この 2 値を `337169763788` / `270242382571` として記録する。`EMAIL_ALREADY_EXISTS` で失敗した場合は別のプラスアドレス（例: `aws+prod2@panicboat.net`）で再試行する
 
-- [ ] **Step 6: 両アカウントで `OrganizationAccountAccessRole` を assume できることを確認**
+- [x] **Step 6: 両アカウントで `OrganizationAccountAccessRole` を assume できることを確認**
 
 ```bash
-for acct in <PROD_ACCOUNT_ID> <DEV_ACCOUNT_ID>; do
+for acct in 337169763788 270242382571; do
   aws sts assume-role \
     --role-arn "arn:aws:iam::${acct}:role/OrganizationAccountAccessRole" \
     --role-session-name bootstrap-check \
@@ -419,10 +432,10 @@ done
 
 Expected: 2 行とも `arn:aws:sts::<acct>:assumed-role/OrganizationAccountAccessRole/bootstrap-check`
 
-- [ ] **Step 7: Identity Center の AdministratorAccess を両アカウントに割当**
+- [x] **Step 7: Identity Center の AdministratorAccess を両アカウントに割当**
 
 ```bash
-for acct in <PROD_ACCOUNT_ID> <DEV_ACCOUNT_ID>; do
+for acct in 337169763788 270242382571; do
   aws sso-admin create-account-assignment \
     --instance-arn arn:aws:sso:::instance/ssoins-7758e2d4fb37f3a7 \
     --permission-set-arn arn:aws:sso:::permissionSet/ssoins-7758e2d4fb37f3a7/ps-77583734ef962d6b \
@@ -434,7 +447,7 @@ for acct in <PROD_ACCOUNT_ID> <DEV_ACCOUNT_ID>; do
 done
 ```
 
-- [ ] **Step 8: 割当を確認**
+- [x] **Step 8: 割当を確認**
 
 ```bash
 aws sso-admin list-accounts-for-provisioned-permission-set \
@@ -451,12 +464,12 @@ Expected: `AccountIds` に 3 件（管理 + production + develop）
 
 **Files:** なし
 
-- [ ] **Step 1: production アカウントの認証情報に切り替える**
+- [x] **Step 1: production アカウントの認証情報に切り替える**
 
 ```bash
 unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_SESSION_TOKEN
 CREDS=$(aws sts assume-role \
-  --role-arn arn:aws:iam::<PROD_ACCOUNT_ID>:role/OrganizationAccountAccessRole \
+  --role-arn arn:aws:iam::337169763788:role/OrganizationAccountAccessRole \
   --role-session-name quota-request --query Credentials --output json)
 export AWS_ACCESS_KEY_ID=$(echo "$CREDS" | jq -r .AccessKeyId)
 export AWS_SECRET_ACCESS_KEY=$(echo "$CREDS" | jq -r .SecretAccessKey)
@@ -464,9 +477,9 @@ export AWS_SESSION_TOKEN=$(echo "$CREDS" | jq -r .SessionToken)
 aws sts get-caller-identity --query Account --output text
 ```
 
-Expected: `<PROD_ACCOUNT_ID>`
+Expected: `337169763788`
 
-- [ ] **Step 2: 現在値を確認**
+- [x] **Step 2: 現在値を確認**
 
 ```bash
 for qc in L-1216C47A L-34B43A08; do
@@ -477,7 +490,7 @@ done
 
 Expected: いずれも `5.0`（AWS デフォルト）
 
-- [ ] **Step 3: 増枠を申請**
+- [x] **Step 3: 増枠を申請**
 
 管理アカウントの適用値（On-Demand 64 / Spot 256）に合わせる。
 
@@ -488,7 +501,7 @@ aws service-quotas request-service-quota-increase \
   --service-code ec2 --quota-code L-34B43A08 --desired-value 256 --region ap-northeast-1
 ```
 
-- [ ] **Step 4: 申請が受理されたことを確認**
+- [x] **Step 4: 申請が受理されたことを確認**
 
 ```bash
 aws service-quotas list-requested-service-quota-change-history --region ap-northeast-1 \
@@ -497,18 +510,29 @@ aws service-quotas list-requested-service-quota-change-history --region ap-north
 
 Expected: 2 件が `PENDING` または `CASE_OPENED`
 
-- [ ] **Step 5: Bedrock のモデルアクセスを有効化**
+- [x] **Step 5: Bedrock のモデルアクセス状態を確認**
 
-`us-east-1` の Bedrock コンソールで、HolmesGPT が使う Anthropic Claude モデル（`anthropic.claude-sonnet-4-6` / `anthropic.claude-opus-4-6`）へのアクセスをリクエストする。CLI では完結しないためコンソール操作。
-
-- [ ] **Step 6: モデルが見えることを確認**
+Anthropic の Claude モデルは同意取得が不要になっており、新アカウントでも既定でアクセス可能。コンソールでのアクセスリクエストは不要（2026-08-20 実測）。
 
 ```bash
-aws bedrock list-foundation-models --region us-east-1 \
-  --query 'modelSummaries[?contains(modelId, `claude-sonnet-4-6`)].modelId' --output text
+for m in anthropic.claude-sonnet-4-6 anthropic.claude-opus-4-6-v1; do
+  aws bedrock get-foundation-model-availability --model-id "$m" --region us-east-1 \
+    --query '{model:modelId,agreement:agreementAvailability.status,auth:authorizationStatus,entitlement:entitlementAvailability}' --output json
+done
 ```
 
-Expected: `anthropic.claude-sonnet-4-6` が返る
+Expected: `authorizationStatus: AUTHORIZED` かつ `entitlementAvailability: AVAILABLE`。`agreementAvailability: NOT_AVAILABLE` は「同意取得の仕組み自体が無い」= 不要という意味で、異常ではない。`auth` が `NOT_AUTHORIZED` の場合のみ `us-east-1` の Bedrock コンソールでアクセスをリクエストする
+
+- [x] **Step 6: HolmesGPT が使う inference profile が存在することを確認**
+
+`kubernetes/components/holmesgpt/production/values.yaml.gotmpl` の `modelList` は inference profile ID を直接指定する。
+
+```bash
+aws bedrock list-inference-profiles --region us-east-1 \
+  --query 'inferenceProfileSummaries[?starts_with(inferenceProfileId, `us.anthropic.claude`)].{Id:inferenceProfileId,Status:status}' --output table
+```
+
+Expected: `us.anthropic.claude-sonnet-4-6` が `ACTIVE`。`modelList` の `sonnet-5` / `opus-5` は 2026-08-20 時点で quota 0 のため使えない（`aws/eks-holmesgpt` の IAM ポリシーにも含まれていない）。詳細は設計 §1「既存の不整合」参照
 
 ---
 
@@ -521,7 +545,7 @@ Expected: `anthropic.claude-sonnet-4-6` が返る
 **Files:** なし
 
 **Interfaces:**
-- Consumes: Task 1.1 の `<PROD_ACCOUNT_ID>` / `<DEV_ACCOUNT_ID>`
+- Consumes: Task 1.1 の `337169763788` / `270242382571`
 - Produces: 両アカウントの `terragrunt-state-<ID>` バケットと `terragrunt-state-locks` テーブル
 
 - [ ] **Step 1: production アカウントで bootstrap**
@@ -537,8 +561,8 @@ Expected: S3 バケットと DynamoDB テーブルが作成される旨のログ
 - [ ] **Step 2: production の backend を確認**
 
 ```bash
-aws s3api head-bucket --bucket terragrunt-state-<PROD_ACCOUNT_ID>
-aws s3api get-bucket-versioning --bucket terragrunt-state-<PROD_ACCOUNT_ID>
+aws s3api head-bucket --bucket terragrunt-state-337169763788
+aws s3api get-bucket-versioning --bucket terragrunt-state-337169763788
 aws dynamodb describe-table --table-name terragrunt-state-locks --region ap-northeast-1 \
   --query 'Table.KeySchema' --output json
 ```
@@ -550,7 +574,7 @@ Expected: バケットが存在し versioning が `Enabled`、HASH キーが `Lo
 ```bash
 unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_SESSION_TOKEN
 CREDS=$(aws sts assume-role \
-  --role-arn arn:aws:iam::<DEV_ACCOUNT_ID>:role/OrganizationAccountAccessRole \
+  --role-arn arn:aws:iam::270242382571:role/OrganizationAccountAccessRole \
   --role-session-name terragrunt-bootstrap --query Credentials --output json)
 export AWS_ACCESS_KEY_ID=$(echo "$CREDS" | jq -r .AccessKeyId)
 export AWS_SECRET_ACCESS_KEY=$(echo "$CREDS" | jq -r .SecretAccessKey)
@@ -558,7 +582,7 @@ export AWS_SESSION_TOKEN=$(echo "$CREDS" | jq -r .SessionToken)
 aws sts get-caller-identity --query Account --output text
 ```
 
-Expected: `<DEV_ACCOUNT_ID>`
+Expected: `270242382571`
 
 - [ ] **Step 4: develop アカウントで bootstrap**
 
@@ -571,7 +595,7 @@ cd aws/github-oidc-auth/envs/develop && TG_TF_PATH=tofu terragrunt backend boots
 - [ ] **Step 5: develop の backend を確認**
 
 ```bash
-aws s3api head-bucket --bucket terragrunt-state-<DEV_ACCOUNT_ID>
+aws s3api head-bucket --bucket terragrunt-state-270242382571
 aws dynamodb describe-table --table-name terragrunt-state-locks --region ap-northeast-1 \
   --query 'Table.KeySchema' --output json
 ```
@@ -810,7 +834,7 @@ locals {
 
   # production アカウント (= route53-zone-access を assume する側)。
   # Task 1.1 で確定した値に置き換えること。
-  production_account_id = "<PROD_ACCOUNT_ID>"
+  production_account_id = "337169763788"
 
   # Environment-specific tags
   environment_tags = {
@@ -1207,7 +1231,7 @@ aws iam get-role --role-name route53-zone-access --query 'Role.AssumeRolePolicyD
 aws iam get-role-policy --role-name route53-zone-access --policy-name route53-zone-access --output json
 ```
 
-Expected: trust の Principal が `arn:aws:iam::<PROD_ACCOUNT_ID>:root`、ポリシー 1 つ目の Resource が 2 zone ARN
+Expected: trust の Principal が `arn:aws:iam::337169763788:root`、ポリシー 1 つ目の Resource が 2 zone ARN
 
 - [ ] **Step 7: コミット**
 
@@ -1309,7 +1333,7 @@ git commit -s -m "feat(aws/github-oidc-auth): allow granting cross-account assum
 ```bash
 unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_SESSION_TOKEN
 CREDS=$(aws sts assume-role \
-  --role-arn arn:aws:iam::<DEV_ACCOUNT_ID>:role/OrganizationAccountAccessRole \
+  --role-arn arn:aws:iam::270242382571:role/OrganizationAccountAccessRole \
   --role-session-name oidc-bootstrap --query Credentials --output json)
 export AWS_ACCESS_KEY_ID=$(echo "$CREDS" | jq -r .AccessKeyId)
 export AWS_SECRET_ACCESS_KEY=$(echo "$CREDS" | jq -r .SecretAccessKey)
@@ -1317,7 +1341,7 @@ export AWS_SESSION_TOKEN=$(echo "$CREDS" | jq -r .SessionToken)
 aws sts get-caller-identity --query Account --output text
 ```
 
-Expected: `<DEV_ACCOUNT_ID>`
+Expected: `270242382571`
 
 - [ ] **Step 2: plan**
 
@@ -1343,7 +1367,7 @@ aws iam get-role --role-name github-oidc-auth-develop-github-actions-plan-role -
 aws iam get-role --role-name github-oidc-auth-develop-github-actions-apply-role --query 'Role.Arn' --output text
 ```
 
-Expected: provider が 1 件、両ロールの ARN が `<DEV_ACCOUNT_ID>`
+Expected: provider が 1 件、両ロールの ARN が `270242382571`
 
 ### Task 4.3: `production` の OIDC ロールを新アカウントに作る
 
@@ -1402,7 +1426,7 @@ Expected: provider が 1 件、両ロールの ARN が `<DEV_ACCOUNT_ID>`
 ```bash
 unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_SESSION_TOKEN
 CREDS=$(aws sts assume-role \
-  --role-arn arn:aws:iam::<PROD_ACCOUNT_ID>:role/OrganizationAccountAccessRole \
+  --role-arn arn:aws:iam::337169763788:role/OrganizationAccountAccessRole \
   --role-session-name oidc-bootstrap --query Credentials --output json)
 export AWS_ACCESS_KEY_ID=$(echo "$CREDS" | jq -r .AccessKeyId)
 export AWS_SECRET_ACCESS_KEY=$(echo "$CREDS" | jq -r .SecretAccessKey)
@@ -1410,7 +1434,7 @@ export AWS_SESSION_TOKEN=$(echo "$CREDS" | jq -r .SessionToken)
 aws sts get-caller-identity --query Account --output text
 ```
 
-Expected: `<PROD_ACCOUNT_ID>`
+Expected: `337169763788`
 
 - [ ] **Step 5: plan と apply**
 
@@ -1430,7 +1454,7 @@ aws iam get-role-policy --role-name github-oidc-auth-production-github-actions-p
   --policy-name cross-account-assume --output json
 ```
 
-Expected: 両ロールの ARN が `<PROD_ACCOUNT_ID>`、assume ポリシーの Resource が `route53-zone-access` ARN
+Expected: 両ロールの ARN が `337169763788`、assume ポリシーの Resource が `route53-zone-access` ARN
 
 - [ ] **Step 7: クロスアカウント assume の疎通を確認**
 
@@ -1460,7 +1484,7 @@ git commit -s -m "feat(aws/github-oidc-auth): provision production OIDC in its d
 差し替え前の必須ゲート。ここを飛ばして先にマージすると CI が存在しないロールを assume して壊れる。
 
 ```bash
-for acct in <DEV_ACCOUNT_ID> <PROD_ACCOUNT_ID>; do
+for acct in 270242382571 337169763788; do
   CREDS=$(aws sts assume-role --role-arn "arn:aws:iam::${acct}:role/OrganizationAccountAccessRole" \
     --role-session-name verify --query Credentials --output json)
   AWS_ACCESS_KEY_ID=$(echo "$CREDS" | jq -r .AccessKeyId) \
@@ -1479,15 +1503,15 @@ Expected: develop アカウントで develop の 2 ロール、production アカ
     stacks:
       terragrunt:
         aws_region: us-east-1
-        iam_role_plan: arn:aws:iam::<DEV_ACCOUNT_ID>:role/github-oidc-auth-develop-github-actions-plan-role
-        iam_role_apply: arn:aws:iam::<DEV_ACCOUNT_ID>:role/github-oidc-auth-develop-github-actions-apply-role
+        iam_role_plan: arn:aws:iam::270242382571:role/github-oidc-auth-develop-github-actions-plan-role
+        iam_role_apply: arn:aws:iam::270242382571:role/github-oidc-auth-develop-github-actions-apply-role
 
   - environment: production
     stacks:
       terragrunt:
         aws_region: ap-northeast-1
-        iam_role_plan: arn:aws:iam::<PROD_ACCOUNT_ID>:role/github-oidc-auth-production-github-actions-plan-role
-        iam_role_apply: arn:aws:iam::<PROD_ACCOUNT_ID>:role/github-oidc-auth-production-github-actions-apply-role
+        iam_role_plan: arn:aws:iam::337169763788:role/github-oidc-auth-production-github-actions-plan-role
+        iam_role_apply: arn:aws:iam::337169763788:role/github-oidc-auth-production-github-actions-apply-role
 ```
 
 - [ ] **Step 3: 3 env が正しいアカウントを向いていることを確認**
@@ -1502,7 +1526,7 @@ for e in d['environments']:
 EOF
 ```
 
-Expected: `master` が `559744160976`、`develop` が `<DEV_ACCOUNT_ID>`、`production` が `<PROD_ACCOUNT_ID>`
+Expected: `master` が `559744160976`、`develop` が `270242382571`、`production` が `337169763788`
 
 - [ ] **Step 4: コミット**
 
@@ -1816,7 +1840,7 @@ cd aws/iam-service-linked-roles/envs/production && TG_TF_PATH=tofu terragrunt in
 aws iam get-role --role-name AWSServiceRoleForEC2Spot --query 'Role.Arn' --output text
 ```
 
-Expected: `arn:aws:iam::<PROD_ACCOUNT_ID>:role/aws-service-role/spot.amazonaws.com/AWSServiceRoleForEC2Spot`
+Expected: `arn:aws:iam::337169763788:role/aws-service-role/spot.amazonaws.com/AWSServiceRoleForEC2Spot`
 
 - [ ] **Step 3: platform 管理外の secret 6 件を作成**
 
@@ -1886,14 +1910,14 @@ Expected: 12 行（親 5 + 子 6 + Task 5.3 で追加した `--aws-assume-role` 
 ```bash
 grep -rl "559744160976" kubernetes/helmfile.yaml.gotmpl kubernetes/components/ \
   | grep -v 'external-dns/production/values.yaml.gotmpl' \
-  | xargs sed -i '' 's/559744160976/<PROD_ACCOUNT_ID>/g'
+  | xargs sed -i '' 's/559744160976/337169763788/g'
 ```
 
 - [ ] **Step 3: 置換結果を検証**
 
 ```bash
 grep -rn "559744160976" kubernetes/helmfile.yaml.gotmpl kubernetes/components/
-grep -rn "<PROD_ACCOUNT_ID>" kubernetes/helmfile.yaml.gotmpl kubernetes/components/ | wc -l
+grep -rn "337169763788" kubernetes/helmfile.yaml.gotmpl kubernetes/components/ | wc -l
 ```
 
 Expected: 1 つ目は `external-dns/production/values.yaml.gotmpl` の `--aws-assume-role` 行 1 本のみ。2 つ目は 11
@@ -1940,12 +1964,12 @@ Expected: On-Demand が 64 以上、Spot が 256 以上
 2.2 節の operator environment 記述:
 
 ```
-- production アカウント (= `<PROD_ACCOUNT_ID>`) の AdministratorAccess 相当の principal
+- production アカウント (= `337169763788`) の AdministratorAccess 相当の principal
   (= IAM Identity Center の AdministratorAccess、または管理アカウントから
   `OrganizationAccountAccessRole` を assume した session)
 ```
 
-Phase 0 の期待値コメント `# → arn:aws:iam::559744160976:user/panicboat` は、`aws sts get-caller-identity --query Account --output text` が `<PROD_ACCOUNT_ID>` を返すことを確認する記述に変える。
+Phase 0 の期待値コメント `# → arn:aws:iam::559744160976:user/panicboat` は、`aws sts get-caller-identity --query Account --output text` が `337169763788` を返すことを確認する記述に変える。
 
 - [ ] **Step 3: runbook の Phase 1-10 を実行**
 
@@ -2049,21 +2073,21 @@ environments:
     stacks:
       terragrunt:
         aws_region: ap-northeast-1
-        iam_role_plan: arn:aws:iam::<DEV_ACCOUNT_ID>:role/github-oidc-auth-develop-github-actions-plan-role
-        iam_role_apply: arn:aws:iam::<DEV_ACCOUNT_ID>:role/github-oidc-auth-develop-github-actions-apply-role
+        iam_role_plan: arn:aws:iam::270242382571:role/github-oidc-auth-develop-github-actions-plan-role
+        iam_role_apply: arn:aws:iam::270242382571:role/github-oidc-auth-develop-github-actions-apply-role
 
   - environment: production
     stacks:
       terragrunt:
         aws_region: ap-northeast-1
-        iam_role_plan: arn:aws:iam::<PROD_ACCOUNT_ID>:role/github-oidc-auth-production-github-actions-plan-role
-        iam_role_apply: arn:aws:iam::<PROD_ACCOUNT_ID>:role/github-oidc-auth-production-github-actions-apply-role
+        iam_role_plan: arn:aws:iam::337169763788:role/github-oidc-auth-production-github-actions-plan-role
+        iam_role_apply: arn:aws:iam::337169763788:role/github-oidc-auth-production-github-actions-apply-role
 ```
 
 - [ ] **Step 6: 新アカウントの state を確認**
 
 ```bash
-aws s3 ls s3://terragrunt-state-<PROD_ACCOUNT_ID>/ --recursive
+aws s3 ls s3://terragrunt-state-337169763788/ --recursive
 ```
 
 Expected: `services/monolith/production` と `system-components/holmes/production` が存在する
@@ -2223,7 +2247,7 @@ Expected: Draft のまま。レビュー依頼は Verification Checklist を全�
 
 - [ ] `aws organizations list-accounts` に ACTIVE なアカウントが 3 件（管理 + production + develop）
 - [ ] `aws iam list-open-id-connect-providers` が 3 アカウントそれぞれで 1 件を返す
-- [ ] `terragrunt-state-<PROD_ACCOUNT_ID>` と `terragrunt-state-<DEV_ACCOUNT_ID>` が存在する
+- [ ] `terragrunt-state-337169763788` と `terragrunt-state-270242382571` が存在する
 - [ ] 管理アカウントの state バケットに残るのが `platform/*/master/` 5 件と `services/nginx-app/develop` のみ
 - [ ] 新 production アカウントから `route53-zone-access` を assume できる
 - [ ] `aws eks list-clusters --region ap-northeast-1` が新 production アカウントで `eks-production` を返す

--- a/docs/superpowers/plans/2026-08-18-production-account-migration.md
+++ b/docs/superpowers/plans/2026-08-18-production-account-migration.md
@@ -904,7 +904,7 @@ Compute Optimizer と Cost Optimization Hub の登録は支払アカウント単
 cd aws/cost-management/envs/develop && TG_TF_PATH=tofu terragrunt state list
 ```
 
-Expected: `aws_computeoptimizer_enrollment_status.this` と `terraform_data.cost_optimization_hub_enrollment` の 2 件
+Expected: `aws_computeoptimizer_enrollment_status.this` と `aws_costoptimizationhub_enrollment_status.this` の 2 件（後者は #801 で `terraform_data` + `local-exec` の回避策から置き換え済）
 
 - [ ] **Step 2: `env.hcl` を作成**
 
@@ -980,7 +980,9 @@ terragrunt backend migrate aws/cost-management/envs/develop aws/cost-management/
 cd aws/cost-management/envs/master && TG_TF_PATH=tofu terragrunt plan
 ```
 
-Expected: `aws_computeoptimizer_enrollment_status` の再作成が無いこと。`terraform_data` の `triggers_replace` は `version = "v1"` で固定なので replace されないこと。タグの in-place update は許容
+Expected: `aws_computeoptimizer_enrollment_status` と `aws_costoptimizationhub_enrollment_status` のどちらにも再作成が出ないこと。タグの in-place update は許容
+
+`aws_costoptimizationhub_enrollment_status` は `include_member_accounts` が `optional + computed` で、省略時は AWS API の返り値を採用するため差分が出ない（#801 で実 state での `No changes.` を確認済）。差分が出る場合は provider のバージョンが上がって挙動が変わっている可能性があるため、apply せずに調査する
 
 - [ ] **Step 6: 旧 env と旧 state を削除**
 

--- a/docs/superpowers/plans/2026-08-18-production-account-migration.md
+++ b/docs/superpowers/plans/2026-08-18-production-account-migration.md
@@ -13,7 +13,7 @@
 ## Global Constraints
 
 - 管理アカウント ID: `559744160976`（Organization `o-es9qoj85gw`、Identity Center `ssoins-7758e2d4fb37f3a7`、permission set `ps-77583734ef962d6b`、ユーザー `e7146ab8-20b1-70eb-a63d-b9887df5d7a6`）
-- 新アカウントのルートメール: production = `aws+production@dystopia.city`、develop = `aws+develop@dystopia.city`
+- 新アカウントのルートメール: production = `aws+production@panicboat.net`、develop = `aws+develop@panicboat.net`
 - `<PROD_ACCOUNT_ID>` / `<DEV_ACCOUNT_ID>` は Task 1.1 で確定する。以降のタスクではこの実値に置換すること
 - hosted zone: `panicboat.net` = `Z07598371GKBU0WMF89MD`、`dystopia.city` = `Z03420722KS9MTSCUSIQZ`
 - クロスアカウントロール: `arn:aws:iam::559744160976:role/route53-zone-access`
@@ -353,29 +353,41 @@ aws organizations list-accounts --query 'Accounts[].{Id:Id,Name:Name,Email:Email
 
 Expected: `583677814390`（CLOSED）、`504150922582`（CLOSED）、`559744160976`（ACTIVE）
 
-- [ ] **Step 2: production アカウントを作成**
+- [ ] **Step 2: `aws@panicboat.net` が受信できることを確認**
 
-`aws@dystopia.city` はクローズ済みアカウントが保持しているが、プラスアドレスは別アドレスとして扱われる。
+`panicboat.net` は Google Workspace（MX = `smtp.google.com`）で、プラスアドレスはベースのメールボックスへ配送される。`aws@panicboat.net` がユーザーまたはエイリアスとして存在しないと、ルートアカウントの検証メールとパスワードリセットが届かずアカウントを復旧できなくなる。
+
+```bash
+dig +short MX panicboat.net
+```
+
+Expected: `1 smtp.google.com.`
+
+Google Workspace 管理コンソール（Directory → Users、または該当ユーザーの Alternate email addresses）で `aws@panicboat.net` の存在を確認する。無ければエイリアスを作成し、外部から `aws+production@panicboat.net` 宛にテストメールを送って受信できることを確かめてから次へ進む。
+
+- [ ] **Step 3: production アカウントを作成**
+
+クローズ済みアカウントが保持しているのは `admin@panicboat.net` と `aws@dystopia.city` で、いずれも下記とは別アドレス。
 
 ```bash
 aws organizations create-account \
-  --email 'aws+production@dystopia.city' \
+  --email 'aws+production@panicboat.net' \
   --account-name 'production' \
   --iam-user-access-to-billing DENY
 ```
 
 Expected: `CreateAccountStatus.State` が `IN_PROGRESS`
 
-- [ ] **Step 3: develop アカウントを作成**
+- [ ] **Step 4: develop アカウントを作成**
 
 ```bash
 aws organizations create-account \
-  --email 'aws+develop@dystopia.city' \
+  --email 'aws+develop@panicboat.net' \
   --account-name 'develop' \
   --iam-user-access-to-billing DENY
 ```
 
-- [ ] **Step 4: 両方の完了とアカウント ID を確認**
+- [ ] **Step 5: 両方の完了とアカウント ID を確認**
 
 ```bash
 aws organizations list-create-account-status --states SUCCEEDED FAILED \
@@ -383,9 +395,9 @@ aws organizations list-create-account-status --states SUCCEEDED FAILED \
   --output table
 ```
 
-Expected: 両方 `SUCCEEDED` で `AccountId` が返る。この 2 値を `<PROD_ACCOUNT_ID>` / `<DEV_ACCOUNT_ID>` として記録する。`EMAIL_ALREADY_EXISTS` で失敗した場合は別のプラスアドレス（例: `aws+prod2@dystopia.city`）で再試行する
+Expected: 両方 `SUCCEEDED` で `AccountId` が返る。この 2 値を `<PROD_ACCOUNT_ID>` / `<DEV_ACCOUNT_ID>` として記録する。`EMAIL_ALREADY_EXISTS` で失敗した場合は別のプラスアドレス（例: `aws+prod2@panicboat.net`）で再試行する
 
-- [ ] **Step 5: 両アカウントで `OrganizationAccountAccessRole` を assume できることを確認**
+- [ ] **Step 6: 両アカウントで `OrganizationAccountAccessRole` を assume できることを確認**
 
 ```bash
 for acct in <PROD_ACCOUNT_ID> <DEV_ACCOUNT_ID>; do
@@ -398,7 +410,7 @@ done
 
 Expected: 2 行とも `arn:aws:sts::<acct>:assumed-role/OrganizationAccountAccessRole/bootstrap-check`
 
-- [ ] **Step 6: Identity Center の AdministratorAccess を両アカウントに割当**
+- [ ] **Step 7: Identity Center の AdministratorAccess を両アカウントに割当**
 
 ```bash
 for acct in <PROD_ACCOUNT_ID> <DEV_ACCOUNT_ID>; do
@@ -413,7 +425,7 @@ for acct in <PROD_ACCOUNT_ID> <DEV_ACCOUNT_ID>; do
 done
 ```
 
-- [ ] **Step 7: 割当を確認**
+- [ ] **Step 8: 割当を確認**
 
 ```bash
 aws sso-admin list-accounts-for-provisioned-permission-set \

--- a/docs/superpowers/plans/2026-08-18-production-account-migration.md
+++ b/docs/superpowers/plans/2026-08-18-production-account-migration.md
@@ -1,25 +1,26 @@
-# Production AWS Account Migration Implementation Plan
+# Multi-account Migration Implementation Plan
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** `production` 環境を AWS Organizations 管理アカウント `559744160976` から専用メンバーアカウントへ分離し、Route53 hosted zone は管理アカウントに残したままクロスアカウント参照で運用する。
+**Goal:** `production` と `develop` をそれぞれ専用 AWS アカウントへ分離し、`559744160976` は横断資産だけを持つ `master` 環境として残す。Route53 hosted zone は管理アカウントに残したままクロスアカウント参照で運用する。
 
-**Architecture:** 管理アカウントに残る横断資産を `master` env として新設し、`aws/route53` をそこへ re-home する。production アカウントからは `route53-zone-access` ロールを assume して zone を操作する。Terraform 側は `aws/alb` の provider alias 1 箇所、実行時は external-dns の `--aws-assume-role` で経路を張る。EKS 再構築自体は既存の `docs/runbooks/eks-production-recreate.md` を再利用する。
+**Architecture:** 管理アカウントに残る横断資産（Route53 / cost-management / GitHub 設定）を `master` env に集約し、`develop` と `production` は新規メンバーアカウントで作り直す。production からは `route53-zone-access` ロールを assume して zone を操作する。Terraform 側は `aws/alb` の provider alias 1 箇所、実行時は external-dns の `--aws-assume-role` で経路を張る。EKS 再構築自体は既存の `docs/runbooks/eks-production-recreate.md` を再利用する。
 
-**Tech Stack:** Terragrunt v1.0.2 + OpenTofu 1.12.0（module 側 `required_version = "1.12.5"`）、AWS provider 6.60.0、Helmfile v1.4、external-dns chart 1.21.1（appVersion 0.21.0）、AWS CLI v2、Flux CD。
+**Tech Stack:** Terragrunt v1.0.2 + OpenTofu 1.12.0（module 側 `required_version = "1.12.5"`）、AWS provider 6.60.0、GitHub provider ~> 6.13、Helmfile v1.4、external-dns chart 1.21.1（appVersion 0.21.0）、AWS CLI v2、Flux CD。
 
 **Spec:** `docs/superpowers/specs/2026-08-18-production-account-migration-design.md`
 
 ## Global Constraints
 
-- 管理アカウント ID: `559744160976`（Organization `o-es9qoj85gw`、Identity Center `ssoins-7758e2d4fb37f3a7`）
-- production hosted zone: `panicboat.net` = `Z07598371GKBU0WMF89MD`、`dystopia.city` = `Z03420722KS9MTSCUSIQZ`
-- クロスアカウントロール名: `route53-zone-access`（管理アカウント側、`arn:aws:iam::559744160976:role/route53-zone-access`）
-- `<PROD_ACCOUNT_ID>` は Task 1.1 で確定する新アカウント ID。以降のタスクではこの実値に置換すること
-- production region は `ap-northeast-1`、`master` env も `ap-northeast-1`、`develop` env は `us-east-1`
+- 管理アカウント ID: `559744160976`（Organization `o-es9qoj85gw`、Identity Center `ssoins-7758e2d4fb37f3a7`、permission set `ps-77583734ef962d6b`、ユーザー `e7146ab8-20b1-70eb-a63d-b9887df5d7a6`）
+- 新アカウントのルートメール: production = `aws+production@dystopia.city`、develop = `aws+develop@dystopia.city`
+- `<PROD_ACCOUNT_ID>` / `<DEV_ACCOUNT_ID>` は Task 1.1 で確定する。以降のタスクではこの実値に置換すること
+- hosted zone: `panicboat.net` = `Z07598371GKBU0WMF89MD`、`dystopia.city` = `Z03420722KS9MTSCUSIQZ`
+- クロスアカウントロール: `arn:aws:iam::559744160976:role/route53-zone-access`
+- region: `master` = `ap-northeast-1`、`develop` = `us-east-1`、`production` = `ap-northeast-1`
 - Terragrunt の state バケット名は全 `root.hcl` で `terragrunt-state-${get_aws_account_id()}` として動的に組まれる。バケット名をコードに書かない
 - コミットは `-s`（`--signoff`）付き。`Co-Authored-By` は付けない
-- 新規ブランチの初回 push は `git push -u origin HEAD`。PR は `gh pr create --draft`
+- PR は `gh pr create --draft`
 
 ---
 
@@ -27,51 +28,51 @@
 
 ### 新規作成
 
-- `aws/github-oidc-auth/envs/master/env.hcl` — `master` env の GitHub OIDC 設定
-- `aws/github-oidc-auth/envs/master/terragrunt.hcl` — 同スタック定義
-- `aws/route53/envs/master/env.hcl` — re-home 先の env 設定 + `production_account_id`
-- `aws/route53/envs/master/terragrunt.hcl` — 同スタック定義
+- `aws/github-oidc-auth/envs/master/{env.hcl,terragrunt.hcl}` — `master` env の OIDC provider とロール
+- `aws/route53/envs/master/{env.hcl,terragrunt.hcl}` — `production` からの re-home 先
 - `aws/route53/modules/zone_access.tf` — `route53-zone-access` ロールとポリシー
+- `aws/cost-management/envs/master/{env.hcl,terragrunt.hcl}` — `develop` からの re-home 先
+
+### 移動（`git mv`）
+
+- `github/repository/envs/develop/` → `github/repository/envs/master/`
+- `github/branch/envs/develop/` → `github/branch/envs/master/`
 
 ### 削除
 
-- `aws/route53/envs/production/` — `master` へ re-home するため
+- `aws/route53/envs/production/`
+- `aws/cost-management/envs/develop/`
 
 ### 変更
 
-- `workflow-config.yaml` — `master` env 追加 + `production` の IAM ロール ARN 差し替え
-- `aws/route53/modules/variables.tf` — `production_account_id` 追加
-- `aws/github-oidc-auth/modules/variables.tf` — `assume_role_arns` 追加
-- `aws/github-oidc-auth/modules/main.tf` — plan ロールへ `sts:AssumeRole` インラインポリシー
-- `aws/github-oidc-auth/envs/production/env.hcl` — OIDC provider 自前作成へ反転 + `assume_role_arns`
-- `aws/github-oidc-auth/envs/production/terragrunt.hcl` — `assume_role_arns` の受け渡し
-- `aws/alb/modules/terraform.tf` — `aws.route53` alias provider
-- `aws/alb/modules/lookups.tf` — `providers = { aws = aws.route53 }`
-- `aws/alb/modules/main.tf` — validation レコード 2 resource に `provider = aws.route53`
-- `aws/alb/modules/variables.tf` / `aws/alb/envs/production/env.hcl` / `aws/alb/envs/production/terragrunt.hcl` — `route53_zone_role_arn`
-- `aws/eks/modules/lookups.tf` — `module "route53"` 削除
-- `aws/eks/modules/addons.tf` — external-dns IAM を assume role 方式へ
-- `kubernetes/helmfile.yaml.gotmpl` — アカウント ID 5 箇所
-- `kubernetes/components/{aws-load-balancer-controller,external-dns,loki,mimir,tempo}/production/helmfile.yaml` — アカウント ID
+- `workflow-config.yaml` — `master` 追加 + `develop` / `production` の ARN 差し替え
+- `aws/github-oidc-auth/modules/{main,variables}.tf` — plan ロールへの `sts:AssumeRole` 付与
+- `aws/github-oidc-auth/envs/production/{env.hcl,terragrunt.hcl}` — provider 自前作成 + `assume_role_arns`
+- `aws/route53/modules/variables.tf` — `production_account_id`
+- `aws/alb/modules/{terraform,lookups,main,variables}.tf` — クロスアカウント provider alias
+- `aws/alb/envs/production/{env.hcl,terragrunt.hcl}` — `route53_zone_role_arn`
+- `aws/eks/modules/{lookups,addons,variables}.tf` — route53 lookup 削除 + external-dns assume role 化
+- `aws/eks/envs/production/{env.hcl,terragrunt.hcl}` — `route53_zone_role_arn`
 - `kubernetes/components/external-dns/production/values.yaml.gotmpl` — `extraArgs`
+- `kubernetes/helmfile.yaml.gotmpl` + 子 helmfile 5 本 — アカウント ID
 - `scripts/eks-lifecycle/lib/30-destroy-stacks.sh` — `STACKS` に `eks-holmesgpt`
-- `README.md` / `README-ja.md` — 環境表に `master`
+- `README.md` / `README-ja.md` — 3 アカウント構成
 
 ---
 
 # Phase 0: 旧アカウントの事前整理
 
-新アカウントを作る前に、管理アカウント側のドリフトと孤児リソースを解消する。ここでの作業は全て現行アカウント `559744160976` で完結する。
+新アカウントを作る前に、管理アカウント側のドリフトと孤児を解消し、失うと復旧できない値を退避する。全て `559744160976` で完結する。
 
 ### Task 0.1: `eks-holmesgpt` を teardown 対象に追加して destroy
 
-`scripts/eks-lifecycle/lib/30-destroy-stacks.sh` の `STACKS` 配列は 8 スタックだが `eks-holmesgpt` が抜けている（#795 でスタック分離した際の追加漏れ）。そのため `eks-production-holmesgpt` ロールが teardown 後も残存し、state 内の `data.aws_eks_cluster.this` が存在しないクラスタ `eks-production` を参照している。
+`scripts/eks-lifecycle/lib/30-destroy-stacks.sh` の `STACKS` 配列は 8 スタックだが `eks-holmesgpt` が抜けている（#795 の追加漏れ）。そのため `eks-production-holmesgpt` ロールが残存し、state 内の `data.aws_eks_cluster.this` が存在しないクラスタ `eks-production` を参照している。
 
 **Files:**
 - Modify: `scripts/eks-lifecycle/lib/30-destroy-stacks.sh`
 
 **Interfaces:**
-- Produces: `platform/eks-holmesgpt/production` state が resources=0 になる。Task 9.1 の後片付け対象から外れる
+- Produces: `platform/eks-holmesgpt/production` state が resources=0 になる。Task 9.2 の削除対象に含められる
 
 - [ ] **Step 1: 現状のドリフトを確認**
 
@@ -83,7 +84,7 @@ Expected: `data.aws_eks_cluster.this` の解決に失敗する（`No cluster fou
 
 - [ ] **Step 2: `STACKS` 配列に `eks-holmesgpt` を追加**
 
-`scripts/eks-lifecycle/lib/30-destroy-stacks.sh` の `STACKS=(` ブロックを以下に置き換える。`eks-holmesgpt` は EKS クラスタの Pod Identity Association を持つため `eks` より前、他の eks-* スタックと同列に置く。
+`scripts/eks-lifecycle/lib/30-destroy-stacks.sh` の `STACKS=(` ブロックを以下に置き換える。`eks-holmesgpt` は EKS クラスタの Pod Identity Association を持つため `eks` より前に置く。
 
 ```bash
 STACKS=(
@@ -99,9 +100,9 @@ STACKS=(
 )
 ```
 
-- [ ] **Step 3: ヘッダコメントの順序記述を更新**
+- [ ] **Step 3: 件数の記述を更新**
 
-同ファイル冒頭の以下のコメントを書き換える。
+同ファイル冒頭のコメントを以下に置き換える。
 
 ```bash
 # 30-destroy-stacks.sh - Destroy 9 EKS-related stacks in fixed order.
@@ -111,11 +112,11 @@ STACKS=(
 #   -> eks-traces -> eks -> alb -> vpc
 ```
 
-同ファイル末尾の `ok "All 8 stacks destroyed"` と、`confirm "About to DESTROY 8 stacks for ENV=${ENV}. Continue?"` の `8` を `9` に変更する。
+さらに `confirm "About to DESTROY 8 stacks for ENV=${ENV}. Continue?"` と `ok "All 8 stacks destroyed"` の `8` を `9` に変更する。
 
-- [ ] **Step 4: state 内の存在しないリソースを state から外す**
+- [ ] **Step 4: 存在しないリソースを state から外す**
 
-クラスタが既に無いため Pod Identity Association は AWS 上に存在しない。destroy 前に state から除去する。
+クラスタが無いため Pod Identity Association は AWS 上に存在しない。
 
 ```bash
 cd aws/eks-holmesgpt/envs/production
@@ -149,8 +150,6 @@ git commit -s -m "fix(scripts/eks-lifecycle): include eks-holmesgpt in destroy o
 
 ### Task 0.2: 孤児リソースの削除
 
-Karpenter が生成した Terraform 管理外の IAM instance profile と、対応する state を持たないログ グループを削除する。
-
 **Files:** なし（AWS API 操作のみ）
 
 - [ ] **Step 1: 孤児 instance profile を確認**
@@ -170,7 +169,7 @@ aws iam delete-instance-profile --instance-profile-name eks-production_513473553
 
 - [ ] **Step 3: レガシーログ グループを削除**
 
-state に対応の無い 3 本を削除する。`/github-repository/{ansible,deploy-actions,dotfiles,monorepo,panicboat-actions,platform}` は `platform/repository/develop` state が管理しているため残す。
+state に対応の無い 3 本のみ。`/github-repository/{ansible,deploy-actions,dotfiles,monorepo,panicboat-actions,platform}` は `platform/repository/develop` state が管理しているため残す。
 
 ```bash
 aws logs delete-log-group --region ap-northeast-1 --log-group-name /github-repository/generated-manifests
@@ -186,11 +185,11 @@ aws logs describe-log-groups --region ap-northeast-1 --query 'logGroups[].logGro
 aws logs describe-log-groups --region us-east-1 --query 'logGroups[].logGroupName' --output text
 ```
 
-Expected: instance profile が空、`ap-northeast-1` のログ グループが 8 本（`/github-actions/github-oidc-auth-{develop,production}` + `/github-repository/*` 6 本）、`us-east-1` が空
+Expected: instance profile が空、`ap-northeast-1` が 8 本、`us-east-1` が空
 
 ### Task 0.3: `dystopia.city` の stale DNS レコード削除
 
-削除済み ALB を指す ALIAS 4 件と external-dns 所有権 TXT 2 件が残っている。Phase 7 で external-dns がレコードを「作成」できることをもって疎通確認したいので、先に消しておく。
+削除済み ALB を指す ALIAS 4 件と external-dns 所有権 TXT 2 件が残っている。Phase 7 で external-dns がレコードを「作成」できることをもって疎通確認したいので先に消す。
 
 **Files:** なし（Route53 API 操作のみ）
 
@@ -201,11 +200,11 @@ aws route53 list-resource-record-sets --hosted-zone-id Z03420722KS9MTSCUSIQZ \
   --query "ResourceRecordSets[?Type=='A'||Type=='AAAA'||(Type=='TXT'&&contains(Name,'auth'))]" --output json
 ```
 
-Expected: 6 件（`dystopia.city.` A/AAAA、`auth.dystopia.city.` A/AAAA、`aaaa-auth.dystopia.city.` TXT、`cname-auth.dystopia.city.` TXT）。ALIAS の向き先が `k8s-application-92fded7941-*` であること
+Expected: 6 件。ALIAS の向き先が `k8s-application-92fded7941-*` であること
 
 - [ ] **Step 2: 削除用 change batch を生成**
 
-Step 1 の出力をそのまま `DELETE` に変換する。値を手で書き写すと ALIAS の `HostedZoneId` を取り違えるため、必ず API 出力から生成する。
+値を手で書き写すと ALIAS の `HostedZoneId` を取り違えるため、必ず API 出力から生成する。
 
 ```bash
 aws route53 list-resource-record-sets --hosted-zone-id Z03420722KS9MTSCUSIQZ \
@@ -227,20 +226,23 @@ aws route53 change-resource-record-sets \
   --change-batch file:///tmp/dystopia-stale-delete.json
 ```
 
-- [ ] **Step 4: zone に SOA / NS / MX / TXT だけが残ったことを確認**
+- [ ] **Step 4: 残存レコードを確認**
 
 ```bash
 aws route53 list-resource-record-sets --hosted-zone-id Z03420722KS9MTSCUSIQZ \
   --query 'ResourceRecordSets[].{N:Name,T:Type}' --output text
 ```
 
-Expected: 5 件（`dystopia.city.` の SOA / NS / MX / TXT、`google._domainkey.dystopia.city.` TXT）。A / AAAA が残っていないこと
+Expected: 5 件（`dystopia.city.` の SOA / NS / MX / TXT、`google._domainkey.dystopia.city.` TXT）
 
 ### Task 0.4: Secrets Manager の値を退避
 
-8 件の secret 値は Terraform 管理外（手動投入）で、旧アカウントを片付けると復旧できない。Phase 6 で新アカウントへ投入するため退避する。
+8 件の値は Terraform 管理外（手動投入）で、旧アカウントを片付けると復旧できない。
 
 **Files:** なし
+
+**Interfaces:**
+- Produces: `$HOME/.secrets-backup-559744160976.json`。Task 6.1 と Task 8.1 が読む
 
 - [ ] **Step 1: 全 secret 名を列挙**
 
@@ -266,9 +268,9 @@ umask "$UMASK_OLD"
 ls -l "$OUT"
 ```
 
-Expected: 8 個の JSON オブジェクトが書かれ、パーミッションが `-rw-------`
+Expected: パーミッションが `-rw-------`
 
-- [ ] **Step 3: 退避内容の件数を確認**
+- [ ] **Step 3: 退避件数を確認**
 
 ```bash
 grep -c '"name"' "$HOME/.secrets-backup-559744160976.json"
@@ -276,18 +278,72 @@ grep -c '"name"' "$HOME/.secrets-backup-559744160976.json"
 
 Expected: `8`
 
+### Task 0.5: GitHub 側の非 IaC 設定を棚卸しする
+
+設計 §5-5 で「変更不要」と判断した項目のうち、org レベルの secret / variable は権限不足で確認できていない。移行前に確定させる。
+
+**Files:** なし
+
+- [ ] **Step 1: org 管理権限のあるトークンで org レベルの設定を確認**
+
+`gh auth token` の既定トークンでは `admin:org` スコープが無く 404 になる。必要なら `gh auth refresh -s admin:org` でスコープを足す。
+
+```bash
+gh api orgs/panicboat/actions/secrets --jq '.secrets[].name' 2>&1
+gh api orgs/panicboat/actions/variables --jq '.variables[].name' 2>&1
+```
+
+Expected: 一覧が返る。AWS アカウント ID を含む値があれば Phase 4 の差し替え対象に加える。404 が続く場合は「スコープ不足のため未確認」として記録し、GitHub Web UI（Settings → Secrets and variables → Actions）で目視確認する
+
+- [ ] **Step 2: リポジトリレベルの設定が AWS アカウントに依存しないことを確認**
+
+```bash
+for r in platform monorepo; do
+  echo "--- $r ---"
+  gh secret list -R "panicboat/$r"
+  gh variable list -R "panicboat/$r"
+done
+```
+
+Expected: `platform` は `APP_PRIVATE_KEY` / `APP_ID`（`1371999`）、`monorepo` は加えて `SLACK_BOT_TOKEN`。いずれも GitHub App とSlack の資格情報で AWS アカウント ID を含まない
+
+- [ ] **Step 3: GitHub Environments の有無を確認**
+
+`aws/github-oidc-auth` の trust policy が `repo:panicboat/*:environment:{master,develop,production}` を許可条件に含むが、Environment が存在しなければこの条件は使われない。
+
+```bash
+for r in platform monorepo; do
+  echo "--- $r ---"
+  gh api "repos/panicboat/$r/environments" --jq '.environments[].name'
+done
+```
+
+Expected: 両方とも出力なし（0 件）。もし存在する場合は、移行後も同名で残っていることを Phase 9 で再確認する
+
+- [ ] **Step 4: ruleset の現状を記録**
+
+Phase 3 の `github/branch` re-home 前後で変化していないことを比較するための基準値。
+
+```bash
+for r in monorepo platform deploy-actions; do
+  gh api "repos/panicboat/$r/rulesets" --jq '.[] | "\(.id) \(.name) \(.enforcement)"'
+done
+```
+
+Expected: 3 本とも `active`（`15519991 monorepo-main` / `15519990 platform-main` / `15519988 deploy-actions-main`）。この出力を控えておく
+
 ---
 
 # Phase 1: 新アカウント作成
 
 手動 AWS 操作のみ。コード変更もコミットも無い。
 
-### Task 1.1: メンバーアカウント作成と Identity Center 割当
+### Task 1.1: メンバーアカウント 2 つを作成
 
 **Files:** なし
 
 **Interfaces:**
-- Produces: `<PROD_ACCOUNT_ID>`。以降の全タスクがこの値に依存する
+- Produces: `<PROD_ACCOUNT_ID>` と `<DEV_ACCOUNT_ID>`。以降の全タスクが依存する
 
 - [ ] **Step 1: 既存アカウント一覧を確認**
 
@@ -297,75 +353,99 @@ aws organizations list-accounts --query 'Accounts[].{Id:Id,Name:Name,Email:Email
 
 Expected: `583677814390`（CLOSED）、`504150922582`（CLOSED）、`559744160976`（ACTIVE）
 
-- [ ] **Step 2: 新しいルートメールアドレスを決める**
+- [ ] **Step 2: production アカウントを作成**
 
-クローズ済みアカウントが `admin@panicboat.net` と `aws@dystopia.city` を保持しているため、これらは使えない。未使用のアドレスを 1 つ用意する（例: `panicboat+aws-production@gmail.com`）。
-
-- [ ] **Step 3: アカウントを作成**
+`aws@dystopia.city` はクローズ済みアカウントが保持しているが、プラスアドレスは別アドレスとして扱われる。
 
 ```bash
 aws organizations create-account \
-  --email '<NEW_ROOT_EMAIL>' \
+  --email 'aws+production@dystopia.city' \
   --account-name 'production' \
   --iam-user-access-to-billing DENY
 ```
 
-Expected: `CreateAccountStatus.State` が `IN_PROGRESS`。`EMAIL_ALREADY_EXISTS` で失敗した場合は Step 2 に戻ってアドレスを変える
+Expected: `CreateAccountStatus.State` が `IN_PROGRESS`
 
-- [ ] **Step 4: 作成完了とアカウント ID を確認**
+- [ ] **Step 3: develop アカウントを作成**
 
 ```bash
-aws organizations list-create-account-status --states SUCCEEDED \
-  --query 'CreateAccountStatuses[?AccountName==`production`].{Id:AccountId,At:CompletedTimestamp}' --output table
+aws organizations create-account \
+  --email 'aws+develop@dystopia.city' \
+  --account-name 'develop' \
+  --iam-user-access-to-billing DENY
 ```
 
-Expected: `SUCCEEDED` になり `AccountId` が返る。この値を `<PROD_ACCOUNT_ID>` として記録する
-
-- [ ] **Step 5: `OrganizationAccountAccessRole` で assume できることを確認**
+- [ ] **Step 4: 両方の完了とアカウント ID を確認**
 
 ```bash
-aws sts assume-role \
-  --role-arn arn:aws:iam::<PROD_ACCOUNT_ID>:role/OrganizationAccountAccessRole \
-  --role-session-name bootstrap-check \
-  --query 'AssumedRoleUser.Arn' --output text
+aws organizations list-create-account-status --states SUCCEEDED FAILED \
+  --query 'CreateAccountStatuses[?AccountName==`production`||AccountName==`develop`].{Name:AccountName,Id:AccountId,State:State,Reason:FailureReason}' \
+  --output table
 ```
 
-Expected: `arn:aws:sts::<PROD_ACCOUNT_ID>:assumed-role/OrganizationAccountAccessRole/bootstrap-check`
+Expected: 両方 `SUCCEEDED` で `AccountId` が返る。この 2 値を `<PROD_ACCOUNT_ID>` / `<DEV_ACCOUNT_ID>` として記録する。`EMAIL_ALREADY_EXISTS` で失敗した場合は別のプラスアドレス（例: `aws+prod2@dystopia.city`）で再試行する
 
-- [ ] **Step 6: Identity Center の AdministratorAccess を新アカウントに割当**
+- [ ] **Step 5: 両アカウントで `OrganizationAccountAccessRole` を assume できることを確認**
 
 ```bash
-aws sso-admin create-account-assignment \
-  --instance-arn arn:aws:sso:::instance/ssoins-7758e2d4fb37f3a7 \
-  --permission-set-arn arn:aws:sso:::permissionSet/ssoins-7758e2d4fb37f3a7/ps-77583734ef962d6b \
-  --principal-type USER \
-  --principal-id e7146ab8-20b1-70eb-a63d-b9887df5d7a6 \
-  --target-id <PROD_ACCOUNT_ID> \
-  --target-type AWS_ACCOUNT \
-  --region ap-northeast-1
+for acct in <PROD_ACCOUNT_ID> <DEV_ACCOUNT_ID>; do
+  aws sts assume-role \
+    --role-arn "arn:aws:iam::${acct}:role/OrganizationAccountAccessRole" \
+    --role-session-name bootstrap-check \
+    --query 'AssumedRoleUser.Arn' --output text
+done
+```
+
+Expected: 2 行とも `arn:aws:sts::<acct>:assumed-role/OrganizationAccountAccessRole/bootstrap-check`
+
+- [ ] **Step 6: Identity Center の AdministratorAccess を両アカウントに割当**
+
+```bash
+for acct in <PROD_ACCOUNT_ID> <DEV_ACCOUNT_ID>; do
+  aws sso-admin create-account-assignment \
+    --instance-arn arn:aws:sso:::instance/ssoins-7758e2d4fb37f3a7 \
+    --permission-set-arn arn:aws:sso:::permissionSet/ssoins-7758e2d4fb37f3a7/ps-77583734ef962d6b \
+    --principal-type USER \
+    --principal-id e7146ab8-20b1-70eb-a63d-b9887df5d7a6 \
+    --target-id "$acct" \
+    --target-type AWS_ACCOUNT \
+    --region ap-northeast-1
+done
 ```
 
 - [ ] **Step 7: 割当を確認**
 
 ```bash
-aws sso-admin list-account-assignments \
+aws sso-admin list-accounts-for-provisioned-permission-set \
   --instance-arn arn:aws:sso:::instance/ssoins-7758e2d4fb37f3a7 \
-  --account-id <PROD_ACCOUNT_ID> \
   --permission-set-arn arn:aws:sso:::permissionSet/ssoins-7758e2d4fb37f3a7/ps-77583734ef962d6b \
   --region ap-northeast-1
 ```
 
-Expected: `AccountAssignments` に 1 件
+Expected: `AccountIds` に 3 件（管理 + production + develop）
 
 ### Task 1.2: Service Quota 増枠申請と Bedrock 有効化
 
-増枠の承認待ちが本移行で最長のクリティカルパスになるため、アカウント作成直後に投げる。
+増枠の承認待ちが本移行で最長のクリティカルパスになるため、アカウント作成直後に投げる。EKS が乗るのは production だけなので production アカウントのみ対象。
 
 **Files:** なし
 
-- [ ] **Step 1: 新アカウントの現在値を確認**
+- [ ] **Step 1: production アカウントの認証情報に切り替える**
 
-`OrganizationAccountAccessRole` を assume した状態で実行する。
+```bash
+unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_SESSION_TOKEN
+CREDS=$(aws sts assume-role \
+  --role-arn arn:aws:iam::<PROD_ACCOUNT_ID>:role/OrganizationAccountAccessRole \
+  --role-session-name quota-request --query Credentials --output json)
+export AWS_ACCESS_KEY_ID=$(echo "$CREDS" | jq -r .AccessKeyId)
+export AWS_SECRET_ACCESS_KEY=$(echo "$CREDS" | jq -r .SecretAccessKey)
+export AWS_SESSION_TOKEN=$(echo "$CREDS" | jq -r .SessionToken)
+aws sts get-caller-identity --query Account --output text
+```
+
+Expected: `<PROD_ACCOUNT_ID>`
+
+- [ ] **Step 2: 現在値を確認**
 
 ```bash
 for qc in L-1216C47A L-34B43A08; do
@@ -374,9 +454,9 @@ for qc in L-1216C47A L-34B43A08; do
 done
 ```
 
-Expected: On-Demand Standard vCPU / Standard Spot がいずれも `5.0`（AWS デフォルト）
+Expected: いずれも `5.0`（AWS デフォルト）
 
-- [ ] **Step 2: 増枠を申請**
+- [ ] **Step 3: 増枠を申請**
 
 管理アカウントの適用値（On-Demand 64 / Spot 256）に合わせる。
 
@@ -387,7 +467,7 @@ aws service-quotas request-service-quota-increase \
   --service-code ec2 --quota-code L-34B43A08 --desired-value 256 --region ap-northeast-1
 ```
 
-- [ ] **Step 3: 申請が受理されたことを確認**
+- [ ] **Step 4: 申請が受理されたことを確認**
 
 ```bash
 aws service-quotas list-requested-service-quota-change-history --region ap-northeast-1 \
@@ -396,11 +476,11 @@ aws service-quotas list-requested-service-quota-change-history --region ap-north
 
 Expected: 2 件が `PENDING` または `CASE_OPENED`
 
-- [ ] **Step 4: Bedrock のモデルアクセスを有効化**
+- [ ] **Step 5: Bedrock のモデルアクセスを有効化**
 
 `us-east-1` の Bedrock コンソールで、HolmesGPT が使う Anthropic Claude モデル（`anthropic.claude-sonnet-4-6` / `anthropic.claude-opus-4-6`）へのアクセスをリクエストする。CLI では完結しないためコンソール操作。
 
-- [ ] **Step 5: モデルが見えることを確認**
+- [ ] **Step 6: モデルが見えることを確認**
 
 ```bash
 aws bedrock list-foundation-models --region us-east-1 \
@@ -413,34 +493,19 @@ Expected: `anthropic.claude-sonnet-4-6` が返る
 
 # Phase 2: State Backend Bootstrap
 
-### Task 2.1: 新アカウントに state バケットとロックテーブルを作る
+### Task 2.1: 両新アカウントに state バケットとロックテーブルを作る
 
-全 `root.hcl` が `bucket = "terragrunt-state-${get_aws_account_id()}"` で組むため、コード変更は不要。新アカウントの認証情報で bootstrap するだけでよい。
+全 `root.hcl` が `bucket = "terragrunt-state-${get_aws_account_id()}"` で組むため、コード変更は不要。
 
 **Files:** なし
 
 **Interfaces:**
-- Consumes: Task 1.1 の `<PROD_ACCOUNT_ID>`
-- Produces: `terragrunt-state-<PROD_ACCOUNT_ID>` バケットと `terragrunt-state-locks` テーブル。Phase 3 以降の全 terragrunt 実行の前提
+- Consumes: Task 1.1 の `<PROD_ACCOUNT_ID>` / `<DEV_ACCOUNT_ID>`
+- Produces: 両アカウントの `terragrunt-state-<ID>` バケットと `terragrunt-state-locks` テーブル
 
-- [ ] **Step 1: 新アカウントの認証情報に切り替える**
+- [ ] **Step 1: production アカウントで bootstrap**
 
-```bash
-unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_SESSION_TOKEN
-CREDS=$(aws sts assume-role \
-  --role-arn arn:aws:iam::<PROD_ACCOUNT_ID>:role/OrganizationAccountAccessRole \
-  --role-session-name terragrunt-bootstrap --query Credentials --output json)
-export AWS_ACCESS_KEY_ID=$(echo "$CREDS" | jq -r .AccessKeyId)
-export AWS_SECRET_ACCESS_KEY=$(echo "$CREDS" | jq -r .SecretAccessKey)
-export AWS_SESSION_TOKEN=$(echo "$CREDS" | jq -r .SessionToken)
-aws sts get-caller-identity --query Account --output text
-```
-
-Expected: `<PROD_ACCOUNT_ID>` が返る
-
-- [ ] **Step 2: backend を bootstrap**
-
-任意の production スタックのディレクトリから実行すればよい。`vpc` は依存が無く最も軽い。
+`vpc` は依存が無く最も軽い。Task 1.2 Step 1 の認証情報がまだ有効ならそのまま使う。
 
 ```bash
 cd aws/vpc/envs/production && TG_TF_PATH=tofu terragrunt backend bootstrap
@@ -448,42 +513,84 @@ cd aws/vpc/envs/production && TG_TF_PATH=tofu terragrunt backend bootstrap
 
 Expected: S3 バケットと DynamoDB テーブルが作成される旨のログ
 
-- [ ] **Step 3: バケットとテーブルを確認**
+- [ ] **Step 2: production の backend を確認**
 
 ```bash
 aws s3api head-bucket --bucket terragrunt-state-<PROD_ACCOUNT_ID>
 aws s3api get-bucket-versioning --bucket terragrunt-state-<PROD_ACCOUNT_ID>
 aws dynamodb describe-table --table-name terragrunt-state-locks --region ap-northeast-1 \
-  --query 'Table.{Keys:KeySchema,Billing:BillingModeSummary.BillingMode}' --output json
+  --query 'Table.KeySchema' --output json
 ```
 
-Expected: バケットが存在し versioning が `Enabled`、テーブルの HASH キーが `LockID`
+Expected: バケットが存在し versioning が `Enabled`、HASH キーが `LockID`
+
+- [ ] **Step 3: develop アカウントの認証情報に切り替える**
+
+```bash
+unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_SESSION_TOKEN
+CREDS=$(aws sts assume-role \
+  --role-arn arn:aws:iam::<DEV_ACCOUNT_ID>:role/OrganizationAccountAccessRole \
+  --role-session-name terragrunt-bootstrap --query Credentials --output json)
+export AWS_ACCESS_KEY_ID=$(echo "$CREDS" | jq -r .AccessKeyId)
+export AWS_SECRET_ACCESS_KEY=$(echo "$CREDS" | jq -r .SecretAccessKey)
+export AWS_SESSION_TOKEN=$(echo "$CREDS" | jq -r .SessionToken)
+aws sts get-caller-identity --query Account --output text
+```
+
+Expected: `<DEV_ACCOUNT_ID>`
+
+- [ ] **Step 4: develop アカウントで bootstrap**
+
+develop env を持つ唯一のスタックが `github-oidc-auth`。
+
+```bash
+cd aws/github-oidc-auth/envs/develop && TG_TF_PATH=tofu terragrunt backend bootstrap
+```
+
+- [ ] **Step 5: develop の backend を確認**
+
+```bash
+aws s3api head-bucket --bucket terragrunt-state-<DEV_ACCOUNT_ID>
+aws dynamodb describe-table --table-name terragrunt-state-locks --region ap-northeast-1 \
+  --query 'Table.KeySchema' --output json
+```
+
+Expected: バケットとテーブルが存在する
 
 ---
 
 # Phase 3: `master` Env 新設
 
-管理アカウントに残る横断資産の受け皿を作り、`aws/route53` を移し、クロスアカウントロールを立てる。ここからは管理アカウントの認証情報（`panicboat` IAM ユーザー）で作業する。
+管理アカウントに残る資産を `master` に集約する。ここからは管理アカウントの認証情報（`panicboat` IAM ユーザー）で作業する。
 
-### Task 3.1: `master` env の GitHub OIDC ロールを作る
+### Task 3.1: `master` env の GitHub OIDC を立て、既存 provider を引き取る
+
+`aws_iam_openid_connect_provider` は 1 アカウント 1 つ。現在は `develop` env が管理しているが、develop はアカウントごと移動するため `master` が引き取る。削除して作り直すと `master` のロール trust が一時的に壊れるので import する。
 
 **Files:**
 - Create: `aws/github-oidc-auth/envs/master/env.hcl`
 - Create: `aws/github-oidc-auth/envs/master/terragrunt.hcl`
 
 **Interfaces:**
-- Produces: `github-oidc-auth-master-github-actions-{plan,apply}-role`。Task 3.2 の `workflow-config.yaml` が参照する
+- Produces: `github-oidc-auth-master-github-actions-{plan,apply}-role` と、`master` state が所有する OIDC provider。Task 3.2 の `workflow-config.yaml` が参照する
 
-- [ ] **Step 1: `env.hcl` を作成**
+- [ ] **Step 1: 管理アカウントの認証情報であることを確認**
 
-OIDC provider は `develop` env が管理する既存のものを再利用するため `create_oidc_provider = false`。
+```bash
+unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_SESSION_TOKEN
+aws sts get-caller-identity --query Arn --output text
+```
+
+Expected: `arn:aws:iam::559744160976:user/panicboat`
+
+- [ ] **Step 2: `env.hcl` を作成**
 
 ```hcl
 # env.hcl - Master environment configuration
 #
 # master = 管理アカウント (= 559744160976) に残る横断資産の env。
-# production を別アカウントへ分離したあとも Route53 hosted zone のように
-# アカウントを跨いで共有するリソースはここに置く。
+# production / develop を専用アカウントへ分離したあと、Route53 hosted zone・
+# GitHub 設定・支払アカウント単位の cost-management がここに集まる。
 locals {
   # Environment metadata
   environment = "master"
@@ -499,10 +606,11 @@ locals {
 
   additional_iam_policies = []
 
-  # OIDC provider は develop env が管理する既存 provider を再利用する
-  # (= 同一アカウント内で provider は 1 つしか作れない)。
-  create_oidc_provider = false
-  oidc_provider_arn    = "arn:aws:iam::${get_aws_account_id()}:oidc-provider/token.actions.githubusercontent.com"
+  # OIDC provider は develop env が作成したものを本 env が import で引き取る
+  # (= develop はアカウントごと移動するため、管理アカウントの provider を
+  #    誰も管理しない状態になるのを避ける)。
+  create_oidc_provider = true
+  oidc_provider_arn    = ""
 
   # Session duration (4 hours, production と同水準)
   max_session_duration = 14400
@@ -514,7 +622,7 @@ locals {
 }
 ```
 
-- [ ] **Step 2: `terragrunt.hcl` を作成**
+- [ ] **Step 3: `terragrunt.hcl` を作成**
 
 ```hcl
 # terragrunt.hcl - Master environment Terragrunt configuration
@@ -560,55 +668,67 @@ inputs = {
 }
 ```
 
-- [ ] **Step 3: 管理アカウントの認証情報であることを確認**
+- [ ] **Step 4: `develop` state から provider を外す**
+
+二重管理を作らないため、import より先に実行する。
 
 ```bash
-unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_SESSION_TOKEN
-aws sts get-caller-identity --query Arn --output text
+cd aws/github-oidc-auth/envs/develop
+TG_TF_PATH=tofu terragrunt state rm 'aws_iam_openid_connect_provider.github[0]'
 ```
 
-Expected: `arn:aws:iam::559744160976:user/panicboat`
+Expected: `Successfully removed 1 resource instance(s).`
 
-- [ ] **Step 4: plan で差分を確認**
+- [ ] **Step 5: `master` state へ provider を import**
 
 ```bash
-cd aws/github-oidc-auth/envs/master && TG_TF_PATH=tofu terragrunt init && TG_TF_PATH=tofu terragrunt plan
+cd aws/github-oidc-auth/envs/master
+TG_TF_PATH=tofu terragrunt init
+TG_TF_PATH=tofu terragrunt import 'aws_iam_openid_connect_provider.github[0]' \
+  arn:aws:iam::559744160976:oidc-provider/token.actions.githubusercontent.com
 ```
 
-Expected: 追加のみ（plan role / apply role / policy / policy attachment 3 / log group）。既存 develop / production のリソースに `destroy` や `replace` が出ないこと
+Expected: `Import successful!`
 
-- [ ] **Step 5: apply**
+- [ ] **Step 6: plan で provider が再作成されないことを確認**
+
+```bash
+cd aws/github-oidc-auth/envs/master && TG_TF_PATH=tofu terragrunt plan
+```
+
+Expected: `aws_iam_openid_connect_provider.github[0]` に `create` や `replace` が出ず、追加は plan / apply role・policy・attachment 3・log group のみ。tag の in-place update は許容
+
+- [ ] **Step 7: apply**
 
 ```bash
 cd aws/github-oidc-auth/envs/master && TG_TF_PATH=tofu terragrunt apply -auto-approve
 ```
 
-- [ ] **Step 6: ロールの存在を確認**
+- [ ] **Step 8: provider とロールを確認**
 
 ```bash
+aws iam list-open-id-connect-providers
 aws iam get-role --role-name github-oidc-auth-master-github-actions-plan-role --query 'Role.Arn' --output text
 aws iam get-role --role-name github-oidc-auth-master-github-actions-apply-role --query 'Role.Arn' --output text
 ```
 
-Expected: 両方の ARN が返る
+Expected: provider が 1 件のまま（重複作成されていない）、両ロールの ARN が返る
 
-- [ ] **Step 7: コミット**
+- [ ] **Step 9: コミット**
 
 ```bash
 git add aws/github-oidc-auth/envs/master/
-git commit -s -m "feat(aws/github-oidc-auth): add master environment for management-account stacks"
+git commit -s -m "feat(aws/github-oidc-auth): add master environment and adopt the shared OIDC provider"
 ```
 
 ### Task 3.2: `workflow-config.yaml` に `master` env を追加
 
-`panicboat/deploy-actions/label-resolver` は `workflow-config.yaml` の `environments:` を読んで `aws/{service}/envs/{environment}/` を解決する（`docs/superpowers/specs/2026-04-26-environment-naming-design.md` 参照）。`master` を宣言しないと Task 3.3 で移した `aws/route53/envs/master` が CI から見えない。
+`panicboat/deploy-actions/label-resolver` は `workflow-config.yaml` の `environments:` を読んで `aws/{service}/envs/{environment}/` と `github/{service}/envs/{environment}/` を解決する（`docs/superpowers/specs/2026-04-26-environment-naming-design.md` 参照）。`master` を宣言しないと Task 3.3-3.5 で移すスタックが CI から見えない。
 
 **Files:**
 - Modify: `workflow-config.yaml`
 
 - [ ] **Step 1: `master` env を `environments:` の先頭に追加**
-
-`workflow-config.yaml` の `environments:` 直下、`develop` の前に挿入する。
 
 ```yaml
   - environment: master
@@ -622,7 +742,7 @@ git commit -s -m "feat(aws/github-oidc-auth): add master environment for managem
 - [ ] **Step 2: YAML として妥当か確認**
 
 ```bash
-python3 -c "import yaml,sys; d=yaml.safe_load(open('workflow-config.yaml')); print([e['environment'] for e in d['environments']])"
+python3 -c "import yaml; d=yaml.safe_load(open('workflow-config.yaml')); print([e['environment'] for e in d['environments']])"
 ```
 
 Expected: `['master', 'develop', 'production']`
@@ -634,9 +754,9 @@ git add workflow-config.yaml
 git commit -s -m "feat(workflow-config): declare master environment"
 ```
 
-### Task 3.3: `aws/route53` を `master` env へ re-home
+### Task 3.3: `aws/route53` を `master` へ re-home
 
-hosted zone は管理アカウントの資産なので、スタックの env 帰属を `production` から `master` へ移す。state key が `platform/route53/production/` から `platform/route53/master/` に変わるため state 移行を伴う（resources=8 の実 state あり）。
+hosted zone は管理アカウントの資産なので env 帰属を移す。state key が変わるため `terragrunt backend migrate` を伴う（resources=8 の実 state あり）。
 
 **Files:**
 - Create: `aws/route53/envs/master/env.hcl`
@@ -645,7 +765,7 @@ hosted zone は管理アカウントの資産なので、スタックの env 帰
 
 **Interfaces:**
 - Consumes: Task 3.2 の `master` env 宣言
-- Produces: `platform/route53/master/terraform.tfstate`。Task 3.4 が同スタックに追記する
+- Produces: `platform/route53/master/terraform.tfstate`。Task 3.6 が同スタックに追記する
 
 - [ ] **Step 1: 移行前の state を確認**
 
@@ -681,8 +801,6 @@ locals {
 ```
 
 - [ ] **Step 3: `terragrunt.hcl` を作成**
-
-`aws/route53/envs/production/terragrunt.hcl` をベースに `production_account_id` の受け渡しを追加する。
 
 ```hcl
 # terragrunt.hcl - Terragrunt configuration for master environment
@@ -723,32 +841,29 @@ inputs = {
 }
 ```
 
-- [ ] **Step 4: state を新しいキーへコピー**
-
-`terragrunt backend migrate` は移行元と移行先の設定を両方解決する。
+- [ ] **Step 4: state を移行**
 
 ```bash
 terragrunt backend migrate aws/route53/envs/production aws/route53/envs/master
 ```
 
-- [ ] **Step 5: 移行先 state の中身を確認**
+- [ ] **Step 5: 移行先 state を確認**
 
 ```bash
-aws s3 ls s3://terragrunt-state-559744160976/platform/route53/master/
 cd aws/route53/envs/master && TG_TF_PATH=tofu terragrunt state list
 ```
 
-Expected: `terraform.tfstate` が存在し、Step 1 と同じ 8 エントリが返る
+Expected: Step 1 と同じ 8 エントリ
 
-- [ ] **Step 6: 差分ゼロを確認**
+- [ ] **Step 6: 差分を確認**
 
 ```bash
 cd aws/route53/envs/master && TG_TF_PATH=tofu terragrunt plan
 ```
 
-Expected: `No changes.`（`production_account_id` はまだ使われていないため差分は出ない）
+Expected: レコードの再作成が無いこと。`Environment` タグの develop→master 変更に伴う in-place update は許容
 
-- [ ] **Step 7: 旧 env ディレクトリと旧 state を削除**
+- [ ] **Step 7: 旧 env と旧 state を削除**
 
 ```bash
 git rm -r aws/route53/envs/production
@@ -762,7 +877,186 @@ git add aws/route53/envs/master/
 git commit -s -m "refactor(aws/route53): re-home stack from production to master environment"
 ```
 
-### Task 3.4: `route53-zone-access` ロールを作る
+### Task 3.4: `aws/cost-management` を `master` へ re-home
+
+Compute Optimizer と Cost Optimization Hub の登録は支払アカウント単位。develop がアカウントごと移動しても、この登録は管理アカウントに残す必要がある。
+
+**Files:**
+- Create: `aws/cost-management/envs/master/env.hcl`
+- Create: `aws/cost-management/envs/master/terragrunt.hcl`
+- Delete: `aws/cost-management/envs/develop/`
+
+- [ ] **Step 1: 移行前の state を確認**
+
+```bash
+cd aws/cost-management/envs/develop && TG_TF_PATH=tofu terragrunt state list
+```
+
+Expected: `aws_computeoptimizer_enrollment_status.this` と `terraform_data.cost_optimization_hub_enrollment` の 2 件
+
+- [ ] **Step 2: `env.hcl` を作成**
+
+module 側が `us-east-1` に固定しているため `aws_region` は現状を踏襲する。
+
+```hcl
+# env.hcl - Environment-specific configuration for master
+
+locals {
+  # Environment-specific settings
+  environment = "master"
+
+  # AWS configuration (Cost Optimization Hub / Compute Optimizer home region)
+  aws_region = "us-east-1"
+
+  # Environment-specific tags
+  environment_tags = {
+    Environment = local.environment
+    Component   = "cost-management"
+    Owner       = "panicboat"
+  }
+}
+```
+
+- [ ] **Step 3: `terragrunt.hcl` を作成**
+
+develop 版との差分は先頭コメントの env 名のみ（`aws_region` は module が `us-east-1` に固定するため渡していない）。
+
+```hcl
+# terragrunt.hcl - Terragrunt configuration for master environment
+
+# Include root configuration
+include "root" {
+  path = find_in_parent_folders("root.hcl")
+}
+
+# Include environment-specific configuration
+include "env" {
+  path   = "env.hcl"
+  expose = true
+}
+
+# Reference to Terraform modules
+terraform {
+  source = "../../modules"
+}
+
+# Input variables for the module
+# aws_region is intentionally not passed; the module pins region to us-east-1.
+inputs = {
+  environment = include.env.locals.environment
+
+  common_tags = merge(
+    include.env.locals.environment_tags,
+    {
+      Project    = "cost-management"
+      ManagedBy  = "terraform"
+      Repository = "panicboat/platform"
+    }
+  )
+}
+```
+
+- [ ] **Step 4: state を移行**
+
+```bash
+terragrunt backend migrate aws/cost-management/envs/develop aws/cost-management/envs/master
+```
+
+- [ ] **Step 5: 差分を確認**
+
+```bash
+cd aws/cost-management/envs/master && TG_TF_PATH=tofu terragrunt plan
+```
+
+Expected: `aws_computeoptimizer_enrollment_status` の再作成が無いこと。`terraform_data` の `triggers_replace` は `version = "v1"` で固定なので replace されないこと。タグの in-place update は許容
+
+- [ ] **Step 6: 旧 env と旧 state を削除**
+
+```bash
+git rm -r aws/cost-management/envs/develop
+aws s3 rm s3://terragrunt-state-559744160976/platform/cost-management/develop/terraform.tfstate
+```
+
+- [ ] **Step 7: コミット**
+
+```bash
+git add aws/cost-management/envs/master/
+git commit -s -m "refactor(aws/cost-management): re-home stack to master environment"
+```
+
+### Task 3.5: `github/repository` と `github/branch` を `master` へ re-home
+
+GitHub リポジトリと ruleset は環境を持たない組織横断資産。付随する CloudWatch ログ グループも管理アカウントに残る。
+
+**Files:**
+- Move: `github/repository/envs/develop/` → `github/repository/envs/master/`
+- Move: `github/branch/envs/develop/` → `github/branch/envs/master/`
+
+- [ ] **Step 1: 移行前の state を確認**
+
+```bash
+cd github/repository/envs/develop && TG_TF_PATH=tofu terragrunt state list
+cd ../../../branch/envs/develop && TG_TF_PATH=tofu terragrunt state list
+```
+
+Expected: repository 側は `aws_cloudwatch_log_group.github_repository_logs` / `github_repository.repository` / `github_workflow_repository_permissions.repository` の 3 件、branch 側は `data.github_repository.repo` / `github_repository_ruleset.branches` の 2 件
+
+- [ ] **Step 2: ディレクトリを `git mv` で移動**
+
+per-repo の `.hcl` ファイル（`monorepo.hcl` 等）も一緒に移す。
+
+```bash
+git mv github/repository/envs/develop github/repository/envs/master
+git mv github/branch/envs/develop github/branch/envs/master
+ls github/repository/envs/master/ github/branch/envs/master/
+```
+
+Expected: repository 側に 7 ファイル（`terragrunt.hcl` + repo 別 6 本）、branch 側に 5 ファイル（`terragrunt.hcl` + `defaults.hcl` + repo 別 3 本）
+
+- [ ] **Step 3: ハードコードされた `develop` が無いことを確認**
+
+env 名は `root.hcl` がディレクトリパスから導出するため、移動だけで切り替わるはず。
+
+```bash
+grep -rn "develop" github/repository/envs/master/ github/branch/envs/master/
+```
+
+Expected: 出力なし。あれば `master` に書き換える
+
+- [ ] **Step 4: `GITHUB_TOKEN` を設定して state を移行**
+
+両スタックとも `get_env("GITHUB_TOKEN")` を読むため、未設定だと terragrunt が評価時に失敗する。
+
+```bash
+export GITHUB_TOKEN=$(gh auth token)
+terragrunt backend migrate github/repository/envs/develop github/repository/envs/master
+terragrunt backend migrate github/branch/envs/develop github/branch/envs/master
+```
+
+- [ ] **Step 5: 差分を確認**
+
+```bash
+cd github/repository/envs/master && TG_TF_PATH=tofu terragrunt plan
+cd ../../../branch/envs/master && TG_TF_PATH=tofu terragrunt plan
+```
+
+Expected: GitHub リポジトリ・ruleset・ログ グループの再作成や削除が無いこと。ログ グループの `Environment` タグ in-place update は許容
+
+- [ ] **Step 6: 旧 state を削除**
+
+```bash
+aws s3 rm s3://terragrunt-state-559744160976/platform/repository/develop/terraform.tfstate
+aws s3 rm s3://terragrunt-state-559744160976/platform/branch/develop/terraform.tfstate
+```
+
+- [ ] **Step 7: コミット**
+
+```bash
+git add github/
+git commit -s -m "refactor(github): re-home repository and branch stacks to master environment"
+```
+
+### Task 3.6: `route53-zone-access` ロールを作る
 
 production アカウントから管理アカウントの hosted zone を操作するためのロール。信頼先は production アカウント root 1 つで、実際に誰が assume できるかは production 側の IAM で制御する（設計 §4 参照）。
 
@@ -772,9 +1066,9 @@ production アカウントから管理アカウントの hosted zone を操作�
 
 **Interfaces:**
 - Consumes: Task 3.3 の `production_account_id` input
-- Produces: `arn:aws:iam::559744160976:role/route53-zone-access`。Task 5.1 の provider alias、Task 5.2 の external-dns IAM、Task 5.3 の helm 値がこの ARN を参照する
+- Produces: `arn:aws:iam::559744160976:role/route53-zone-access`。Task 4.2 の `assume_role_arns`、Task 5.1 の provider alias、Task 5.2 の external-dns IAM、Task 5.3 の helm 値が参照する
 
-- [ ] **Step 1: `variables.tf` に `production_account_id` を追加**
+- [ ] **Step 1: `variables.tf` に変数を追加**
 
 `aws/route53/modules/variables.tf` の末尾に追記する。
 
@@ -791,7 +1085,7 @@ variable "production_account_id" {
 # zone_access.tf - Cross-account role that lets the production account manage
 # records in the hosted zones owned by this (= management) account.
 #
-# Why root principal instead of listing individual role ARNs: IAM rejects a
+# Why a root principal instead of listing individual role ARNs: IAM rejects a
 # trust policy naming a role ARN that does not exist yet
 # (= MalformedPolicyDocument). `eks-production-external-dns` is not created
 # until the EKS stack applies, so enumerating ARNs would pin this role's
@@ -890,7 +1184,7 @@ aws iam get-role --role-name route53-zone-access --query 'Role.AssumeRolePolicyD
 aws iam get-role-policy --role-name route53-zone-access --policy-name route53-zone-access --output json
 ```
 
-Expected: trust の Principal が `arn:aws:iam::<PROD_ACCOUNT_ID>:root`、ポリシーの 1 つ目の statement の Resource が 2 zone ARN
+Expected: trust の Principal が `arn:aws:iam::<PROD_ACCOUNT_ID>:root`、ポリシー 1 つ目の Resource が 2 zone ARN
 
 - [ ] **Step 7: コミット**
 
@@ -901,24 +1195,22 @@ git commit -s -m "feat(aws/route53): add cross-account zone access role for prod
 
 ---
 
-# Phase 4: Production の OIDC ロールと CI 切替
+# Phase 4: `develop` / `production` の OIDC ロールと CI 切替
 
-新アカウントに OIDC provider と plan / apply ロールを作り、CI の向き先を切り替える。**順序が重要**で、ロールの存在を確認してから `workflow-config.yaml` をマージする。
+各新アカウントに OIDC provider と plan / apply ロールを作り、CI の向き先を切り替える。**ロールの存在を確認してから `workflow-config.yaml` をマージする。**
 
 ### Task 4.1: plan ロールに `sts:AssumeRole` を付与できるようにする
 
-`ReadOnlyAccess` 管理ポリシーには `sts:AssumeRole` が含まれないため、plan ロールが `route53-zone-access` を assume できない。module 側に任意の assume 先を渡せる変数を足す。
+`ReadOnlyAccess` 管理ポリシーには `sts:AssumeRole` が含まれないため、production の plan ロールが `route53-zone-access` を assume できない。
 
 **Files:**
 - Modify: `aws/github-oidc-auth/modules/variables.tf`
 - Modify: `aws/github-oidc-auth/modules/main.tf`
 
 **Interfaces:**
-- Produces: `assume_role_arns` input。Task 4.2 の production env.hcl が値を渡す
+- Produces: `assume_role_arns` input。Task 4.3 の production env.hcl が値を渡す
 
 - [ ] **Step 1: `variables.tf` に変数を追加**
-
-`aws/github-oidc-auth/modules/variables.tf` の末尾に追記する。
 
 ```hcl
 variable "assume_role_arns" {
@@ -966,16 +1258,15 @@ cd aws/github-oidc-auth/envs/master && TG_TF_PATH=tofu terragrunt validate
 
 Expected: 成功
 
-- [ ] **Step 4: 既存 env に差分が出ないことを確認**
+- [ ] **Step 4: `master` env に差分が出ないことを確認**
 
-`assume_role_arns` はデフォルト空リストなので `count = 0` となり、develop / master には影響しないはず。
+デフォルト空リストなので `count = 0` となり影響しないはず。
 
 ```bash
-cd aws/github-oidc-auth/envs/develop && TG_TF_PATH=tofu terragrunt plan
-cd aws/github-oidc-auth/envs/master  && TG_TF_PATH=tofu terragrunt plan
+cd aws/github-oidc-auth/envs/master && TG_TF_PATH=tofu terragrunt plan
 ```
 
-Expected: 両方 `No changes.`
+Expected: `No changes.`
 
 - [ ] **Step 5: コミット**
 
@@ -984,19 +1275,66 @@ git add aws/github-oidc-auth/modules/
 git commit -s -m "feat(aws/github-oidc-auth): allow granting cross-account assume to the plan role"
 ```
 
-### Task 4.2: production の OIDC provider とロールを新アカウントに作る
+### Task 4.2: `develop` の OIDC ロールを新アカウントに作る
+
+`aws/github-oidc-auth/envs/develop/env.hcl` は既に `create_oidc_provider = true` で、アカウントが変わるだけなのでコード変更は不要。
+
+**Files:** なし（既存スタックの apply のみ）
+
+- [ ] **Step 1: develop アカウントの認証情報に切り替える**
+
+```bash
+unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_SESSION_TOKEN
+CREDS=$(aws sts assume-role \
+  --role-arn arn:aws:iam::<DEV_ACCOUNT_ID>:role/OrganizationAccountAccessRole \
+  --role-session-name oidc-bootstrap --query Credentials --output json)
+export AWS_ACCESS_KEY_ID=$(echo "$CREDS" | jq -r .AccessKeyId)
+export AWS_SECRET_ACCESS_KEY=$(echo "$CREDS" | jq -r .SecretAccessKey)
+export AWS_SESSION_TOKEN=$(echo "$CREDS" | jq -r .SessionToken)
+aws sts get-caller-identity --query Account --output text
+```
+
+Expected: `<DEV_ACCOUNT_ID>`
+
+- [ ] **Step 2: plan**
+
+state は Task 2.1 で bootstrap した新バケットを向くため、全て新規追加になる。
+
+```bash
+cd aws/github-oidc-auth/envs/develop && TG_TF_PATH=tofu terragrunt init && TG_TF_PATH=tofu terragrunt plan
+```
+
+Expected: OIDC provider / plan role / apply role / state lock policy / attachment 3 / log group が全て新規追加
+
+- [ ] **Step 3: apply**
+
+```bash
+cd aws/github-oidc-auth/envs/develop && TG_TF_PATH=tofu terragrunt apply -auto-approve
+```
+
+- [ ] **Step 4: ロールと provider を確認**
+
+```bash
+aws iam list-open-id-connect-providers
+aws iam get-role --role-name github-oidc-auth-develop-github-actions-plan-role --query 'Role.Arn' --output text
+aws iam get-role --role-name github-oidc-auth-develop-github-actions-apply-role --query 'Role.Arn' --output text
+```
+
+Expected: provider が 1 件、両ロールの ARN が `<DEV_ACCOUNT_ID>`
+
+### Task 4.3: `production` の OIDC ロールを新アカウントに作る
 
 **Files:**
 - Modify: `aws/github-oidc-auth/envs/production/env.hcl`
 - Modify: `aws/github-oidc-auth/envs/production/terragrunt.hcl`
 
 **Interfaces:**
-- Consumes: Task 3.4 の `route53-zone-access` ARN、Task 4.1 の `assume_role_arns`
-- Produces: 新アカウントの `github-oidc-auth-production-github-actions-{plan,apply}-role`。Task 4.3 が `workflow-config.yaml` で参照する
+- Consumes: Task 3.6 の `route53-zone-access` ARN、Task 4.1 の `assume_role_arns`
+- Produces: 新アカウントの production plan / apply ロール
 
 - [ ] **Step 1: `env.hcl` の OIDC provider 設定を反転**
 
-`aws/github-oidc-auth/envs/production/env.hcl` の以下 2 行を置き換える。
+以下 2 行を置き換える。
 
 置換前:
 
@@ -1011,15 +1349,14 @@ git commit -s -m "feat(aws/github-oidc-auth): allow granting cross-account assum
 ```hcl
   # OIDC provider settings
   # production は専用アカウントに分離済で、そのアカウントには provider が
-  # 存在しないため自前で作成する (= develop / master は管理アカウントの
-  # 既存 provider を共有)。
+  # 存在しないため自前で作成する (= master / develop も各アカウントで自前作成)。
   create_oidc_provider = true
   oidc_provider_arn    = ""
 ```
 
 - [ ] **Step 2: `env.hcl` に `assume_role_arns` を追加**
 
-同ファイルの `additional_tags` ブロックの直前に追記する。
+`additional_tags` ブロックの直前に追記する。
 
 ```hcl
   # Route53 hosted zone は管理アカウント (= 559744160976) に残しているため、
@@ -1031,13 +1368,13 @@ git commit -s -m "feat(aws/github-oidc-auth): allow granting cross-account assum
 
 - [ ] **Step 3: `terragrunt.hcl` で input を渡す**
 
-`aws/github-oidc-auth/envs/production/terragrunt.hcl` の `inputs` ブロックに追記する。
+`inputs` ブロックに追記する。
 
 ```hcl
   assume_role_arns = include.env.locals.assume_role_arns
 ```
 
-- [ ] **Step 4: 新アカウントの認証情報に切り替える**
+- [ ] **Step 4: production アカウントの認証情報に切り替える**
 
 ```bash
 unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_SESSION_TOKEN
@@ -1052,33 +1389,27 @@ aws sts get-caller-identity --query Account --output text
 
 Expected: `<PROD_ACCOUNT_ID>`
 
-- [ ] **Step 5: plan**
+- [ ] **Step 5: plan と apply**
 
 ```bash
 cd aws/github-oidc-auth/envs/production && TG_TF_PATH=tofu terragrunt init && TG_TF_PATH=tofu terragrunt plan
-```
-
-Expected: 全て新規追加（OIDC provider / plan role / apply role / state lock policy / cross-account assume policy / attachment 3 / log group）
-
-- [ ] **Step 6: apply**
-
-```bash
 cd aws/github-oidc-auth/envs/production && TG_TF_PATH=tofu terragrunt apply -auto-approve
 ```
 
-- [ ] **Step 7: ロールと provider を確認**
+Expected: plan は全て新規追加。apply が成功する
+
+- [ ] **Step 6: ロールと assume ポリシーを確認**
 
 ```bash
-aws iam list-open-id-connect-providers
 aws iam get-role --role-name github-oidc-auth-production-github-actions-plan-role --query 'Role.Arn' --output text
 aws iam get-role --role-name github-oidc-auth-production-github-actions-apply-role --query 'Role.Arn' --output text
 aws iam get-role-policy --role-name github-oidc-auth-production-github-actions-plan-role \
   --policy-name cross-account-assume --output json
 ```
 
-Expected: provider が 1 件、両ロールの ARN が新アカウント、assume ポリシーの Resource が `route53-zone-access` ARN
+Expected: 両ロールの ARN が `<PROD_ACCOUNT_ID>`、assume ポリシーの Resource が `route53-zone-access` ARN
 
-- [ ] **Step 8: クロスアカウント assume の疎通を確認**
+- [ ] **Step 7: クロスアカウント assume の疎通を確認**
 
 ```bash
 aws sts assume-role \
@@ -1089,39 +1420,54 @@ aws sts assume-role \
 
 Expected: `arn:aws:sts::559744160976:assumed-role/route53-zone-access/migration-check`
 
-- [ ] **Step 9: コミット**
+- [ ] **Step 8: コミット**
 
 ```bash
 git add aws/github-oidc-auth/envs/production/
 git commit -s -m "feat(aws/github-oidc-auth): provision production OIDC in its dedicated account"
 ```
 
-### Task 4.3: `workflow-config.yaml` の production ロール ARN を差し替える
+### Task 4.4: `workflow-config.yaml` の `develop` / `production` を差し替える
 
 **Files:**
 - Modify: `workflow-config.yaml`
 
-- [ ] **Step 1: Task 4.2 のロールが存在することを再確認**
+- [ ] **Step 1: 両アカウントのロールが存在することを再確認**
 
-差し替え前の必須ゲート。ここを飛ばして先にマージすると CI の production plan / apply が存在しないロールを assume して壊れる。
+差し替え前の必須ゲート。ここを飛ばして先にマージすると CI が存在しないロールを assume して壊れる。
 
 ```bash
-aws iam get-role --role-name github-oidc-auth-production-github-actions-plan-role --query 'Role.Arn' --output text
-aws iam get-role --role-name github-oidc-auth-production-github-actions-apply-role --query 'Role.Arn' --output text
+for acct in <DEV_ACCOUNT_ID> <PROD_ACCOUNT_ID>; do
+  CREDS=$(aws sts assume-role --role-arn "arn:aws:iam::${acct}:role/OrganizationAccountAccessRole" \
+    --role-session-name verify --query Credentials --output json)
+  AWS_ACCESS_KEY_ID=$(echo "$CREDS" | jq -r .AccessKeyId) \
+  AWS_SECRET_ACCESS_KEY=$(echo "$CREDS" | jq -r .SecretAccessKey) \
+  AWS_SESSION_TOKEN=$(echo "$CREDS" | jq -r .SessionToken) \
+    aws iam list-roles --query 'Roles[?starts_with(RoleName, `github-oidc-auth-`)].RoleName' --output text
+done
 ```
 
-Expected: 両方が `arn:aws:iam::<PROD_ACCOUNT_ID>:role/...` を返す
+Expected: develop アカウントで develop の 2 ロール、production アカウントで production の 2 ロールが返る
 
-- [ ] **Step 2: `production` ブロックの ARN を差し替え**
-
-`workflow-config.yaml` の `production` 環境の 2 行を置き換える。
+- [ ] **Step 2: `develop` と `production` の ARN を差し替え**
 
 ```yaml
+  - environment: develop
+    stacks:
+      terragrunt:
+        aws_region: us-east-1
+        iam_role_plan: arn:aws:iam::<DEV_ACCOUNT_ID>:role/github-oidc-auth-develop-github-actions-plan-role
+        iam_role_apply: arn:aws:iam::<DEV_ACCOUNT_ID>:role/github-oidc-auth-develop-github-actions-apply-role
+
+  - environment: production
+    stacks:
+      terragrunt:
+        aws_region: ap-northeast-1
         iam_role_plan: arn:aws:iam::<PROD_ACCOUNT_ID>:role/github-oidc-auth-production-github-actions-plan-role
         iam_role_apply: arn:aws:iam::<PROD_ACCOUNT_ID>:role/github-oidc-auth-production-github-actions-apply-role
 ```
 
-- [ ] **Step 3: 管理アカウント ID が production ブロックから消えたことを確認**
+- [ ] **Step 3: 3 env が正しいアカウントを向いていることを確認**
 
 ```bash
 python3 - <<'EOF'
@@ -1133,13 +1479,13 @@ for e in d['environments']:
 EOF
 ```
 
-Expected: `master` と `develop` が `559744160976`、`production` が `<PROD_ACCOUNT_ID>`
+Expected: `master` が `559744160976`、`develop` が `<DEV_ACCOUNT_ID>`、`production` が `<PROD_ACCOUNT_ID>`
 
 - [ ] **Step 4: コミット**
 
 ```bash
 git add workflow-config.yaml
-git commit -s -m "feat(workflow-config): point production stacks at the dedicated account"
+git commit -s -m "feat(workflow-config): point develop and production at their dedicated accounts"
 ```
 
 ---
@@ -1161,12 +1507,10 @@ git commit -s -m "feat(workflow-config): point production stacks at the dedicate
 - Modify: `aws/alb/envs/production/terragrunt.hcl`
 
 **Interfaces:**
-- Consumes: Task 3.4 の `route53-zone-access` ARN
-- Produces: `var.route53_zone_role_arn`（`aws/alb` 内のみ。`aws/eks` は Task 5.2 で lookup ごと削除するため不要）
+- Consumes: Task 3.6 の `route53-zone-access` ARN
+- Produces: `var.route53_zone_role_arn`（`aws/alb` 内）
 
 - [ ] **Step 1: `variables.tf` に変数を追加**
-
-`aws/alb/modules/variables.tf` の末尾に追記する。
 
 ```hcl
 variable "route53_zone_role_arn" {
@@ -1177,7 +1521,7 @@ variable "route53_zone_role_arn" {
 
 - [ ] **Step 2: `terraform.tf` に alias provider を追加**
 
-`aws/alb/modules/terraform.tf` の既存 `provider "aws"` ブロックの直後に追記する。
+既存 `provider "aws"` ブロックの直後に追記する。
 
 ```hcl
 # Hosted zone は管理アカウント (= 559744160976) に残しているため、
@@ -1198,7 +1542,7 @@ provider "aws" {
 
 - [ ] **Step 3: `lookups.tf` で provider を差し替え**
 
-`aws/alb/modules/lookups.tf` を以下に置き換える。
+ファイル全体を以下に置き換える。
 
 ```hcl
 # lookups.tf - External stack lookups.
@@ -1218,7 +1562,7 @@ module "route53" {
 
 - [ ] **Step 4: validation レコードに provider を指定**
 
-`aws/alb/modules/main.tf` の `aws_route53_record.wildcard_panicboat_net_validation` と `aws_route53_record.wildcard_dystopia_city_validation` の両方に、`for_each` ブロックの直前へ 1 行追加する。
+`aws/alb/modules/main.tf` の `aws_route53_record.wildcard_panicboat_net_validation` と `aws_route53_record.wildcard_dystopia_city_validation` の両方に、`for_each` の直前へ 1 行追加する。
 
 ```hcl
   provider = aws.route53
@@ -1228,7 +1572,7 @@ ACM 証明書（`aws_acm_certificate`）と検証待ち（`aws_acm_certificate_v
 
 - [ ] **Step 5: `env.hcl` に ARN を追加**
 
-`aws/alb/envs/production/env.hcl` の `environment_tags` ブロックの直前に追記する。
+`environment_tags` ブロックの直前に追記する。
 
 ```hcl
   # 管理アカウント (= 559744160976) の hosted zone を操作するための assume 先。
@@ -1237,7 +1581,7 @@ ACM 証明書（`aws_acm_certificate`）と検証待ち（`aws_acm_certificate_v
 
 - [ ] **Step 6: `terragrunt.hcl` で input を渡す**
 
-`aws/alb/envs/production/terragrunt.hcl` の `inputs` ブロック、`aws_region` の次の行に追記する。
+`inputs` ブロック、`aws_region` の次の行に追記する。
 
 ```hcl
   route53_zone_role_arn = include.env.locals.route53_zone_role_arn
@@ -1254,7 +1598,7 @@ Expected: 成功
 
 - [ ] **Step 8: plan で zone が解決できることを確認**
 
-新アカウントの認証情報で実行する。
+production アカウントの認証情報で実行する。
 
 ```bash
 cd aws/alb/envs/production && TG_TF_PATH=tofu terragrunt plan
@@ -1281,8 +1625,8 @@ git commit -s -m "feat(aws/alb): resolve hosted zones through a cross-account pr
 - Modify: `aws/eks/envs/production/terragrunt.hcl`
 
 **Interfaces:**
-- Consumes: Task 3.4 の `route53-zone-access` ARN
-- Produces: `eks-production-external-dns` ロールが Route53 権限ではなく `sts:AssumeRole` を持つ。Task 5.3 の helm 値と対になる
+- Consumes: Task 3.6 の `route53-zone-access` ARN
+- Produces: `eks-production-external-dns` ロールが `sts:AssumeRole` を持つ。Task 5.3 の helm 値と対になる
 
 - [ ] **Step 1: `module.route53` の参照箇所が 1 つだけであることを再確認**
 
@@ -1293,8 +1637,6 @@ grep -rn "module\.route53" aws/eks/modules/
 Expected: `addons.tf` の 2 行（`panicboat_net.arn` / `dystopia_city.arn`）のみ
 
 - [ ] **Step 2: `variables.tf` に変数を追加**
-
-`aws/eks/modules/variables.tf` の末尾に追記する。
 
 ```hcl
 variable "route53_zone_role_arn" {
@@ -1345,7 +1687,7 @@ module "external_dns_irsa" {
 
 - [ ] **Step 4: `lookups.tf` から route53 lookup を削除**
 
-`aws/eks/modules/lookups.tf` を以下に置き換える。
+ファイル全体を以下に置き換える。
 
 ```hcl
 # lookups.tf - External stack lookups for the EKS cluster.
@@ -1358,7 +1700,7 @@ module "vpc" {
 
 - [ ] **Step 5: `env.hcl` に ARN を追加**
 
-`aws/eks/envs/production/env.hcl` の `environment_tags` ブロックの直前に追記する。
+`environment_tags` ブロックの直前に追記する。
 
 ```hcl
   # external-dns が管理アカウント (= 559744160976) の hosted zone を操作するための assume 先。
@@ -1367,7 +1709,7 @@ module "vpc" {
 
 - [ ] **Step 6: `terragrunt.hcl` で input を渡す**
 
-`aws/eks/envs/production/terragrunt.hcl` の `inputs` ブロックに追記する。
+`inputs` ブロックに追記する。
 
 ```hcl
   route53_zone_role_arn = include.env.locals.route53_zone_role_arn
@@ -1395,11 +1737,11 @@ git commit -s -m "feat(aws/eks): grant external-dns cross-account assume instead
 - Modify: `kubernetes/components/external-dns/production/values.yaml.gotmpl`
 
 **Interfaces:**
-- Consumes: Task 5.2 の IRSA ロール（`sts:AssumeRole` のみを持つ）、Task 3.4 の `route53-zone-access`
+- Consumes: Task 5.2 の IRSA ロール、Task 3.6 の `route53-zone-access`
 
 - [ ] **Step 1: `extraArgs` セクションを追加**
 
-`kubernetes/components/external-dns/production/values.yaml.gotmpl` の `txtOwnerId` ブロックと `serviceAccount` ブロックの間に挿入する。
+`txtOwnerId` ブロックと `serviceAccount` ブロックの間に挿入する。
 
 ```yaml
 # =============================================================================
@@ -1416,10 +1758,10 @@ extraArgs:
 
 ```bash
 helmfile -e production -f kubernetes/components/external-dns/production/helmfile.yaml template \
-  | grep -A3 -- "--aws-assume-role"
+  | grep -- "--aws-assume-role"
 ```
 
-Expected: Deployment の args に `--aws-assume-role=arn:aws:iam::559744160976:role/route53-zone-access` が含まれる
+Expected: `--aws-assume-role=arn:aws:iam::559744160976:role/route53-zone-access` が出力される
 
 - [ ] **Step 3: コミット**
 
@@ -1432,14 +1774,14 @@ git commit -s -m "feat(external-dns): assume the management-account role for Rou
 
 # Phase 6: 共有リソースの再作成
 
-### Task 6.1: service-linked role と Secrets Manager を新アカウントに作る
+### Task 6.1: service-linked role と Secrets Manager を production アカウントに作る
 
 **Files:** なし（既存スタックの apply と手動投入）
 
 **Interfaces:**
 - Consumes: Task 0.4 の退避ファイル `$HOME/.secrets-backup-559744160976.json`
 
-- [ ] **Step 1: 新アカウントの認証情報で `iam-service-linked-roles` を apply**
+- [ ] **Step 1: production アカウントの認証情報で `iam-service-linked-roles` を apply**
 
 ```bash
 cd aws/iam-service-linked-roles/envs/production && TG_TF_PATH=tofu terragrunt init && TG_TF_PATH=tofu terragrunt apply -auto-approve
@@ -1453,9 +1795,9 @@ aws iam get-role --role-name AWSServiceRoleForEC2Spot --query 'Role.Arn' --outpu
 
 Expected: `arn:aws:iam::<PROD_ACCOUNT_ID>:role/aws-service-role/spot.amazonaws.com/AWSServiceRoleForEC2Spot`
 
-- [ ] **Step 3: monorepo 側の Secrets Manager スタックを apply**
+- [ ] **Step 3: platform 管理外の secret 6 件を作成**
 
-`panicboat/holmes/slack` と `panicboat/holmes/alertmanager` は monorepo が管理する。Task 8.1 で扱うため、ここでは platform 管理外の残り 6 件を手動作成する。
+`panicboat/holmes/{slack,alertmanager}` は monorepo が管理するため Task 8.1 で扱う。
 
 ```bash
 for name in \
@@ -1504,11 +1846,7 @@ helmfile v1.4 は親 `helmfile.yaml.gotmpl` の environments values を子 helmf
 
 **Files:**
 - Modify: `kubernetes/helmfile.yaml.gotmpl`
-- Modify: `kubernetes/components/aws-load-balancer-controller/production/helmfile.yaml`
-- Modify: `kubernetes/components/external-dns/production/helmfile.yaml`
-- Modify: `kubernetes/components/loki/production/helmfile.yaml`
-- Modify: `kubernetes/components/mimir/production/helmfile.yaml`
-- Modify: `kubernetes/components/tempo/production/helmfile.yaml`
+- Modify: `kubernetes/components/{aws-load-balancer-controller,external-dns,loki,mimir,tempo}/production/helmfile.yaml`
 
 - [ ] **Step 1: 差し替え対象を列挙**
 
@@ -1516,11 +1854,11 @@ helmfile v1.4 は親 `helmfile.yaml.gotmpl` の environments values を子 helmf
 grep -rn "559744160976" kubernetes/helmfile.yaml.gotmpl kubernetes/components/
 ```
 
-Expected: 11 行（親 5 + 子 6）
+Expected: 12 行（親 5 + 子 6 + Task 5.3 で追加した `--aws-assume-role` 1）
 
 - [ ] **Step 2: 一括置換**
 
-`kubernetes/components/external-dns/production/values.yaml.gotmpl` の `--aws-assume-role` は **管理アカウント ID のまま残す**必要があるため、置換対象から除外する。
+`values.yaml.gotmpl` の `--aws-assume-role` は**管理アカウント ID のまま残す**必要があるため除外する。
 
 ```bash
 grep -rl "559744160976" kubernetes/helmfile.yaml.gotmpl kubernetes/components/ \
@@ -1531,11 +1869,11 @@ grep -rl "559744160976" kubernetes/helmfile.yaml.gotmpl kubernetes/components/ \
 - [ ] **Step 3: 置換結果を検証**
 
 ```bash
-grep -rn "559744160976" kubernetes/
-grep -rn "<PROD_ACCOUNT_ID>" kubernetes/ | wc -l
+grep -rn "559744160976" kubernetes/helmfile.yaml.gotmpl kubernetes/components/
+grep -rn "<PROD_ACCOUNT_ID>" kubernetes/helmfile.yaml.gotmpl kubernetes/components/ | wc -l
 ```
 
-Expected: 1 つ目は `kubernetes/components/external-dns/production/values.yaml.gotmpl` の `--aws-assume-role` 行と `kubernetes/manifests/` 配下の rendered 出力のみ。2 つ目は 11
+Expected: 1 つ目は `external-dns/production/values.yaml.gotmpl` の `--aws-assume-role` 行 1 本のみ。2 つ目は 11
 
 - [ ] **Step 4: helmfile が template できることを確認**
 
@@ -1554,10 +1892,10 @@ git commit -s -m "feat(kubernetes): point production values at the dedicated AWS
 
 ### Task 7.2: EKS を新アカウントで再構築する
 
-既存の recreate runbook をそのまま実行する。本タスクは runbook を呼び出す薄いラッパで、runbook 内の手順を複製しない。
+既存の recreate runbook を実行する。本タスクは runbook を呼び出す薄いラッパで、runbook 内の手順を複製しない。
 
 **Files:**
-- Modify: `docs/runbooks/eks-production-recreate.md`（Phase 0 の期待値をアカウント非依存に直す）
+- Modify: `docs/runbooks/eks-production-recreate.md`
 
 - [ ] **Step 1: Service Quota の増枠が承認済みか確認**
 
@@ -1572,9 +1910,11 @@ done
 
 Expected: On-Demand が 64 以上、Spot が 256 以上
 
-- [ ] **Step 2: runbook の Phase 0 の期待値を更新**
+- [ ] **Step 2: runbook の前提記述を更新**
 
-`docs/runbooks/eks-production-recreate.md` の 2.2 節と Phase 0 に `arn:aws:iam::559744160976:user/panicboat` がハードコードされている。production はアカウントが変わったため、以下の記述に置き換える。
+`docs/runbooks/eks-production-recreate.md` の 2.2 節と Phase 0 に `arn:aws:iam::559744160976:user/panicboat` がハードコードされている。production はアカウントが変わったため置き換える。
+
+2.2 節の operator environment 記述:
 
 ```
 - production アカウント (= `<PROD_ACCOUNT_ID>`) の AdministratorAccess 相当の principal
@@ -1582,11 +1922,11 @@ Expected: On-Demand が 64 以上、Spot が 256 以上
   `OrganizationAccountAccessRole` を assume した session)
 ```
 
-Phase 0 の期待値コメント `# → arn:aws:iam::559744160976:user/panicboat` は、返るアカウント ID が `<PROD_ACCOUNT_ID>` であることを確認する記述に変える。
+Phase 0 の期待値コメント `# → arn:aws:iam::559744160976:user/panicboat` は、`aws sts get-caller-identity --query Account --output text` が `<PROD_ACCOUNT_ID>` を返すことを確認する記述に変える。
 
 - [ ] **Step 3: runbook の Phase 1-10 を実行**
 
-`docs/runbooks/eks-production-recreate.md` に従う。Phase 7 の残りスタック apply には `eks-holmesgpt` が含まれていないため、`eks-secrets eks-logs eks-metrics eks-traces` の後に追加で apply する。
+Phase 7 の残りスタック apply には `eks-holmesgpt` が含まれていないため、`eks-secrets eks-logs eks-metrics eks-traces` の後に追加で apply する。
 
 ```bash
 cd aws/eks-holmesgpt/envs/production && TG_TF_PATH=tofu terragrunt init -upgrade && TG_TF_PATH=tofu terragrunt apply -auto-approve
@@ -1627,13 +1967,11 @@ git commit -s -m "docs(runbooks): decouple the recreate runbook from the managem
 
 ### Task 8.1: monorepo の production スタックを新アカウントへ
 
-`panicboat/monorepo` の `system-components/holmes/terragrunt`（Secrets Manager 2 件）と `services/monolith/terragrunt`（resources=0）が、同じ `terragrunt-state-${get_aws_account_id()}` 規約で state を持つ。
-
 **Files（monorepo リポジトリ）:**
 - Modify: `workflow-config.yaml`
 
 **Interfaces:**
-- Consumes: Task 2.1 の state バケット、Task 4.2 の production ロール、Task 0.4 の退避ファイル
+- Consumes: Task 2.1 の state バケット、Task 4.3 の production ロール、Task 0.4 の退避ファイル
 
 - [ ] **Step 1: 現状の state を確認**
 
@@ -1644,7 +1982,7 @@ aws s3 ls s3://terragrunt-state-559744160976/system-components/ --recursive
 
 Expected: `services/monolith/production`、`services/nginx-app/develop`、`system-components/holmes/production` の 3 件
 
-- [ ] **Step 2: 新アカウントの認証情報で holmes スタックを apply**
+- [ ] **Step 2: production アカウントの認証情報で holmes スタックを apply**
 
 ```bash
 cd ../monorepo/system-components/holmes/terragrunt/envs/production
@@ -1678,11 +2016,19 @@ cd ../monorepo/services/monolith/terragrunt/envs/production
 TG_TF_PATH=tofu terragrunt init && TG_TF_PATH=tofu terragrunt apply -auto-approve
 ```
 
-- [ ] **Step 5: monorepo の `workflow-config.yaml` に production env を追加**
+- [ ] **Step 5: monorepo の `workflow-config.yaml` を更新**
 
-現状 `develop` のみ宣言されており、production スタックは手動 apply 運用になっている。CI に載せるため追加する。
+現状 `develop` のみ宣言され、production スタックは手動 apply 運用になっている。develop もアカウントが変わるため両方書く。
 
 ```yaml
+environments:
+  - environment: develop
+    stacks:
+      terragrunt:
+        aws_region: ap-northeast-1
+        iam_role_plan: arn:aws:iam::<DEV_ACCOUNT_ID>:role/github-oidc-auth-develop-github-actions-plan-role
+        iam_role_apply: arn:aws:iam::<DEV_ACCOUNT_ID>:role/github-oidc-auth-develop-github-actions-apply-role
+
   - environment: production
     stacks:
       terragrunt:
@@ -1704,18 +2050,16 @@ Expected: `services/monolith/production` と `system-components/holmes/productio
 ```bash
 cd ../monorepo
 git add workflow-config.yaml
-git commit -s -m "feat(workflow-config): declare production environment on the dedicated account"
+git commit -s -m "feat(workflow-config): point stacks at the dedicated AWS accounts"
 ```
 
 ---
 
 # Phase 9: 旧アカウントの後片付け
 
-### Task 9.1: 管理アカウントから production 資産を除去
+### Task 9.1: 管理アカウントから production / develop の IAM 資産を除去
 
-**Files:**
-- Modify: `README.md`
-- Modify: `README-ja.md`
+**Files:** なし
 
 - [ ] **Step 1: 管理アカウントの認証情報に戻す**
 
@@ -1726,54 +2070,74 @@ aws sts get-caller-identity --query Arn --output text
 
 Expected: `arn:aws:iam::559744160976:user/panicboat`
 
-- [ ] **Step 2: 旧 production の IAM 資産を削除**
+- [ ] **Step 2: 削除対象が旧アカウント側であることを確認**
 
-Task 4.2 で `aws/github-oidc-auth/envs/production` は新アカウントを向くよう変更済のため、`terragrunt destroy` を打つと**新アカウント側**が消える。旧アカウント側は AWS API で直接削除する。
-
-削除前に、対象が旧アカウントのロールであることを確認する。
+Task 4.2 / 4.3 でスタックは新アカウントを向いているため、`terragrunt destroy` を打つと新アカウント側が消える。旧アカウント側は AWS API で直接削除する。
 
 ```bash
-aws iam get-role --role-name github-oidc-auth-production-github-actions-apply-role --query 'Role.Arn' --output text
+aws iam list-roles --query 'Roles[?starts_with(RoleName, `github-oidc-auth-`)].Arn' --output text | tr '\t' '\n'
 ```
 
-Expected: `arn:aws:iam::559744160976:role/github-oidc-auth-production-github-actions-apply-role`（管理アカウント ID であること）
+Expected: `arn:aws:iam::559744160976:role/github-oidc-auth-{develop,production,master}-github-actions-{plan,apply}-role` の 6 本
 
-確認できたら削除する。旧 state は Step 4 でまとめて消す。
+- [ ] **Step 3: develop と production のロール・ポリシー・ログ グループを削除**
+
+`master` の 2 本は残す。
 
 ```bash
-aws iam detach-role-policy --role-name github-oidc-auth-production-github-actions-apply-role \
-  --policy-arn arn:aws:iam::aws:policy/AdministratorAccess
-aws iam detach-role-policy --role-name github-oidc-auth-production-github-actions-plan-role \
-  --policy-arn arn:aws:iam::aws:policy/ReadOnlyAccess
-aws iam detach-role-policy --role-name github-oidc-auth-production-github-actions-plan-role \
-  --policy-arn arn:aws:iam::559744160976:policy/github-oidc-auth-production-terragrunt-state-lock
-aws iam delete-role --role-name github-oidc-auth-production-github-actions-apply-role
-aws iam delete-role --role-name github-oidc-auth-production-github-actions-plan-role
-aws iam delete-policy --policy-arn arn:aws:iam::559744160976:policy/github-oidc-auth-production-terragrunt-state-lock
-aws logs delete-log-group --region ap-northeast-1 --log-group-name /github-actions/github-oidc-auth-production
+for env in develop production; do
+  aws iam detach-role-policy --role-name "github-oidc-auth-${env}-github-actions-apply-role" \
+    --policy-arn arn:aws:iam::aws:policy/AdministratorAccess
+  aws iam detach-role-policy --role-name "github-oidc-auth-${env}-github-actions-plan-role" \
+    --policy-arn arn:aws:iam::aws:policy/ReadOnlyAccess
+  aws iam detach-role-policy --role-name "github-oidc-auth-${env}-github-actions-plan-role" \
+    --policy-arn "arn:aws:iam::559744160976:policy/github-oidc-auth-${env}-terragrunt-state-lock"
+  aws iam delete-role --role-name "github-oidc-auth-${env}-github-actions-apply-role"
+  aws iam delete-role --role-name "github-oidc-auth-${env}-github-actions-plan-role"
+  aws iam delete-policy --policy-arn "arn:aws:iam::559744160976:policy/github-oidc-auth-${env}-terragrunt-state-lock"
+  aws logs delete-log-group --region ap-northeast-1 --log-group-name "/github-actions/github-oidc-auth-${env}"
+done
 ```
 
-- [ ] **Step 3: 残存ロールを確認**
+- [ ] **Step 4: 残存ロールを確認**
 
 ```bash
 aws iam list-roles --query 'Roles[?!contains(Path, `aws-service-role`)].RoleName' --output text | tr '\t' '\n'
 ```
 
-Expected: `AWSReservedSSO_AdministratorAccess_*`、`github-oidc-auth-develop-github-actions-{plan,apply}-role`、`route53-zone-access` の 4 つ
+Expected: `AWSReservedSSO_AdministratorAccess_*`、`github-oidc-auth-master-github-actions-{plan,apply}-role`、`route53-zone-access` の 4 つ
 
-- [ ] **Step 4: 旧 production state を削除**
+### Task 9.2: 旧 state と旧 secret を削除
 
-`platform/route53/production` は Task 3.3 で削除済。残りの production state を消す。
+**Files:** なし
+
+- [ ] **Step 1: production / develop の旧 state を削除**
+
+`platform/{route53,cost-management,repository,branch}` は Phase 3 で `master` へ移行済。
 
 ```bash
 for key in alb eks eks-holmesgpt eks-logs eks-metrics eks-secrets eks-traces github-oidc-auth iam-service-linked-roles karpenter vpc; do
   aws s3 rm "s3://terragrunt-state-559744160976/platform/${key}/production/terraform.tfstate"
 done
+aws s3 rm s3://terragrunt-state-559744160976/platform/github-oidc-auth/develop/terraform.tfstate
 aws s3 rm s3://terragrunt-state-559744160976/services/monolith/production/terraform.tfstate
 aws s3 rm s3://terragrunt-state-559744160976/system-components/holmes/production/terraform.tfstate
 ```
 
-- [ ] **Step 5: 旧 production secret を削除**
+- [ ] **Step 2: 孤児 state を削除**
+
+対応する env ディレクトリを持たないもの。`platform/github-repository/{monorepo,platform}` は `github_repository` を `platform/repository/master` と二重管理しており、`github_branch_protection` は GitHub 上に存在しない（3 リポジトリとも 404、現在の保護は ruleset）。
+
+```bash
+aws s3 rm s3://terragrunt-state-559744160976/platform/ai-assistant/develop/terraform.tfstate
+aws s3 rm s3://terragrunt-state-559744160976/platform/claude-code/develop/terraform.tfstate
+aws s3 rm s3://terragrunt-state-559744160976/platform/claude-code-action/develop/terraform.tfstate
+aws s3 rm s3://terragrunt-state-559744160976/platform/github-oidc-auth/staging/terraform.tfstate
+aws s3 rm s3://terragrunt-state-559744160976/platform/github-repository/monorepo/terraform.tfstate
+aws s3 rm s3://terragrunt-state-559744160976/platform/github-repository/platform/terraform.tfstate
+```
+
+- [ ] **Step 3: 旧 secret を削除**
 
 新アカウントへの投入完了（Task 6.1 Step 5 と Task 8.1 Step 3）を確認してから実行する。
 
@@ -1783,46 +2147,67 @@ for name in $(aws secretsmanager list-secrets --region ap-northeast-1 --query 'S
 done
 ```
 
-- [ ] **Step 6: 管理アカウントに残った state を確認**
+- [ ] **Step 4: 管理アカウントに残った state を確認**
 
 ```bash
 aws s3 ls s3://terragrunt-state-559744160976/ --recursive
 ```
 
-Expected: `platform/{branch,cost-management,github-oidc-auth,github-repository,repository,route53}/...` と `services/nginx-app/develop` のみ。`*/production/` が `platform/route53/master` を除いて残っていないこと
+Expected: `platform/{branch,cost-management,github-oidc-auth,repository,route53}/master/terraform.tfstate` の 5 件と `services/nginx-app/develop/terraform.tfstate` のみ
 
-- [ ] **Step 7: README の環境表に `master` を追加**
+### Task 9.3: README を更新して PR を出す
 
-`README.md` の「Environments and authentication」節と `README-ja.md` の対応箇所に、`master` env が管理アカウントの横断資産（Route53 hosted zone）を持つこと、`production` が専用アカウントであることを追記する。
+**Files:**
+- Modify: `README.md`
+- Modify: `README-ja.md`
 
-- [ ] **Step 8: コミット**
+- [ ] **Step 1: 環境表を 3 アカウント構成に更新**
+
+`README.md` の「Environments and authentication」節と `README-ja.md` の対応箇所に以下を反映する。
+
+- `master` = 管理アカウント `559744160976`。Route53 hosted zone、GitHub リポジトリ / ruleset、cost-management を持つ
+- `develop` = 専用アカウント。現時点では `aws/github-oidc-auth` のみ
+- `production` = 専用アカウント。EKS 一式
+- Route53 hosted zone は `master` に残り、production からは `route53-zone-access` を assume して操作する
+
+- [ ] **Step 2: 差分を確認**
+
+```bash
+git diff README.md README-ja.md
+```
+
+Expected: 環境表と認証まわりの記述のみが変わっている
+
+- [ ] **Step 3: コミット**
 
 ```bash
 git add README.md README-ja.md
-git commit -s -m "docs: describe the master environment and the dedicated production account"
+git commit -s -m "docs: describe the three-account layout"
 ```
 
-- [ ] **Step 9: Draft PR を作成**
+- [ ] **Step 4: PR を更新**
 
 ```bash
-git push -u origin HEAD
-gh pr create --draft \
-  --title "Migrate production to a dedicated AWS account" \
-  --body "See docs/superpowers/specs/2026-08-18-production-account-migration-design.md"
+git push
+gh pr view --json isDraft,title --jq '{draft: .isDraft, title: .title}'
 ```
+
+Expected: Draft のまま。レビュー依頼は Verification Checklist を全て満たしてから
 
 ---
 
 ## Verification Checklist
 
-- [ ] `aws organizations list-accounts` に ACTIVE な production アカウントが 1 件ある
-- [ ] `aws s3api head-bucket --bucket terragrunt-state-<PROD_ACCOUNT_ID>` が成功する
-- [ ] 新アカウントの `github-oidc-auth-production-github-actions-{plan,apply}-role` が存在する
-- [ ] 新アカウントから `route53-zone-access` を assume できる
-- [ ] `aws eks list-clusters --region ap-northeast-1` が新アカウントで `eks-production` を返す
-- [ ] `*.panicboat.net` / `*.dystopia.city` の ACM 証明書が新アカウントで `ISSUED`
+- [ ] `aws organizations list-accounts` に ACTIVE なアカウントが 3 件（管理 + production + develop）
+- [ ] `aws iam list-open-id-connect-providers` が 3 アカウントそれぞれで 1 件を返す
+- [ ] `terragrunt-state-<PROD_ACCOUNT_ID>` と `terragrunt-state-<DEV_ACCOUNT_ID>` が存在する
+- [ ] 管理アカウントの state バケットに残るのが `platform/*/master/` 5 件と `services/nginx-app/develop` のみ
+- [ ] 新 production アカウントから `route53-zone-access` を assume できる
+- [ ] `aws eks list-clusters --region ap-northeast-1` が新 production アカウントで `eks-production` を返す
+- [ ] `*.panicboat.net` / `*.dystopia.city` の ACM 証明書が新 production アカウントで `ISSUED`
 - [ ] external-dns が管理アカウントの zone にレコードを作成できている
-- [ ] `git grep -n 559744160976 -- kubernetes/ workflow-config.yaml` の結果が、`master` / `develop` env の ARN と external-dns の `--aws-assume-role` だけになっている
-- [ ] 管理アカウントの state バケットに `*/production/` の state が残っていない（`platform/route53/master` は移行済のため対象外）
+- [ ] `git grep -n 559744160976 -- kubernetes/ workflow-config.yaml` の結果が、`master` env の ARN 2 本と external-dns の `--aws-assume-role` 1 本だけ
+- [ ] GitHub の ruleset 3 本が `active` のまま（`gh api repos/panicboat/{monorepo,platform,deploy-actions}/rulesets`）
 - [ ] 管理アカウントの Secrets Manager が空
 - [ ] `aws iam list-instance-profiles` が空
+- [ ] `master` env の CI が plan を通せる（`GITHUB_TOKEN` の供給経路が機能している）

--- a/docs/superpowers/plans/2026-08-18-production-account-migration.md
+++ b/docs/superpowers/plans/2026-08-18-production-account-migration.md
@@ -1,0 +1,1828 @@
+# Production AWS Account Migration Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** `production` 環境を AWS Organizations 管理アカウント `559744160976` から専用メンバーアカウントへ分離し、Route53 hosted zone は管理アカウントに残したままクロスアカウント参照で運用する。
+
+**Architecture:** 管理アカウントに残る横断資産を `master` env として新設し、`aws/route53` をそこへ re-home する。production アカウントからは `route53-zone-access` ロールを assume して zone を操作する。Terraform 側は `aws/alb` の provider alias 1 箇所、実行時は external-dns の `--aws-assume-role` で経路を張る。EKS 再構築自体は既存の `docs/runbooks/eks-production-recreate.md` を再利用する。
+
+**Tech Stack:** Terragrunt v1.0.2 + OpenTofu 1.12.0（module 側 `required_version = "1.12.5"`）、AWS provider 6.60.0、Helmfile v1.4、external-dns chart 1.21.1（appVersion 0.21.0）、AWS CLI v2、Flux CD。
+
+**Spec:** `docs/superpowers/specs/2026-08-18-production-account-migration-design.md`
+
+## Global Constraints
+
+- 管理アカウント ID: `559744160976`（Organization `o-es9qoj85gw`、Identity Center `ssoins-7758e2d4fb37f3a7`）
+- production hosted zone: `panicboat.net` = `Z07598371GKBU0WMF89MD`、`dystopia.city` = `Z03420722KS9MTSCUSIQZ`
+- クロスアカウントロール名: `route53-zone-access`（管理アカウント側、`arn:aws:iam::559744160976:role/route53-zone-access`）
+- `<PROD_ACCOUNT_ID>` は Task 1.1 で確定する新アカウント ID。以降のタスクではこの実値に置換すること
+- production region は `ap-northeast-1`、`master` env も `ap-northeast-1`、`develop` env は `us-east-1`
+- Terragrunt の state バケット名は全 `root.hcl` で `terragrunt-state-${get_aws_account_id()}` として動的に組まれる。バケット名をコードに書かない
+- コミットは `-s`（`--signoff`）付き。`Co-Authored-By` は付けない
+- 新規ブランチの初回 push は `git push -u origin HEAD`。PR は `gh pr create --draft`
+
+---
+
+## File Structure
+
+### 新規作成
+
+- `aws/github-oidc-auth/envs/master/env.hcl` — `master` env の GitHub OIDC 設定
+- `aws/github-oidc-auth/envs/master/terragrunt.hcl` — 同スタック定義
+- `aws/route53/envs/master/env.hcl` — re-home 先の env 設定 + `production_account_id`
+- `aws/route53/envs/master/terragrunt.hcl` — 同スタック定義
+- `aws/route53/modules/zone_access.tf` — `route53-zone-access` ロールとポリシー
+
+### 削除
+
+- `aws/route53/envs/production/` — `master` へ re-home するため
+
+### 変更
+
+- `workflow-config.yaml` — `master` env 追加 + `production` の IAM ロール ARN 差し替え
+- `aws/route53/modules/variables.tf` — `production_account_id` 追加
+- `aws/github-oidc-auth/modules/variables.tf` — `assume_role_arns` 追加
+- `aws/github-oidc-auth/modules/main.tf` — plan ロールへ `sts:AssumeRole` インラインポリシー
+- `aws/github-oidc-auth/envs/production/env.hcl` — OIDC provider 自前作成へ反転 + `assume_role_arns`
+- `aws/github-oidc-auth/envs/production/terragrunt.hcl` — `assume_role_arns` の受け渡し
+- `aws/alb/modules/terraform.tf` — `aws.route53` alias provider
+- `aws/alb/modules/lookups.tf` — `providers = { aws = aws.route53 }`
+- `aws/alb/modules/main.tf` — validation レコード 2 resource に `provider = aws.route53`
+- `aws/alb/modules/variables.tf` / `aws/alb/envs/production/env.hcl` / `aws/alb/envs/production/terragrunt.hcl` — `route53_zone_role_arn`
+- `aws/eks/modules/lookups.tf` — `module "route53"` 削除
+- `aws/eks/modules/addons.tf` — external-dns IAM を assume role 方式へ
+- `kubernetes/helmfile.yaml.gotmpl` — アカウント ID 5 箇所
+- `kubernetes/components/{aws-load-balancer-controller,external-dns,loki,mimir,tempo}/production/helmfile.yaml` — アカウント ID
+- `kubernetes/components/external-dns/production/values.yaml.gotmpl` — `extraArgs`
+- `scripts/eks-lifecycle/lib/30-destroy-stacks.sh` — `STACKS` に `eks-holmesgpt`
+- `README.md` / `README-ja.md` — 環境表に `master`
+
+---
+
+# Phase 0: 旧アカウントの事前整理
+
+新アカウントを作る前に、管理アカウント側のドリフトと孤児リソースを解消する。ここでの作業は全て現行アカウント `559744160976` で完結する。
+
+### Task 0.1: `eks-holmesgpt` を teardown 対象に追加して destroy
+
+`scripts/eks-lifecycle/lib/30-destroy-stacks.sh` の `STACKS` 配列は 8 スタックだが `eks-holmesgpt` が抜けている（#795 でスタック分離した際の追加漏れ）。そのため `eks-production-holmesgpt` ロールが teardown 後も残存し、state 内の `data.aws_eks_cluster.this` が存在しないクラスタ `eks-production` を参照している。
+
+**Files:**
+- Modify: `scripts/eks-lifecycle/lib/30-destroy-stacks.sh`
+
+**Interfaces:**
+- Produces: `platform/eks-holmesgpt/production` state が resources=0 になる。Task 9.1 の後片付け対象から外れる
+
+- [ ] **Step 1: 現状のドリフトを確認**
+
+```bash
+cd aws/eks-holmesgpt/envs/production && TG_TF_PATH=tofu terragrunt plan
+```
+
+Expected: `data.aws_eks_cluster.this` の解決に失敗する（`No cluster found for name: eks-production`）
+
+- [ ] **Step 2: `STACKS` 配列に `eks-holmesgpt` を追加**
+
+`scripts/eks-lifecycle/lib/30-destroy-stacks.sh` の `STACKS=(` ブロックを以下に置き換える。`eks-holmesgpt` は EKS クラスタの Pod Identity Association を持つため `eks` より前、他の eks-* スタックと同列に置く。
+
+```bash
+STACKS=(
+  "eks-karpenter"
+  "eks-holmesgpt"
+  "eks-secrets"
+  "eks-logs"
+  "eks-metrics"
+  "eks-traces"
+  "eks"
+  "alb"
+  "vpc"
+)
+```
+
+- [ ] **Step 3: ヘッダコメントの順序記述を更新**
+
+同ファイル冒頭の以下のコメントを書き換える。
+
+```bash
+# 30-destroy-stacks.sh - Destroy 9 EKS-related stacks in fixed order.
+#
+# Order:
+#   eks-karpenter -> eks-holmesgpt -> eks-secrets -> eks-logs -> eks-metrics
+#   -> eks-traces -> eks -> alb -> vpc
+```
+
+同ファイル末尾の `ok "All 8 stacks destroyed"` と、`confirm "About to DESTROY 8 stacks for ENV=${ENV}. Continue?"` の `8` を `9` に変更する。
+
+- [ ] **Step 4: state 内の存在しないリソースを state から外す**
+
+クラスタが既に無いため Pod Identity Association は AWS 上に存在しない。destroy 前に state から除去する。
+
+```bash
+cd aws/eks-holmesgpt/envs/production
+TG_TF_PATH=tofu terragrunt state rm aws_eks_pod_identity_association.this
+```
+
+Expected: `Successfully removed 1 resource instance(s).`
+
+- [ ] **Step 5: 残りを destroy**
+
+```bash
+cd aws/eks-holmesgpt/envs/production && TG_TF_PATH=tofu terragrunt destroy -auto-approve
+```
+
+Expected: `aws_iam_role.pod_identity` と `aws_iam_role_policy.bedrock_invoke` が destroy される
+
+- [ ] **Step 6: ロールが消えたことを確認**
+
+```bash
+aws iam get-role --role-name eks-production-holmesgpt
+```
+
+Expected: `NoSuchEntity` エラー
+
+- [ ] **Step 7: コミット**
+
+```bash
+git add scripts/eks-lifecycle/lib/30-destroy-stacks.sh
+git commit -s -m "fix(scripts/eks-lifecycle): include eks-holmesgpt in destroy order"
+```
+
+### Task 0.2: 孤児リソースの削除
+
+Karpenter が生成した Terraform 管理外の IAM instance profile と、対応する state を持たないログ グループを削除する。
+
+**Files:** なし（AWS API 操作のみ）
+
+- [ ] **Step 1: 孤児 instance profile を確認**
+
+```bash
+aws iam list-instance-profiles \
+  --query 'InstanceProfiles[].{Name:InstanceProfileName,Roles:Roles[].RoleName}' --output json
+```
+
+Expected: `eks-production_513473553642647435` が `Roles: []` で 1 件返る
+
+- [ ] **Step 2: instance profile を削除**
+
+```bash
+aws iam delete-instance-profile --instance-profile-name eks-production_513473553642647435
+```
+
+- [ ] **Step 3: レガシーログ グループを削除**
+
+state に対応の無い 3 本を削除する。`/github-repository/{ansible,deploy-actions,dotfiles,monorepo,panicboat-actions,platform}` は `platform/repository/develop` state が管理しているため残す。
+
+```bash
+aws logs delete-log-group --region ap-northeast-1 --log-group-name /github-repository/generated-manifests
+aws logs delete-log-group --region ap-northeast-1 --log-group-name /github-repository/kubernetes-clusters
+aws logs delete-log-group --region us-east-1   --log-group-name /github-actions/claude-code-action-monorepo
+```
+
+- [ ] **Step 4: 削除を確認**
+
+```bash
+aws iam list-instance-profiles --query 'InstanceProfiles[].InstanceProfileName' --output text
+aws logs describe-log-groups --region ap-northeast-1 --query 'logGroups[].logGroupName' --output text
+aws logs describe-log-groups --region us-east-1 --query 'logGroups[].logGroupName' --output text
+```
+
+Expected: instance profile が空、`ap-northeast-1` のログ グループが 8 本（`/github-actions/github-oidc-auth-{develop,production}` + `/github-repository/*` 6 本）、`us-east-1` が空
+
+### Task 0.3: `dystopia.city` の stale DNS レコード削除
+
+削除済み ALB を指す ALIAS 4 件と external-dns 所有権 TXT 2 件が残っている。Phase 7 で external-dns がレコードを「作成」できることをもって疎通確認したいので、先に消しておく。
+
+**Files:** なし（Route53 API 操作のみ）
+
+- [ ] **Step 1: 対象レコードを確認**
+
+```bash
+aws route53 list-resource-record-sets --hosted-zone-id Z03420722KS9MTSCUSIQZ \
+  --query "ResourceRecordSets[?Type=='A'||Type=='AAAA'||(Type=='TXT'&&contains(Name,'auth'))]" --output json
+```
+
+Expected: 6 件（`dystopia.city.` A/AAAA、`auth.dystopia.city.` A/AAAA、`aaaa-auth.dystopia.city.` TXT、`cname-auth.dystopia.city.` TXT）。ALIAS の向き先が `k8s-application-92fded7941-*` であること
+
+- [ ] **Step 2: 削除用 change batch を生成**
+
+Step 1 の出力をそのまま `DELETE` に変換する。値を手で書き写すと ALIAS の `HostedZoneId` を取り違えるため、必ず API 出力から生成する。
+
+```bash
+aws route53 list-resource-record-sets --hosted-zone-id Z03420722KS9MTSCUSIQZ \
+  --query "ResourceRecordSets[?Type=='A'||Type=='AAAA'||(Type=='TXT'&&contains(Name,'auth'))]" \
+  --output json \
+  | jq '{Changes: [.[] | {Action: "DELETE", ResourceRecordSet: .}]}' \
+  > /tmp/dystopia-stale-delete.json
+
+cat /tmp/dystopia-stale-delete.json
+```
+
+Expected: `Changes` が 6 要素
+
+- [ ] **Step 3: 削除を実行**
+
+```bash
+aws route53 change-resource-record-sets \
+  --hosted-zone-id Z03420722KS9MTSCUSIQZ \
+  --change-batch file:///tmp/dystopia-stale-delete.json
+```
+
+- [ ] **Step 4: zone に SOA / NS / MX / TXT だけが残ったことを確認**
+
+```bash
+aws route53 list-resource-record-sets --hosted-zone-id Z03420722KS9MTSCUSIQZ \
+  --query 'ResourceRecordSets[].{N:Name,T:Type}' --output text
+```
+
+Expected: 5 件（`dystopia.city.` の SOA / NS / MX / TXT、`google._domainkey.dystopia.city.` TXT）。A / AAAA が残っていないこと
+
+### Task 0.4: Secrets Manager の値を退避
+
+8 件の secret 値は Terraform 管理外（手動投入）で、旧アカウントを片付けると復旧できない。Phase 6 で新アカウントへ投入するため退避する。
+
+**Files:** なし
+
+- [ ] **Step 1: 全 secret 名を列挙**
+
+```bash
+aws secretsmanager list-secrets --region ap-northeast-1 --query 'SecretList[].Name' --output text | tr '\t' '\n'
+```
+
+Expected: 8 件（`panicboat/oauth2-proxy/google`, `panicboat/grafana/admin`, `panicboat/github-app/panicboat`, `panicboat/keycloak/admin`, `panicboat/holmes/slack`, `panicboat/holmes/alertmanager`, `panicboat/holmes/github`, `panicboat/alertmanager/slack-notify`）
+
+- [ ] **Step 2: 値を退避**
+
+出力には認証情報が含まれるため、リポジトリ外かつパーミッション 0600 のファイルに書く。
+
+```bash
+UMASK_OLD=$(umask); umask 077
+OUT="$HOME/.secrets-backup-559744160976.json"
+: > "$OUT"
+for name in $(aws secretsmanager list-secrets --region ap-northeast-1 --query 'SecretList[].Name' --output text); do
+  aws secretsmanager get-secret-value --region ap-northeast-1 --secret-id "$name" \
+    --query '{name: Name, value: SecretString}' --output json >> "$OUT"
+done
+umask "$UMASK_OLD"
+ls -l "$OUT"
+```
+
+Expected: 8 個の JSON オブジェクトが書かれ、パーミッションが `-rw-------`
+
+- [ ] **Step 3: 退避内容の件数を確認**
+
+```bash
+grep -c '"name"' "$HOME/.secrets-backup-559744160976.json"
+```
+
+Expected: `8`
+
+---
+
+# Phase 1: 新アカウント作成
+
+手動 AWS 操作のみ。コード変更もコミットも無い。
+
+### Task 1.1: メンバーアカウント作成と Identity Center 割当
+
+**Files:** なし
+
+**Interfaces:**
+- Produces: `<PROD_ACCOUNT_ID>`。以降の全タスクがこの値に依存する
+
+- [ ] **Step 1: 既存アカウント一覧を確認**
+
+```bash
+aws organizations list-accounts --query 'Accounts[].{Id:Id,Name:Name,Email:Email,State:State}' --output table
+```
+
+Expected: `583677814390`（CLOSED）、`504150922582`（CLOSED）、`559744160976`（ACTIVE）
+
+- [ ] **Step 2: 新しいルートメールアドレスを決める**
+
+クローズ済みアカウントが `admin@panicboat.net` と `aws@dystopia.city` を保持しているため、これらは使えない。未使用のアドレスを 1 つ用意する（例: `panicboat+aws-production@gmail.com`）。
+
+- [ ] **Step 3: アカウントを作成**
+
+```bash
+aws organizations create-account \
+  --email '<NEW_ROOT_EMAIL>' \
+  --account-name 'production' \
+  --iam-user-access-to-billing DENY
+```
+
+Expected: `CreateAccountStatus.State` が `IN_PROGRESS`。`EMAIL_ALREADY_EXISTS` で失敗した場合は Step 2 に戻ってアドレスを変える
+
+- [ ] **Step 4: 作成完了とアカウント ID を確認**
+
+```bash
+aws organizations list-create-account-status --states SUCCEEDED \
+  --query 'CreateAccountStatuses[?AccountName==`production`].{Id:AccountId,At:CompletedTimestamp}' --output table
+```
+
+Expected: `SUCCEEDED` になり `AccountId` が返る。この値を `<PROD_ACCOUNT_ID>` として記録する
+
+- [ ] **Step 5: `OrganizationAccountAccessRole` で assume できることを確認**
+
+```bash
+aws sts assume-role \
+  --role-arn arn:aws:iam::<PROD_ACCOUNT_ID>:role/OrganizationAccountAccessRole \
+  --role-session-name bootstrap-check \
+  --query 'AssumedRoleUser.Arn' --output text
+```
+
+Expected: `arn:aws:sts::<PROD_ACCOUNT_ID>:assumed-role/OrganizationAccountAccessRole/bootstrap-check`
+
+- [ ] **Step 6: Identity Center の AdministratorAccess を新アカウントに割当**
+
+```bash
+aws sso-admin create-account-assignment \
+  --instance-arn arn:aws:sso:::instance/ssoins-7758e2d4fb37f3a7 \
+  --permission-set-arn arn:aws:sso:::permissionSet/ssoins-7758e2d4fb37f3a7/ps-77583734ef962d6b \
+  --principal-type USER \
+  --principal-id e7146ab8-20b1-70eb-a63d-b9887df5d7a6 \
+  --target-id <PROD_ACCOUNT_ID> \
+  --target-type AWS_ACCOUNT \
+  --region ap-northeast-1
+```
+
+- [ ] **Step 7: 割当を確認**
+
+```bash
+aws sso-admin list-account-assignments \
+  --instance-arn arn:aws:sso:::instance/ssoins-7758e2d4fb37f3a7 \
+  --account-id <PROD_ACCOUNT_ID> \
+  --permission-set-arn arn:aws:sso:::permissionSet/ssoins-7758e2d4fb37f3a7/ps-77583734ef962d6b \
+  --region ap-northeast-1
+```
+
+Expected: `AccountAssignments` に 1 件
+
+### Task 1.2: Service Quota 増枠申請と Bedrock 有効化
+
+増枠の承認待ちが本移行で最長のクリティカルパスになるため、アカウント作成直後に投げる。
+
+**Files:** なし
+
+- [ ] **Step 1: 新アカウントの現在値を確認**
+
+`OrganizationAccountAccessRole` を assume した状態で実行する。
+
+```bash
+for qc in L-1216C47A L-34B43A08; do
+  aws service-quotas get-service-quota --service-code ec2 --quota-code $qc \
+    --region ap-northeast-1 --query 'Quota.{Name:QuotaName,Value:Value}' --output json
+done
+```
+
+Expected: On-Demand Standard vCPU / Standard Spot がいずれも `5.0`（AWS デフォルト）
+
+- [ ] **Step 2: 増枠を申請**
+
+管理アカウントの適用値（On-Demand 64 / Spot 256）に合わせる。
+
+```bash
+aws service-quotas request-service-quota-increase \
+  --service-code ec2 --quota-code L-1216C47A --desired-value 64 --region ap-northeast-1
+aws service-quotas request-service-quota-increase \
+  --service-code ec2 --quota-code L-34B43A08 --desired-value 256 --region ap-northeast-1
+```
+
+- [ ] **Step 3: 申請が受理されたことを確認**
+
+```bash
+aws service-quotas list-requested-service-quota-change-history --region ap-northeast-1 \
+  --query 'RequestedQuotas[].{Q:QuotaName,V:DesiredValue,S:Status}' --output table
+```
+
+Expected: 2 件が `PENDING` または `CASE_OPENED`
+
+- [ ] **Step 4: Bedrock のモデルアクセスを有効化**
+
+`us-east-1` の Bedrock コンソールで、HolmesGPT が使う Anthropic Claude モデル（`anthropic.claude-sonnet-4-6` / `anthropic.claude-opus-4-6`）へのアクセスをリクエストする。CLI では完結しないためコンソール操作。
+
+- [ ] **Step 5: モデルが見えることを確認**
+
+```bash
+aws bedrock list-foundation-models --region us-east-1 \
+  --query 'modelSummaries[?contains(modelId, `claude-sonnet-4-6`)].modelId' --output text
+```
+
+Expected: `anthropic.claude-sonnet-4-6` が返る
+
+---
+
+# Phase 2: State Backend Bootstrap
+
+### Task 2.1: 新アカウントに state バケットとロックテーブルを作る
+
+全 `root.hcl` が `bucket = "terragrunt-state-${get_aws_account_id()}"` で組むため、コード変更は不要。新アカウントの認証情報で bootstrap するだけでよい。
+
+**Files:** なし
+
+**Interfaces:**
+- Consumes: Task 1.1 の `<PROD_ACCOUNT_ID>`
+- Produces: `terragrunt-state-<PROD_ACCOUNT_ID>` バケットと `terragrunt-state-locks` テーブル。Phase 3 以降の全 terragrunt 実行の前提
+
+- [ ] **Step 1: 新アカウントの認証情報に切り替える**
+
+```bash
+unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_SESSION_TOKEN
+CREDS=$(aws sts assume-role \
+  --role-arn arn:aws:iam::<PROD_ACCOUNT_ID>:role/OrganizationAccountAccessRole \
+  --role-session-name terragrunt-bootstrap --query Credentials --output json)
+export AWS_ACCESS_KEY_ID=$(echo "$CREDS" | jq -r .AccessKeyId)
+export AWS_SECRET_ACCESS_KEY=$(echo "$CREDS" | jq -r .SecretAccessKey)
+export AWS_SESSION_TOKEN=$(echo "$CREDS" | jq -r .SessionToken)
+aws sts get-caller-identity --query Account --output text
+```
+
+Expected: `<PROD_ACCOUNT_ID>` が返る
+
+- [ ] **Step 2: backend を bootstrap**
+
+任意の production スタックのディレクトリから実行すればよい。`vpc` は依存が無く最も軽い。
+
+```bash
+cd aws/vpc/envs/production && TG_TF_PATH=tofu terragrunt backend bootstrap
+```
+
+Expected: S3 バケットと DynamoDB テーブルが作成される旨のログ
+
+- [ ] **Step 3: バケットとテーブルを確認**
+
+```bash
+aws s3api head-bucket --bucket terragrunt-state-<PROD_ACCOUNT_ID>
+aws s3api get-bucket-versioning --bucket terragrunt-state-<PROD_ACCOUNT_ID>
+aws dynamodb describe-table --table-name terragrunt-state-locks --region ap-northeast-1 \
+  --query 'Table.{Keys:KeySchema,Billing:BillingModeSummary.BillingMode}' --output json
+```
+
+Expected: バケットが存在し versioning が `Enabled`、テーブルの HASH キーが `LockID`
+
+---
+
+# Phase 3: `master` Env 新設
+
+管理アカウントに残る横断資産の受け皿を作り、`aws/route53` を移し、クロスアカウントロールを立てる。ここからは管理アカウントの認証情報（`panicboat` IAM ユーザー）で作業する。
+
+### Task 3.1: `master` env の GitHub OIDC ロールを作る
+
+**Files:**
+- Create: `aws/github-oidc-auth/envs/master/env.hcl`
+- Create: `aws/github-oidc-auth/envs/master/terragrunt.hcl`
+
+**Interfaces:**
+- Produces: `github-oidc-auth-master-github-actions-{plan,apply}-role`。Task 3.2 の `workflow-config.yaml` が参照する
+
+- [ ] **Step 1: `env.hcl` を作成**
+
+OIDC provider は `develop` env が管理する既存のものを再利用するため `create_oidc_provider = false`。
+
+```hcl
+# env.hcl - Master environment configuration
+#
+# master = 管理アカウント (= 559744160976) に残る横断資産の env。
+# production を別アカウントへ分離したあとも Route53 hosted zone のように
+# アカウントを跨いで共有するリソースはここに置く。
+locals {
+  # Environment metadata
+  environment = "master"
+  aws_region  = "ap-northeast-1"
+
+  # GitHub configuration
+  github_org   = "panicboat"
+  github_repos = ["monorepo", "platform"]
+
+  github_environments = [
+    "master"
+  ]
+
+  additional_iam_policies = []
+
+  # OIDC provider は develop env が管理する既存 provider を再利用する
+  # (= 同一アカウント内で provider は 1 つしか作れない)。
+  create_oidc_provider = false
+  oidc_provider_arn    = "arn:aws:iam::${get_aws_account_id()}:oidc-provider/token.actions.githubusercontent.com"
+
+  # Session duration (4 hours, production と同水準)
+  max_session_duration = 14400
+
+  additional_tags = {
+    Component = "github-oidc-auth"
+    Owner     = "panicboat"
+  }
+}
+```
+
+- [ ] **Step 2: `terragrunt.hcl` を作成**
+
+```hcl
+# terragrunt.hcl - Master environment Terragrunt configuration
+
+# Include root configuration
+include "root" {
+  path = find_in_parent_folders("root.hcl")
+}
+
+# Include environment-specific configuration
+include "env" {
+  path   = "env.hcl"
+  expose = true
+}
+
+# Reference to Terraform modules
+terraform {
+  source = "../../modules"
+}
+
+# Environment-specific inputs
+inputs = {
+  # Core configuration from env.hcl
+  aws_region              = include.env.locals.aws_region
+  github_org              = include.env.locals.github_org
+  github_repos            = include.env.locals.github_repos
+  github_environments     = include.env.locals.github_environments
+  additional_iam_policies = include.env.locals.additional_iam_policies
+  create_oidc_provider    = include.env.locals.create_oidc_provider
+  oidc_provider_arn       = include.env.locals.oidc_provider_arn
+  max_session_duration    = include.env.locals.max_session_duration
+
+  # Merge environment-specific tags with common tags
+  common_tags = merge(
+    {
+      Environment = include.env.locals.environment
+      ManagedBy   = "terraform"
+      Project     = "github-oidc-auth"
+      Repository  = "panicboat/platform"
+    },
+    include.env.locals.additional_tags
+  )
+}
+```
+
+- [ ] **Step 3: 管理アカウントの認証情報であることを確認**
+
+```bash
+unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_SESSION_TOKEN
+aws sts get-caller-identity --query Arn --output text
+```
+
+Expected: `arn:aws:iam::559744160976:user/panicboat`
+
+- [ ] **Step 4: plan で差分を確認**
+
+```bash
+cd aws/github-oidc-auth/envs/master && TG_TF_PATH=tofu terragrunt init && TG_TF_PATH=tofu terragrunt plan
+```
+
+Expected: 追加のみ（plan role / apply role / policy / policy attachment 3 / log group）。既存 develop / production のリソースに `destroy` や `replace` が出ないこと
+
+- [ ] **Step 5: apply**
+
+```bash
+cd aws/github-oidc-auth/envs/master && TG_TF_PATH=tofu terragrunt apply -auto-approve
+```
+
+- [ ] **Step 6: ロールの存在を確認**
+
+```bash
+aws iam get-role --role-name github-oidc-auth-master-github-actions-plan-role --query 'Role.Arn' --output text
+aws iam get-role --role-name github-oidc-auth-master-github-actions-apply-role --query 'Role.Arn' --output text
+```
+
+Expected: 両方の ARN が返る
+
+- [ ] **Step 7: コミット**
+
+```bash
+git add aws/github-oidc-auth/envs/master/
+git commit -s -m "feat(aws/github-oidc-auth): add master environment for management-account stacks"
+```
+
+### Task 3.2: `workflow-config.yaml` に `master` env を追加
+
+`panicboat/deploy-actions/label-resolver` は `workflow-config.yaml` の `environments:` を読んで `aws/{service}/envs/{environment}/` を解決する（`docs/superpowers/specs/2026-04-26-environment-naming-design.md` 参照）。`master` を宣言しないと Task 3.3 で移した `aws/route53/envs/master` が CI から見えない。
+
+**Files:**
+- Modify: `workflow-config.yaml`
+
+- [ ] **Step 1: `master` env を `environments:` の先頭に追加**
+
+`workflow-config.yaml` の `environments:` 直下、`develop` の前に挿入する。
+
+```yaml
+  - environment: master
+    stacks:
+      terragrunt:
+        aws_region: ap-northeast-1
+        iam_role_plan: arn:aws:iam::559744160976:role/github-oidc-auth-master-github-actions-plan-role
+        iam_role_apply: arn:aws:iam::559744160976:role/github-oidc-auth-master-github-actions-apply-role
+```
+
+- [ ] **Step 2: YAML として妥当か確認**
+
+```bash
+python3 -c "import yaml,sys; d=yaml.safe_load(open('workflow-config.yaml')); print([e['environment'] for e in d['environments']])"
+```
+
+Expected: `['master', 'develop', 'production']`
+
+- [ ] **Step 3: コミット**
+
+```bash
+git add workflow-config.yaml
+git commit -s -m "feat(workflow-config): declare master environment"
+```
+
+### Task 3.3: `aws/route53` を `master` env へ re-home
+
+hosted zone は管理アカウントの資産なので、スタックの env 帰属を `production` から `master` へ移す。state key が `platform/route53/production/` から `platform/route53/master/` に変わるため state 移行を伴う（resources=8 の実 state あり）。
+
+**Files:**
+- Create: `aws/route53/envs/master/env.hcl`
+- Create: `aws/route53/envs/master/terragrunt.hcl`
+- Delete: `aws/route53/envs/production/`
+
+**Interfaces:**
+- Consumes: Task 3.2 の `master` env 宣言
+- Produces: `platform/route53/master/terraform.tfstate`。Task 3.4 が同スタックに追記する
+
+- [ ] **Step 1: 移行前の state を確認**
+
+```bash
+cd aws/route53/envs/production && TG_TF_PATH=tofu terragrunt state list
+```
+
+Expected: 6 個の `aws_route53_record` と 2 個の `module.route53.data.aws_route53_zone`
+
+- [ ] **Step 2: `env.hcl` を作成**
+
+```hcl
+# env.hcl - Environment-specific configuration for master
+
+locals {
+  # Environment-specific settings
+  environment = "master"
+
+  # AWS configuration
+  aws_region = "ap-northeast-1"
+
+  # production アカウント (= route53-zone-access を assume する側)。
+  # Task 1.1 で確定した値に置き換えること。
+  production_account_id = "<PROD_ACCOUNT_ID>"
+
+  # Environment-specific tags
+  environment_tags = {
+    Environment = local.environment
+    Component   = "route53"
+    Owner       = "panicboat"
+  }
+}
+```
+
+- [ ] **Step 3: `terragrunt.hcl` を作成**
+
+`aws/route53/envs/production/terragrunt.hcl` をベースに `production_account_id` の受け渡しを追加する。
+
+```hcl
+# terragrunt.hcl - Terragrunt configuration for master environment
+
+# Include root configuration
+include "root" {
+  path = find_in_parent_folders("root.hcl")
+}
+
+# Include environment-specific configuration
+include "env" {
+  path   = "env.hcl"
+  expose = true
+}
+
+# Reference to Terraform modules.
+# Use go-getter `//` subdir notation so the entire `aws/` tree is copied to
+# the Terragrunt cache. This lets `module "route53"` in modules/lookups.tf
+# resolve `../lookup` from within the cache.
+terraform {
+  source = "../../..//route53/modules"
+}
+
+# Input variables for the module
+inputs = {
+  environment           = include.env.locals.environment
+  aws_region            = include.env.locals.aws_region
+  production_account_id = include.env.locals.production_account_id
+
+  common_tags = merge(
+    include.env.locals.environment_tags,
+    {
+      Project    = "route53"
+      ManagedBy  = "terraform"
+      Repository = "panicboat/platform"
+    }
+  )
+}
+```
+
+- [ ] **Step 4: state を新しいキーへコピー**
+
+`terragrunt backend migrate` は移行元と移行先の設定を両方解決する。
+
+```bash
+terragrunt backend migrate aws/route53/envs/production aws/route53/envs/master
+```
+
+- [ ] **Step 5: 移行先 state の中身を確認**
+
+```bash
+aws s3 ls s3://terragrunt-state-559744160976/platform/route53/master/
+cd aws/route53/envs/master && TG_TF_PATH=tofu terragrunt state list
+```
+
+Expected: `terraform.tfstate` が存在し、Step 1 と同じ 8 エントリが返る
+
+- [ ] **Step 6: 差分ゼロを確認**
+
+```bash
+cd aws/route53/envs/master && TG_TF_PATH=tofu terragrunt plan
+```
+
+Expected: `No changes.`（`production_account_id` はまだ使われていないため差分は出ない）
+
+- [ ] **Step 7: 旧 env ディレクトリと旧 state を削除**
+
+```bash
+git rm -r aws/route53/envs/production
+aws s3 rm s3://terragrunt-state-559744160976/platform/route53/production/terraform.tfstate
+```
+
+- [ ] **Step 8: コミット**
+
+```bash
+git add aws/route53/envs/master/
+git commit -s -m "refactor(aws/route53): re-home stack from production to master environment"
+```
+
+### Task 3.4: `route53-zone-access` ロールを作る
+
+production アカウントから管理アカウントの hosted zone を操作するためのロール。信頼先は production アカウント root 1 つで、実際に誰が assume できるかは production 側の IAM で制御する（設計 §4 参照）。
+
+**Files:**
+- Create: `aws/route53/modules/zone_access.tf`
+- Modify: `aws/route53/modules/variables.tf`
+
+**Interfaces:**
+- Consumes: Task 3.3 の `production_account_id` input
+- Produces: `arn:aws:iam::559744160976:role/route53-zone-access`。Task 5.1 の provider alias、Task 5.2 の external-dns IAM、Task 5.3 の helm 値がこの ARN を参照する
+
+- [ ] **Step 1: `variables.tf` に `production_account_id` を追加**
+
+`aws/route53/modules/variables.tf` の末尾に追記する。
+
+```hcl
+variable "production_account_id" {
+  description = "AWS account ID of the production account allowed to assume route53-zone-access"
+  type        = string
+}
+```
+
+- [ ] **Step 2: `zone_access.tf` を作成**
+
+```hcl
+# zone_access.tf - Cross-account role that lets the production account manage
+# records in the hosted zones owned by this (= management) account.
+#
+# Why root principal instead of listing individual role ARNs: IAM rejects a
+# trust policy naming a role ARN that does not exist yet
+# (= MalformedPolicyDocument). `eks-production-external-dns` is not created
+# until the EKS stack applies, so enumerating ARNs would pin this role's
+# creation to the very end of the migration. Delegating to the production
+# account's own IAM is the standard cross-account pattern.
+#
+# Why read and write live in one role: Terraform provider aliases are static
+# configuration and there is no way to point plan and apply at different
+# assume-role targets under the current setup (= terragrunt inputs are fixed
+# per env, and the CI executor lives in an external repository). The plan
+# role therefore gains assume access to a write-capable role, scoped to these
+# two zones. `terragrunt plan` never calls ChangeResourceRecordSets.
+
+data "aws_iam_policy_document" "zone_access_assume" {
+  statement {
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "AWS"
+      identifiers = ["arn:aws:iam::${var.production_account_id}:root"]
+    }
+  }
+}
+
+resource "aws_iam_role" "zone_access" {
+  name               = "route53-zone-access"
+  assume_role_policy = data.aws_iam_policy_document.zone_access_assume.json
+
+  tags = merge(var.common_tags, {
+    Name = "route53-zone-access"
+  })
+}
+
+resource "aws_iam_role_policy" "zone_access" {
+  name = "route53-zone-access"
+  role = aws_iam_role.zone_access.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "route53:ChangeResourceRecordSets",
+          "route53:ListResourceRecordSets",
+          "route53:GetHostedZone",
+        ]
+        Resource = [
+          module.route53.zones.panicboat_net.arn,
+          module.route53.zones.dystopia_city.arn,
+        ]
+      },
+      {
+        # zone 名引き (= data.aws_route53_zone) と変更伝播待ち (= GetChange) は
+        # zone 単位に絞れない API のため Resource = "*"。
+        Effect = "Allow"
+        Action = [
+          "route53:ListHostedZones",
+          "route53:ListHostedZonesByName",
+          "route53:GetChange",
+        ]
+        Resource = "*"
+      },
+    ]
+  })
+}
+```
+
+- [ ] **Step 3: fmt と validate**
+
+```bash
+tofu fmt -recursive aws/route53/
+cd aws/route53/envs/master && TG_TF_PATH=tofu terragrunt validate
+```
+
+Expected: fmt が差分を出さず、validate が成功
+
+- [ ] **Step 4: plan で追加内容を確認**
+
+```bash
+cd aws/route53/envs/master && TG_TF_PATH=tofu terragrunt plan
+```
+
+Expected: `aws_iam_role.zone_access` と `aws_iam_role_policy.zone_access` の 2 追加のみ。既存レコード 6 件に変更が出ないこと
+
+- [ ] **Step 5: apply**
+
+```bash
+cd aws/route53/envs/master && TG_TF_PATH=tofu terragrunt apply -auto-approve
+```
+
+- [ ] **Step 6: ロールとポリシーを確認**
+
+```bash
+aws iam get-role --role-name route53-zone-access --query 'Role.AssumeRolePolicyDocument' --output json
+aws iam get-role-policy --role-name route53-zone-access --policy-name route53-zone-access --output json
+```
+
+Expected: trust の Principal が `arn:aws:iam::<PROD_ACCOUNT_ID>:root`、ポリシーの 1 つ目の statement の Resource が 2 zone ARN
+
+- [ ] **Step 7: コミット**
+
+```bash
+git add aws/route53/modules/
+git commit -s -m "feat(aws/route53): add cross-account zone access role for production"
+```
+
+---
+
+# Phase 4: Production の OIDC ロールと CI 切替
+
+新アカウントに OIDC provider と plan / apply ロールを作り、CI の向き先を切り替える。**順序が重要**で、ロールの存在を確認してから `workflow-config.yaml` をマージする。
+
+### Task 4.1: plan ロールに `sts:AssumeRole` を付与できるようにする
+
+`ReadOnlyAccess` 管理ポリシーには `sts:AssumeRole` が含まれないため、plan ロールが `route53-zone-access` を assume できない。module 側に任意の assume 先を渡せる変数を足す。
+
+**Files:**
+- Modify: `aws/github-oidc-auth/modules/variables.tf`
+- Modify: `aws/github-oidc-auth/modules/main.tf`
+
+**Interfaces:**
+- Produces: `assume_role_arns` input。Task 4.2 の production env.hcl が値を渡す
+
+- [ ] **Step 1: `variables.tf` に変数を追加**
+
+`aws/github-oidc-auth/modules/variables.tf` の末尾に追記する。
+
+```hcl
+variable "assume_role_arns" {
+  description = "Cross-account role ARNs the plan role is allowed to assume (apply role already has AdministratorAccess)"
+  type        = list(string)
+  default     = []
+}
+```
+
+- [ ] **Step 2: `main.tf` にインラインポリシーを追加**
+
+`aws_iam_role_policy_attachment.plan_state_lock` リソースの直後に追記する。
+
+```hcl
+# Plan role cross-account assume grant.
+#
+# ReadOnlyAccess (= plan role の主権限) には sts:AssumeRole が含まれないため、
+# クロスアカウントの data source 解決に必要な assume を明示付与する。
+# apply role は AdministratorAccess で既に assume 可能なので対象外。
+resource "aws_iam_role_policy" "plan_assume_role" {
+  count = length(var.assume_role_arns) > 0 ? 1 : 0
+
+  name = "cross-account-assume"
+  role = aws_iam_role.plan.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect   = "Allow"
+        Action   = "sts:AssumeRole"
+        Resource = var.assume_role_arns
+      }
+    ]
+  })
+}
+```
+
+- [ ] **Step 3: fmt と validate**
+
+```bash
+tofu fmt -recursive aws/github-oidc-auth/
+cd aws/github-oidc-auth/envs/master && TG_TF_PATH=tofu terragrunt validate
+```
+
+Expected: 成功
+
+- [ ] **Step 4: 既存 env に差分が出ないことを確認**
+
+`assume_role_arns` はデフォルト空リストなので `count = 0` となり、develop / master には影響しないはず。
+
+```bash
+cd aws/github-oidc-auth/envs/develop && TG_TF_PATH=tofu terragrunt plan
+cd aws/github-oidc-auth/envs/master  && TG_TF_PATH=tofu terragrunt plan
+```
+
+Expected: 両方 `No changes.`
+
+- [ ] **Step 5: コミット**
+
+```bash
+git add aws/github-oidc-auth/modules/
+git commit -s -m "feat(aws/github-oidc-auth): allow granting cross-account assume to the plan role"
+```
+
+### Task 4.2: production の OIDC provider とロールを新アカウントに作る
+
+**Files:**
+- Modify: `aws/github-oidc-auth/envs/production/env.hcl`
+- Modify: `aws/github-oidc-auth/envs/production/terragrunt.hcl`
+
+**Interfaces:**
+- Consumes: Task 3.4 の `route53-zone-access` ARN、Task 4.1 の `assume_role_arns`
+- Produces: 新アカウントの `github-oidc-auth-production-github-actions-{plan,apply}-role`。Task 4.3 が `workflow-config.yaml` で参照する
+
+- [ ] **Step 1: `env.hcl` の OIDC provider 設定を反転**
+
+`aws/github-oidc-auth/envs/production/env.hcl` の以下 2 行を置き換える。
+
+置換前:
+
+```hcl
+  # OIDC provider settings (reuse existing provider if created in develop)
+  create_oidc_provider = false
+  oidc_provider_arn    = "arn:aws:iam::${get_aws_account_id()}:oidc-provider/token.actions.githubusercontent.com"
+```
+
+置換後:
+
+```hcl
+  # OIDC provider settings
+  # production は専用アカウントに分離済で、そのアカウントには provider が
+  # 存在しないため自前で作成する (= develop / master は管理アカウントの
+  # 既存 provider を共有)。
+  create_oidc_provider = true
+  oidc_provider_arn    = ""
+```
+
+- [ ] **Step 2: `env.hcl` に `assume_role_arns` を追加**
+
+同ファイルの `additional_tags` ブロックの直前に追記する。
+
+```hcl
+  # Route53 hosted zone は管理アカウント (= 559744160976) に残しているため、
+  # plan 時の data.aws_route53_zone 解決に cross-account assume が要る。
+  assume_role_arns = [
+    "arn:aws:iam::559744160976:role/route53-zone-access",
+  ]
+```
+
+- [ ] **Step 3: `terragrunt.hcl` で input を渡す**
+
+`aws/github-oidc-auth/envs/production/terragrunt.hcl` の `inputs` ブロックに追記する。
+
+```hcl
+  assume_role_arns = include.env.locals.assume_role_arns
+```
+
+- [ ] **Step 4: 新アカウントの認証情報に切り替える**
+
+```bash
+unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_SESSION_TOKEN
+CREDS=$(aws sts assume-role \
+  --role-arn arn:aws:iam::<PROD_ACCOUNT_ID>:role/OrganizationAccountAccessRole \
+  --role-session-name oidc-bootstrap --query Credentials --output json)
+export AWS_ACCESS_KEY_ID=$(echo "$CREDS" | jq -r .AccessKeyId)
+export AWS_SECRET_ACCESS_KEY=$(echo "$CREDS" | jq -r .SecretAccessKey)
+export AWS_SESSION_TOKEN=$(echo "$CREDS" | jq -r .SessionToken)
+aws sts get-caller-identity --query Account --output text
+```
+
+Expected: `<PROD_ACCOUNT_ID>`
+
+- [ ] **Step 5: plan**
+
+```bash
+cd aws/github-oidc-auth/envs/production && TG_TF_PATH=tofu terragrunt init && TG_TF_PATH=tofu terragrunt plan
+```
+
+Expected: 全て新規追加（OIDC provider / plan role / apply role / state lock policy / cross-account assume policy / attachment 3 / log group）
+
+- [ ] **Step 6: apply**
+
+```bash
+cd aws/github-oidc-auth/envs/production && TG_TF_PATH=tofu terragrunt apply -auto-approve
+```
+
+- [ ] **Step 7: ロールと provider を確認**
+
+```bash
+aws iam list-open-id-connect-providers
+aws iam get-role --role-name github-oidc-auth-production-github-actions-plan-role --query 'Role.Arn' --output text
+aws iam get-role --role-name github-oidc-auth-production-github-actions-apply-role --query 'Role.Arn' --output text
+aws iam get-role-policy --role-name github-oidc-auth-production-github-actions-plan-role \
+  --policy-name cross-account-assume --output json
+```
+
+Expected: provider が 1 件、両ロールの ARN が新アカウント、assume ポリシーの Resource が `route53-zone-access` ARN
+
+- [ ] **Step 8: クロスアカウント assume の疎通を確認**
+
+```bash
+aws sts assume-role \
+  --role-arn arn:aws:iam::559744160976:role/route53-zone-access \
+  --role-session-name migration-check \
+  --query 'AssumedRoleUser.Arn' --output text
+```
+
+Expected: `arn:aws:sts::559744160976:assumed-role/route53-zone-access/migration-check`
+
+- [ ] **Step 9: コミット**
+
+```bash
+git add aws/github-oidc-auth/envs/production/
+git commit -s -m "feat(aws/github-oidc-auth): provision production OIDC in its dedicated account"
+```
+
+### Task 4.3: `workflow-config.yaml` の production ロール ARN を差し替える
+
+**Files:**
+- Modify: `workflow-config.yaml`
+
+- [ ] **Step 1: Task 4.2 のロールが存在することを再確認**
+
+差し替え前の必須ゲート。ここを飛ばして先にマージすると CI の production plan / apply が存在しないロールを assume して壊れる。
+
+```bash
+aws iam get-role --role-name github-oidc-auth-production-github-actions-plan-role --query 'Role.Arn' --output text
+aws iam get-role --role-name github-oidc-auth-production-github-actions-apply-role --query 'Role.Arn' --output text
+```
+
+Expected: 両方が `arn:aws:iam::<PROD_ACCOUNT_ID>:role/...` を返す
+
+- [ ] **Step 2: `production` ブロックの ARN を差し替え**
+
+`workflow-config.yaml` の `production` 環境の 2 行を置き換える。
+
+```yaml
+        iam_role_plan: arn:aws:iam::<PROD_ACCOUNT_ID>:role/github-oidc-auth-production-github-actions-plan-role
+        iam_role_apply: arn:aws:iam::<PROD_ACCOUNT_ID>:role/github-oidc-auth-production-github-actions-apply-role
+```
+
+- [ ] **Step 3: 管理アカウント ID が production ブロックから消えたことを確認**
+
+```bash
+python3 - <<'EOF'
+import yaml
+d = yaml.safe_load(open('workflow-config.yaml'))
+for e in d['environments']:
+    tg = e.get('stacks', {}).get('terragrunt', {})
+    print(e['environment'], tg.get('aws_region'), tg.get('iam_role_apply'))
+EOF
+```
+
+Expected: `master` と `develop` が `559744160976`、`production` が `<PROD_ACCOUNT_ID>`
+
+- [ ] **Step 4: コミット**
+
+```bash
+git add workflow-config.yaml
+git commit -s -m "feat(workflow-config): point production stacks at the dedicated account"
+```
+
+---
+
+# Phase 5: クロスアカウント配線
+
+`aws/alb` の provider alias、`aws/eks` の external-dns IAM、helmfile の実行時設定を揃える。コード変更のみで apply は Phase 7 に回す。
+
+### Task 5.1: `aws/alb` にクロスアカウント provider を通す
+
+`aws/route53/lookup` は provider を宣言せず呼び出し側の default provider を継承する作りなので、`providers = { aws = aws.route53 }` で差し替えるだけでよい（lookup module 自体は無変更）。
+
+**Files:**
+- Modify: `aws/alb/modules/terraform.tf`
+- Modify: `aws/alb/modules/lookups.tf`
+- Modify: `aws/alb/modules/main.tf`
+- Modify: `aws/alb/modules/variables.tf`
+- Modify: `aws/alb/envs/production/env.hcl`
+- Modify: `aws/alb/envs/production/terragrunt.hcl`
+
+**Interfaces:**
+- Consumes: Task 3.4 の `route53-zone-access` ARN
+- Produces: `var.route53_zone_role_arn`（`aws/alb` 内のみ。`aws/eks` は Task 5.2 で lookup ごと削除するため不要）
+
+- [ ] **Step 1: `variables.tf` に変数を追加**
+
+`aws/alb/modules/variables.tf` の末尾に追記する。
+
+```hcl
+variable "route53_zone_role_arn" {
+  description = "Role in the management account assumed to read/write the hosted zones"
+  type        = string
+}
+```
+
+- [ ] **Step 2: `terraform.tf` に alias provider を追加**
+
+`aws/alb/modules/terraform.tf` の既存 `provider "aws"` ブロックの直後に追記する。
+
+```hcl
+# Hosted zone は管理アカウント (= 559744160976) に残しているため、
+# zone の読み取りと ACM DNS validation レコードの書き込みはこの alias 経由で行う。
+provider "aws" {
+  alias  = "route53"
+  region = var.aws_region
+
+  assume_role {
+    role_arn = var.route53_zone_role_arn
+  }
+
+  default_tags {
+    tags = var.common_tags
+  }
+}
+```
+
+- [ ] **Step 3: `lookups.tf` で provider を差し替え**
+
+`aws/alb/modules/lookups.tf` を以下に置き換える。
+
+```hcl
+# lookups.tf - External stack lookups.
+#
+# route53/lookup は provider を宣言せず呼び出し側の default provider を継承する
+# ため、ここで aws.route53 (= 管理アカウントへの assume role) を default として
+# 渡すことで zone を別アカウントから解決する。
+
+module "route53" {
+  source = "../../route53/lookup"
+
+  providers = {
+    aws = aws.route53
+  }
+}
+```
+
+- [ ] **Step 4: validation レコードに provider を指定**
+
+`aws/alb/modules/main.tf` の `aws_route53_record.wildcard_panicboat_net_validation` と `aws_route53_record.wildcard_dystopia_city_validation` の両方に、`for_each` ブロックの直前へ 1 行追加する。
+
+```hcl
+  provider = aws.route53
+```
+
+ACM 証明書（`aws_acm_certificate`）と検証待ち（`aws_acm_certificate_validation`）は production アカウント側のリソースなので default provider のまま。
+
+- [ ] **Step 5: `env.hcl` に ARN を追加**
+
+`aws/alb/envs/production/env.hcl` の `environment_tags` ブロックの直前に追記する。
+
+```hcl
+  # 管理アカウント (= 559744160976) の hosted zone を操作するための assume 先。
+  route53_zone_role_arn = "arn:aws:iam::559744160976:role/route53-zone-access"
+```
+
+- [ ] **Step 6: `terragrunt.hcl` で input を渡す**
+
+`aws/alb/envs/production/terragrunt.hcl` の `inputs` ブロック、`aws_region` の次の行に追記する。
+
+```hcl
+  route53_zone_role_arn = include.env.locals.route53_zone_role_arn
+```
+
+- [ ] **Step 7: fmt と validate**
+
+```bash
+tofu fmt -recursive aws/alb/
+cd aws/alb/envs/production && TG_TF_PATH=tofu terragrunt init -upgrade && TG_TF_PATH=tofu terragrunt validate
+```
+
+Expected: 成功
+
+- [ ] **Step 8: plan で zone が解決できることを確認**
+
+新アカウントの認証情報で実行する。
+
+```bash
+cd aws/alb/envs/production && TG_TF_PATH=tofu terragrunt plan
+```
+
+Expected: `data.aws_route53_zone` の解決に成功し、ACM 証明書 2 枚と validation レコードの新規作成が計画される。`Invalid provider configuration` や `no matching Route53Zone found` が出ないこと
+
+- [ ] **Step 9: コミット**
+
+```bash
+git add aws/alb/
+git commit -s -m "feat(aws/alb): resolve hosted zones through a cross-account provider"
+```
+
+### Task 5.2: `aws/eks` の external-dns IAM を assume role 方式へ
+
+`module.route53` の参照は `addons.tf` の `external_dns_hosted_zone_arns` 1 箇所のみ。assume role 方式にすると zone ARN が不要になり、lookup ごと削除できる。
+
+**Files:**
+- Modify: `aws/eks/modules/addons.tf`
+- Modify: `aws/eks/modules/lookups.tf`
+- Modify: `aws/eks/modules/variables.tf`
+- Modify: `aws/eks/envs/production/env.hcl`
+- Modify: `aws/eks/envs/production/terragrunt.hcl`
+
+**Interfaces:**
+- Consumes: Task 3.4 の `route53-zone-access` ARN
+- Produces: `eks-production-external-dns` ロールが Route53 権限ではなく `sts:AssumeRole` を持つ。Task 5.3 の helm 値と対になる
+
+- [ ] **Step 1: `module.route53` の参照箇所が 1 つだけであることを再確認**
+
+```bash
+grep -rn "module\.route53" aws/eks/modules/
+```
+
+Expected: `addons.tf` の 2 行（`panicboat_net.arn` / `dystopia_city.arn`）のみ
+
+- [ ] **Step 2: `variables.tf` に変数を追加**
+
+`aws/eks/modules/variables.tf` の末尾に追記する。
+
+```hcl
+variable "route53_zone_role_arn" {
+  description = "Role in the management account that external-dns assumes to manage hosted zone records"
+  type        = string
+}
+```
+
+- [ ] **Step 3: `addons.tf` の external-dns IRSA を差し替え**
+
+`module "external_dns_irsa"` ブロック全体を以下に置き換える。`terraform-aws-modules/iam//modules/iam-role-for-service-accounts` v6 は `source_policy_documents` が非空なら `create_policy` が真になりインラインポリシーを生成する。
+
+```hcl
+# external-dns IAM role.
+#
+# Hosted zone は管理アカウント (= 559744160976) に残っているため、Pod は
+# 直接 Route53 を叩かず route53-zone-access を assume する
+# (= external-dns の --aws-assume-role フラグ、
+#   kubernetes/components/external-dns/production/values.yaml.gotmpl)。
+# そのため attach_external_dns_policy (= 同一アカウントの zone を前提とする
+# Route53 権限) ではなく sts:AssumeRole のみを付与する。
+data "aws_iam_policy_document" "external_dns_assume_zone_access" {
+  statement {
+    actions   = ["sts:AssumeRole"]
+    resources = [var.route53_zone_role_arn]
+  }
+}
+
+module "external_dns_irsa" {
+  source  = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts"
+  version = "~> 6.8"
+
+  name            = "eks-${var.environment}-external-dns"
+  use_name_prefix = false
+
+  source_policy_documents = [data.aws_iam_policy_document.external_dns_assume_zone_access.json]
+
+  oidc_providers = {
+    main = {
+      provider_arn               = module.eks.oidc_provider_arn
+      namespace_service_accounts = ["external-dns:external-dns"]
+    }
+  }
+
+  tags = var.common_tags
+}
+```
+
+- [ ] **Step 4: `lookups.tf` から route53 lookup を削除**
+
+`aws/eks/modules/lookups.tf` を以下に置き換える。
+
+```hcl
+# lookups.tf - External stack lookups for the EKS cluster.
+
+module "vpc" {
+  source      = "../../vpc/lookup"
+  environment = var.environment
+}
+```
+
+- [ ] **Step 5: `env.hcl` に ARN を追加**
+
+`aws/eks/envs/production/env.hcl` の `environment_tags` ブロックの直前に追記する。
+
+```hcl
+  # external-dns が管理アカウント (= 559744160976) の hosted zone を操作するための assume 先。
+  route53_zone_role_arn = "arn:aws:iam::559744160976:role/route53-zone-access"
+```
+
+- [ ] **Step 6: `terragrunt.hcl` で input を渡す**
+
+`aws/eks/envs/production/terragrunt.hcl` の `inputs` ブロックに追記する。
+
+```hcl
+  route53_zone_role_arn = include.env.locals.route53_zone_role_arn
+```
+
+- [ ] **Step 7: fmt と validate**
+
+```bash
+tofu fmt -recursive aws/eks/
+cd aws/eks/envs/production && TG_TF_PATH=tofu terragrunt init -upgrade && TG_TF_PATH=tofu terragrunt validate
+```
+
+Expected: 成功。`module.route53` への未解決参照が残っていればここで落ちる
+
+- [ ] **Step 8: コミット**
+
+```bash
+git add aws/eks/
+git commit -s -m "feat(aws/eks): grant external-dns cross-account assume instead of zone-scoped Route53"
+```
+
+### Task 5.3: external-dns に `--aws-assume-role` を設定
+
+**Files:**
+- Modify: `kubernetes/components/external-dns/production/values.yaml.gotmpl`
+
+**Interfaces:**
+- Consumes: Task 5.2 の IRSA ロール（`sts:AssumeRole` のみを持つ）、Task 3.4 の `route53-zone-access`
+
+- [ ] **Step 1: `extraArgs` セクションを追加**
+
+`kubernetes/components/external-dns/production/values.yaml.gotmpl` の `txtOwnerId` ブロックと `serviceAccount` ブロックの間に挿入する。
+
+```yaml
+# =============================================================================
+# Cross-account Route53 access
+# =============================================================================
+# hosted zone は管理アカウント (= 559744160976) に残しているため、Pod の IRSA
+# ロールでは直接 Route53 を叩けない。route53-zone-access を assume して操作する。
+# IRSA ロール側の権限は sts:AssumeRole のみ (= aws/eks/modules/addons.tf)。
+extraArgs:
+  - --aws-assume-role=arn:aws:iam::559744160976:role/route53-zone-access
+```
+
+- [ ] **Step 2: helmfile が template できることを確認**
+
+```bash
+helmfile -e production -f kubernetes/components/external-dns/production/helmfile.yaml template \
+  | grep -A3 -- "--aws-assume-role"
+```
+
+Expected: Deployment の args に `--aws-assume-role=arn:aws:iam::559744160976:role/route53-zone-access` が含まれる
+
+- [ ] **Step 3: コミット**
+
+```bash
+git add kubernetes/components/external-dns/production/values.yaml.gotmpl
+git commit -s -m "feat(external-dns): assume the management-account role for Route53"
+```
+
+---
+
+# Phase 6: 共有リソースの再作成
+
+### Task 6.1: service-linked role と Secrets Manager を新アカウントに作る
+
+**Files:** なし（既存スタックの apply と手動投入）
+
+**Interfaces:**
+- Consumes: Task 0.4 の退避ファイル `$HOME/.secrets-backup-559744160976.json`
+
+- [ ] **Step 1: 新アカウントの認証情報で `iam-service-linked-roles` を apply**
+
+```bash
+cd aws/iam-service-linked-roles/envs/production && TG_TF_PATH=tofu terragrunt init && TG_TF_PATH=tofu terragrunt apply -auto-approve
+```
+
+- [ ] **Step 2: service-linked role を確認**
+
+```bash
+aws iam get-role --role-name AWSServiceRoleForEC2Spot --query 'Role.Arn' --output text
+```
+
+Expected: `arn:aws:iam::<PROD_ACCOUNT_ID>:role/aws-service-role/spot.amazonaws.com/AWSServiceRoleForEC2Spot`
+
+- [ ] **Step 3: monorepo 側の Secrets Manager スタックを apply**
+
+`panicboat/holmes/slack` と `panicboat/holmes/alertmanager` は monorepo が管理する。Task 8.1 で扱うため、ここでは platform 管理外の残り 6 件を手動作成する。
+
+```bash
+for name in \
+  panicboat/oauth2-proxy/google \
+  panicboat/grafana/admin \
+  panicboat/github-app/panicboat \
+  panicboat/keycloak/admin \
+  panicboat/holmes/github \
+  panicboat/alertmanager/slack-notify
+do
+  aws secretsmanager create-secret --region ap-northeast-1 --name "$name"
+done
+```
+
+- [ ] **Step 4: 退避した値を投入**
+
+```bash
+jq -c 'select(.name | test("holmes/(slack|alertmanager)$") | not)' \
+  "$HOME/.secrets-backup-559744160976.json" \
+| while read -r row; do
+    name=$(echo "$row" | jq -r .name)
+    value=$(echo "$row" | jq -r .value)
+    aws secretsmanager put-secret-value --region ap-northeast-1 \
+      --secret-id "$name" --secret-string "$value" >/dev/null
+    echo "restored: $name"
+  done
+```
+
+Expected: 6 件の `restored:` 行
+
+- [ ] **Step 5: 投入結果を確認**
+
+```bash
+aws secretsmanager list-secrets --region ap-northeast-1 --query 'SecretList[].Name' --output text | tr '\t' '\n' | sort
+```
+
+Expected: 6 件（holmes の 2 件は Task 8.1 で追加される）
+
+---
+
+# Phase 7: helmfile 更新と EKS 再構築
+
+### Task 7.1: helmfile のアカウント ID を差し替える
+
+helmfile v1.4 は親 `helmfile.yaml.gotmpl` の environments values を子 helmfile に継承しないため、同じ値が両方に定義されている。片方だけ直すと不整合になる。
+
+**Files:**
+- Modify: `kubernetes/helmfile.yaml.gotmpl`
+- Modify: `kubernetes/components/aws-load-balancer-controller/production/helmfile.yaml`
+- Modify: `kubernetes/components/external-dns/production/helmfile.yaml`
+- Modify: `kubernetes/components/loki/production/helmfile.yaml`
+- Modify: `kubernetes/components/mimir/production/helmfile.yaml`
+- Modify: `kubernetes/components/tempo/production/helmfile.yaml`
+
+- [ ] **Step 1: 差し替え対象を列挙**
+
+```bash
+grep -rn "559744160976" kubernetes/helmfile.yaml.gotmpl kubernetes/components/
+```
+
+Expected: 11 行（親 5 + 子 6）
+
+- [ ] **Step 2: 一括置換**
+
+`kubernetes/components/external-dns/production/values.yaml.gotmpl` の `--aws-assume-role` は **管理アカウント ID のまま残す**必要があるため、置換対象から除外する。
+
+```bash
+grep -rl "559744160976" kubernetes/helmfile.yaml.gotmpl kubernetes/components/ \
+  | grep -v 'external-dns/production/values.yaml.gotmpl' \
+  | xargs sed -i '' 's/559744160976/<PROD_ACCOUNT_ID>/g'
+```
+
+- [ ] **Step 3: 置換結果を検証**
+
+```bash
+grep -rn "559744160976" kubernetes/
+grep -rn "<PROD_ACCOUNT_ID>" kubernetes/ | wc -l
+```
+
+Expected: 1 つ目は `kubernetes/components/external-dns/production/values.yaml.gotmpl` の `--aws-assume-role` 行と `kubernetes/manifests/` 配下の rendered 出力のみ。2 つ目は 11
+
+- [ ] **Step 4: helmfile が template できることを確認**
+
+```bash
+helmfile -e production template > /dev/null && echo OK
+```
+
+Expected: `OK`
+
+- [ ] **Step 5: コミット**
+
+```bash
+git add kubernetes/helmfile.yaml.gotmpl kubernetes/components/
+git commit -s -m "feat(kubernetes): point production values at the dedicated AWS account"
+```
+
+### Task 7.2: EKS を新アカウントで再構築する
+
+既存の recreate runbook をそのまま実行する。本タスクは runbook を呼び出す薄いラッパで、runbook 内の手順を複製しない。
+
+**Files:**
+- Modify: `docs/runbooks/eks-production-recreate.md`（Phase 0 の期待値をアカウント非依存に直す）
+
+- [ ] **Step 1: Service Quota の増枠が承認済みか確認**
+
+未承認なら Karpenter がノードを 1 台も出せずに詰むため、ここが本 Phase のゲート。
+
+```bash
+for qc in L-1216C47A L-34B43A08; do
+  aws service-quotas get-service-quota --service-code ec2 --quota-code $qc \
+    --region ap-northeast-1 --query 'Quota.{Name:QuotaName,Value:Value}' --output json
+done
+```
+
+Expected: On-Demand が 64 以上、Spot が 256 以上
+
+- [ ] **Step 2: runbook の Phase 0 の期待値を更新**
+
+`docs/runbooks/eks-production-recreate.md` の 2.2 節と Phase 0 に `arn:aws:iam::559744160976:user/panicboat` がハードコードされている。production はアカウントが変わったため、以下の記述に置き換える。
+
+```
+- production アカウント (= `<PROD_ACCOUNT_ID>`) の AdministratorAccess 相当の principal
+  (= IAM Identity Center の AdministratorAccess、または管理アカウントから
+  `OrganizationAccountAccessRole` を assume した session)
+```
+
+Phase 0 の期待値コメント `# → arn:aws:iam::559744160976:user/panicboat` は、返るアカウント ID が `<PROD_ACCOUNT_ID>` であることを確認する記述に変える。
+
+- [ ] **Step 3: runbook の Phase 1-10 を実行**
+
+`docs/runbooks/eks-production-recreate.md` に従う。Phase 7 の残りスタック apply には `eks-holmesgpt` が含まれていないため、`eks-secrets eks-logs eks-metrics eks-traces` の後に追加で apply する。
+
+```bash
+cd aws/eks-holmesgpt/envs/production && TG_TF_PATH=tofu terragrunt init -upgrade && TG_TF_PATH=tofu terragrunt apply -auto-approve
+```
+
+- [ ] **Step 4: クラスタと証明書を確認**
+
+```bash
+aws eks list-clusters --region ap-northeast-1
+aws acm list-certificates --region ap-northeast-1 --certificate-statuses ISSUED \
+  --query 'CertificateSummaryList[].DomainName' --output text
+```
+
+Expected: `eks-production` が返り、`*.panicboat.net` と `*.dystopia.city` が `ISSUED`
+
+- [ ] **Step 5: external-dns のクロスアカウント書き込みを確認**
+
+Task 0.3 で zone を掃除してあるため、レコードが「増える」ことで疎通を確認できる。
+
+```bash
+kubectl -n external-dns logs deploy/external-dns --tail=50 | grep -i "assume\|error\|record"
+aws route53 list-resource-record-sets --hosted-zone-id Z03420722KS9MTSCUSIQZ \
+  --query 'ResourceRecordSets[].{N:Name,T:Type}' --output text
+```
+
+Expected: ログに assume role エラーが無く、Ingress の hostname に対応する A / TXT レコードが zone に作成されている
+
+- [ ] **Step 6: コミット**
+
+```bash
+git add docs/runbooks/eks-production-recreate.md
+git commit -s -m "docs(runbooks): decouple the recreate runbook from the management account"
+```
+
+---
+
+# Phase 8: monorepo リポジトリの移行
+
+### Task 8.1: monorepo の production スタックを新アカウントへ
+
+`panicboat/monorepo` の `system-components/holmes/terragrunt`（Secrets Manager 2 件）と `services/monolith/terragrunt`（resources=0）が、同じ `terragrunt-state-${get_aws_account_id()}` 規約で state を持つ。
+
+**Files（monorepo リポジトリ）:**
+- Modify: `workflow-config.yaml`
+
+**Interfaces:**
+- Consumes: Task 2.1 の state バケット、Task 4.2 の production ロール、Task 0.4 の退避ファイル
+
+- [ ] **Step 1: 現状の state を確認**
+
+```bash
+aws s3 ls s3://terragrunt-state-559744160976/services/ --recursive
+aws s3 ls s3://terragrunt-state-559744160976/system-components/ --recursive
+```
+
+Expected: `services/monolith/production`、`services/nginx-app/develop`、`system-components/holmes/production` の 3 件
+
+- [ ] **Step 2: 新アカウントの認証情報で holmes スタックを apply**
+
+```bash
+cd ../monorepo/system-components/holmes/terragrunt/envs/production
+TG_TF_PATH=tofu terragrunt init && TG_TF_PATH=tofu terragrunt apply -auto-approve
+```
+
+Expected: `aws_secretsmanager_secret` 2 件が新規作成される
+
+- [ ] **Step 3: holmes の secret 値を投入**
+
+```bash
+jq -c 'select(.name | test("holmes/(slack|alertmanager)$"))' \
+  "$HOME/.secrets-backup-559744160976.json" \
+| while read -r row; do
+    name=$(echo "$row" | jq -r .name)
+    value=$(echo "$row" | jq -r .value)
+    aws secretsmanager put-secret-value --region ap-northeast-1 \
+      --secret-id "$name" --secret-string "$value" >/dev/null
+    echo "restored: $name"
+  done
+```
+
+Expected: 2 件の `restored:` 行
+
+- [ ] **Step 4: monolith スタックを apply**
+
+resources=0 のため state を新規に作るだけ。
+
+```bash
+cd ../monorepo/services/monolith/terragrunt/envs/production
+TG_TF_PATH=tofu terragrunt init && TG_TF_PATH=tofu terragrunt apply -auto-approve
+```
+
+- [ ] **Step 5: monorepo の `workflow-config.yaml` に production env を追加**
+
+現状 `develop` のみ宣言されており、production スタックは手動 apply 運用になっている。CI に載せるため追加する。
+
+```yaml
+  - environment: production
+    stacks:
+      terragrunt:
+        aws_region: ap-northeast-1
+        iam_role_plan: arn:aws:iam::<PROD_ACCOUNT_ID>:role/github-oidc-auth-production-github-actions-plan-role
+        iam_role_apply: arn:aws:iam::<PROD_ACCOUNT_ID>:role/github-oidc-auth-production-github-actions-apply-role
+```
+
+- [ ] **Step 6: 新アカウントの state を確認**
+
+```bash
+aws s3 ls s3://terragrunt-state-<PROD_ACCOUNT_ID>/ --recursive
+```
+
+Expected: `services/monolith/production` と `system-components/holmes/production` が存在する
+
+- [ ] **Step 7: コミット（monorepo リポジトリ）**
+
+```bash
+cd ../monorepo
+git add workflow-config.yaml
+git commit -s -m "feat(workflow-config): declare production environment on the dedicated account"
+```
+
+---
+
+# Phase 9: 旧アカウントの後片付け
+
+### Task 9.1: 管理アカウントから production 資産を除去
+
+**Files:**
+- Modify: `README.md`
+- Modify: `README-ja.md`
+
+- [ ] **Step 1: 管理アカウントの認証情報に戻す**
+
+```bash
+unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_SESSION_TOKEN
+aws sts get-caller-identity --query Arn --output text
+```
+
+Expected: `arn:aws:iam::559744160976:user/panicboat`
+
+- [ ] **Step 2: 旧 production の IAM 資産を削除**
+
+Task 4.2 で `aws/github-oidc-auth/envs/production` は新アカウントを向くよう変更済のため、`terragrunt destroy` を打つと**新アカウント側**が消える。旧アカウント側は AWS API で直接削除する。
+
+削除前に、対象が旧アカウントのロールであることを確認する。
+
+```bash
+aws iam get-role --role-name github-oidc-auth-production-github-actions-apply-role --query 'Role.Arn' --output text
+```
+
+Expected: `arn:aws:iam::559744160976:role/github-oidc-auth-production-github-actions-apply-role`（管理アカウント ID であること）
+
+確認できたら削除する。旧 state は Step 4 でまとめて消す。
+
+```bash
+aws iam detach-role-policy --role-name github-oidc-auth-production-github-actions-apply-role \
+  --policy-arn arn:aws:iam::aws:policy/AdministratorAccess
+aws iam detach-role-policy --role-name github-oidc-auth-production-github-actions-plan-role \
+  --policy-arn arn:aws:iam::aws:policy/ReadOnlyAccess
+aws iam detach-role-policy --role-name github-oidc-auth-production-github-actions-plan-role \
+  --policy-arn arn:aws:iam::559744160976:policy/github-oidc-auth-production-terragrunt-state-lock
+aws iam delete-role --role-name github-oidc-auth-production-github-actions-apply-role
+aws iam delete-role --role-name github-oidc-auth-production-github-actions-plan-role
+aws iam delete-policy --policy-arn arn:aws:iam::559744160976:policy/github-oidc-auth-production-terragrunt-state-lock
+aws logs delete-log-group --region ap-northeast-1 --log-group-name /github-actions/github-oidc-auth-production
+```
+
+- [ ] **Step 3: 残存ロールを確認**
+
+```bash
+aws iam list-roles --query 'Roles[?!contains(Path, `aws-service-role`)].RoleName' --output text | tr '\t' '\n'
+```
+
+Expected: `AWSReservedSSO_AdministratorAccess_*`、`github-oidc-auth-develop-github-actions-{plan,apply}-role`、`route53-zone-access` の 4 つ
+
+- [ ] **Step 4: 旧 production state を削除**
+
+`platform/route53/production` は Task 3.3 で削除済。残りの production state を消す。
+
+```bash
+for key in alb eks eks-holmesgpt eks-logs eks-metrics eks-secrets eks-traces github-oidc-auth iam-service-linked-roles karpenter vpc; do
+  aws s3 rm "s3://terragrunt-state-559744160976/platform/${key}/production/terraform.tfstate"
+done
+aws s3 rm s3://terragrunt-state-559744160976/services/monolith/production/terraform.tfstate
+aws s3 rm s3://terragrunt-state-559744160976/system-components/holmes/production/terraform.tfstate
+```
+
+- [ ] **Step 5: 旧 production secret を削除**
+
+新アカウントへの投入完了（Task 6.1 Step 5 と Task 8.1 Step 3）を確認してから実行する。
+
+```bash
+for name in $(aws secretsmanager list-secrets --region ap-northeast-1 --query 'SecretList[].Name' --output text); do
+  aws secretsmanager delete-secret --region ap-northeast-1 --secret-id "$name" --force-delete-without-recovery
+done
+```
+
+- [ ] **Step 6: 管理アカウントに残った state を確認**
+
+```bash
+aws s3 ls s3://terragrunt-state-559744160976/ --recursive
+```
+
+Expected: `platform/{branch,cost-management,github-oidc-auth,github-repository,repository,route53}/...` と `services/nginx-app/develop` のみ。`*/production/` が `platform/route53/master` を除いて残っていないこと
+
+- [ ] **Step 7: README の環境表に `master` を追加**
+
+`README.md` の「Environments and authentication」節と `README-ja.md` の対応箇所に、`master` env が管理アカウントの横断資産（Route53 hosted zone）を持つこと、`production` が専用アカウントであることを追記する。
+
+- [ ] **Step 8: コミット**
+
+```bash
+git add README.md README-ja.md
+git commit -s -m "docs: describe the master environment and the dedicated production account"
+```
+
+- [ ] **Step 9: Draft PR を作成**
+
+```bash
+git push -u origin HEAD
+gh pr create --draft \
+  --title "Migrate production to a dedicated AWS account" \
+  --body "See docs/superpowers/specs/2026-08-18-production-account-migration-design.md"
+```
+
+---
+
+## Verification Checklist
+
+- [ ] `aws organizations list-accounts` に ACTIVE な production アカウントが 1 件ある
+- [ ] `aws s3api head-bucket --bucket terragrunt-state-<PROD_ACCOUNT_ID>` が成功する
+- [ ] 新アカウントの `github-oidc-auth-production-github-actions-{plan,apply}-role` が存在する
+- [ ] 新アカウントから `route53-zone-access` を assume できる
+- [ ] `aws eks list-clusters --region ap-northeast-1` が新アカウントで `eks-production` を返す
+- [ ] `*.panicboat.net` / `*.dystopia.city` の ACM 証明書が新アカウントで `ISSUED`
+- [ ] external-dns が管理アカウントの zone にレコードを作成できている
+- [ ] `git grep -n 559744160976 -- kubernetes/ workflow-config.yaml` の結果が、`master` / `develop` env の ARN と external-dns の `--aws-assume-role` だけになっている
+- [ ] 管理アカウントの state バケットに `*/production/` の state が残っていない（`platform/route53/master` は移行済のため対象外）
+- [ ] 管理アカウントの Secrets Manager が空
+- [ ] `aws iam list-instance-profiles` が空

--- a/docs/superpowers/specs/2026-08-18-production-account-migration-design.md
+++ b/docs/superpowers/specs/2026-08-18-production-account-migration-design.md
@@ -307,19 +307,31 @@ Terraform 管理外だが、クラスタ再構築で自動的に作り直され�
 
 ## 7. State Migration Map
 
-`master` へ移すスタックは、アカウントは変わらず state key だけが変わる（`terragrunt backend migrate`）。`develop` / `production` はアカウントごと変わるため、state を移送せず新アカウントで作り直す。
+state の所在は 2 つの要素で決まり、移行では**それぞれ独立に変わる**。
 
-| 現 state key | 移行後 | 方式 |
-|---|---|---|
-| `platform/route53/production` | `platform/route53/master` | `terragrunt backend migrate` |
-| `platform/repository/develop` | `platform/repository/master` | 同上 |
-| `platform/branch/develop` | `platform/branch/master` | 同上 |
-| `platform/cost-management/develop` | `platform/cost-management/master` | 同上 |
-| `platform/github-oidc-auth/develop` | provider のみ `platform/github-oidc-auth/master` へ | `state rm` + `import` |
-| `platform/github-oidc-auth/production` | 新 production アカウントで新規作成 | 移送しない |
-| `platform/iam-service-linked-roles/production` | 同上 | 移送しない |
-| `platform/eks-holmesgpt/production` | 同上 | 移送しない（先にドリフト解消して destroy） |
-| `system-components/holmes/production` | 同上 | 移送しない（値は手動退避 → 再投入） |
+- **key** — 全 `root.hcl` が `platform/{service}/${local.environment}/terraform.tfstate` で組む。`local.environment` は `path_relative_to_include()` の末尾要素、つまり `envs/` 直下のディレクトリ名から導出される。したがって `envs/develop` → `envs/master` のリネームだけで key が変わり、`root.hcl` の編集は不要
+- **バケット** — 全 `root.hcl` が `terragrunt-state-${get_aws_account_id()}` で組む。実行時の認証情報で解決されるため、assume するアカウントを変えるだけでバケットが変わる。こちらも編集は不要
+
+| スタック | key | バケット | 方式 |
+|---|---|---|---|
+| `aws/route53` | `.../production` → `.../master` | 559744160976 のまま | `terragrunt backend migrate` |
+| `aws/cost-management` | `.../develop` → `.../master` | 同上 | 同上 |
+| `github/repository` | `.../develop` → `.../master` | 同上 | 同上 |
+| `github/branch` | `.../develop` → `.../master` | 同上 | 同上 |
+| `aws/github-oidc-auth`（master） | 新規 `.../master` | 同上 | 新規作成 + provider を `state rm` → `import` |
+| `aws/github-oidc-auth`（develop） | `.../develop` のまま | **`terragrunt-state-<DEV_ACCOUNT_ID>` へ** | 移送せず新アカウントで新規作成 |
+| `aws/{vpc,alb,eks,eks-*,iam-service-linked-roles,github-oidc-auth}`（production） | `.../production` のまま | **`terragrunt-state-<PROD_ACCOUNT_ID>` へ** | 同上 |
+| `system-components/holmes`（monorepo） | `.../production` のまま | 同上 | 同上（値は手動退避 → 再投入） |
+| `services/monolith`（monorepo） | `.../production` のまま | 同上 | 同上（resources=0） |
+
+### 同名 key が新旧バケットに並存する点への注意
+
+`platform/github-oidc-auth/develop` と `platform/*/production` は、**key が完全に同じまま**バケットだけが変わる。移行期間中は旧バケット（`terragrunt-state-559744160976`）と新バケットの両方に同名の state が存在する。
+
+どちらを操作するかは `get_aws_account_id()` の解決結果、つまり**そのとき assume しているアカウント**だけで決まる。terragrunt のコマンドラインからは区別がつかないため、以下を守る。
+
+- state を破壊する操作（`destroy` / `state rm` / `aws s3 rm`）の前に必ず `aws sts get-caller-identity --query Account --output text` で対象アカウントを確認する
+- Phase 9 の旧 state 削除は `aws s3 rm s3://terragrunt-state-559744160976/...` とバケット名を明示した形で行い、`terragrunt destroy` を使わない（Task 9.1 / 9.2 はこの方針で書いてある）
 
 ### 削除する孤児 state
 

--- a/docs/superpowers/specs/2026-08-18-production-account-migration-design.md
+++ b/docs/superpowers/specs/2026-08-18-production-account-migration-design.md
@@ -1,0 +1,309 @@
+# Production AWS Account Migration Design
+
+`production` 環境を、現在の AWS アカウント `559744160976`（= AWS Organizations の管理アカウント）から専用のメンバーアカウントへ分離する。
+
+## 1. Background
+
+### 現状のアカウント構成
+
+`559744160976` は Organization `o-es9qoj85gw`（FeatureSet `ALL`）の管理アカウントであり、同時に `develop` と `production` の両環境が同居している。環境分離はリソース命名と IAM ロール名のプレフィックスだけで担保されており、アカウント境界による分離が無い。
+
+IAM Identity Center インスタンス `ssoins-7758e2d4fb37f3a7`（primary region `ap-northeast-1`）も同アカウントが保有する。permission set は `AdministratorAccess` 1 つのみで、`559744160976` に対してユーザー `me@panicboat.net` が割当済。
+
+過去に 2 回メンバーアカウントを作成して両方クローズしている。
+
+| Account | Name | 作成 | 状態 |
+|---|---|---|---|
+| 583677814390 | Production (`admin@panicboat.net`) | 2026-08-05 | SUSPENDED / CLOSED |
+| 504150922582 | dystopia (`aws@dystopia.city`) | 2026-08-18 | SUSPENDED / CLOSED |
+
+Support プランは Basic（Premium Support 未契約）。
+
+### 現状の稼働リソース
+
+`ap-northeast-1` に EKS クラスタ・VPC・EC2・NAT Gateway・EIP・ELBv2・Security Group・Launch Template はいずれも存在しない（デフォルト VPC も無い）。ACM は `ap-northeast-1` / `us-east-1` ともに 0 件、ECR・KMS CMK・SNS・SQS も 0 件。EKS スタック群は teardown 済で、移行対象は基盤リソースと state に限られる。
+
+state は 26 ファイル中 11 ファイルにのみ resources が入っている。`production` 系で実体があるのは以下の 4 つ。
+
+| state key | resources | 内容 |
+|---|---|---|
+| `platform/route53/production` | 8 | MX / TXT / DKIM レコード 6 + zone data 2 |
+| `platform/eks-holmesgpt/production` | 7 | IAM role + inline policy + Pod Identity Association |
+| `platform/github-oidc-auth/production` | 9 | plan / apply role + policy + log group |
+| `platform/iam-service-linked-roles/production` | 1 | `AWSServiceRoleForEC2Spot` |
+
+`eks` / `vpc` / `alb` / `eks-logs` / `eks-metrics` / `eks-traces` / `eks-secrets` / `karpenter` は resources=0 の空 state。
+
+残存する実リソースは以下。
+
+- S3: `terragrunt-state-559744160976`（`ap-northeast-1`、versioning 有効、SSE-KMS `alias/aws/s3`、public access block 全 true、Terragrunt 自動生成の `EnforcedTLS` + `RootAccess` バケットポリシー）、`panicboat-attached-storage`（Terraform 管理外・platform 無関係）
+- DynamoDB: `terragrunt-state-locks`（`ap-northeast-1`、HASH=`LockID`、PAY_PER_REQUEST）
+- IAM: OIDC provider 1、ロール 5（`github-oidc-auth-{develop,production}-github-actions-{plan,apply}-role` + `eks-production-holmesgpt`）、カスタマー管理ポリシー 2、IAM ユーザー `panicboat`（AdministratorAccess）
+- Secrets Manager（`ap-northeast-1`）8 件: `panicboat/{oauth2-proxy/google, grafana/admin, github-app/panicboat, keycloak/admin, holmes/slack, holmes/alertmanager, holmes/github, alertmanager/slack-notify}`
+- Route53: hosted zone 3 本（`panicboat.net` = `Z07598371GKBU0WMF89MD`、`dystopia.city` = `Z03420722KS9MTSCUSIQZ`、`nyx.place` = `Z05920991VJAPXQE581DN`）+ Route53 Registrar 登録ドメイン 3 件
+- CloudWatch Logs: `ap-northeast-1` 10 本、`us-east-1` 1 本
+
+### Service Quota の乖離
+
+`ap-northeast-1` の増枠申請履歴は空だが、適用値は AWS 側の自動調整で新規アカウントのデフォルトから乖離している。新アカウントはデフォルト値から始まるため、Karpenter が worker node を出す前に増枠が必要になる。
+
+| Quota | 現アカウント適用値 | AWS デフォルト値 |
+|---|---|---|
+| Running On-Demand Standard vCPU | 64 | 5 |
+| All Standard Spot Instance Requests | 256 | 5 |
+| EC2-VPC Elastic IPs | 5 | 5 |
+| VPCs per Region | 5 | 5 |
+
+`us-east-1` では Bedrock の Sonnet 5 / Opus 5 増枠申請 4 件がいずれも `CASE_CLOSED`（未取得）。
+
+### 既存の不整合
+
+- `scripts/eks-lifecycle/lib/30-destroy-stacks.sh` の `STACKS` 配列（8 スタック）に `eks-holmesgpt` が含まれていない。#795 でスタック分離した際に追加漏れとなり、`eks-production-holmesgpt` ロールが teardown 後も残存している。`platform/eks-holmesgpt/production` state は存在しないクラスタを `data.aws_eks_cluster.this` で参照しており、現状 plan が data source 解決で失敗する
+- IAM instance profile `eks-production_513473553642647435`（Roles 空）が孤児として残存。Karpenter が生成した Terraform 管理外リソース
+- state に対応の無いログ グループ 3 本: `/github-repository/generated-manifests`、`/github-repository/kubernetes-clusters`、`us-east-1` の `/github-actions/claude-code-action-monorepo`
+- `dystopia.city` zone に削除済み ALB を指す ALIAS レコード 4 件（`dystopia.city.` A/AAAA、`auth.dystopia.city.` A/AAAA）と external-dns 所有権 TXT 2 件（`aaaa-auth.` / `cname-auth.`、`owner=eks-production`）が残存
+
+## 2. Decisions
+
+| 論点 | 決定 | 理由 |
+|---|---|---|
+| 新アカウントの位置づけ | 同 Organization のメンバーとして新規作成 | `OrganizationAccountAccessRole` が自動生成され bootstrap 経路が確保できる。請求も管理アカウントに集約される |
+| Route53 hosted zone | 管理アカウントに残し、クロスアカウント参照にする | NS 切替に伴う DNS 断と Google Workspace の MX / DKIM 再検証を回避する |
+| 管理アカウント側の横断資産の env 名 | `master` を新設 | `production` でも `develop` でもない「管理アカウントに残る横断資産」を表す env が必要 |
+
+クローズ済みアカウントのメールアドレス（`admin@panicboat.net` / `aws@dystopia.city`）は再利用できない前提で、新しいアドレスを用意する。
+
+## 3. Environment Taxonomy
+
+| env | アカウント | region | 対象スタック |
+|---|---|---|---|
+| `master`（新設） | 559744160976（管理） | `ap-northeast-1` | `aws/route53`、`aws/github-oidc-auth` |
+| `develop` | 559744160976（管理） | `us-east-1` | `github/repository`、`github/branch`、`aws/cost-management`、`aws/github-oidc-auth` |
+| `production` | 新アカウント | `ap-northeast-1` | `aws/{vpc,alb,eks,eks-karpenter,eks-secrets,eks-logs,eks-metrics,eks-traces,eks-holmesgpt,iam-service-linked-roles}`、`aws/github-oidc-auth` |
+
+`develop` は管理アカウントに残るが、既存の GitHub / cost-management スタックを `master` へ寄せるのは state 移行を伴う別作業のため本設計の対象外とする（§9 参照）。
+
+`master` env は `aws/github-oidc-auth/envs/master` で専用の plan / apply ロールを持つ。OIDC provider は `develop` が管理する既存のもの（`arn:aws:iam::559744160976:oidc-provider/token.actions.githubusercontent.com`）を再利用するため `create_oidc_provider = false`。
+
+対して `production` env は新アカウントに provider が存在しないため、`aws/github-oidc-auth/envs/production/env.hcl` を `create_oidc_provider = true` に反転する。
+
+## 4. Cross-account Route53 Architecture
+
+### 依存の実体
+
+Route53 hosted zone を参照しているのは 3 箇所のみ（cert-manager は self-signed ClusterIssuer のみで DNS01 を使わない）。
+
+1. `aws/alb/modules/main.tf` — ACM ワイルドカード証明書（`*.panicboat.net` / `*.dystopia.city`）の DNS validation レコードを zone に書き込む
+2. `aws/eks/modules/addons.tf:53-70` — external-dns IRSA ロールに zone ARN スコープの Route53 権限を付与する
+3. external-dns（実行時） — Ingress / Service の hostname から Route53 レコードを作成する
+
+1 と 2 はいずれも `aws/route53/lookup` の `data "aws_route53_zone"`（名前引き）に依存する。data source は実行中の認証情報のアカウント内しか解決できないため、zone を管理アカウントに残す以上、両者に管理アカウントへの assume role 経路が要る。
+
+### 管理アカウント側のロール
+
+`aws/route53`（`master` env）が `route53-zone-access` ロールを 1 本作る。
+
+**権限**
+
+| Action | Resource |
+|---|---|
+| `route53:ChangeResourceRecordSets`, `route53:ListResourceRecordSets`, `route53:GetHostedZone` | `Z07598371GKBU0WMF89MD` / `Z03420722KS9MTSCUSIQZ` の 2 zone ARN |
+| `route53:ListHostedZones`, `route53:ListHostedZonesByName`, `route53:GetChange` | `*`（zone 名引きと変更伝播待ちに必要。zone 単位に絞れない API） |
+
+**信頼するプリンシパル**
+
+`arn:aws:iam::<PROD_ACCOUNT_ID>:root` の 1 つ。実際に誰が assume できるかは production アカウント側の IAM で制御する。
+
+| production 側のプリンシパル | assume 許可の出どころ |
+|---|---|
+| `github-oidc-auth-production-github-actions-plan-role` | `aws/github-oidc-auth` が付与するインラインポリシー（`ReadOnlyAccess` に `sts:AssumeRole` は含まれないため明示付与が必要） |
+| `github-oidc-auth-production-github-actions-apply-role` | `AdministratorAccess` |
+| `eks-production-external-dns` | `aws/eks/modules/addons.tf` の `source_policy_documents` |
+| `OrganizationAccountAccessRole` | `AdministratorAccess` |
+
+**個別ロール ARN ではなく root を信頼する理由:** IAM は trust policy に存在しないロール ARN を書くと `MalformedPolicyDocument` で拒否する。`eks-production-external-dns` は Phase 7 の EKS apply まで存在せず、`github-oidc-auth-production-*` も Phase 4 まで存在しないため、個別 ARN を列挙すると zone access ロールの作成順序が最後尾に固定され、Phase 5 の疎通確認より後ろになってしまう。root 信頼にすれば新アカウント ID が確定した時点で作成でき、順序依存が消える。信頼先アカウントは自分たちが完全に管理下に置いているため、委譲先を production アカウントの IAM に寄せる標準パターンで問題ない。
+
+**read / write を 1 本にまとめた理由（= なぜ reader / writer に分けないか）**
+
+Terraform の provider alias は静的な設定であり、plan と apply で assume 先を切り替える手段が現構成に無い（terragrunt inputs は env 単位で固定、CI executor は外部リポジトリ `panicboat/panicboat-actions/terragrunt-run`）。分離するには plan / apply で異なる `TF_VAR` を注入する仕組みが必要になり、コストに見合わない。
+
+トレードオフとして、plan ロールが Route53 の 2 zone に限って書き込み可能なロールを assume できるようになる。`terragrunt plan` が `ChangeResourceRecordSets` を呼ぶことはないため実害は無いが、plan ロールの read-only 保証がこの範囲で緩む点は認識しておく。
+
+加えて、`ReadOnlyAccess` 管理ポリシーには `sts:AssumeRole` が含まれないため、`aws/github-oidc-auth` の plan ロールに assume 許可のインラインポリシーを追加する必要がある。
+
+### Terraform 側の配線
+
+`aws/route53/lookup` は provider を宣言せず呼び出し側の default provider を継承する作りになっている（`aws/route53/lookup/terraform.tf` にコメント明記）。この性質をそのまま利用し、**呼び出し側で `providers = { aws = aws.route53 }` を渡して default provider を差し替える**。`configuration_aliases` の追加は不要で、`aws/route53/lookup` は無変更のまま。
+
+```
+aws/alb/modules/terraform.tf
+  provider "aws" { alias = "route53"; region = var.aws_region
+                   assume_role { role_arn = var.route53_zone_role_arn } }
+
+aws/alb/modules/lookups.tf
+  module "route53" { providers = { aws = aws.route53 } }
+
+aws/alb/modules/main.tf
+  aws_route53_record.*_validation に provider = aws.route53
+```
+
+**`aws/eks` は provider alias 不要。** `module.route53` の参照は `addons.tf:60-61` の `external_dns_hosted_zone_arns` 1 箇所だけで（`grep -rn "module\.route53" aws/eks/modules/` で確認済）、external-dns を assume role 方式に切り替えると zone ARN が不要になる。`aws/eks/modules/lookups.tf` から `module "route53"` ブロックごと削除する。
+
+`aws/route53`（`master` env）自身は管理アカウントで動くため alias 不要。default provider のまま `../lookup` を呼ぶ。
+
+`var.route53_zone_role_arn` は決定論的な値（`arn:aws:iam::559744160976:role/route53-zone-access`）なので、`aws/alb/envs/production/env.hcl` に定数として置く。
+
+### external-dns 側の配線
+
+external-dns chart 1.21.1（appVersion 0.21.0）の `extraArgs` に `--aws-assume-role` を渡す。
+
+```yaml
+extraArgs:
+  - --aws-assume-role=arn:aws:iam::559744160976:role/route53-zone-access
+```
+
+IRSA ロール側は Route53 権限を持たず `sts:AssumeRole` のみを持つ。`terraform-aws-modules/iam//modules/iam-role-for-service-accounts` v6 は `source_policy_documents` にポリシードキュメントを渡すと `create_policy` が真になりインラインポリシーを生成するため、`attach_external_dns_policy` / `external_dns_hosted_zone_arns` を外して `source_policy_documents` に差し替える。
+
+## 5. Files Changed
+
+### 新規作成
+
+- `aws/github-oidc-auth/envs/master/{env.hcl,terragrunt.hcl}` — `master` env の plan / apply ロール
+- `aws/route53/envs/master/{env.hcl,terragrunt.hcl}` — `production` からの re-home 先
+- `aws/route53/modules/zone_access.tf` — `route53-zone-access` ロールとポリシー
+
+### 変更
+
+| ファイル | 内容 |
+|---|---|
+| `workflow-config.yaml` | `master` env を追加。`production` の `iam_role_plan` / `iam_role_apply` を新アカウント ARN に差し替え |
+| `aws/github-oidc-auth/envs/production/env.hcl:22-23` | `create_oidc_provider = true`、`oidc_provider_arn = ""` |
+| `aws/github-oidc-auth/modules/main.tf` | plan ロールへ `sts:AssumeRole` インラインポリシーを追加（対象 ARN は変数化） |
+| `aws/github-oidc-auth/modules/variables.tf` | `assume_role_arns` 変数を追加 |
+| `aws/route53/modules/variables.tf` | `production_account_id` 変数を追加（zone access ロールの信頼先） |
+| `aws/alb/modules/terraform.tf` | `provider "aws"` の alias `route53` を追加 |
+| `aws/alb/modules/lookups.tf` | `module "route53"` に `providers = { aws = aws.route53 }` を渡す |
+| `aws/alb/modules/main.tf` | validation レコード 2 resource に `provider = aws.route53` |
+| `aws/alb/modules/variables.tf` / `envs/production/env.hcl` / `envs/production/terragrunt.hcl` | `route53_zone_role_arn` |
+| `aws/eks/modules/lookups.tf` | `module "route53"` ブロックを削除 |
+| `aws/eks/modules/addons.tf:53-70` | `attach_external_dns_policy` / `external_dns_hosted_zone_arns` を `source_policy_documents` に差し替え |
+| `kubernetes/components/external-dns/production/values.yaml.gotmpl` | `extraArgs` に `--aws-assume-role` |
+| `kubernetes/components/external-dns/production/helmfile.yaml` | `externalDnsRoleArn` のアカウント ID |
+| `kubernetes/helmfile.yaml.gotmpl:43,45,57,64,69` | ロール ARN 2 + バケット名 3 のアカウント ID |
+| `kubernetes/components/{aws-load-balancer-controller,loki,mimir,tempo}/production/helmfile.yaml` | 同上（helmfile v1.4 は親 → 子の値継承をしないため二重定義） |
+| `scripts/eks-lifecycle/lib/30-destroy-stacks.sh` | `STACKS` に `eks-holmesgpt` を追加 |
+| `README.md` / `README-ja.md` | 環境表に `master` を追加 |
+
+### 別リポジトリ（`panicboat/monorepo`）
+
+- `system-components/holmes/terragrunt` — Secrets Manager 2 件を新アカウントで再作成し、値を手動再投入
+- `services/monolith/terragrunt` — resources=0 のため state を新規作成するのみ
+- `workflow-config.yaml` — `production` env が未定義（手動 apply 運用）。追加するかは実装時に判断
+
+## 6. Migration Sequence
+
+順序の制約は 2 つ。
+
+1. **`workflow-config.yaml` の `production` ロール ARN 差し替えは、新アカウントに state バケットと OIDC ロールが揃った後**。先に main へマージすると CI の production plan / apply が存在しないロールを assume して壊れる
+2. **`route53-zone-access` ロールの作成は、`aws/alb` / `aws/eks` の apply より前**。trust policy に production 側の役割 ARN を書くため、新アカウント ID の確定が前提
+
+| Phase | 内容 | 実行場所 |
+|---|---|---|
+| 0 | 旧アカウントの事前整理（`eks-holmesgpt` destroy、孤児リソース削除、stale DNS レコード削除） | 管理アカウント |
+| 1 | 新アカウント作成、Identity Center 割当、**Service Quota 増枠申請**、Bedrock モデルアクセス有効化 | 管理アカウント → 新アカウント |
+| 2 | `OrganizationAccountAccessRole` assume → `terragrunt backend bootstrap` で S3 + DynamoDB 作成 | ローカル |
+| 3 | `master` env 新設 + `aws/route53` re-home + `route53-zone-access` ロール作成 | 管理アカウント |
+| 4 | `github-oidc-auth/production` をローカル apply → `workflow-config.yaml` 差し替え | ローカル → CI |
+| 5 | クロスアカウント配線のコード変更（provider alias / external-dns） | コードのみ |
+| 6 | `iam-service-linked-roles` apply + Secrets Manager 8 件の再作成と値投入 | 新アカウント |
+| 7 | helmfile のアカウント ID 更新 + `docs/runbooks/eks-production-recreate.md` の Phase 1-10 実行 | 新アカウント |
+| 8 | monorepo リポジトリの production スタック移行 | 新アカウント |
+| 9 | 旧アカウントの production 資産の後片付け | 管理アカウント |
+
+Phase 1 の Service Quota 増枠は承認待ちが最長のクリティカルパスになるため、アカウント作成直後に投げる。
+
+## 7. Risks & Mitigations
+
+### リスク 1: Service Quota 不足で Karpenter が node を出せない
+
+新アカウントの On-Demand / Spot vCPU はデフォルト 5。Phase 7 の EKS 再構築でノードが 1 台も上がらず詰む。
+
+**対策:** Phase 1 で増枠申請を投げ、Phase 7 開始前に `aws service-quotas get-service-quota` で適用値を確認する。承認が下りていなければ Phase 7 を開始しない。
+
+### リスク 2: `workflow-config.yaml` の差し替えタイミングを誤り CI が壊れる
+
+**対策:** Phase 4 で `github-oidc-auth/production` のローカル apply が成功し、新ロールの存在を `aws iam get-role` で確認してから `workflow-config.yaml` を含む PR をマージする。
+
+### リスク 3: クロスアカウント assume が効かず `alb` / `eks` の apply が失敗する
+
+trust policy の ARN 誤記、`sts:AssumeRole` 権限の欠落、provider alias の渡し忘れのいずれでも起きる。
+
+**対策:** Phase 5 完了後、Phase 7 の本番 apply の前に `aws sts assume-role --role-arn arn:aws:iam::559744160976:role/route53-zone-access` を新アカウントの認証情報から実行して疎通を確認する。加えて `aws/alb/envs/production` で `terragrunt plan` を打ち、zone data source が解決できることを確認する。
+
+### リスク 4: クローズ済みアカウントのメールアドレスが再利用できない
+
+`admin@panicboat.net` / `aws@dystopia.city` は closed account が保持している可能性が高い。
+
+**対策:** Phase 1 で新しいアドレスを用意する。`create-account` が `EMAIL_ALREADY_EXISTS` で失敗した場合はアドレスを変えて再試行する。
+
+### リスク 5: `dystopia.city` の stale レコードがクロスアカウント経路の不備を隠す
+
+残存する ALIAS 4 件 + 所有権 TXT 2 件は `policy: sync` + 同一 `txtOwnerId=eks-production` の新クラスタが上がれば自動削除されるはずだが、assume role が効いていなければ削除されない。
+
+**対策:** Phase 0 で手動削除しておき、Phase 7 以降に external-dns が新規レコードを作れることをもって疎通を確認する（削除ではなく作成で検証する）。
+
+### リスク 6: Secrets Manager の値が失われる
+
+8 件の値は Terraform 管理外（手動投入）で、旧アカウントを片付けると復旧できない。
+
+**対策:** Phase 6 の前に旧アカウントから全 8 件の値を取得して安全な場所に退避し、新アカウントへの投入完了を確認してから Phase 9 に進む。
+
+## 8. Validation
+
+### Phase 2 完了時
+
+```bash
+aws s3api head-bucket --bucket terragrunt-state-<PROD_ACCOUNT_ID>
+aws dynamodb describe-table --table-name terragrunt-state-locks --region ap-northeast-1
+```
+
+### Phase 4 完了時
+
+```bash
+aws iam get-role --role-name github-oidc-auth-production-github-actions-apply-role
+aws iam list-open-id-connect-providers
+```
+
+新アカウントで両方が返ること。
+
+### Phase 5 完了時（本番 apply 前）
+
+```bash
+# 新アカウントの認証情報で管理アカウントのロールを assume できるか
+aws sts assume-role \
+  --role-arn arn:aws:iam::559744160976:role/route53-zone-access \
+  --role-session-name migration-check
+
+# zone data source が解決できるか
+( cd aws/alb/envs/production && TG_TF_PATH=tofu terragrunt plan )
+```
+
+### Phase 7 完了時
+
+- `aws eks list-clusters --region ap-northeast-1` で `eks-production` が返る
+- external-dns が新アカウントから管理アカウントの zone にレコードを作成できている（Ingress の hostname が `dig` で解決する）
+- `aws acm list-certificates --region ap-northeast-1` でワイルドカード証明書 2 枚が `ISSUED`
+
+### Phase 9 完了時
+
+- 旧アカウントに `github-oidc-auth-production-*` ロールが残っていない
+- 旧アカウントの `terragrunt-state-559744160976` に `platform/*/production/` の state が残っていない（`master` へ re-home した route53 を除く）
+
+## 9. Out of Scope
+
+- `develop` env（`github/repository`、`github/branch`、`aws/cost-management`）の `master` への統合。管理アカウントに残る点は `master` と同じだが、state key 変更を伴うため別作業とする
+- `panicboat-attached-storage` バケットの移行。Terraform 管理外かつ platform と無関係
+- `nyx.place` zone とドメイン登録。`aws/route53/lookup` の管理対象外
+- Route53 登録ドメイン 3 件のアカウント間移管。zone を管理アカウントに残す決定により不要
+- IAM Identity Center の permission set 細分化。`AdministratorAccess` 1 本のまま新アカウントへ割当を追加するのみ
+- SCP による新アカウントのガードレール設定

--- a/docs/superpowers/specs/2026-08-18-production-account-migration-design.md
+++ b/docs/superpowers/specs/2026-08-18-production-account-migration-design.md
@@ -80,18 +80,20 @@ state は 26 ファイル中 11 ファイルにのみ resources が入ってい�
 
 | env | アドレス |
 |---|---|
-| `production` | `aws+production@dystopia.city` |
-| `develop` | `aws+develop@dystopia.city` |
+| `production` | `aws+production@panicboat.net` |
+| `develop` | `aws+develop@panicboat.net` |
 
-クローズ済みアカウント `504150922582` が `aws@dystopia.city` を保持しているが、プラスアドレスは AWS から別アドレスとして扱われるため衝突しない。`dystopia.city` は Google Workspace（MX = `smtp.google.com`）でプラスアドレスが配送される。
+クローズ済みアカウントが保持しているのは `admin@panicboat.net`（583677814390）と `aws@dystopia.city`（504150922582）で、いずれも上記とは別アドレスのため衝突しない。
+
+**前提条件:** `panicboat.net` は Google Workspace（MX = `smtp.google.com`）で、プラスアドレスはベースとなるメールボックスへ配送される。したがって `aws@panicboat.net` がユーザーまたはエイリアスとして存在している必要がある。存在しないとルートアカウントの検証メールとパスワードリセットが届かず、アカウントを復旧できなくなる。アカウント作成前に実際に受信できることを確認する。
 
 ## 3. Environment Taxonomy
 
 | env | アカウント | workflow-config の region | スタック |
 |---|---|---|---|
 | `master` | 559744160976（管理） | `ap-northeast-1` | `aws/route53`、`aws/cost-management`、`aws/github-oidc-auth`、`github/repository`、`github/branch` |
-| `develop` | 新規（`aws+develop@dystopia.city`） | `us-east-1` | `aws/github-oidc-auth` |
-| `production` | 新規（`aws+production@dystopia.city`） | `ap-northeast-1` | `aws/{vpc,alb,eks,eks-karpenter,eks-secrets,eks-logs,eks-metrics,eks-traces,eks-holmesgpt,iam-service-linked-roles,github-oidc-auth}` |
+| `develop` | 新規（`aws+develop@panicboat.net`） | `us-east-1` | `aws/github-oidc-auth` |
+| `production` | 新規（`aws+production@panicboat.net`） | `ap-northeast-1` | `aws/{vpc,alb,eks,eks-karpenter,eks-secrets,eks-logs,eks-metrics,eks-traces,eks-holmesgpt,iam-service-linked-roles,github-oidc-auth}` |
 
 `workflow-config.yaml` の `aws_region` は CI が OIDC ロールを assume する際のリージョンであり、スタック内のリソースリージョンとは独立している（現状も `develop` = `us-east-1` に対し `github/repository/root.hcl` の inputs は `ap-northeast-1` で既に乖離している）。`aws/cost-management` は module 側で `us-east-1` に固定されているため `master` に移しても挙動は変わらない。
 

--- a/docs/superpowers/specs/2026-08-18-production-account-migration-design.md
+++ b/docs/superpowers/specs/2026-08-18-production-account-migration-design.md
@@ -65,10 +65,9 @@ state は 26 ファイル中 11 ファイルにのみ resources が入ってい�
 - `dystopia.city` zone に削除済み ALB を指す ALIAS レコード 4 件（`dystopia.city.` A/AAAA、`auth.dystopia.city.` A/AAAA）と external-dns 所有権 TXT 2 件（`aaaa-auth.` / `cname-auth.`、`owner=eks-production`）が残存
 - ~~`aws/cost-management/modules/cost_optimization_hub.tf` の `terraform_data` + `local-exec` 回避策~~ → **#801 で解消済み**。provider 6.60.0 で `include_member_accounts` が `optional + computed` になり恒久差分が出なくなっていたため、native リソースに置き換えた（§10 参照）
 - `workflow-config.yaml` の `stack_conventions` で **`aws/{service}` の規約だけがコメントアウトされている**。そのため `aws/` 配下の変更は label-dispatcher がサービスとして検出せず、deploy label が付かず CI の terragrunt が起動しない（§8 末尾参照）
-- `aws/eks-holmesgpt` の IAM ポリシーと HolmesGPT の `modelList` が食い違っている（**本移行の対象外。記録のみ**）
-  - ポリシー（`modules/main.tf:58-65`）は `us.anthropic.claude-opus-4-6` と `anthropic.claude-opus-4-6` を許可しているが、実在する ID は `us.anthropic.claude-opus-4-6-v1` / `anthropic.claude-opus-4-6-v1` で **`-v1` サフィックスが欠けている**。Opus 4.6 を呼ぶと IAM で拒否される
-  - `kubernetes/components/holmesgpt/production/values.yaml.gotmpl` の `modelList` は `sonnet-4-6` / `sonnet-5` / `opus-5` を並べており、**Opus 4.6 は使っていない**。逆に `sonnet-5` / `opus-5` はポリシーに含まれていない
-  - 実際に使えているのは `sonnet-4-6` のみ（ポリシーと ID が一致する唯一の組み合わせ）。`sonnet-5` / `opus-5` は quota 0 で呼べないため、現状は顕在化していない
+- ~~`aws/eks-holmesgpt` の IAM ポリシーと HolmesGPT の `modelList` の食い違い~~ → **#803 で解消**。ポリシーは `us.anthropic.claude-opus-4-6`（実在 ID は `-v1` 付き）を許可する一方、`modelList` が使う `sonnet-5` / `opus-5` を含んでいなかった。model ID のリスト 1 つから両形式の ARN を導出する形に変更
+  - あわせてコメントの誤りも訂正した。`sonnet-5` / `opus-5` が使えない理由は「model access の反映待ち」ではなく **quota が 0**（`aws service-quotas list-service-quotas --service-code bedrock` で TPM 系が全て `0.0`、`sonnet-4-6` のみ 6,000,000）。self-service 増枠は 4 件とも `CASE_CLOSED` で、利用実績の無いアカウントには承認されない
+  - 実際に invoke できるのは `sonnet-4-6` のみという状態は #803 の後も変わらない
 
 ## 2. Decisions
 

--- a/docs/superpowers/specs/2026-08-18-production-account-migration-design.md
+++ b/docs/superpowers/specs/2026-08-18-production-account-migration-design.md
@@ -65,9 +65,8 @@ state は 26 ファイル中 11 ファイルにのみ resources が入ってい�
 - `dystopia.city` zone に削除済み ALB を指す ALIAS レコード 4 件（`dystopia.city.` A/AAAA、`auth.dystopia.city.` A/AAAA）と external-dns 所有権 TXT 2 件（`aaaa-auth.` / `cname-auth.`、`owner=eks-production`）が残存
 - ~~`aws/cost-management/modules/cost_optimization_hub.tf` の `terraform_data` + `local-exec` 回避策~~ → **#801 で解消済み**。provider 6.60.0 で `include_member_accounts` が `optional + computed` になり恒久差分が出なくなっていたため、native リソースに置き換えた（§10 参照）
 - `workflow-config.yaml` の `stack_conventions` で **`aws/{service}` の規約だけがコメントアウトされている**。そのため `aws/` 配下の変更は label-dispatcher がサービスとして検出せず、deploy label が付かず CI の terragrunt が起動しない（§8 末尾参照）
-- ~~`aws/eks-holmesgpt` の IAM ポリシーと HolmesGPT の `modelList` の食い違い~~ → **#803 で解消**。ポリシーは `us.anthropic.claude-opus-4-6`（実在 ID は `-v1` 付き）を許可する一方、`modelList` が使う `sonnet-5` / `opus-5` を含んでいなかった。model ID のリスト 1 つから両形式の ARN を導出する形に変更
-  - あわせてコメントの誤りも訂正した。`sonnet-5` / `opus-5` が使えない理由は「model access の反映待ち」ではなく **quota が 0**（`aws service-quotas list-service-quotas --service-code bedrock` で TPM 系が全て `0.0`、`sonnet-4-6` のみ 6,000,000）。self-service 増枠は 4 件とも `CASE_CLOSED` で、利用実績の無いアカウントには承認されない
-  - 実際に invoke できるのは `sonnet-4-6` のみという状態は #803 の後も変わらない
+- ~~`aws/eks-holmesgpt` の IAM ポリシーと HolmesGPT の `modelList` の食い違い~~ → **#803 で解消**。ポリシーは実在しない ID の `opus-4-6`（正しくは `-v1` 付き）を許可する一方、`modelList` が使う `sonnet-5` / `opus-5` を含んでいなかった。実際に invoke できる `sonnet-4-6` だけに揃え、ARN は model ID のリスト 1 つから導出する形に変更
+  - `sonnet-5` / `opus-5` は TPM quota が全種別 `0.0`、self-service 増枠は 4 件とも `CASE_CLOSED`（利用実績の無いアカウントには承認されない）。`sonnet-4-6` のみ 6,000,000
 
 ## 2. Decisions
 

--- a/docs/superpowers/specs/2026-08-18-production-account-migration-design.md
+++ b/docs/superpowers/specs/2026-08-18-production-account-migration-design.md
@@ -63,7 +63,7 @@ state は 26 ファイル中 11 ファイルにのみ resources が入ってい�
 - IAM instance profile `eks-production_513473553642647435`（Roles 空）が孤児として残存。Karpenter が生成した Terraform 管理外リソース
 - state に対応の無いログ グループ 3 本: `/github-repository/generated-manifests`、`/github-repository/kubernetes-clusters`、`us-east-1` の `/github-actions/claude-code-action-monorepo`
 - `dystopia.city` zone に削除済み ALB を指す ALIAS レコード 4 件（`dystopia.city.` A/AAAA、`auth.dystopia.city.` A/AAAA）と external-dns 所有権 TXT 2 件（`aaaa-auth.` / `cname-auth.`、`owner=eks-production`）が残存
-- `aws/cost-management/modules/cost_optimization_hub.tf` のコメントが「standalone account」「Add this resource back when the account becomes an Organization management account」と書かれているが、`559744160976` は 2026-08-04 に管理アカウントになっている。前提が変わった記述が残っている（本移行の対象外。§10 参照）
+- `aws/cost-management/modules/cost_optimization_hub.tf` が 2 つの回避策（`terraform_data` + `local-exec` による enrollment、`aws_costoptimizationhub_preferences` の非管理）を抱えているが、どちらも根拠が「非管理アカウントだから」であり、`559744160976` は 2026-08-04 に管理アカウントになっている。**本移行の前に別 PR で解消する**（§10 参照）
 
 ## 2. Decisions
 
@@ -396,5 +396,19 @@ trust policy の ARN 誤記、`sts:AssumeRole` 権限の欠落、provider alias 
 - Route53 登録ドメイン 3 件のアカウント間移管。zone を管理アカウントに残す決定により不要
 - IAM Identity Center の permission set 細分化。`AdministratorAccess` 1 本のまま新 2 アカウントへ割当を追加するのみ
 - SCP による新アカウントのガードレール設定
-- `aws/cost-management` の `include_member_accounts` / `aws_costoptimizationhub_preferences` の見直し。`559744160976` が管理アカウントになったことでモジュール内コメントの前提が変わっているが、挙動変更を伴うため本移行とは分ける
+- `aws/cost-management` の回避策解消と org 横断化。詳細は下記
+
+### `aws/cost-management` の切り分け
+
+3 つの作業が混在しているため、依存関係で分ける。本移行が扱うのは 2 のみ。
+
+| # | 作業 | いつ | 依存 |
+|---|---|---|---|
+| 1 | 回避策 A / B の解消（native リソース化） | **本移行の前に別 PR** | 無し。単独で検証できる |
+| 2 | env を `develop` → `master` へ移す | 本移行（Task 3.4） | 1 が先行していれば差分が env 移動だけになる |
+| 3 | org 横断化（`include_member_accounts = true`） | 本移行の完了後 | member アカウントの存在。加えて Organizations の信頼されたサービスアクセス有効化と最大 24 時間の反映待ち |
+
+**1 と 3 は独立している。** `UpdateEnrollmentStatus` API は `includeMemberAccounts` を引数に取るため、現行の `local-exec` に `--include-member-accounts` を足すだけでも 3 は達成できてしまう。それでは回避策の代償（state に載らない・ドリフトを検知しない・destroy で解除されない・AWS CLI への暗黙依存）が残るため、1 を先に片付ける。
+
+3 の前提として、現在 Organizations で有効な信頼されたサービスアクセスは `sso.amazonaws.com` のみ（`aws organizations list-aws-service-access-for-organization` で確認）。`aws cost-optimization-hub list-enrollment-statuses --include-organization-info` は `AccessDeniedException: Service access must be enabled to access member account data` を返す。`compute-optimizer.amazonaws.com` と `cost-optimization-hub.amazonaws.com` の有効化が要る。
 - develop アカウントへのワークロード構築。器を用意するところまで

--- a/docs/superpowers/specs/2026-08-18-production-account-migration-design.md
+++ b/docs/superpowers/specs/2026-08-18-production-account-migration-design.md
@@ -63,7 +63,8 @@ state は 26 ファイル中 11 ファイルにのみ resources が入ってい�
 - IAM instance profile `eks-production_513473553642647435`（Roles 空）が孤児として残存。Karpenter が生成した Terraform 管理外リソース
 - state に対応の無いログ グループ 3 本: `/github-repository/generated-manifests`、`/github-repository/kubernetes-clusters`、`us-east-1` の `/github-actions/claude-code-action-monorepo`
 - `dystopia.city` zone に削除済み ALB を指す ALIAS レコード 4 件（`dystopia.city.` A/AAAA、`auth.dystopia.city.` A/AAAA）と external-dns 所有権 TXT 2 件（`aaaa-auth.` / `cname-auth.`、`owner=eks-production`）が残存
-- `aws/cost-management/modules/cost_optimization_hub.tf` が 2 つの回避策（`terraform_data` + `local-exec` による enrollment、`aws_costoptimizationhub_preferences` の非管理）を抱えているが、どちらも根拠が「非管理アカウントだから」であり、`559744160976` は 2026-08-04 に管理アカウントになっている。**本移行の前に別 PR で解消する**（§10 参照）
+- ~~`aws/cost-management/modules/cost_optimization_hub.tf` の `terraform_data` + `local-exec` 回避策~~ → **#801 で解消済み**。provider 6.60.0 で `include_member_accounts` が `optional + computed` になり恒久差分が出なくなっていたため、native リソースに置き換えた（§10 参照）
+- `workflow-config.yaml` の `stack_conventions` で **`aws/{service}` の規約だけがコメントアウトされている**。そのため `aws/` 配下の変更は label-dispatcher がサービスとして検出せず、deploy label が付かず CI の terragrunt が起動しない（§8 末尾参照）
 
 ## 2. Decisions
 
@@ -347,6 +348,27 @@ Terraform 管理外だが、クラスタ再構築で自動的に作り直され�
 
 Phase 1 の Service Quota 増枠は承認待ちが最長のクリティカルパスになるため、アカウント作成直後に投げる。
 
+### `aws/` スタックは CI の自動 apply 対象ではない
+
+`workflow-config.yaml` の `stack_conventions` は `github/{service}` と `kubernetes/components/{service}` のみ有効で、`aws/{service}` はコメントアウトされている。そのため `aws/` 配下だけを変更した PR は label-dispatcher がサービスを検出せず、deploy label が付かない。
+
+#801（`aws/cost-management/modules/cost_optimization_hub.tf` の 1 ファイル変更）で実測した dispatcher の出力:
+
+```
+CHANGED_FILES:     ["aws/cost-management/modules/cost_optimization_hub.tf"]
+SERVICES_DETECTED: []
+DEPLOY_LABELS:     []
+```
+
+結果として main へマージしても terragrunt は起動せず、手元から apply する必要があった。過去の `aws/` 変更にラベルが付いていたのは、同じ PR が `kubernetes/components/{service}` も触っていたためで（#798 の `deploy:karpenter`、#795 の `deploy:holmesgpt`）、`aws/` 側は寄与していない。
+
+本移行への影響は 2 つ。
+
+1. Phase 3-7 の terragrunt 実行はいずれもローカル apply で書いてあるため、手順自体は成立する
+2. `master` env に置く 3 スタック（`aws/route53`、`aws/cost-management`、`aws/github-oidc-auth`）は移行後も自動デプロイされない。`github/{service}` の 2 スタックのみ CI に載る
+
+`stack_conventions` の有効化は全 `aws/` PR を自動デプロイ対象に変える影響範囲の大きい変更のため、本移行とは分ける（§10 参照）。
+
 ## 9. Risks & Mitigations
 
 ### リスク 1: Service Quota 不足で Karpenter が node を出せない
@@ -363,7 +385,9 @@ Phase 1 の Service Quota 増枠は承認待ちが最長のクリティカルパ
 
 ### リスク 3: `workflow-config.yaml` の差し替えタイミングを誤り CI が壊れる
 
-**対策:** Phase 4 で各アカウントのロール存在を `aws iam get-role` で確認してから `workflow-config.yaml` を含む PR をマージする。
+`aws/{service}` が `stack_conventions` で無効なため、`aws/` 配下の変更だけでは deploy label が付かず CI の terragrunt は起動しない（§8 末尾）。したがって差し替え直後に自動で壊れることは無く、誰かが手動でラベルを付けたときに顕在化する遅発性のリスクになる。
+
+**対策:** Phase 4 で各アカウントのロール存在を `aws iam get-role` で確認してから `workflow-config.yaml` を含む PR をマージする。`github/{service}` の 2 スタックは `master` env で自動デプロイ対象になるため、こちらは差し替え後の初回 CI で即座に検証できる。
 
 ### リスク 4: クロスアカウント assume が効かず `alb` / `eks` の apply が失敗する
 
@@ -396,19 +420,24 @@ trust policy の ARN 誤記、`sts:AssumeRole` 権限の欠落、provider alias 
 - Route53 登録ドメイン 3 件のアカウント間移管。zone を管理アカウントに残す決定により不要
 - IAM Identity Center の permission set 細分化。`AdministratorAccess` 1 本のまま新 2 アカウントへ割当を追加するのみ
 - SCP による新アカウントのガードレール設定
-- `aws/cost-management` の回避策解消と org 横断化。詳細は下記
+- `workflow-config.yaml` の `stack_conventions` で `aws/{service}` を有効化すること。全 `aws/` PR が自動デプロイ対象に変わる影響範囲の大きい変更で、移行作業中の PR と race するリスクがある。移行完了後に単独で判断する
+- `aws/cost-management` の org 横断化。詳細は下記
 
 ### `aws/cost-management` の切り分け
 
 3 つの作業が混在しているため、依存関係で分ける。本移行が扱うのは 2 のみ。
 
-| # | 作業 | いつ | 依存 |
+| # | 作業 | いつ | 状態 |
 |---|---|---|---|
-| 1 | 回避策 A / B の解消（native リソース化） | **本移行の前に別 PR** | 無し。単独で検証できる |
-| 2 | env を `develop` → `master` へ移す | 本移行（Task 3.4） | 1 が先行していれば差分が env 移動だけになる |
-| 3 | org 横断化（`include_member_accounts = true`） | 本移行の完了後 | member アカウントの存在。加えて Organizations の信頼されたサービスアクセス有効化と最大 24 時間の反映待ち |
+| 1 | 回避策 A の解消（native リソース化） | 本移行の前に別 PR | **完了（#801、2026-08-19 apply 済）** |
+| 2 | env を `develop` → `master` へ移す | 本移行（Task 3.4） | 本移行で実施 |
+| 3 | org 横断化（`include_member_accounts = true`） | 本移行の完了後 | 未着手 |
 
-**1 と 3 は独立している。** `UpdateEnrollmentStatus` API は `includeMemberAccounts` を引数に取るため、現行の `local-exec` に `--include-member-accounts` を足すだけでも 3 は達成できてしまう。それでは回避策の代償（state に載らない・ドリフトを検知しない・destroy で解除されない・AWS CLI への暗黙依存）が残るため、1 を先に片付ける。
+1 は provider 6.60.0 で `include_member_accounts` が `optional + computed`、`status` が computed 専用になっており、#39520 の恒久差分が解消していたため native リソースへ置き換えた。apply 後の plan が `No changes.` になることを実 state で確認済。
+
+回避策 B（`aws_costoptimizationhub_preferences` の非管理）は**維持**した。`member_account_discount_visibility` は `optional + computed` だが AWS API の `GetPreferences` がこの属性を返さないため、リソースを追加すると provider が毎回 `"All"` を書き込もうとする。AWS 既定値も `"All"` のため管理する動機が無い。
+
+**1 と 3 は独立していた。** `UpdateEnrollmentStatus` API は `includeMemberAccounts` を引数に取るため、回避策のまま `local-exec` に `--include-member-accounts` を足すだけでも 3 は達成できた。それでは回避策の代償（state に載らない・ドリフトを検知しない・destroy で解除されない・AWS CLI への暗黙依存）が残るため 1 を先に片付けた。
 
 3 の前提として、現在 Organizations で有効な信頼されたサービスアクセスは `sso.amazonaws.com` のみ（`aws organizations list-aws-service-access-for-organization` で確認）。`aws cost-optimization-hub list-enrollment-statuses --include-organization-info` は `AccessDeniedException: Service access must be enabled to access member account data` を返す。`compute-optimizer.amazonaws.com` と `cost-optimization-hub.amazonaws.com` の有効化が要る。
 - develop アカウントへのワークロード構築。器を用意するところまで

--- a/docs/superpowers/specs/2026-08-18-production-account-migration-design.md
+++ b/docs/superpowers/specs/2026-08-18-production-account-migration-design.md
@@ -1,6 +1,6 @@
-# Production AWS Account Migration Design
+# Multi-account Migration Design
 
-`production` 環境を、現在の AWS アカウント `559744160976`（= AWS Organizations の管理アカウント）から専用のメンバーアカウントへ分離する。
+`production` と `develop` をそれぞれ専用の AWS アカウントへ分離し、現在の `559744160976`（= AWS Organizations 管理アカウント）は横断資産だけを持つ `master` 環境として残す。
 
 ## 1. Background
 
@@ -23,25 +23,23 @@ Support プランは Basic（Premium Support 未契約）。
 
 `ap-northeast-1` に EKS クラスタ・VPC・EC2・NAT Gateway・EIP・ELBv2・Security Group・Launch Template はいずれも存在しない（デフォルト VPC も無い）。ACM は `ap-northeast-1` / `us-east-1` ともに 0 件、ECR・KMS CMK・SNS・SQS も 0 件。EKS スタック群は teardown 済で、移行対象は基盤リソースと state に限られる。
 
-state は 26 ファイル中 11 ファイルにのみ resources が入っている。`production` 系で実体があるのは以下の 4 つ。
+state は 26 ファイル中 11 ファイルにのみ resources が入っている。実体があるのは以下。
 
-| state key | resources | 内容 |
-|---|---|---|
-| `platform/route53/production` | 8 | MX / TXT / DKIM レコード 6 + zone data 2 |
-| `platform/eks-holmesgpt/production` | 7 | IAM role + inline policy + Pod Identity Association |
-| `platform/github-oidc-auth/production` | 9 | plan / apply role + policy + log group |
-| `platform/iam-service-linked-roles/production` | 1 | `AWSServiceRoleForEC2Spot` |
+| state key | resources | 内容 | 移行後の所属 |
+|---|---|---|---|
+| `platform/route53/production` | 8 | MX / TXT / DKIM レコード 6 + zone data 2 | `master` |
+| `platform/repository/develop` | 3 | GitHub repo 6 + log group 6 + workflow permissions 2 | `master` |
+| `platform/branch/develop` | 2 | ruleset 3 + repo data 3 | `master` |
+| `platform/cost-management/develop` | 2 | Compute Optimizer + Cost Optimization Hub 登録 | `master` |
+| `platform/github-oidc-auth/develop` | 10 | OIDC provider + plan / apply role + policy + log group | provider のみ `master`、残りは廃棄 |
+| `platform/github-oidc-auth/production` | 9 | plan / apply role + policy + log group | 廃棄（新アカウントで再作成） |
+| `platform/eks-holmesgpt/production` | 7 | IAM role + inline policy + Pod Identity Association | 廃棄（ドリフト済、§1 末尾参照） |
+| `platform/iam-service-linked-roles/production` | 1 | `AWSServiceRoleForEC2Spot` | 廃棄（新アカウントで再作成） |
+| `platform/github-repository/monorepo` | 4 | **レガシー孤児**（§1 末尾参照） | 削除 |
+| `platform/github-repository/platform` | 4 | **レガシー孤児**（同上） | 削除 |
+| `system-components/holmes/production` | 2 | Secrets Manager 2 件（monorepo 管理） | 新 production アカウント |
 
-`eks` / `vpc` / `alb` / `eks-logs` / `eks-metrics` / `eks-traces` / `eks-secrets` / `karpenter` は resources=0 の空 state。
-
-残存する実リソースは以下。
-
-- S3: `terragrunt-state-559744160976`（`ap-northeast-1`、versioning 有効、SSE-KMS `alias/aws/s3`、public access block 全 true、Terragrunt 自動生成の `EnforcedTLS` + `RootAccess` バケットポリシー）、`panicboat-attached-storage`（Terraform 管理外・platform 無関係）
-- DynamoDB: `terragrunt-state-locks`（`ap-northeast-1`、HASH=`LockID`、PAY_PER_REQUEST）
-- IAM: OIDC provider 1、ロール 5（`github-oidc-auth-{develop,production}-github-actions-{plan,apply}-role` + `eks-production-holmesgpt`）、カスタマー管理ポリシー 2、IAM ユーザー `panicboat`（AdministratorAccess）
-- Secrets Manager（`ap-northeast-1`）8 件: `panicboat/{oauth2-proxy/google, grafana/admin, github-app/panicboat, keycloak/admin, holmes/slack, holmes/alertmanager, holmes/github, alertmanager/slack-notify}`
-- Route53: hosted zone 3 本（`panicboat.net` = `Z07598371GKBU0WMF89MD`、`dystopia.city` = `Z03420722KS9MTSCUSIQZ`、`nyx.place` = `Z05920991VJAPXQE581DN`）+ Route53 Registrar 登録ドメイン 3 件
-- CloudWatch Logs: `ap-northeast-1` 10 本、`us-east-1` 1 本
+`eks` / `vpc` / `alb` / `eks-logs` / `eks-metrics` / `eks-traces` / `eks-secrets` / `karpenter` / `ai-assistant` / `claude-code` / `claude-code-action` / `github-oidc-auth/staging` / `services/monolith/production` は resources=0 の空 state。
 
 ### Service Quota の乖離
 
@@ -58,34 +56,58 @@ state は 26 ファイル中 11 ファイルにのみ resources が入ってい�
 
 ### 既存の不整合
 
-- `scripts/eks-lifecycle/lib/30-destroy-stacks.sh` の `STACKS` 配列（8 スタック）に `eks-holmesgpt` が含まれていない。#795 でスタック分離した際に追加漏れとなり、`eks-production-holmesgpt` ロールが teardown 後も残存している。`platform/eks-holmesgpt/production` state は存在しないクラスタを `data.aws_eks_cluster.this` で参照しており、現状 plan が data source 解決で失敗する
+移行のついでに解消するもの。
+
+- `scripts/eks-lifecycle/lib/30-destroy-stacks.sh` の `STACKS` 配列（8 スタック）に `eks-holmesgpt` が含まれていない。#795 でスタック分離した際の追加漏れで、`eks-production-holmesgpt` ロールが teardown 後も残存している。`platform/eks-holmesgpt/production` state は存在しないクラスタを `data.aws_eks_cluster.this` で参照しており、現状 plan が data source 解決で失敗する
+- `platform/github-repository/{monorepo,platform}` state は対応する env ディレクトリを持たないレガシー孤児。`github_repository` を `platform/repository/develop` と二重管理しており、さらに `github_branch_protection` は GitHub 上に既に存在しない（`gh api repos/panicboat/{monorepo,platform,deploy-actions}/branches/main/protection` が全て 404、現在の保護は `platform/branch/develop` が管理する ruleset 3 本）
 - IAM instance profile `eks-production_513473553642647435`（Roles 空）が孤児として残存。Karpenter が生成した Terraform 管理外リソース
 - state に対応の無いログ グループ 3 本: `/github-repository/generated-manifests`、`/github-repository/kubernetes-clusters`、`us-east-1` の `/github-actions/claude-code-action-monorepo`
 - `dystopia.city` zone に削除済み ALB を指す ALIAS レコード 4 件（`dystopia.city.` A/AAAA、`auth.dystopia.city.` A/AAAA）と external-dns 所有権 TXT 2 件（`aaaa-auth.` / `cname-auth.`、`owner=eks-production`）が残存
+- `aws/cost-management/modules/cost_optimization_hub.tf` のコメントが「standalone account」「Add this resource back when the account becomes an Organization management account」と書かれているが、`559744160976` は 2026-08-04 に管理アカウントになっている。前提が変わった記述が残っている（本移行の対象外。§10 参照）
 
 ## 2. Decisions
 
 | 論点 | 決定 | 理由 |
 |---|---|---|
+| アカウント分割 | `production` / `develop` をそれぞれ専用メンバーアカウントに分離し、`559744160976` は横断資産のみ保持 | 環境境界をアカウント境界に一致させる |
 | 新アカウントの位置づけ | 同 Organization のメンバーとして新規作成 | `OrganizationAccountAccessRole` が自動生成され bootstrap 経路が確保できる。請求も管理アカウントに集約される |
 | Route53 hosted zone | 管理アカウントに残し、クロスアカウント参照にする | NS 切替に伴う DNS 断と Google Workspace の MX / DKIM 再検証を回避する |
-| 管理アカウント側の横断資産の env 名 | `master` を新設 | `production` でも `develop` でもない「管理アカウントに残る横断資産」を表す env が必要 |
+| 管理アカウントに残る資産の env 名 | `master` を新設 | `production` でも `develop` でもない「横断資産」を表す env が必要 |
+| `github/*` スタックの所属 | `master` | GitHub リポジトリ・ruleset は環境を持たない組織横断資産。付随する CloudWatch ログ グループも管理アカウントに残る |
+| `aws/cost-management` の所属 | `master` | Compute Optimizer / Cost Optimization Hub の登録は支払アカウント単位。管理アカウントから離せない |
 
-クローズ済みアカウントのメールアドレス（`admin@panicboat.net` / `aws@dystopia.city`）は再利用できない前提で、新しいアドレスを用意する。
+### 新アカウントのルートメールアドレス
+
+| env | アドレス |
+|---|---|
+| `production` | `aws+production@dystopia.city` |
+| `develop` | `aws+develop@dystopia.city` |
+
+クローズ済みアカウント `504150922582` が `aws@dystopia.city` を保持しているが、プラスアドレスは AWS から別アドレスとして扱われるため衝突しない。`dystopia.city` は Google Workspace（MX = `smtp.google.com`）でプラスアドレスが配送される。
 
 ## 3. Environment Taxonomy
 
-| env | アカウント | region | 対象スタック |
+| env | アカウント | workflow-config の region | スタック |
 |---|---|---|---|
-| `master`（新設） | 559744160976（管理） | `ap-northeast-1` | `aws/route53`、`aws/github-oidc-auth` |
-| `develop` | 559744160976（管理） | `us-east-1` | `github/repository`、`github/branch`、`aws/cost-management`、`aws/github-oidc-auth` |
-| `production` | 新アカウント | `ap-northeast-1` | `aws/{vpc,alb,eks,eks-karpenter,eks-secrets,eks-logs,eks-metrics,eks-traces,eks-holmesgpt,iam-service-linked-roles}`、`aws/github-oidc-auth` |
+| `master` | 559744160976（管理） | `ap-northeast-1` | `aws/route53`、`aws/cost-management`、`aws/github-oidc-auth`、`github/repository`、`github/branch` |
+| `develop` | 新規（`aws+develop@dystopia.city`） | `us-east-1` | `aws/github-oidc-auth` |
+| `production` | 新規（`aws+production@dystopia.city`） | `ap-northeast-1` | `aws/{vpc,alb,eks,eks-karpenter,eks-secrets,eks-logs,eks-metrics,eks-traces,eks-holmesgpt,iam-service-linked-roles,github-oidc-auth}` |
 
-`develop` は管理アカウントに残るが、既存の GitHub / cost-management スタックを `master` へ寄せるのは state 移行を伴う別作業のため本設計の対象外とする（§9 参照）。
+`workflow-config.yaml` の `aws_region` は CI が OIDC ロールを assume する際のリージョンであり、スタック内のリソースリージョンとは独立している（現状も `develop` = `us-east-1` に対し `github/repository/root.hcl` の inputs は `ap-northeast-1` で既に乖離している）。`aws/cost-management` は module 側で `us-east-1` に固定されているため `master` に移しても挙動は変わらない。
 
-`master` env は `aws/github-oidc-auth/envs/master` で専用の plan / apply ロールを持つ。OIDC provider は `develop` が管理する既存のもの（`arn:aws:iam::559744160976:oidc-provider/token.actions.githubusercontent.com`）を再利用するため `create_oidc_provider = false`。
+移行後の `develop` アカウントは `aws/github-oidc-auth` だけを持つほぼ空のアカウントになる。将来の develop ワークロード（EKS 等）を受け入れる器として先に用意する位置づけ。
 
-対して `production` env は新アカウントに provider が存在しないため、`aws/github-oidc-auth/envs/production/env.hcl` を `create_oidc_provider = true` に反転する。
+### OIDC provider の所有
+
+`aws_iam_openid_connect_provider` は 1 アカウントに 1 つしか作れない。現在は `develop` env が `559744160976` に作ったものを `production` env が ARN 参照で共有している。分離後は 3 アカウントそれぞれが自前で持つ。
+
+| env | `create_oidc_provider` | 備考 |
+|---|---|---|
+| `master` | `true` | **既存 provider を import する**（新規作成ではない） |
+| `develop` | `true` | 新アカウントに新規作成 |
+| `production` | `true` | 新アカウントに新規作成 |
+
+`master` が import で引き取る理由: provider は現在 `platform/github-oidc-auth/develop` state が管理しているが、`develop` env はアカウントごと移動する。管理アカウントの provider を誰も管理しない状態を避けるため、`develop` state から `state rm` した上で `master` state へ import する。削除して作り直すと、その間 `master` の plan / apply ロールの trust が壊れる。
 
 ## 4. Cross-account Route53 Architecture
 
@@ -121,15 +143,9 @@ Route53 hosted zone を参照しているのは 3 箇所のみ（cert-manager �
 | `eks-production-external-dns` | `aws/eks/modules/addons.tf` の `source_policy_documents` |
 | `OrganizationAccountAccessRole` | `AdministratorAccess` |
 
-**個別ロール ARN ではなく root を信頼する理由:** IAM は trust policy に存在しないロール ARN を書くと `MalformedPolicyDocument` で拒否する。`eks-production-external-dns` は Phase 7 の EKS apply まで存在せず、`github-oidc-auth-production-*` も Phase 4 まで存在しないため、個別 ARN を列挙すると zone access ロールの作成順序が最後尾に固定され、Phase 5 の疎通確認より後ろになってしまう。root 信頼にすれば新アカウント ID が確定した時点で作成でき、順序依存が消える。信頼先アカウントは自分たちが完全に管理下に置いているため、委譲先を production アカウントの IAM に寄せる標準パターンで問題ない。
+**個別ロール ARN ではなく root を信頼する理由:** IAM は trust policy に存在しないロール ARN を書くと `MalformedPolicyDocument` で拒否する。`eks-production-external-dns` は EKS apply まで存在せず、`github-oidc-auth-production-*` も production アカウントの bootstrap まで存在しないため、個別 ARN を列挙すると zone access ロールの作成順序が最後尾に固定され、疎通確認より後ろになってしまう。root 信頼にすれば新アカウント ID が確定した時点で作成でき、順序依存が消える。信頼先アカウントは自分たちが完全に管理下に置いているため、委譲先を production アカウントの IAM に寄せる標準パターンで問題ない。
 
-**read / write を 1 本にまとめた理由（= なぜ reader / writer に分けないか）**
-
-Terraform の provider alias は静的な設定であり、plan と apply で assume 先を切り替える手段が現構成に無い（terragrunt inputs は env 単位で固定、CI executor は外部リポジトリ `panicboat/panicboat-actions/terragrunt-run`）。分離するには plan / apply で異なる `TF_VAR` を注入する仕組みが必要になり、コストに見合わない。
-
-トレードオフとして、plan ロールが Route53 の 2 zone に限って書き込み可能なロールを assume できるようになる。`terragrunt plan` が `ChangeResourceRecordSets` を呼ぶことはないため実害は無いが、plan ロールの read-only 保証がこの範囲で緩む点は認識しておく。
-
-加えて、`ReadOnlyAccess` 管理ポリシーには `sts:AssumeRole` が含まれないため、`aws/github-oidc-auth` の plan ロールに assume 許可のインラインポリシーを追加する必要がある。
+**read / write を 1 本にまとめた理由:** Terraform の provider alias は静的な設定であり、plan と apply で assume 先を切り替える手段が現構成に無い（terragrunt inputs は env 単位で固定、CI executor は外部リポジトリ `panicboat/panicboat-actions/terragrunt-run`）。分離するには plan / apply で異なる `TF_VAR` を注入する仕組みが必要になり、コストに見合わない。トレードオフとして plan ロールが Route53 の 2 zone に限って書き込み可能なロールを assume できるようになるが、`terragrunt plan` が `ChangeResourceRecordSets` を呼ぶことはない。
 
 ### Terraform 側の配線
 
@@ -151,8 +167,6 @@ aws/alb/modules/main.tf
 
 `aws/route53`（`master` env）自身は管理アカウントで動くため alias 不要。default provider のまま `../lookup` を呼ぶ。
 
-`var.route53_zone_role_arn` は決定論的な値（`arn:aws:iam::559744160976:role/route53-zone-access`）なので、`aws/alb/envs/production/env.hcl` に定数として置く。
-
 ### external-dns 側の配線
 
 external-dns chart 1.21.1（appVersion 0.21.0）の `extraArgs` に `--aws-assume-role` を渡す。
@@ -164,65 +178,174 @@ extraArgs:
 
 IRSA ロール側は Route53 権限を持たず `sts:AssumeRole` のみを持つ。`terraform-aws-modules/iam//modules/iam-role-for-service-accounts` v6 は `source_policy_documents` にポリシードキュメントを渡すと `create_policy` が真になりインラインポリシーを生成するため、`attach_external_dns_policy` / `external_dns_hosted_zone_arns` を外して `source_policy_documents` に差し替える。
 
-## 5. Files Changed
+## 5. Non-IaC Resources
+
+Terraform / Terragrunt の state に入らないため、アカウント分割で自動的には追随しないリソース。移行時は個別に対応する。
+
+### 5-1. AWS — アカウント基盤
+
+| リソース | 現在の所在 | 対応 |
+|---|---|---|
+| Organization / OU 構成 | 559744160976 | メンバーアカウント 2 つを追加。OU は未使用（root 直下）のまま |
+| IAM Identity Center インスタンス | 559744160976（`ap-northeast-1`） | 管理アカウントに残す。`AdministratorAccess` permission set を新 2 アカウントへ割当追加 |
+| IAM ユーザー `panicboat` | 559744160976 | 管理アカウントに残す。新アカウントへは Identity Center か `OrganizationAccountAccessRole` でアクセスする（新アカウントに IAM ユーザーは作らない） |
+| `OrganizationAccountAccessRole` | 新アカウントに自動生成 | 作成されることを確認するのみ。Terraform 管理下に置かない |
+| 支払い手段（payment instrument） | 559744160976 | 管理アカウントに残る。メンバーアカウントは連結請求で自動的に追随 |
+| Service Quota 適用値 | 559744160976（On-Demand 64 / Spot 256） | 新 production アカウントで**増枠申請が必要**。デフォルトは 5 |
+| Bedrock モデルアクセス | 559744160976（`us-east-1`） | 新 production アカウントでコンソールから有効化が必要 |
+| Support プラン | Basic | 変更しない |
+
+### 5-2. AWS — Terragrunt backend
+
+Terragrunt が bootstrap するため、どの state にも入らない。
+
+| リソース | 対応 |
+|---|---|
+| S3 `terragrunt-state-559744160976` | 管理アカウントに残す（`master` スタックの state 置き場） |
+| S3 `terragrunt-state-<PROD_ACCOUNT_ID>` | `terragrunt backend bootstrap` で新規作成 |
+| S3 `terragrunt-state-<DEV_ACCOUNT_ID>` | 同上 |
+| DynamoDB `terragrunt-state-locks` | 3 アカウントそれぞれに必要（バケットと同時に bootstrap される） |
+
+### 5-3. AWS — シークレットの値
+
+容器（`aws_secretsmanager_secret`）は Terraform 管理だが、**値は手動投入**（`aws/eks-secrets` および monorepo の holmes スタックのコメントに明記）。
+
+| Secret | 管理スタック | 対応 |
+|---|---|---|
+| `panicboat/oauth2-proxy/google` | なし（手動） | 新 production アカウントで再作成 + 値投入 |
+| `panicboat/grafana/admin` | なし（手動） | 同上 |
+| `panicboat/github-app/panicboat` | なし（手動） | 同上 |
+| `panicboat/keycloak/admin` | なし（手動） | 同上 |
+| `panicboat/holmes/github` | なし（手動） | 同上 |
+| `panicboat/alertmanager/slack-notify` | なし（手動） | 同上 |
+| `panicboat/holmes/slack` | monorepo `system-components/holmes` | スタック apply 後に値投入 |
+| `panicboat/holmes/alertmanager` | monorepo `system-components/holmes` | 同上 |
+
+**旧アカウントを片付ける前に全 8 件の値を退避する。** 退避せずに削除すると復旧できない。
+
+### 5-4. AWS — コントローラが実行時に生成するリソース
+
+Terraform 管理外だが、クラスタ再構築で自動的に作り直される。旧アカウント側では孤児として残るため掃除が要る。
+
+| 生成元 | リソース | 対応 |
+|---|---|---|
+| Karpenter | EC2 インスタンス、launch template、IAM instance profile | 旧アカウントの孤児 instance profile `eks-production_513473553642647435` を削除 |
+| AWS Load Balancer Controller | ALB / NLB、自動生成 Security Group | 旧アカウントには残存なし（destroy 時に `30-destroy-stacks.sh` が掃除済） |
+| external-dns | Route53 レコード | 管理アカウントの zone に残存。`dystopia.city` の 6 件を削除 |
+| EBS CSI Driver | EBS ボリューム | 旧アカウントには残存なし |
+
+### 5-5. GitHub
+
+| リソース | 現在の状態 | 対応 |
+|---|---|---|
+| GitHub App（App ID `1371999`） | `panicboat` org にインストール | **変更不要。** AWS アカウントに依存しない |
+| リポジトリ variable `APP_ID` | `platform` / `monorepo` の両方に設定 | 変更不要 |
+| リポジトリ secret `APP_PRIVATE_KEY` | `platform` / `monorepo` の両方に設定 | 変更不要 |
+| リポジトリ secret `SLACK_BOT_TOKEN` | `monorepo` のみ | 変更不要 |
+| Organization レベルの secret / variable | `gh api orgs/panicboat/actions/{secrets,variables}` が 404（トークンのスコープ不足の可能性あり、**未確認**） | 実装時に org 管理権限のあるトークンで再確認する |
+| GitHub Environments | `platform` / `monorepo` ともに **0 件** | `aws/github-oidc-auth` の trust policy が `repo:panicboat/*:environment:{master,develop,production}` を許可条件に含むが、Environment が存在しないためこの条件は現状使われていない。environment gate を使う場合は GitHub 側での作成が別途必要 |
+| `GITHUB_TOKEN` 環境変数 | `github/{repository,branch}/envs/*/terragrunt.hcl` が `get_env("GITHUB_TOKEN")` で読む | `master` env に移しても供給経路は変わらない。CI 側で `panicboat/panicboat-actions/terragrunt-run` が `token` input を `GITHUB_TOKEN` として export しているかは**未確認**。`master` env の初回 CI 実行で検証する |
+| ruleset 3 本（`{monorepo,platform,deploy-actions}-main`） | `platform/branch/develop` state が管理、GitHub 上で `active` | state を `master` へ移すのみ。GitHub 側の実体は変わらない |
+| 旧 branch protection | GitHub 上に**存在しない**（3 リポジトリとも 404） | `platform/github-repository/{monorepo,platform}` state を削除するだけでよい |
+
+### 5-6. 外部 SaaS
+
+| サービス | 用途 | 対応 |
+|---|---|---|
+| Google Workspace | `panicboat.net` / `dystopia.city` のメール（MX / DKIM / site verification） | **変更不要。** zone を管理アカウントに残す決定により DNS レコードが動かない |
+| Google OAuth client | monitoring UIs 4 host の oauth2-proxy 認証（GCP プロジェクト `526108552713`） | redirect URI はホスト名ベースで AWS アカウントに依存しない。**変更不要** |
+| Slack App | holmes / Alertmanager 通知 | 変更不要。トークンは Secrets Manager 経由（§5-3） |
+| Route53 Registrar 登録ドメイン 3 件 | `panicboat.net`（TransferLock ON）、`dystopia.city`（TransferLock ON）、`nyx.place` | **管理アカウントに残す。** zone を移さない決定によりアカウント間移管は不要 |
+
+## 6. Files Changed
 
 ### 新規作成
 
-- `aws/github-oidc-auth/envs/master/{env.hcl,terragrunt.hcl}` — `master` env の plan / apply ロール
-- `aws/route53/envs/master/{env.hcl,terragrunt.hcl}` — `production` からの re-home 先
-- `aws/route53/modules/zone_access.tf` — `route53-zone-access` ロールとポリシー
+- `aws/github-oidc-auth/envs/master/{env.hcl,terragrunt.hcl}`
+- `aws/route53/envs/master/{env.hcl,terragrunt.hcl}`
+- `aws/route53/modules/zone_access.tf`
+- `aws/cost-management/envs/master/{env.hcl,terragrunt.hcl}`
+- `github/repository/envs/master/*`（`develop` からの `git mv`）
+- `github/branch/envs/master/*`（同上）
+
+### 削除
+
+- `aws/route53/envs/production/`
+- `aws/cost-management/envs/develop/`
+- `github/repository/envs/develop/`、`github/branch/envs/develop/`
 
 ### 変更
 
 | ファイル | 内容 |
 |---|---|
-| `workflow-config.yaml` | `master` env を追加。`production` の `iam_role_plan` / `iam_role_apply` を新アカウント ARN に差し替え |
-| `aws/github-oidc-auth/envs/production/env.hcl:22-23` | `create_oidc_provider = true`、`oidc_provider_arn = ""` |
-| `aws/github-oidc-auth/modules/main.tf` | plan ロールへ `sts:AssumeRole` インラインポリシーを追加（対象 ARN は変数化） |
-| `aws/github-oidc-auth/modules/variables.tf` | `assume_role_arns` 変数を追加 |
-| `aws/route53/modules/variables.tf` | `production_account_id` 変数を追加（zone access ロールの信頼先） |
-| `aws/alb/modules/terraform.tf` | `provider "aws"` の alias `route53` を追加 |
-| `aws/alb/modules/lookups.tf` | `module "route53"` に `providers = { aws = aws.route53 }` を渡す |
-| `aws/alb/modules/main.tf` | validation レコード 2 resource に `provider = aws.route53` |
-| `aws/alb/modules/variables.tf` / `envs/production/env.hcl` / `envs/production/terragrunt.hcl` | `route53_zone_role_arn` |
-| `aws/eks/modules/lookups.tf` | `module "route53"` ブロックを削除 |
-| `aws/eks/modules/addons.tf:53-70` | `attach_external_dns_policy` / `external_dns_hosted_zone_arns` を `source_policy_documents` に差し替え |
+| `workflow-config.yaml` | `master` env 追加、`develop` / `production` の IAM ロール ARN を各新アカウントへ差し替え |
+| `aws/github-oidc-auth/envs/production/env.hcl` | `create_oidc_provider = true` に反転、`oidc_provider_arn = ""`、`assume_role_arns` 追加 |
+| `aws/github-oidc-auth/envs/production/terragrunt.hcl` | `assume_role_arns` の受け渡し |
+| `aws/github-oidc-auth/modules/{main,variables}.tf` | plan ロールへ `sts:AssumeRole` インラインポリシー（`assume_role_arns` 変数） |
+| `aws/route53/modules/variables.tf` | `production_account_id` 追加 |
+| `aws/alb/modules/{terraform,lookups,main,variables}.tf` | クロスアカウント provider alias |
+| `aws/alb/envs/production/{env.hcl,terragrunt.hcl}` | `route53_zone_role_arn` |
+| `aws/eks/modules/{lookups,addons,variables}.tf` | route53 lookup 削除、external-dns を assume role 方式へ |
+| `aws/eks/envs/production/{env.hcl,terragrunt.hcl}` | `route53_zone_role_arn` |
 | `kubernetes/components/external-dns/production/values.yaml.gotmpl` | `extraArgs` に `--aws-assume-role` |
-| `kubernetes/components/external-dns/production/helmfile.yaml` | `externalDnsRoleArn` のアカウント ID |
-| `kubernetes/helmfile.yaml.gotmpl:43,45,57,64,69` | ロール ARN 2 + バケット名 3 のアカウント ID |
-| `kubernetes/components/{aws-load-balancer-controller,loki,mimir,tempo}/production/helmfile.yaml` | 同上（helmfile v1.4 は親 → 子の値継承をしないため二重定義） |
-| `scripts/eks-lifecycle/lib/30-destroy-stacks.sh` | `STACKS` に `eks-holmesgpt` を追加 |
-| `README.md` / `README-ja.md` | 環境表に `master` を追加 |
+| `kubernetes/helmfile.yaml.gotmpl` + 子 helmfile 5 本 | アカウント ID 11 箇所 |
+| `scripts/eks-lifecycle/lib/30-destroy-stacks.sh` | `STACKS` に `eks-holmesgpt` |
+| `README.md` / `README-ja.md` | 環境表に `master` を追加、3 アカウント構成を記載 |
+
+### 変更しないもの
+
+`aws/github-oidc-auth/envs/develop/env.hcl` は既に `create_oidc_provider = true` で、`aws_region` も `us-east-1` のまま使える。develop はアカウントが変わるだけでスタック定義は無変更。差し替えるのは `workflow-config.yaml` のロール ARN のみ。
 
 ### 別リポジトリ（`panicboat/monorepo`）
 
-- `system-components/holmes/terragrunt` — Secrets Manager 2 件を新アカウントで再作成し、値を手動再投入
+- `system-components/holmes/terragrunt` — Secrets Manager 2 件を新 production アカウントで再作成し値を投入
 - `services/monolith/terragrunt` — resources=0 のため state を新規作成するのみ
 - `workflow-config.yaml` — `production` env が未定義（手動 apply 運用）。追加するかは実装時に判断
 
-## 6. Migration Sequence
+## 7. State Migration Map
 
-順序の制約は 2 つ。
+`master` へ移すスタックは、アカウントは変わらず state key だけが変わる（`terragrunt backend migrate`）。`develop` / `production` はアカウントごと変わるため、state を移送せず新アカウントで作り直す。
 
-1. **`workflow-config.yaml` の `production` ロール ARN 差し替えは、新アカウントに state バケットと OIDC ロールが揃った後**。先に main へマージすると CI の production plan / apply が存在しないロールを assume して壊れる
-2. **`route53-zone-access` ロールの作成は、`aws/alb` / `aws/eks` の apply より前**。trust policy に production 側の役割 ARN を書くため、新アカウント ID の確定が前提
+| 現 state key | 移行後 | 方式 |
+|---|---|---|
+| `platform/route53/production` | `platform/route53/master` | `terragrunt backend migrate` |
+| `platform/repository/develop` | `platform/repository/master` | 同上 |
+| `platform/branch/develop` | `platform/branch/master` | 同上 |
+| `platform/cost-management/develop` | `platform/cost-management/master` | 同上 |
+| `platform/github-oidc-auth/develop` | provider のみ `platform/github-oidc-auth/master` へ | `state rm` + `import` |
+| `platform/github-oidc-auth/production` | 新 production アカウントで新規作成 | 移送しない |
+| `platform/iam-service-linked-roles/production` | 同上 | 移送しない |
+| `platform/eks-holmesgpt/production` | 同上 | 移送しない（先にドリフト解消して destroy） |
+| `system-components/holmes/production` | 同上 | 移送しない（値は手動退避 → 再投入） |
+
+### 削除する孤児 state
+
+`platform/{ai-assistant,claude-code,claude-code-action}/develop`、`platform/github-oidc-auth/staging`、`platform/karpenter/production`（#798 で `eks-karpenter` に改名済）、`platform/github-repository/{monorepo,platform}`、`services/monolith/production`。
+
+## 8. Migration Sequence
+
+順序の制約は 3 つ。
+
+1. **`workflow-config.yaml` のロール ARN 差し替えは、対象アカウントに state バケットと OIDC ロールが揃った後**。先に main へマージすると CI が存在しないロールを assume して壊れる
+2. **OIDC provider の `state rm` → `import` は、`master` env の apply より前**。二重管理を作らない
+3. **Secrets Manager の値の退避は、旧アカウントの片付けより前**
 
 | Phase | 内容 | 実行場所 |
 |---|---|---|
-| 0 | 旧アカウントの事前整理（`eks-holmesgpt` destroy、孤児リソース削除、stale DNS レコード削除） | 管理アカウント |
-| 1 | 新アカウント作成、Identity Center 割当、**Service Quota 増枠申請**、Bedrock モデルアクセス有効化 | 管理アカウント → 新アカウント |
-| 2 | `OrganizationAccountAccessRole` assume → `terragrunt backend bootstrap` で S3 + DynamoDB 作成 | ローカル |
-| 3 | `master` env 新設 + `aws/route53` re-home + `route53-zone-access` ロール作成 | 管理アカウント |
-| 4 | `github-oidc-auth/production` をローカル apply → `workflow-config.yaml` 差し替え | ローカル → CI |
+| 0 | 旧アカウントの事前整理（`eks-holmesgpt` destroy、孤児リソース削除、stale DNS 削除、シークレット値退避） | 管理アカウント |
+| 1 | 新アカウント 2 つを作成、Identity Center 割当、**Service Quota 増枠申請**、Bedrock 有効化 | 管理アカウント → 新アカウント |
+| 2 | 両新アカウントで `terragrunt backend bootstrap` | ローカル |
+| 3 | `master` env 新設（OIDC provider import、`route53` / `cost-management` / `github/*` の re-home、`route53-zone-access` 作成） | 管理アカウント |
+| 4 | `develop` / `production` の OIDC ロールをローカル apply → `workflow-config.yaml` 差し替え | ローカル → CI |
 | 5 | クロスアカウント配線のコード変更（provider alias / external-dns） | コードのみ |
-| 6 | `iam-service-linked-roles` apply + Secrets Manager 8 件の再作成と値投入 | 新アカウント |
-| 7 | helmfile のアカウント ID 更新 + `docs/runbooks/eks-production-recreate.md` の Phase 1-10 実行 | 新アカウント |
-| 8 | monorepo リポジトリの production スタック移行 | 新アカウント |
-| 9 | 旧アカウントの production 資産の後片付け | 管理アカウント |
+| 6 | `iam-service-linked-roles` apply + Secrets Manager 再作成と値投入 | 新 production |
+| 7 | helmfile のアカウント ID 更新 + `docs/runbooks/eks-production-recreate.md` の Phase 1-10 実行 | 新 production |
+| 8 | monorepo リポジトリの production スタック移行 | 新 production |
+| 9 | 旧アカウントの production / develop 資産の後片付け | 管理アカウント |
 
 Phase 1 の Service Quota 増枠は承認待ちが最長のクリティカルパスになるため、アカウント作成直後に投げる。
 
-## 7. Risks & Mitigations
+## 9. Risks & Mitigations
 
 ### リスク 1: Service Quota 不足で Karpenter が node を出せない
 
@@ -230,21 +353,21 @@ Phase 1 の Service Quota 増枠は承認待ちが最長のクリティカルパ
 
 **対策:** Phase 1 で増枠申請を投げ、Phase 7 開始前に `aws service-quotas get-service-quota` で適用値を確認する。承認が下りていなければ Phase 7 を開始しない。
 
-### リスク 2: `workflow-config.yaml` の差し替えタイミングを誤り CI が壊れる
+### リスク 2: OIDC provider の二重管理
 
-**対策:** Phase 4 で `github-oidc-auth/production` のローカル apply が成功し、新ロールの存在を `aws iam get-role` で確認してから `workflow-config.yaml` を含む PR をマージする。
+`master` が import する前に `develop` state を消すと provider が孤児になり、`master` の apply が「作成」を試みて `EntityAlreadyExists` で落ちる。逆に `develop` state に残したまま `master` で import すると 2 つの state が同じリソースを管理する。
 
-### リスク 3: クロスアカウント assume が効かず `alb` / `eks` の apply が失敗する
+**対策:** Phase 3 で `develop` state から `state rm` → `master` state へ `import` → `master` の plan が `No changes.` になることを確認、の順を厳守する。
+
+### リスク 3: `workflow-config.yaml` の差し替えタイミングを誤り CI が壊れる
+
+**対策:** Phase 4 で各アカウントのロール存在を `aws iam get-role` で確認してから `workflow-config.yaml` を含む PR をマージする。
+
+### リスク 4: クロスアカウント assume が効かず `alb` / `eks` の apply が失敗する
 
 trust policy の ARN 誤記、`sts:AssumeRole` 権限の欠落、provider alias の渡し忘れのいずれでも起きる。
 
-**対策:** Phase 5 完了後、Phase 7 の本番 apply の前に `aws sts assume-role --role-arn arn:aws:iam::559744160976:role/route53-zone-access` を新アカウントの認証情報から実行して疎通を確認する。加えて `aws/alb/envs/production` で `terragrunt plan` を打ち、zone data source が解決できることを確認する。
-
-### リスク 4: クローズ済みアカウントのメールアドレスが再利用できない
-
-`admin@panicboat.net` / `aws@dystopia.city` は closed account が保持している可能性が高い。
-
-**対策:** Phase 1 で新しいアドレスを用意する。`create-account` が `EMAIL_ALREADY_EXISTS` で失敗した場合はアドレスを変えて再試行する。
+**対策:** Phase 5 完了後、Phase 7 の本番 apply の前に新 production アカウントの認証情報から `aws sts assume-role --role-arn arn:aws:iam::559744160976:role/route53-zone-access` を実行して疎通を確認する。加えて `aws/alb/envs/production` で `terragrunt plan` を打ち zone data source が解決できることを確認する。
 
 ### リスク 5: `dystopia.city` の stale レコードがクロスアカウント経路の不備を隠す
 
@@ -256,54 +379,20 @@ trust policy の ARN 誤記、`sts:AssumeRole` 権限の欠落、provider alias 
 
 8 件の値は Terraform 管理外（手動投入）で、旧アカウントを片付けると復旧できない。
 
-**対策:** Phase 6 の前に旧アカウントから全 8 件の値を取得して安全な場所に退避し、新アカウントへの投入完了を確認してから Phase 9 に進む。
+**対策:** Phase 0 で全 8 件の値を退避し、新アカウントへの投入完了を確認してから Phase 9 に進む。
 
-## 8. Validation
+### リスク 7: `GITHUB_TOKEN` が `master` env の CI に供給されない
 
-### Phase 2 完了時
+`github/{repository,branch}` は `get_env("GITHUB_TOKEN")` でトークンを読む。CI executor（外部リポジトリ `panicboat/panicboat-actions/terragrunt-run`）が `token` input をこの環境変数として export しているかは未確認。
 
-```bash
-aws s3api head-bucket --bucket terragrunt-state-<PROD_ACCOUNT_ID>
-aws dynamodb describe-table --table-name terragrunt-state-locks --region ap-northeast-1
-```
+**対策:** Phase 3 で `master` env の PR を出した際、CI の plan が通ることをもって確認する。落ちた場合は executor 側の対応か、`master` env の `github/*` を手動 apply 運用に留める。
 
-### Phase 4 完了時
+## 10. Out of Scope
 
-```bash
-aws iam get-role --role-name github-oidc-auth-production-github-actions-apply-role
-aws iam list-open-id-connect-providers
-```
-
-新アカウントで両方が返ること。
-
-### Phase 5 完了時（本番 apply 前）
-
-```bash
-# 新アカウントの認証情報で管理アカウントのロールを assume できるか
-aws sts assume-role \
-  --role-arn arn:aws:iam::559744160976:role/route53-zone-access \
-  --role-session-name migration-check
-
-# zone data source が解決できるか
-( cd aws/alb/envs/production && TG_TF_PATH=tofu terragrunt plan )
-```
-
-### Phase 7 完了時
-
-- `aws eks list-clusters --region ap-northeast-1` で `eks-production` が返る
-- external-dns が新アカウントから管理アカウントの zone にレコードを作成できている（Ingress の hostname が `dig` で解決する）
-- `aws acm list-certificates --region ap-northeast-1` でワイルドカード証明書 2 枚が `ISSUED`
-
-### Phase 9 完了時
-
-- 旧アカウントに `github-oidc-auth-production-*` ロールが残っていない
-- 旧アカウントの `terragrunt-state-559744160976` に `platform/*/production/` の state が残っていない（`master` へ re-home した route53 を除く）
-
-## 9. Out of Scope
-
-- `develop` env（`github/repository`、`github/branch`、`aws/cost-management`）の `master` への統合。管理アカウントに残る点は `master` と同じだが、state key 変更を伴うため別作業とする
 - `panicboat-attached-storage` バケットの移行。Terraform 管理外かつ platform と無関係
 - `nyx.place` zone とドメイン登録。`aws/route53/lookup` の管理対象外
 - Route53 登録ドメイン 3 件のアカウント間移管。zone を管理アカウントに残す決定により不要
-- IAM Identity Center の permission set 細分化。`AdministratorAccess` 1 本のまま新アカウントへ割当を追加するのみ
+- IAM Identity Center の permission set 細分化。`AdministratorAccess` 1 本のまま新 2 アカウントへ割当を追加するのみ
 - SCP による新アカウントのガードレール設定
+- `aws/cost-management` の `include_member_accounts` / `aws_costoptimizationhub_preferences` の見直し。`559744160976` が管理アカウントになったことでモジュール内コメントの前提が変わっているが、挙動変更を伴うため本移行とは分ける
+- develop アカウントへのワークロード構築。器を用意するところまで

--- a/docs/superpowers/specs/2026-08-18-production-account-migration-design.md
+++ b/docs/superpowers/specs/2026-08-18-production-account-migration-design.md
@@ -65,6 +65,10 @@ state は 26 ファイル中 11 ファイルにのみ resources が入ってい�
 - `dystopia.city` zone に削除済み ALB を指す ALIAS レコード 4 件（`dystopia.city.` A/AAAA、`auth.dystopia.city.` A/AAAA）と external-dns 所有権 TXT 2 件（`aaaa-auth.` / `cname-auth.`、`owner=eks-production`）が残存
 - ~~`aws/cost-management/modules/cost_optimization_hub.tf` の `terraform_data` + `local-exec` 回避策~~ → **#801 で解消済み**。provider 6.60.0 で `include_member_accounts` が `optional + computed` になり恒久差分が出なくなっていたため、native リソースに置き換えた（§10 参照）
 - `workflow-config.yaml` の `stack_conventions` で **`aws/{service}` の規約だけがコメントアウトされている**。そのため `aws/` 配下の変更は label-dispatcher がサービスとして検出せず、deploy label が付かず CI の terragrunt が起動しない（§8 末尾参照）
+- `aws/eks-holmesgpt` の IAM ポリシーと HolmesGPT の `modelList` が食い違っている（**本移行の対象外。記録のみ**）
+  - ポリシー（`modules/main.tf:58-65`）は `us.anthropic.claude-opus-4-6` と `anthropic.claude-opus-4-6` を許可しているが、実在する ID は `us.anthropic.claude-opus-4-6-v1` / `anthropic.claude-opus-4-6-v1` で **`-v1` サフィックスが欠けている**。Opus 4.6 を呼ぶと IAM で拒否される
+  - `kubernetes/components/holmesgpt/production/values.yaml.gotmpl` の `modelList` は `sonnet-4-6` / `sonnet-5` / `opus-5` を並べており、**Opus 4.6 は使っていない**。逆に `sonnet-5` / `opus-5` はポリシーに含まれていない
+  - 実際に使えているのは `sonnet-4-6` のみ（ポリシーと ID が一致する唯一の組み合わせ）。`sonnet-5` / `opus-5` は quota 0 で呼べないため、現状は顕在化していない
 
 ## 2. Decisions
 
@@ -77,24 +81,24 @@ state は 26 ファイル中 11 ファイルにのみ resources が入ってい�
 | `github/*` スタックの所属 | `master` | GitHub リポジトリ・ruleset は環境を持たない組織横断資産。付随する CloudWatch ログ グループも管理アカウントに残る |
 | `aws/cost-management` の所属 | `master` | Compute Optimizer / Cost Optimization Hub の登録は支払アカウント単位。管理アカウントから離せない |
 
-### 新アカウントのルートメールアドレス
+### 新アカウント（2026-08-20 作成済）
 
-| env | アドレス |
-|---|---|
-| `production` | `aws+production@panicboat.net` |
-| `develop` | `aws+develop@panicboat.net` |
+| env | Account ID | ルートメールアドレス |
+|---|---|---|
+| `production` | `337169763788` | `aws+production@panicboat.net` |
+| `develop` | `270242382571` | `aws+develop@panicboat.net` |
 
-クローズ済みアカウントが保持しているのは `admin@panicboat.net`（583677814390）と `aws@dystopia.city`（504150922582）で、いずれも上記とは別アドレスのため衝突しない。
+クローズ済みアカウントが保持しているのは `admin@panicboat.net`（583677814390）と `aws@dystopia.city`（504150922582）で、いずれも上記とは別アドレスのため衝突しなかった。
 
-**前提条件:** `panicboat.net` は Google Workspace（MX = `smtp.google.com`）で、プラスアドレスはベースとなるメールボックスへ配送される。したがって `aws@panicboat.net` がユーザーまたはエイリアスとして存在している必要がある。存在しないとルートアカウントの検証メールとパスワードリセットが届かず、アカウントを復旧できなくなる。アカウント作成前に実際に受信できることを確認する。
+`panicboat.net` は Google Workspace（MX = `smtp.google.com`）で、プラスアドレスはベースとなるメールボックスへ配送される。`aws@panicboat.net` がエイリアスとして存在することを作成前に確認済（存在しないとルートアカウントの検証メールとパスワードリセットが届かず復旧不能になる）。
 
 ## 3. Environment Taxonomy
 
 | env | アカウント | workflow-config の region | スタック |
 |---|---|---|---|
 | `master` | 559744160976（管理） | `ap-northeast-1` | `aws/route53`、`aws/cost-management`、`aws/github-oidc-auth`、`github/repository`、`github/branch` |
-| `develop` | 新規（`aws+develop@panicboat.net`） | `us-east-1` | `aws/github-oidc-auth` |
-| `production` | 新規（`aws+production@panicboat.net`） | `ap-northeast-1` | `aws/{vpc,alb,eks,eks-karpenter,eks-secrets,eks-logs,eks-metrics,eks-traces,eks-holmesgpt,iam-service-linked-roles,github-oidc-auth}` |
+| `develop` | 270242382571 | `us-east-1` | `aws/github-oidc-auth` |
+| `production` | 337169763788 | `ap-northeast-1` | `aws/{vpc,alb,eks,eks-karpenter,eks-secrets,eks-logs,eks-metrics,eks-traces,eks-holmesgpt,iam-service-linked-roles,github-oidc-auth}` |
 
 `workflow-config.yaml` の `aws_region` は CI が OIDC ロールを assume する際のリージョンであり、スタック内のリソースリージョンとは独立している（現状も `develop` = `us-east-1` に対し `github/repository/root.hcl` の inputs は `ap-northeast-1` で既に乖離している）。`aws/cost-management` は module 側で `us-east-1` に固定されているため `master` に移しても挙動は変わらない。
 
@@ -137,7 +141,7 @@ Route53 hosted zone を参照しているのは 3 箇所のみ（cert-manager �
 
 **信頼するプリンシパル**
 
-`arn:aws:iam::<PROD_ACCOUNT_ID>:root` の 1 つ。実際に誰が assume できるかは production アカウント側の IAM で制御する。
+`arn:aws:iam::337169763788:root` の 1 つ。実際に誰が assume できるかは production アカウント側の IAM で制御する。
 
 | production 側のプリンシパル | assume 許可の出どころ |
 |---|---|
@@ -205,8 +209,8 @@ Terragrunt が bootstrap するため、どの state にも入らない。
 | リソース | 対応 |
 |---|---|
 | S3 `terragrunt-state-559744160976` | 管理アカウントに残す（`master` スタックの state 置き場） |
-| S3 `terragrunt-state-<PROD_ACCOUNT_ID>` | `terragrunt backend bootstrap` で新規作成 |
-| S3 `terragrunt-state-<DEV_ACCOUNT_ID>` | 同上 |
+| S3 `terragrunt-state-337169763788` | `terragrunt backend bootstrap` で新規作成 |
+| S3 `terragrunt-state-270242382571` | 同上 |
 | DynamoDB `terragrunt-state-locks` | 3 アカウントそれぞれに必要（バケットと同時に bootstrap される） |
 
 ### 5-3. AWS — シークレットの値
@@ -319,8 +323,8 @@ state の所在は 2 つの要素で決まり、移行では**それぞれ独立
 | `github/repository` | `.../develop` → `.../master` | 同上 | 同上 |
 | `github/branch` | `.../develop` → `.../master` | 同上 | 同上 |
 | `aws/github-oidc-auth`（master） | 新規 `.../master` | 同上 | 新規作成 + provider を `state rm` → `import` |
-| `aws/github-oidc-auth`（develop） | `.../develop` のまま | **`terragrunt-state-<DEV_ACCOUNT_ID>` へ** | 移送せず新アカウントで新規作成 |
-| `aws/{vpc,alb,eks,eks-*,iam-service-linked-roles,github-oidc-auth}`（production） | `.../production` のまま | **`terragrunt-state-<PROD_ACCOUNT_ID>` へ** | 同上 |
+| `aws/github-oidc-auth`（develop） | `.../develop` のまま | **`terragrunt-state-270242382571` へ** | 移送せず新アカウントで新規作成 |
+| `aws/{vpc,alb,eks,eks-*,iam-service-linked-roles,github-oidc-auth}`（production） | `.../production` のまま | **`terragrunt-state-337169763788` へ** | 同上 |
 | `system-components/holmes`（monorepo） | `.../production` のまま | 同上 | 同上（値は手動退避 → 再投入） |
 | `services/monolith`（monorepo） | `.../production` のまま | 同上 | 同上（resources=0） |
 

--- a/docs/superpowers/specs/2026-08-18-production-account-migration-design.md
+++ b/docs/superpowers/specs/2026-08-18-production-account-migration-design.md
@@ -245,7 +245,7 @@ Terraform 管理外だが、クラスタ再構築で自動的に作り直され�
 | リポジトリ variable `APP_ID` | `platform` / `monorepo` の両方に設定 | 変更不要 |
 | リポジトリ secret `APP_PRIVATE_KEY` | `platform` / `monorepo` の両方に設定 | 変更不要 |
 | リポジトリ secret `SLACK_BOT_TOKEN` | `monorepo` のみ | 変更不要 |
-| Organization レベルの secret / variable | `gh api orgs/panicboat/actions/{secrets,variables}` が 404（トークンのスコープ不足の可能性あり、**未確認**） | 実装時に org 管理権限のあるトークンで再確認する |
+| Organization レベルの secret / variable | **存在し得ない。** `panicboat` は Organization ではなく User アカウント（`gh api users/panicboat` が `"type":"User"`）。org secrets / variables は Organization 専用機能 | 対応不要 |
 | GitHub Environments | `platform` / `monorepo` ともに **0 件** | `aws/github-oidc-auth` の trust policy が `repo:panicboat/*:environment:{master,develop,production}` を許可条件に含むが、Environment が存在しないためこの条件は現状使われていない。environment gate を使う場合は GitHub 側での作成が別途必要 |
 | `GITHUB_TOKEN` 環境変数 | `github/{repository,branch}/envs/*/terragrunt.hcl` が `get_env("GITHUB_TOKEN")` で読む | `master` env に移しても供給経路は変わらない。CI 側で `panicboat/panicboat-actions/terragrunt-run` が `token` input を `GITHUB_TOKEN` として export しているかは**未確認**。`master` env の初回 CI 実行で検証する |
 | ruleset 3 本（`{monorepo,platform,deploy-actions}-main`） | `platform/branch/develop` state が管理、GitHub 上で `active` | state を `master` へ移すのみ。GitHub 側の実体は変わらない |


### PR DESCRIPTION
## Why

`production` と `develop` が AWS Organizations 管理アカウント `559744160976` に同居しており、環境分離がリソース命名と IAM ロール名のプレフィックスだけに依存している。production を専用メンバーアカウントへ分離する。

現状の実リソースを調査した結果、EKS / VPC / EC2 / ACM はいずれも 0 件で、移行対象は state と基盤リソースに限られることを確認した。移行の適期。

## What

調査結果と設計判断を design doc に、タスク分解を plan に記録する。コード変更はこの PR には含まない。

- `docs/superpowers/specs/2026-08-18-production-account-migration-design.md`
- `docs/superpowers/plans/2026-08-18-production-account-migration.md`

## Decisions

- **新アカウントは同 Organization のメンバーとして作成** — `OrganizationAccountAccessRole` で bootstrap 経路が確保でき、請求も集約される
- **Route53 hosted zone は管理アカウントに残しクロスアカウント参照にする** — NS 切替に伴う DNS 断と Google Workspace の MX / DKIM 再検証を回避する
- **`master` env を新設** — 管理アカウントに残る横断資産（Route53）の受け皿。`aws/route53` をここへ re-home する

## 調査で判明した既存の不整合

いずれも plan の Phase 0 で解消する。

- `scripts/eks-lifecycle/lib/30-destroy-stacks.sh` の `STACKS` に `eks-holmesgpt` が無く（#795 の追加漏れ）、state が存在しないクラスタを参照してドリフトしている
- 孤児 IAM instance profile `eks-production_513473553642647435` と、state に対応の無いログ グループ 3 本
- `dystopia.city` zone に削除済み ALB を指す ALIAS 4 件 + external-dns 所有権 TXT 2 件

## Notes

- 新アカウントは On-Demand / Spot vCPU がデフォルト 5 で始まる（現アカウントは 64 / 256）。増枠承認が最長のクリティカルパスのため、plan では Phase 1 で先行申請する
- クローズ済みアカウント 2 件（`583677814390` / `504150922582`）がメールアドレスを保持しているため、新しいルートアドレスが必要

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FJMY2CQPbJLzu5daCKMuM5