### PR TITLE
chore: Align HolmesGPT Bedrock grants with the models it invokes

### DIFF
--- a/aws/eks-holmesgpt/modules/main.tf
+++ b/aws/eks-holmesgpt/modules/main.tf
@@ -12,37 +12,20 @@
 #
 # `us.` inference profiles route to three regions. Listing only the profile ARN
 # is not enough — the call fails on whichever region the profile picks.
-#
-# Sonnet 5 / Opus 5 are granted but cannot currently be invoked: every
-# tokens-per-minute quota for them reads 0, and the self-service increase
-# requests were closed without approval (the account has no usage history to
-# justify one). Only Sonnet 4.6 has non-zero quota. The IAM grant is
-# independent of those quotas, so listing them costs nothing and avoids a
-# second apply if the quotas are ever raised.
 
 data "aws_caller_identity" "current" {}
 
 locals {
   service_name = "holmesgpt" # K8s ServiceAccount name
 
-  # Models HolmesGPT invokes. Must stay in sync with `modelList` in
-  # kubernetes/components/holmesgpt/production/values.yaml.gotmpl — a model
-  # present there but missing here fails at runtime with AccessDenied.
-  #
-  # Written once and expanded into both the inference-profile ARNs and the
-  # foundation-model ARNs below. Hand-listing both forms is what let
-  # `anthropic.claude-opus-4-6` (the real id carries a `-v1` suffix) sit here
-  # unused while the models actually in `modelList` went ungranted.
+  # Must match `modelList` in
+  # kubernetes/components/holmesgpt/production/values.yaml.gotmpl; a model there
+  # but not here fails at runtime with AccessDenied.
   bedrock_models = [
     "anthropic.claude-sonnet-4-6",
-    "anthropic.claude-sonnet-5",
-    "anthropic.claude-opus-5",
   ]
 
-  # Regions the `us.` cross-region profiles route to, from
-  # `aws bedrock get-inference-profile --inference-profile-identifier us.<model>`
-  # (models[].modelArn). Granting the profile alone is not enough: the call is
-  # authorized against the foundation model in whichever region it lands on.
+  # Routing targets of the `us.` profiles, per `aws bedrock get-inference-profile`.
   bedrock_profile_regions = ["us-east-1", "us-east-2", "us-west-2"]
 
   bedrock_invoke_resources = concat(

--- a/aws/eks-holmesgpt/modules/main.tf
+++ b/aws/eks-holmesgpt/modules/main.tf
@@ -13,14 +13,50 @@
 # `us.` inference profiles route to three regions. Listing only the profile ARN
 # is not enough — the call fails on whichever region the profile picks.
 #
-# Opus 5 is included even though model access has not finished propagating for
-# this account: the IAM grant is independent of Bedrock model-access enablement,
-# so having it in place avoids a second apply once propagation completes.
+# Sonnet 5 / Opus 5 are granted but cannot currently be invoked: every
+# tokens-per-minute quota for them reads 0, and the self-service increase
+# requests were closed without approval (the account has no usage history to
+# justify one). Only Sonnet 4.6 has non-zero quota. The IAM grant is
+# independent of those quotas, so listing them costs nothing and avoids a
+# second apply if the quotas are ever raised.
 
 data "aws_caller_identity" "current" {}
 
 locals {
   service_name = "holmesgpt" # K8s ServiceAccount name
+
+  # Models HolmesGPT invokes. Must stay in sync with `modelList` in
+  # kubernetes/components/holmesgpt/production/values.yaml.gotmpl — a model
+  # present there but missing here fails at runtime with AccessDenied.
+  #
+  # Written once and expanded into both the inference-profile ARNs and the
+  # foundation-model ARNs below. Hand-listing both forms is what let
+  # `anthropic.claude-opus-4-6` (the real id carries a `-v1` suffix) sit here
+  # unused while the models actually in `modelList` went ungranted.
+  bedrock_models = [
+    "anthropic.claude-sonnet-4-6",
+    "anthropic.claude-sonnet-5",
+    "anthropic.claude-opus-5",
+  ]
+
+  # Regions the `us.` cross-region profiles route to, from
+  # `aws bedrock get-inference-profile --inference-profile-identifier us.<model>`
+  # (models[].modelArn). Granting the profile alone is not enough: the call is
+  # authorized against the foundation model in whichever region it lands on.
+  bedrock_profile_regions = ["us-east-1", "us-east-2", "us-west-2"]
+
+  bedrock_invoke_resources = concat(
+    [
+      for m in local.bedrock_models :
+      "arn:aws:bedrock:us-east-1:${data.aws_caller_identity.current.account_id}:inference-profile/us.${m}"
+    ],
+    flatten([
+      for m in local.bedrock_models : [
+        for r in local.bedrock_profile_regions :
+        "arn:aws:bedrock:${r}::foundation-model/${m}"
+      ]
+    ]),
+  )
 }
 
 # IAM role for Pod Identity Association
@@ -54,16 +90,7 @@ resource "aws_iam_role_policy" "bedrock_invoke" {
           "bedrock:InvokeModel",
           "bedrock:InvokeModelWithResponseStream",
         ]
-        Resource = [
-          "arn:aws:bedrock:us-east-1:${data.aws_caller_identity.current.account_id}:inference-profile/us.anthropic.claude-sonnet-4-6",
-          "arn:aws:bedrock:us-east-1:${data.aws_caller_identity.current.account_id}:inference-profile/us.anthropic.claude-opus-4-6",
-          "arn:aws:bedrock:us-east-1::foundation-model/anthropic.claude-sonnet-4-6",
-          "arn:aws:bedrock:us-east-2::foundation-model/anthropic.claude-sonnet-4-6",
-          "arn:aws:bedrock:us-west-2::foundation-model/anthropic.claude-sonnet-4-6",
-          "arn:aws:bedrock:us-east-1::foundation-model/anthropic.claude-opus-4-6",
-          "arn:aws:bedrock:us-east-2::foundation-model/anthropic.claude-opus-4-6",
-          "arn:aws:bedrock:us-west-2::foundation-model/anthropic.claude-opus-4-6",
-        ]
+        Resource = local.bedrock_invoke_resources
       }
     ]
   })

