### PR TITLE
feat(aws/eks): grant SSO AdministratorAccess an EKS access entry

### DIFF
--- a/aws/eks/modules/access_entries.tf
+++ b/aws/eks/modules/access_entries.tf
@@ -1,7 +1,9 @@
 # access_entries.tf - EKS Access Entries (Kubernetes RBAC mapping for IAM principals).
 #
-# We keep this minimal: only the human kubectl admin role is granted RBAC.
-# The CI apply role (github-oidc-auth-production-github-actions-role)
+# We keep this minimal: the human kubectl admin role and the IAM Identity
+# Center AdministratorAccess role (AWS Console EKS "Resources" tab needs an
+# access entry independent of the IAM-level AWS API permissions) are
+# granted RBAC. The CI apply role (github-oidc-auth-production-github-actions-role)
 # operates on AWS APIs only and never touches Kubernetes API; under the
 # GitOps model, all Kubernetes-side changes flow through Flux CD.
 #
@@ -10,10 +12,31 @@
 # managed policy form `arn:aws:iam::aws:policy/<NAME>`. Passing the IAM
 # form to AssociateAccessPolicy yields InvalidParameterException (400).
 
+# IAM Identity Center provisions the SSO permission-set role name with a
+# random hash suffix (AWSReservedSSO_<PermissionSetName>_<hash>) that isn't
+# knowable in advance, so it's looked up by name_regex instead of hardcoded.
+data "aws_iam_roles" "sso_admin" {
+  name_regex  = "AWSReservedSSO_AdministratorAccess_.*"
+  path_prefix = "/aws-reserved/sso.amazonaws.com/"
+}
+
 locals {
   access_entries = {
     human_admin = {
       principal_arn = aws_iam_role.eks_admin.arn
+
+      policy_associations = {
+        cluster_admin = {
+          policy_arn = "arn:aws:eks::aws:cluster-access-policy/AmazonEKSClusterAdminPolicy"
+          access_scope = {
+            type = "cluster"
+          }
+        }
+      }
+    }
+
+    sso_admin = {
+      principal_arn = one(data.aws_iam_roles.sso_admin.arns)
 
       policy_associations = {
         cluster_admin = {


### PR DESCRIPTION
## Summary
- production アカウントに IAM Identity Center (SSO) の AdministratorAccess で
  ログインした際、AWS Console の EKS "Resources" タブが
  "リソースのロード中にエラーが発生しました" で失敗していた問題を修正
- 原因: EKS access entry (Kubernetes RBAC マッピング) が IAM 側の
  AdministratorAccess 権限とは独立しており、SSO permission set のロールに
  access entry が無かった
- 緊急対応として CLI で作成済みの access entry / policy association を
  Terraform state に import 済み。plan は tags の軽微な正規化のみで
  他に差分なし

## Test plan
- [x] `tofu plan` で access entry / policy association に予期しない diff が無いことを確認
- [x] AWS Console の EKS Resources タブが正常表示されることを確認済み（CLI 作成時点）