### PR TITLE
fix(scripts/eks-lifecycle): assume into production's dedicated account

### DIFF
--- a/scripts/eks-lifecycle/lib/00-auth.sh
+++ b/scripts/eks-lifecycle/lib/00-auth.sh
@@ -1,23 +1,28 @@
 #!/usr/bin/env bash
-# 00-auth.sh - Use operator's IAM principal for AWS calls + assume admin role for kubectl.
+# 00-auth.sh - Assume into the environment's dedicated AWS account for both
+# terragrunt destroy and kubectl (admin role) operations.
 #
-# Design spec §3 Decision 1 prerequisite: operator's IAM principal has
-# sufficient AWS permissions for terragrunt apply/destroy. panicboat IAM
-# user holds AdministratorAccess.
+# production lives in its own member account under the panicboat
+# Organization since the account-separation migration; the operator's
+# default identity (management account IAM user) has no direct
+# AdministratorAccess there anymore, so every operation hops through
+# OrganizationAccountAccessRole first. This mirrors the fix applied to
+# eks-login.sh for the same root cause (直接 assume は AccessDenied).
 #
 # The GitHub OIDC apply role (= github-oidc-auth-${ENV}-github-actions-apply-role)
 # trust policy allows only sts:AssumeRoleWithWebIdentity from GitHub Actions
-# tokens — it cannot be assumed from an IAM user, so we use the operator's
-# default credential chain directly for terragrunt operations.
+# tokens — it cannot be assumed from an IAM user, so this script drives
+# terragrunt with the OrganizationAccountAccessRole hop instead.
 #
 # Sets:
 #   - ADMIN_CREDS_FILE (= /tmp file with eks-admin-${ENV} STS session creds)
+#   - APPLY_CREDS_FILE (= /tmp file with OrganizationAccountAccessRole STS session creds, used for terragrunt)
 #   - CLUSTER_EXISTS (= "true" or "false", consumed by 10-k8s-cleanup.sh)
 #   - CREDS_EXPIRE_FILE (= UNIX epoch of admin creds expiration, for re-source)
 #   - ~/.kube/config (= updated by `aws eks update-kubeconfig` via admin role assume;
 #     KUBECONFIG env not exported)
 #
-# Idempotent: re-sourcing refreshes admin credentials with a new assume.
+# Idempotent: re-sourcing refreshes both credential sets with a new assume.
 
 # Source common.sh from same directory
 LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -27,12 +32,13 @@ LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 require_env
 require_cmd aws jq kubectl
 
-# Capture operator's original AWS credentials env state so use_apply_creds
-# can restore it after use_admin_creds temporarily overrides the env.
-ORIG_AWS_ACCESS_KEY_ID="${AWS_ACCESS_KEY_ID:-}"
-ORIG_AWS_SECRET_ACCESS_KEY="${AWS_SECRET_ACCESS_KEY:-}"
-ORIG_AWS_SESSION_TOKEN="${AWS_SESSION_TOKEN:-}"
-export ORIG_AWS_ACCESS_KEY_ID ORIG_AWS_SECRET_ACCESS_KEY ORIG_AWS_SESSION_TOKEN
+# Environment -> dedicated AWS account ID. require_env already restricts
+# ENV to "production"; keep this a case (not a bare literal) so a future
+# ENV addition fails loudly here instead of silently reusing the wrong account.
+case "${ENV}" in
+  production) TARGET_ACCOUNT_ID="337169763788" ;;
+  *)          error "no account mapping for ENV='${ENV}'"; exit 1 ;;
+esac
 
 # Helper for sub-scripts that need admin credentials (= kubectl ops in 10/60/70).
 # Split declare + assign so jq failure (= file corrupted) propagates under set -e.
@@ -50,40 +56,70 @@ use_admin_creds() {
   fi
 }
 