--- a/kubernetes/components/holmesgpt/production/values.yaml.gotmpl
+++ b/kubernetes/components/holmesgpt/production/values.yaml.gotmpl
@@ -25,10 +25,6 @@ k8sRBAC: false
 # model ID は LiteLLM 形式の `bedrock/` 接頭辞 + inference profile ID。
 # us. profile は us-east-1 / us-east-2 / us-west-2 へルーティングする。
 #
-# Claude 5 世代は載せない。tokens-per-minute quota が 0 で invoke できず、
-# self-service の増枠申請も CASE_CLOSED (= 利用実績が無いと承認されない)。
-# model access は AUTHORIZED を返すため使えそうに見えるが拒否は quota 側で起きる。
-#
 # 追加時は aws/eks-holmesgpt/modules/main.tf の `bedrock_models` も同時に更新する。
 additionalEnvVars:
   - name: AWS_REGION_NAME

--- a/kubernetes/components/holmesgpt/production/values.yaml.gotmpl
+++ b/kubernetes/components/holmesgpt/production/values.yaml.gotmpl
@@ -25,17 +25,11 @@ k8sRBAC: false
 # model ID は LiteLLM 形式の `bedrock/` 接頭辞 + inference profile ID。
 # us. profile は us-east-1 / us-east-2 / us-west-2 へルーティングする。
 #
-# 二段階で採点する。sonnet-4-6 は OpenSRE 評価と同一 model であり、ツール間の
-# 比較を model 差に汚されずに行うために置く。opus-5 は現行世代での上限を見る。
+# Claude 5 世代は載せない。tokens-per-minute quota が 0 で invoke できず、
+# self-service の増枠申請も CASE_CLOSED (= 利用実績が無いと承認されない)。
+# model access は AUTHORIZED を返すため使えそうに見えるが拒否は quota 側で起きる。
 #
-# NOTE: sonnet-5 と opus-5 は quota が 0 のため invoke できない。
-# `aws service-quotas list-service-quotas --service-code bedrock --region us-east-1`
-# で両 model の tokens-per-minute 系が全て 0.0、sonnet-4-6 のみ 6,000,000 (TPM) /
-# 10,000 (RPM)。self-service の増枠申請は 4 件とも CASE_CLOSED で、利用実績が無い
-# アカウントには承認されない。model access (= agreement / authorization) は
-# AVAILABLE / AUTHORIZED を返すため一見使えそうに見えるが、拒否は quota 側で起きる。
-# 増枠が通ればそのまま使えるよう modelList には残す。
-# 実際に採点に使えるのは sonnet-4-6 だけ。
+# 追加時は aws/eks-holmesgpt/modules/main.tf の `bedrock_models` も同時に更新する。
 additionalEnvVars:
   - name: AWS_REGION_NAME
     value: us-east-1
@@ -43,12 +37,6 @@ additionalEnvVars:
 modelList:
   sonnet-4-6:
     model: bedrock/us.anthropic.claude-sonnet-4-6
-    temperature: 0
-  sonnet-5:
-    model: bedrock/us.anthropic.claude-sonnet-5
-    temperature: 0
-  opus-5:
-    model: bedrock/us.anthropic.claude-opus-5
     temperature: 0
 
 # -----------------------------------------------------------------------------

--- a/kubernetes/components/holmesgpt/production/values.yaml.gotmpl
+++ b/kubernetes/components/holmesgpt/production/values.yaml.gotmpl
@@ -28,12 +28,14 @@ k8sRBAC: false
 # 二段階で採点する。sonnet-4-6 は OpenSRE 評価と同一 model であり、ツール間の
 # 比較を model 差に汚されずに行うために置く。opus-5 は現行世代での上限を見る。
 #
