### PR TITLE
chore(workflow-config): enable aws/{service} stack convention

### DIFF
--- a/workflow-config.yaml
+++ b/workflow-config.yaml
@@ -6,27 +6,26 @@ environments:
         iam_role_plan: arn:aws:iam::559744160976:role/github-oidc-auth-master-github-actions-plan-role
         iam_role_apply: arn:aws:iam::559744160976:role/github-oidc-auth-master-github-actions-apply-role
 
-  - environment: develop
-    stacks:
-      terragrunt:
-        aws_region: us-east-1
-        iam_role_plan: arn:aws:iam::270242382571:role/github-oidc-auth-develop-github-actions-plan-role
-        iam_role_apply: arn:aws:iam::270242382571:role/github-oidc-auth-develop-github-actions-apply-role
+  # - environment: develop
+  #   stacks:
+  #     terragrunt:
+  #       aws_region: us-east-1
+  #       iam_role_plan: arn:aws:iam::270242382571:role/github-oidc-auth-develop-github-actions-plan-role
+  #       iam_role_apply: arn:aws:iam::270242382571:role/github-oidc-auth-develop-github-actions-apply-role
 
-  - environment: production
-    stacks:
-      terragrunt:
-        aws_region: ap-northeast-1
-        iam_role_plan: arn:aws:iam::337169763788:role/github-oidc-auth-production-github-actions-plan-role
-        iam_role_apply: arn:aws:iam::337169763788:role/github-oidc-auth-production-github-actions-apply-role
+  # - environment: production
+  #   stacks:
+  #     terragrunt:
+  #       aws_region: ap-northeast-1
+  #       iam_role_plan: arn:aws:iam::337169763788:role/github-oidc-auth-production-github-actions-plan-role
+  #       iam_role_apply: arn:aws:iam::337169763788:role/github-oidc-auth-production-github-actions-apply-role
 
 stack_conventions:
-  # TODO: Define conventions for Terragrunt stacks when we have active Terragrunt targets.
-  # - root: "aws/{service}"
-  #   stacks:
-  #     - name: terragrunt
-  #       directory: "envs/{environment}"
-  #       required_attributes: [aws_region, iam_role_plan, iam_role_apply]
+  - root: "aws/{service}"
+    stacks:
+      - name: terragrunt
+        directory: "envs/{environment}"
+        required_attributes: [aws_region, iam_role_plan, iam_role_apply]
 
   - root: "github/{service}"
     stacks:


### PR DESCRIPTION
## Summary
- `aws/{service}` の stack_conventions を有効化し、master の aws/ 配下変更が label-dispatcher で検出されるようにする
- develop / production の environment 定義は引き続きコメントアウト（develop は EKS 未構築、production は teardown 済で CI 自動 apply 対象外の方針）

## Test plan
- [ ] merge 後、master の aws/ 配下を触る PR で deploy label が付くことを確認