### PR TITLE
chore: Manage Cost Optimization Hub enrollment with the native resource

### DIFF
--- a/aws/cost-management/modules/cost_optimization_hub.tf
+++ b/aws/cost-management/modules/cost_optimization_hub.tf
@@ -1,36 +1,22 @@
 # cost_optimization_hub.tf - AWS Cost Optimization Hub enrollment
 
-# Workaround for hashicorp/terraform-provider-aws#39520: the
-# aws_costoptimizationhub_enrollment_status resource produces a perpetual
-# in-place update on every plan because the provider always plans
-# include_member_accounts=false even when omitted from HCL, while the AWS
-# API does not return that attribute on Read for non-management accounts.
-# lifecycle.ignore_changes (including = all) does not suppress this.
+# `status` は provider 6.60.0 で computed 属性 (= 設定不可)。リソースが存在する
+# こと自体が Active を意味し、destroy で Inactive に戻る。
 #
-# Workaround: invoke the AWS CLI directly via terraform_data + local-exec.
-# This bypasses the broken provider resource while keeping enrollment
-# managed in Terraform. The call is idempotent (re-enrolling an Active
-# account is a no-op).
-resource "terraform_data" "cost_optimization_hub_enrollment" {
-  triggers_replace = {
-    # Re-run only when this version string changes.
-    version = "v1"
-  }
-
-  provisioner "local-exec" {
-    command = "aws cost-optimization-hub update-enrollment-status --status Active --region us-east-1"
-  }
-}
+# `include_member_accounts` は optional + computed。省略すると AWS API が返す値を
+# そのまま採用するため、省略した状態で plan に差分が出ない。org 横断の登録
+# (= member アカウントを一括 opt-in) を有効にする場合のみ true を明示する。
+# 有効化には Organizations 側で cost-optimization-hub.amazonaws.com の信頼された
+# サービスアクセスが別途必要。
+resource "aws_costoptimizationhub_enrollment_status" "this" {}
 
 # aws_costoptimizationhub_preferences is intentionally NOT managed here.
-# The AWS Terraform provider always sends member_account_discount_visibility
-# (defaulting to "All" if unset), and the AWS API rejects that attribute
-# from non-management accounts with:
-#   ValidationException: Only management accounts can update member account
-#   discount visibility.
-# AWS defaults are used: savings_estimation_mode = "AfterDiscounts" (verified
-# via "aws cost-optimization-hub get-preferences"). For a standalone account
-# without enterprise discount programs, BeforeDiscounts and AfterDiscounts
-# produce identical numbers.
-# Add this resource back when the account becomes an Organization management
-# account.
+#
+# `member_account_discount_visibility` は optional + computed だが、AWS API の
+# GetPreferences がこの属性を返さないため、リソースを追加すると provider が
+# 毎回 "All" を書き込もうとする (= plan に `+ member_account_discount_visibility
+# = "All"` が出続ける)。AWS 既定値も "All" のため、管理しても得られるものが無い。
+#
+# savings_estimation_mode も AWS 既定の "AfterDiscounts" のまま
+# (= `aws cost-optimization-hub get-preferences` で確認)。既定から変える要件が
+# 出た時点で、上記の書き込みを許容するかと併せて再検討する。


### PR DESCRIPTION
## Why

`aws/cost-management` の Cost Optimization Hub 登録は `terraform_data` + `local-exec` で AWS CLI を叩く回避策になっていた。根拠は hashicorp/terraform-provider-aws#39520（`include_member_accounts` が毎回 in-place update に出る）で、当時 `559744160976` は standalone アカウントだった。

この回避策には代償があった。

1. 登録が state に載らない（`terraform_data` が持つのは `version = "v1"` の文字列だけ）
2. ドリフトを検知も修復もしない
3. `terragrunt destroy` で解除されない（destroy provisioner が無い）
4. 実行環境の AWS CLI と資格情報に暗黙依存する

実例として、state の最終更新が 2026-05-03 なのに対し `list-enrollment-statuses` の `lastUpdatedTimestamp` は 2026-08-18 で、Terraform の外で登録が触られていた（代償 2）。

## What

provider 6.60.0 のスキーマを確認したところ、#39520 の原因は解消されていた。

```
aws_costoptimizationhub_enrollment_status
  include_member_accounts   bool     ['optional', 'computed']
  status                    string   ['computed']
```

`include_member_accounts` が `optional + computed` になり、省略時は AWS API が返す値を採用するため恒久差分が出ない。`status` は computed 専用になり、リソースの存在自体が Active を意味する形に変わっている。

回避策を native リソースに置き換えた。

## 検証

**1. 隔離した local state で恒久差分が出ないことを確認**（実 state には触れていない）

既存の登録を import して plan を実行:

```
$ tofu import aws_costoptimizationhub_enrollment_status.this 559744160976
Import successful!

$ tofu plan
（aws_costoptimizationhub_enrollment_status は plan に一切現れない）
```

import 後の state:

```json
{ "id": "559744160976", "include_member_accounts": false, "status": "Active" }
```

**2. 実 state での plan**

```
  # aws_costoptimizationhub_enrollment_status.this will be created
  + include_member_accounts = false
  + status                  = (known after apply)

  # terraform_data.cost_optimization_hub_enrollment will be destroyed
Plan: 1 to add, 0 to change, 1 to destroy.
```

`terraform_data` は destroy provisioner を持たないため state から落ちるだけで AWS 側への操作は無い。create 側の `UpdateEnrollmentStatus(Active)` は既に Active のアカウントに対して冪等（既存コメントにも同旨の記載あり）。手動の state 操作は不要で、通常の apply で移行できる。

## 挙動が変わる点

`terragrunt destroy` がスタックを消すと Cost Optimization Hub の登録も Inactive に戻る。回避策では登録が残り続けていた。これは代償 3 の解消であり意図した変更。

## preferences について

`aws_costoptimizationhub_preferences` は引き続き管理しない。`member_account_discount_visibility` は `optional + computed` だが AWS API の `GetPreferences` がこの属性を返さないため、リソースを追加すると provider が毎回 `"All"` を書き込もうとする。

```
  ~ resource "aws_costoptimizationhub_preferences" "this" {
      + member_account_discount_visibility = "All"
    }
```

AWS 既定値も `"All"` のため管理しても得るものが無い。コメントを「非管理アカウントだから拒否される」という古い前提から現在の理由に書き換えた。

## Out of scope

org 横断の登録（`include_member_accounts = true`）は別作業。Organizations の信頼されたサービスアクセスが現在 `sso.amazonaws.com` のみで、`cost-optimization-hub.amazonaws.com` の有効化が別途必要（`list-enrollment-statuses --include-organization-info` が `AccessDeniedException` を返す）。member アカウントが存在してから意味を持つため、#800 のアカウント分離完了後に扱う。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FJMY2CQPbJLzu5daCKMuM5