### PR TITLE
chore(kubernetes): rename Secrets Manager keys to {service}/{component}/{role}

### DIFF
--- a/kubernetes/clusters/production/repositories/monorepo.yaml
+++ b/kubernetes/clusters/production/repositories/monorepo.yaml
@@ -41,11 +41,11 @@ spec:
 # =============================================================================
 # ExternalSecret: Sync GitHub App credentials from AWS Secrets Manager
 # =============================================================================
-# AWS Secrets Manager の `panicboat/github-app/panicboat` から App
+# AWS Secrets Manager の `github-app/fluxcd-bot` から App
 # credentials (appID / installationID / privateKey) を flux-system の K8s
-# Secret として sync し、GitRepository monorepo の write 認証に使う。
-# AWS Secrets Manager 内の secret は user が console で 1 回手動で put した
-# 既存 panicboat App の credentials (Contents: Read & Write 権限あり)。
+# Secret として sync し、GitRepository monorepo の clone 認証に使う。
+# panicboat-fluxcd-bot は monorepo clone 専用の GitHub App (Contents: Read-only)。
+# CI (panicboat-ci-bot) とは別の App。
 # =============================================================================
 apiVersion: external-secrets.io/v1
 kind: ExternalSecret
@@ -63,13 +63,13 @@ spec:
   data:
     - secretKey: githubAppID
       remoteRef:
-        key: panicboat/github-app/panicboat
+        key: github-app/fluxcd-bot
         property: app_id
     - secretKey: githubAppInstallationID
       remoteRef:
-        key: panicboat/github-app/panicboat
+        key: github-app/fluxcd-bot
         property: installation_id
     - secretKey: githubAppPrivateKey
       remoteRef:
-        key: panicboat/github-app/panicboat
+        key: github-app/fluxcd-bot
         property: private_key

--- a/kubernetes/components/keycloak/production/kustomization/external-secret.yaml
+++ b/kubernetes/components/keycloak/production/kustomization/external-secret.yaml
@@ -1,7 +1,7 @@
 # =============================================================================
 # ExternalSecret: Keycloak admin bootstrap credentials
 # =============================================================================
-# AWS Secrets Manager の panicboat/keycloak/admin を K8s Secret keycloak-admin
+# AWS Secrets Manager の eks/keycloak/admin を K8s Secret keycloak-admin
 # (= username / password) に sync。oauth2-proxy-google と同一パターン。
 # AWS 側 secret 本体は本 PR merge 後に手動で put-secret-value する
 # (= monolith-database の初期化と同様、platform リポジトリ側に Terraform
@@ -23,9 +23,9 @@ spec:
   data:
     - secretKey: username
       remoteRef:
-        key: panicboat/keycloak/admin
+        key: eks/keycloak/admin
         property: username
     - secretKey: password
       remoteRef:
-        key: panicboat/keycloak/admin
+        key: eks/keycloak/admin
         property: password

--- a/kubernetes/components/oauth2-proxy/production/kustomization/external-secret.yaml
+++ b/kubernetes/components/oauth2-proxy/production/kustomization/external-secret.yaml
@@ -1,7 +1,7 @@
 # =============================================================================
 # ExternalSecret: oauth2-proxy Google OAuth credentials
 # =============================================================================
-# AWS Secrets Manager の panicboat/oauth2-proxy/google を K8s Secret
+# AWS Secrets Manager の eks/oauth2-proxy/google を K8s Secret
 # oauth2-proxy-google (= 3 keys) に sync。Reloader が Secret 変更を検知して
 # oauth2-proxy Deployment auto-rollout (= 強制 logout 全 user 等の rotation 対応)。
 # =============================================================================
@@ -21,13 +21,13 @@ spec:
   data:
     - secretKey: client-id
       remoteRef:
-        key: panicboat/oauth2-proxy/google
+        key: eks/oauth2-proxy/google
         property: client_id
     - secretKey: client-secret
       remoteRef:
-        key: panicboat/oauth2-proxy/google
+        key: eks/oauth2-proxy/google
         property: client_secret
     - secretKey: cookie-secret
       remoteRef:
-        key: panicboat/oauth2-proxy/google
+        key: eks/oauth2-proxy/google
         property: cookie_secret

--- a/kubernetes/components/prometheus-operator/production/kustomization/alertmanager-slack-notify-external-secret.yaml
+++ b/kubernetes/components/prometheus-operator/production/kustomization/alertmanager-slack-notify-external-secret.yaml
@@ -1,7 +1,7 @@
 # =============================================================================
 # ExternalSecret: Alertmanager critical-alert Slack notification webhook
 # =============================================================================
-# Deliberately independent of panicboat/holmes/* — this Incoming Webhook
+# Deliberately independent of eks/holmes/* — this Incoming Webhook
 # belongs to its own dedicated Slack app, not holmes's, so neither the
 # notification channel nor its credentials are coupled to holmes's app
 # registration or pod availability.
@@ -22,5 +22,5 @@ spec:
   data:
     - secretKey: SLACK_WEBHOOK_URL
       remoteRef:
