### PR TITLE
chore(workflow-config): revert aws/{service} stack convention

### DIFF
--- a/workflow-config.yaml
+++ b/workflow-config.yaml
@@ -6,26 +6,27 @@ environments:
         iam_role_plan: arn:aws:iam::559744160976:role/github-oidc-auth-master-github-actions-plan-role
         iam_role_apply: arn:aws:iam::559744160976:role/github-oidc-auth-master-github-actions-apply-role
 
-  # - environment: develop
-  #   stacks:
-  #     terragrunt:
-  #       aws_region: us-east-1
-  #       iam_role_plan: arn:aws:iam::270242382571:role/github-oidc-auth-develop-github-actions-plan-role
-  #       iam_role_apply: arn:aws:iam::270242382571:role/github-oidc-auth-develop-github-actions-apply-role
+  - environment: develop
+    stacks:
+      terragrunt:
+        aws_region: us-east-1
+        iam_role_plan: arn:aws:iam::270242382571:role/github-oidc-auth-develop-github-actions-plan-role
+        iam_role_apply: arn:aws:iam::270242382571:role/github-oidc-auth-develop-github-actions-apply-role
 
-  # - environment: production
-  #   stacks:
-  #     terragrunt:
-  #       aws_region: ap-northeast-1
-  #       iam_role_plan: arn:aws:iam::337169763788:role/github-oidc-auth-production-github-actions-plan-role
-  #       iam_role_apply: arn:aws:iam::337169763788:role/github-oidc-auth-production-github-actions-apply-role
+  - environment: production
+    stacks:
+      terragrunt:
+        aws_region: ap-northeast-1
+        iam_role_plan: arn:aws:iam::337169763788:role/github-oidc-auth-production-github-actions-plan-role
+        iam_role_apply: arn:aws:iam::337169763788:role/github-oidc-auth-production-github-actions-apply-role
 
 stack_conventions:
-  - root: "aws/{service}"
-    stacks:
-      - name: terragrunt
-        directory: "envs/{environment}"
-        required_attributes: [aws_region, iam_role_plan, iam_role_apply]
+  # TODO: Define conventions for Terragrunt stacks when we have active Terragrunt targets.
+  # - root: "aws/{service}"
+  #   stacks:
+  #     - name: terragrunt
+  #       directory: "envs/{environment}"
+  #       required_attributes: [aws_region, iam_role_plan, iam_role_apply]
 
   - root: "github/{service}"
     stacks:


### PR DESCRIPTION
## Summary
- PR #822 を revert する
- stack_conventions の設計を整理してから改めて判断するため

## Why
#822 は効果が限定的なわりに、設計判断が未確定のまま入っていた。
`environments` を指定せずに label-resolver を呼ぶと `config.environments.keys`
（= 現状 master のみ）が target になるため、`aws/{service}` を有効化しても
`envs/master` を持つ 3 service (cost-management / github-oidc-auth / route53)
しか検出されない。`alb` / `eks*` / `vpc` などは `envs/production` のみなので
対象外のままだった。