### PR TITLE
chore(scripts): Include eks-holmesgpt in the EKS teardown order

### DIFF
--- a/scripts/eks-lifecycle/README.md
+++ b/scripts/eks-lifecycle/README.md
@@ -50,7 +50,7 @@ make eks-teardown ENV=production
 実行内容:
 
 1. `10-k8s-cleanup.sh`: kubectl delete ingress / LB svc / Karpenter NodePool、ノード drain 待機
-2. `30-destroy-stacks.sh`: 「8 stack を destroy するか」y/N 確認 → 8 stacks を固定順で `terragrunt destroy` (= karpenter → eks-secrets → eks-logs/metrics/traces → eks → alb → vpc)
+2. `30-destroy-stacks.sh`: 「9 stack を destroy するか」y/N 確認 → 9 stacks を固定順で `terragrunt destroy` (= eks-karpenter → eks-holmesgpt → eks-secrets → eks-logs/metrics/traces → eks → alb → vpc)
 3. `40-orphan-verify.sh`: ENI / EBS / target group / SG / Route53 record / CloudWatch log group の orphan 検出 (= 削除はしない、人間に diagnostic 提示)
 
 部分実行:
@@ -72,9 +72,9 @@ make eks-teardown-verify ENV=production    # orphan verify only
 - ロールバックは前進復旧のみ (= teardown 中断は再 teardown)
 - admin role 一時 credentials の expire (= 1h STS session) は `30-destroy-stacks.sh` の各 stack 開始時に `creds_expiring_soon` (< 5min) で検出して `00-auth.sh` を re-source、admin role を assume し直す
 - `40-orphan-verify.sh` は read-only verify で auto-delete しない (= false-positive 含み得る出力を operator が目視精査し、必要なら提示された AWS CLI コマンドで個別削除)。検出時の exit code は live run = 1 (= operator 注意喚起 + make chain 停止)、DRY_RUN=1 = 0 (= live cluster の現役 resource を warn として列挙、make chain は継続)