-# Restore operator's default credential state for terragrunt operations.
-# When operator uses AWS_PROFILE / IAM Identity Center / instance profile,
-# unsetting AWS_*_KEY env returns the SDK to its default lookup chain.
-# When operator had AWS_*_KEY set directly, restore the captured values.
+# Switch to OrganizationAccountAccessRole credentials for terragrunt
+# operations (= AdministratorAccess-equivalent within the target account).
 use_apply_creds() {
-  if [ -n "${ORIG_AWS_ACCESS_KEY_ID}" ]; then
-    export AWS_ACCESS_KEY_ID="$ORIG_AWS_ACCESS_KEY_ID"
-    export AWS_SECRET_ACCESS_KEY="$ORIG_AWS_SECRET_ACCESS_KEY"
-    if [ -n "${ORIG_AWS_SESSION_TOKEN}" ]; then
-      export AWS_SESSION_TOKEN="$ORIG_AWS_SESSION_TOKEN"
-    else
-      unset AWS_SESSION_TOKEN
-    fi
-  else
-    unset AWS_ACCESS_KEY_ID
-    unset AWS_SECRET_ACCESS_KEY
-    unset AWS_SESSION_TOKEN
+  if [ -n "${APPLY_CREDS_FILE:-}" ] && [ -f "$APPLY_CREDS_FILE" ]; then
+    local _id _secret _token
+    _id=$(jq -r .AccessKeyId "$APPLY_CREDS_FILE")
+    _secret=$(jq -r .SecretAccessKey "$APPLY_CREDS_FILE")
+    _token=$(jq -r .SessionToken "$APPLY_CREDS_FILE")
+    export AWS_ACCESS_KEY_ID="$_id"
+    export AWS_SECRET_ACCESS_KEY="$_secret"
+    export AWS_SESSION_TOKEN="$_token"
   fi
+}
+
+# The panicboat.net hosted zone stays in the management account (master)
+# even though production lives in its own member account; external-dns
+# itself reaches it the same way, via route53-zone-access
+# (trust policy: arn:aws:iam::337169763788:root, i.e. any permitted
+# principal in the production account). Callers that need to inspect or
+# clean up Route53 records (10-k8s-cleanup.sh Step 10.8,
+# 40-orphan-verify.sh Step 40.5) must use this instead of use_apply_creds,
+# whose credentials have no cross-account Route53 access.
+use_route53_creds() {
+  use_apply_creds
+  local _creds
+  _creds=$(aws sts assume-role \
+    --role-arn "arn:aws:iam::559744160976:role/route53-zone-access" \
+    --role-session-name "eks-lifecycle-route53-${USER:-debug}-$$" \
+    --query Credentials --output json)
+  export AWS_ACCESS_KEY_ID=$(echo "$_creds" | jq -r .AccessKeyId)
+  export AWS_SECRET_ACCESS_KEY=$(echo "$_creds" | jq -r .SecretAccessKey)
+  export AWS_SESSION_TOKEN=$(echo "$_creds" | jq -r .SessionToken)
 }
 
 REGION="$(resolve_aws_region)"
 CALLER_ARN="$(aws sts get-caller-identity --query Arn --output text)"
-ACCOUNT_ID="$(aws sts get-caller-identity --query Account --output text)"
-
-ADMIN_ROLE_ARN="arn:aws:iam::${ACCOUNT_ID}:role/eks-admin-${ENV}"
 
 info "Operator IAM principal: ${CALLER_ARN}"
 
-info "Assuming admin role for kubectl: ${ADMIN_ROLE_ARN}"
-if ! ADMIN_CREDS=$(aws sts assume-role \
-  --role-arn "$ADMIN_ROLE_ARN" \
-  --role-session-name "eks-lifecycle-admin-${USER:-debug}-$$" \
+ORG_ROLE_ARN="arn:aws:iam::${TARGET_ACCOUNT_ID}:role/OrganizationAccountAccessRole"
+info "Assuming ${ORG_ROLE_ARN} for terragrunt operations"
+APPLY_CREDS=$(aws sts assume-role \
+  --role-arn "$ORG_ROLE_ARN" \
+  --role-session-name "eks-lifecycle-apply-${USER:-debug}-$$" \
   --query Credentials \
-  --output json 2>/dev/null); then
+  --output json)
+APPLY_CREDS_FILE="/tmp/eks-lifecycle-apply-creds-$$"
+( umask 077 && : > "$APPLY_CREDS_FILE" )
+echo "$APPLY_CREDS" > "$APPLY_CREDS_FILE"
+export APPLY_CREDS_FILE
+
+ADMIN_ROLE_ARN="arn:aws:iam::${TARGET_ACCOUNT_ID}:role/eks-admin-${ENV}"
+
+info "Assuming admin role for kubectl: ${ADMIN_ROLE_ARN}"
+if ! ADMIN_CREDS=$(
+  AWS_ACCESS_KEY_ID=$(jq -r .AccessKeyId "$APPLY_CREDS_FILE") \
+  AWS_SECRET_ACCESS_KEY=$(jq -r .SecretAccessKey "$APPLY_CREDS_FILE") \
+  AWS_SESSION_TOKEN=$(jq -r .SessionToken "$APPLY_CREDS_FILE") \
+  aws sts assume-role \
+    --role-arn "$ADMIN_ROLE_ARN" \
+    --role-session-name "eks-lifecycle-admin-${USER:-debug}-$$" \
+    --query Credentials \
+    --output json 2>/dev/null
+); then
   warn "Admin role not found (= cluster may already be destroyed). Setting CLUSTER_EXISTS=false."
   export CLUSTER_EXISTS="false"
   use_apply_creds

