### PR TITLE
chore(kubernetes): fix component name to holmesgpt in secret key

### DIFF
--- a/kubernetes/components/prometheus-operator/production/kustomization/alertmanager-slack-notify-external-secret.yaml
+++ b/kubernetes/components/prometheus-operator/production/kustomization/alertmanager-slack-notify-external-secret.yaml
@@ -1,7 +1,7 @@
 # =============================================================================
 # ExternalSecret: Alertmanager critical-alert Slack notification webhook
 # =============================================================================
-# Deliberately independent of eks/holmes/* — this Incoming Webhook
+# Deliberately independent of eks/holmesgpt/* — this Incoming Webhook
 # belongs to its own dedicated Slack app, not holmes's, so neither the
 # notification channel nor its credentials are coupled to holmes's app
 # registration or pod availability.

--- a/kubernetes/components/prometheus-operator/production/kustomization/holmes-alertmanager-external-secret.yaml
+++ b/kubernetes/components/prometheus-operator/production/kustomization/holmes-alertmanager-external-secret.yaml
@@ -21,5 +21,5 @@ spec:
   data:
     - secretKey: ALERTMANAGER_SHARED_TOKEN
       remoteRef:
-        key: eks/holmes/alertmanager
+        key: eks/holmesgpt/alertmanager
         property: shared_token

--- a/kubernetes/manifests/production/prometheus-operator/manifest.yaml
+++ b/kubernetes/manifests/production/prometheus-operator/manifest.yaml
@@ -82054,7 +82054,7 @@ metadata:
 spec:
   data:
   - remoteRef:
-      key: eks/holmes/alertmanager
+      key: eks/holmesgpt/alertmanager
       property: shared_token
     secretKey: ALERTMANAGER_SHARED_TOKEN
   refreshInterval: 1h


### PR DESCRIPTION
## Summary
- 直前の #818 で `eks/holmes/alertmanager` としたが、正しくは `eks/holmesgpt/alertmanager`
- Secrets Manager 側は `eks/holmesgpt/alertmanager` を新規作成済み、旧 `eks/holmes/alertmanager` は本 PR merge・sync 確認後に削除する

## Test plan
- [ ] merge 後、alertmanager-slack-notify / holmes-alertmanager ExternalSecret が SecretSynced: True になることを確認