-        key: panicboat/alertmanager/slack-notify
+        key: eks/alertmanager/slack
         property: webhook_url

--- a/kubernetes/components/prometheus-operator/production/kustomization/grafana-admin-external-secret.yaml
+++ b/kubernetes/components/prometheus-operator/production/kustomization/grafana-admin-external-secret.yaml
@@ -1,7 +1,7 @@
 # =============================================================================
 # ExternalSecret: Grafana admin password
 # =============================================================================
-# AWS Secrets Manager の panicboat/grafana/admin を K8s Secret grafana-admin
+# AWS Secrets Manager の eks/grafana/admin を K8s Secret grafana-admin
 # (= 2 keys: admin-user / admin-password) に sync、kube-prometheus-stack chart の
 # grafana.admin.existingSecret から参照される。Reloader が Secret 変更を検知して
 # Grafana Deployment auto-rollout (= values.yaml.gotmpl の Reloader watch
@@ -24,9 +24,9 @@ spec:
   data:
     - secretKey: admin-user
       remoteRef:
-        key: panicboat/grafana/admin
+        key: eks/grafana/admin
         property: admin-user
     - secretKey: admin-password
       remoteRef:
-        key: panicboat/grafana/admin
+        key: eks/grafana/admin
         property: admin-password

--- a/kubernetes/components/prometheus-operator/production/kustomization/holmes-alertmanager-external-secret.yaml
+++ b/kubernetes/components/prometheus-operator/production/kustomization/holmes-alertmanager-external-secret.yaml
@@ -21,5 +21,5 @@ spec:
   data:
     - secretKey: ALERTMANAGER_SHARED_TOKEN
       remoteRef:
-        key: panicboat/holmes/alertmanager
+        key: eks/holmes/alertmanager
         property: shared_token

--- a/kubernetes/manifests/production/keycloak/manifest.yaml
+++ b/kubernetes/manifests/production/keycloak/manifest.yaml
@@ -243,11 +243,11 @@ metadata:
 spec:
   data:
   - remoteRef:
-      key: panicboat/keycloak/admin
+      key: eks/keycloak/admin
       property: username
     secretKey: username
   - remoteRef:
-      key: panicboat/keycloak/admin
+      key: eks/keycloak/admin
       property: password
     secretKey: password
   refreshInterval: 1h

--- a/kubernetes/manifests/production/oauth2-proxy/manifest.yaml
+++ b/kubernetes/manifests/production/oauth2-proxy/manifest.yaml
@@ -1043,15 +1043,15 @@ metadata:
 spec:
   data:
   - remoteRef:
-      key: panicboat/oauth2-proxy/google
+      key: eks/oauth2-proxy/google
       property: client_id
     secretKey: client-id
   - remoteRef:
-      key: panicboat/oauth2-proxy/google
+      key: eks/oauth2-proxy/google
       property: client_secret
     secretKey: client-secret
   - remoteRef:
-      key: panicboat/oauth2-proxy/google
+      key: eks/oauth2-proxy/google
       property: cookie_secret
     secretKey: cookie-secret
   refreshInterval: 1h

--- a/kubernetes/manifests/production/prometheus-operator/manifest.yaml
+++ b/kubernetes/manifests/production/prometheus-operator/manifest.yaml
@@ -82012,7 +82012,7 @@ metadata:
 spec:
   data:
   - remoteRef:
-      key: panicboat/alertmanager/slack-notify
+      key: eks/alertmanager/slack
       property: webhook_url
     secretKey: SLACK_WEBHOOK_URL
   refreshInterval: 1h
@@ -82031,11 +82031,11 @@ metadata:
 spec:
   data:
   - remoteRef:
-      key: panicboat/grafana/admin
+      key: eks/grafana/admin
       property: admin-user
     secretKey: admin-user
   - remoteRef:
-      key: panicboat/grafana/admin
+      key: eks/grafana/admin
       property: admin-password
     secretKey: admin-password
   refreshInterval: 1h
@@ -82054,7 +82054,7 @@ metadata:
 spec:
   data:
   - remoteRef:
-      key: panicboat/holmes/alertmanager
+      key: eks/holmes/alertmanager
       property: shared_token
     secretKey: ALERTMANAGER_SHARED_TOKEN
   refreshInterval: 1h


### PR DESCRIPTION
## Summary
- 全 ExternalSecret の remoteRef.key を `panicboat/` prefix 方式から `{service}/{component}/{role}` 方式に変更
- Flux の monorepo GitRepository 認証を CI (panicboat-ci-bot) と共用していた GitHub App から専用の `github-app/fluxcd-bot` (Contents: Read-only) に分離
- production アカウントの Secrets Manager には新旧の名前が一時的に共存中。本 PR マージ・Flux 反映・sync 確認後に旧名前を削除する

## Test plan
- [x] hydrate 後の manifest 差分が `key:` フィールドのみであることを確認
- [ ] merge 後、Flux reconcile で全 ExternalSecret が `SecretSynced: True` になることを確認
- [ ] 確認後、production の旧名前 (panicboat/*) と master アカウントの8件を削除