### PR TITLE
fix(auto-approve): skip self-authored PRs from panicboat-ci-bot

### DIFF
--- a/.github/workflows/auto-approve.yaml
+++ b/.github/workflows/auto-approve.yaml
@@ -11,7 +11,10 @@ permissions:
 jobs:
   auto-approve:
     runs-on: ubuntu-latest
-    if: endsWith(github.actor, '[bot]')
+    # panicboat-ci-bot (= the App whose token this job uses) cannot approve its
+    # own PRs (release-please); GitHub rejects self-approval with 422. Those
+    # need a human review instead.
+    if: endsWith(github.actor, '[bot]') && github.event.pull_request.user.login != 'panicboat-ci-bot[bot]'
     steps:
       - name: Generate GitHub App token
         id: app-token

--- a/.github/workflows/auto-approve.yaml
+++ b/.github/workflows/auto-approve.yaml
@@ -11,9 +11,7 @@ permissions:
 jobs:
   auto-approve:
     runs-on: ubuntu-latest
-    # panicboat-ci-bot (= the App whose token this job uses) cannot approve its
-    # own PRs (release-please); GitHub rejects self-approval with 422. Those
-    # need a human review instead.
+    # panicboat-ci-bot can't approve its own PRs; GitHub rejects that with 422.
     if: endsWith(github.actor, '[bot]') && github.event.pull_request.user.login != 'panicboat-ci-bot[bot]'
     steps:
       - name: Generate GitHub App token


### PR DESCRIPTION
## Why

`release-please` PR（例: #422）が `hmarr/auto-approve-action` で自動承認されず、`Auto-approve PRs` チェックが常に失敗していた。

```
Current user is github-actions[bot]
Pull request #422 has not been approved yet, creating approving review
##[error]Unprocessable Entity: "Review Can not approve your own pull request"
```

`hmarr/auto-approve-action` の `getLoginForToken` は `GET /user` を叩き、GitHub App の installation token は必ずこれに 403 を返すため、実際の identity を確認せず `"github-actions[bot]"` という文字列を決め打ちで返す（[ソース](https://github.com/hmarr/auto-approve-action/blob/main/src/approve.ts#L96-L109)）。実際に `createReview` を呼ぶ token は本物の App identity（`panicboat-ci-bot[bot]`）で認証されるため、PR の author も同じ App のときだけ GitHub 側が自己承認として 422 で拒否する。

`app-id` 1371999（`panicboat-ci-bot`）は release-please の PR 作成にも auto-approve のトークン生成にも使われている。renovate（別 App）の PR は問題なく承認できている実績がある。

```
$ gh pr list --repo panicboat/monorepo --state merged ...
app/renovate         → reviewers: ["renovate-approve","panicboat-ci-bot"]   OK
app/panicboat-ci-bot → reviewers: []                                        常に失敗
```

## What

job の `if` 条件に、PR の author が `panicboat-ci-bot[bot]` 自身のときは skip する条件を追加した。

```yaml
if: endsWith(github.actor, '[bot]') && github.event.pull_request.user.login != 'panicboat-ci-bot[bot]'
```

release-please PR は人間がレビューする運用になる。renovate 等の他 bot PR は影響なく自動承認される。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FJMY2CQPbJLzu5daCKMuM5