-# NOTE: sonnet-5 と opus-5 は 2026-08-13 時点で model access の反映待ち。
-# agreement は全 region で AVAILABLE / AUTHORIZED を返すが、inference profile
-# 経由でも foundation model 直接でも runtime が AccessDenied を返す状態が
-# 1 時間以上継続した。control plane と data plane の乖離である。
-# 反映され次第そのまま使えるよう、両方を modelList に置いておく。
-# 段階 1 の採点は sonnet-4-6 だけで成立する。
+# NOTE: sonnet-5 と opus-5 は quota が 0 のため invoke できない。
+# `aws service-quotas list-service-quotas --service-code bedrock --region us-east-1`
+# で両 model の tokens-per-minute 系が全て 0.0、sonnet-4-6 のみ 6,000,000 (TPM) /
+# 10,000 (RPM)。self-service の増枠申請は 4 件とも CASE_CLOSED で、利用実績が無い
+# アカウントには承認されない。model access (= agreement / authorization) は
+# AVAILABLE / AUTHORIZED を返すため一見使えそうに見えるが、拒否は quota 側で起きる。
+# 増枠が通ればそのまま使えるよう modelList には残す。
+# 実際に採点に使えるのは sonnet-4-6 だけ。
 additionalEnvVars:
   - name: AWS_REGION_NAME
     value: us-east-1

--- a/kubernetes/manifests/production/holmesgpt/manifest.yaml
+++ b/kubernetes/manifests/production/holmesgpt/manifest.yaml
@@ -640,14 +640,8 @@ data:
     mcp_servers: 
       {}
   model_list.yaml: |-
-    opus-5:
-      model: bedrock/us.anthropic.claude-opus-5
-      temperature: 0
     sonnet-4-6:
       model: bedrock/us.anthropic.claude-sonnet-4-6
-      temperature: 0
-    sonnet-5:
-      model: bedrock/us.anthropic.claude-sonnet-5
       temperature: 0
 ---
 # Source: holmes/templates/holmesgpt-service-account.yaml
@@ -1082,7 +1076,7 @@ spec:
         
       annotations:
         # checksum annotation triggering pod reload when .Values.toolsets changes by helm upgrade
-        checksum/toolset-config: a6e1a24f2da6b95ef97ee6b08272388346bdcc4e674666e818cb76156cedccf9
+        checksum/toolset-config: 8469f9a442ce7f65ca0434c519d281a590aba50015ce6316f4914cef3db15872
     spec:
       serviceAccountName: holmesgpt
       securityContext:


### PR DESCRIPTION
## Why

IAM ポリシーと `modelList` が食い違っていた。

| | 対象 |
|---|---|
| IAM ポリシー | `sonnet-4-6`、`opus-4-6` |
| `modelList` | `sonnet-4-6`、`sonnet-5`、`opus-5` |

一致するのは `sonnet-4-6` のみ。さらに `opus-4-6` の ARN は ID が存在しない（実在するのは `us.anthropic.claude-opus-4-6-v1` / `anthropic.claude-opus-4-6-v1` で `-v1` が付く）。ファイル冒頭のコメントは `Opus 5 is included ...` と書いており、意図は Opus 5 だったものが転記時に取り違えられている。

`sonnet-5` / `opus-5` は tokens-per-minute quota が全種別 `0.0` で invoke できない。self-service の増枠申請は 4 件とも `CASE_CLOSED`。

```
Cross-region model inference tokens per minute for Anthropic Claude Sonnet 5   0.0
Cross-region model inference tokens per minute for Anthropic Claude Opus 5     0.0
Cross-region model inference tokens per minute for Anthropic Claude Sonnet 4.6 6000000.0
```

## What

実際に invoke できる `sonnet-4-6` だけに揃えた。

- IAM ポリシーから `opus-4-6`（未使用かつ ID 誤り）を削除
- `modelList` から `sonnet-5` / `opus-5` を削除
- ARN 12 本の手書きをやめ、model ID のリスト 1 つから inference profile 側と foundation model 側を導出。同じ取り違えが再発しない形にした

ルーティング先 region は `aws bedrock get-inference-profile` の `models[].modelArn` から取得した値。

## 検証

```
$ tofu fmt -check -recursive aws/eks-holmesgpt/   # OK
$ terragrunt validate                             # Success!
$ bash scripts/kubernetes-hydrate/hydrate-component.sh holmesgpt production

modelList : ['anthropic.claude-sonnet-4-6']
IAM policy: ['anthropic.claude-sonnet-4-6']
一致: YES
```

manifest 再生成の差分は `model_list.yaml` から 2 model が消え、toolset checksum が更新されるのみ。

## 挙動

`sonnet-5` / `opus-5` は quota 0 で元から invoke できていないため、実効的な変化はない。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FJMY2CQPbJLzu5daCKMuM5