-- `terragrunt destroy` で `Module version requirements have changed` (= 既存 `.terragrunt-cache/` の module version と現行 main.tf の constraint が乖離) のエラーが出たら、対象 stack を `terragrunt init -upgrade` で更新してから再開する。 8 stack 一括は以下:
+- `terragrunt destroy` で `Module version requirements have changed` (= 既存 `.terragrunt-cache/` の module version と現行 main.tf の constraint が乖離) のエラーが出たら、対象 stack を `terragrunt init -upgrade` で更新してから再開する。 9 stack 一括は以下:
   ```bash
-  for stack in eks-karpenter eks-secrets eks-logs eks-metrics eks-traces eks alb vpc; do
+  for stack in eks-karpenter eks-holmesgpt eks-secrets eks-logs eks-metrics eks-traces eks alb vpc; do
     echo "=== init: $stack ==="
     ( cd aws/$stack/envs/production && TG_TF_PATH=tofu terragrunt init -upgrade )
   done
@@ -92,6 +92,6 @@ make eks-teardown-verify ENV=production    # orphan verify only
 
 ## What is destroyed
 
-- `aws/eks`, `aws/eks-karpenter`, `aws/eks-secrets`, `aws/eks-logs`, `aws/eks-metrics`, `aws/eks-traces` (= EKS 専用)
+- `aws/eks`, `aws/eks-karpenter`, `aws/eks-holmesgpt`, `aws/eks-secrets`, `aws/eks-logs`, `aws/eks-metrics`, `aws/eks-traces` (= EKS 専用)
 - `aws/alb` (= ACM wildcard cert *.panicboat.net、recreate 時は DNS validation 5〜10 分)
 - `aws/vpc` (= NAT gateway 含む)

--- a/scripts/eks-lifecycle/lib/30-destroy-stacks.sh
+++ b/scripts/eks-lifecycle/lib/30-destroy-stacks.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
-# 30-destroy-stacks.sh - Destroy 8 EKS-related stacks in fixed order.
+# 30-destroy-stacks.sh - Destroy 9 EKS-related stacks in fixed order.
 #
 # Order:
-#   eks-karpenter -> eks-secrets -> eks-logs -> eks-metrics -> eks-traces
-#   -> eks -> alb -> vpc
+#   eks-karpenter -> eks-holmesgpt -> eks-secrets -> eks-logs -> eks-metrics
+#   -> eks-traces -> eks -> alb -> vpc
 #
 # Each stack runs `terragrunt destroy -auto-approve`. On failure, fail
 # fast with a diagnostic. 30s sleep between stacks for AWS API
@@ -69,8 +69,13 @@ sweep_lb_controller_orphans() {
   fi
 }
 
+# eks-holmesgpt は eks より前に置く必要がある。同 stack の module "eks" が
+# `data "aws_eks_cluster"` で cluster を名前引きしており、cluster 削除後に
+# destroy すると plan 生成時点で "couldn't find resource" になって落ちる
+# (= 順序を誤ると `-refresh=false` を付けた手動 destroy が必要になる)。
 STACKS=(
   "eks-karpenter"
+  "eks-holmesgpt"
   "eks-secrets"
   "eks-logs"
   "eks-metrics"
@@ -80,7 +85,7 @@ STACKS=(
   "vpc"
 )
 
-confirm "About to DESTROY 8 stacks for ENV=${ENV}. Continue?"
+confirm "About to DESTROY 9 stacks for ENV=${ENV}. Continue?"
 
 for stack in "${STACKS[@]}"; do
   info "Step 30.${stack}: terragrunt destroy aws/${stack}/envs/${ENV}"
@@ -112,4 +117,4 @@ After resolving, re-run: make eks-teardown-aws ENV=${ENV}"
   fi
 done
 
-ok "All 8 stacks destroyed"
+ok "All 9 stacks destroyed"


### PR DESCRIPTION
## Why

`scripts/eks-lifecycle/lib/30-destroy-stacks.sh` の `STACKS` 配列に `eks-holmesgpt` が含まれていなかった。#795 で HolmesGPT の IAM を専用スタックへ分離した際の追加漏れ。

結果として `make eks-teardown` を完走しても `eks-production-holmesgpt` ロールが残り、`platform/eks-holmesgpt/production` state が存在しないクラスタを参照したままドリフトしていた。

```
$ cd aws/eks-holmesgpt/envs/production && terragrunt plan
Error: reading EKS Cluster (eks-production): couldn't find resource
  with module.eks.data.aws_eks_cluster.this,
  on ../../eks/lookup/main.tf line 3, in data "aws_eks_cluster" "this":
```

## What

- `STACKS` に `eks-holmesgpt` を追加（`eks` より前）
- 件数の記述を 8 → 9 に統一（スクリプト冒頭コメント / confirm メッセージ / 完了メッセージ / README 3 箇所）
- 順序の制約を「なぜそこに置くか」としてコメント化

## 順序が `eks` より前でなければならない理由

`aws/eks-holmesgpt` の `module "eks"` は `data "aws_eks_cluster"` でクラスタを名前引きしている。クラスタ削除後に destroy すると plan 生成の時点で解決に失敗し、`terragrunt destroy` そのものが落ちる。`state rm` でリソースを外しても data source は config 上に残るため同じ結果になる。

実際に今回のドリフト解消では `-refresh=false` を付けた手動 destroy が必要だった。

```
$ terragrunt destroy -auto-approve -refresh=false
Plan: 0 to add, 0 to change, 2 to destroy.
aws_iam_role_policy.bedrock_invoke: Destruction complete after 1s
aws_iam_role.pod_identity: Destruction complete after 1s
Destroy complete! Resources: 2 destroyed.
```

正しい順序で回っていればクラスタが存命なので data source は解決でき、`-refresh=false` は不要。

## 検証

ドリフトは既に解消済み（本 PR とは別に手動対応）。

```
$ aws iam get-role --role-name eks-production-holmesgpt
An error occurred (NoSuchEntity) ... cannot be found.

$ # platform/eks-holmesgpt/production/terraform.tfstate
serial: 4 resources: 0
```

スクリプト自体は `bash -n` と `shellcheck` を通している（SC1091 の info は sourced file 由来で既存のもの）。次回の teardown で実地検証される。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FJMY2CQPbJLzu5daCKMuM5