--- a/scripts/eks-lifecycle/lib/10-k8s-cleanup.sh
+++ b/scripts/eks-lifecycle/lib/10-k8s-cleanup.sh
@@ -130,7 +130,7 @@ info "Step 10.8: AWS-API fallback — delete leftover external-dns Route53 recor
 # 残る。 cluster destroy 後は external-dns 経路で消せないので、 ownership marker tag を頼りに
 # AWS API で直接削除する。
 if [ "${DRY_RUN:-0}" != "1" ]; then
-  use_apply_creds  # = need route53 permissions (= operator's chain)
+  use_route53_creds  # = panicboat.net zone lives in master, not production
   HOSTED_ZONE_ID=$(aws route53 list-hosted-zones-by-name \
     --dns-name panicboat.net --query 'HostedZones[0].Id' --output text 2>/dev/null | sed 's|/hostedzone/||')
   if [ -n "$HOSTED_ZONE_ID" ] && [ "$HOSTED_ZONE_ID" != "None" ]; then

--- a/scripts/eks-lifecycle/lib/40-orphan-verify.sh
+++ b/scripts/eks-lifecycle/lib/40-orphan-verify.sh
@@ -57,6 +57,7 @@ if [ -n "$SG_IDS" ]; then
 fi
 
 info "Step 40.5: Route53 stale external-dns records"
+use_route53_creds  # = panicboat.net zone lives in master, not production
 HOSTED_ZONE_ID=$(aws route53 list-hosted-zones-by-name \
   --dns-name panicboat.net --query 'HostedZones[0].Id' --output text 2>/dev/null | sed 's|/hostedzone/||')
 if [ -n "$HOSTED_ZONE_ID" ] && [ "$HOSTED_ZONE_ID" != "None" ]; then
@@ -80,6 +81,8 @@ if [ -n "$HOSTED_ZONE_ID" ] && [ "$HOSTED_ZONE_ID" != "None" ]; then
     ORPHAN_FOUND=1
   fi
 fi
+
+use_apply_creds  # = back to production account creds (Step 40.5 switched to master for Route53)
 
 info "Step 40.6: CloudWatch log groups"
 LG_NAMES=$(aws logs describe-log-groups --region "$REGION" \


### PR DESCRIPTION
## Summary
- eks-lifecycle teardown script が account-separation migration 前提のまま
  だったため、production 環境で teardown を実行すると各所で認証が壊れて
  いた（eks-login.sh で直したのと同じ根本原因）
- `00-auth.sh`: ENV->account の固定 mapping + OrganizationAccountAccessRole
  経由の 2-hop assume に変更
- Route53 (panicboat.net zone は master 側) 用に `use_route53_creds` を追加

## Test plan
- [x] `DRY_RUN=1 bash scripts/eks-lifecycle/lib/10-k8s-cleanup.sh` が
      org-hop + admin-role assume 込みで正常完走することを確認
- [x] `use_route53_creds` を直接呼び、master アカウントの
      route53-zone-access に正しく assume できることを確認
- [x] `DRY_RUN=1 bash scripts/eks-lifecycle/lib/40-orphan-verify.sh` が
      production 側 (ENI/EBS/TG/SG/CloudWatch) と master 側 (Route53) を
      正しく切り替えながら全項目を検出できることを確認（現存クラスタの
      resource が正しく列挙された）