### PR TITLE
fix(cilium-gateway): allow HTTPRoutes from any namespace

### DIFF
--- a/kubernetes/clusters/production/repositories/monorepo.yaml
+++ b/kubernetes/clusters/production/repositories/monorepo.yaml
@@ -32,10 +32,6 @@ spec:
   sourceRef:
     kind: GitRepository
     name: monorepo
-  # monorepo 側の workload (= monolith / frontend) は現状 production で正常に
-  # 動作しないため停止中。monolith は required な Secret (= monolith-database)
-  # が無く CreateContainerConfigError で起動しない。
-  # 再開する場合は monorepo 側の動作を確認してから `false` に戻す。
   suspend: false
 ---
 # =============================================================================

--- a/kubernetes/components/cilium/production/kustomization/cilium-gateway.yaml
+++ b/kubernetes/components/cilium/production/kustomization/cilium-gateway.yaml
@@ -24,6 +24,11 @@ spec:
     - name: http
       port: 8080  # = hostNetwork mode、 eks-pod-identity-agent の port 80 と collision 回避
       protocol: HTTP
+      # allowedRoutes.namespaces.from: All so monorepo can add product
+      # namespaces (dystopia / system-components / future ones) without
+      # editing this file each time. The cluster is a single GitOps tenant,
+      # so Selector's "only namespaces I labelled" gate has no threat model
+      # to enforce.
       allowedRoutes:
         namespaces:
-          from: Same
+          from: All


### PR DESCRIPTION
## Summary

- `cilium-gateway`'s `allowedRoutes.namespaces.from` moves from `Same` to `All` so the monorepo can add product namespaces without a paired platform PR
- Drop a stale comment on the monorepo Flux `Kustomization` that documented a bootstrap gap that no longer exists

## Why

`Same` restricted route attachment to namespace `default`. The monorepo is moving its workloads out of `default` into product-owned namespaces (`dystopia`, `system-components`, likely more later — see panicboat/monorepo#1007). Under `Same` every such move requires this repo to grow a matching selector label; under `All` the monorepo owns its own namespace list end-to-end.

`Selector` was considered. It still needs a label per namespace, so the operational burden is identical to `Same` in practice. The cluster is a single GitOps tenant, so gating who may attach routes protects against no realistic threat.

The monorepo Kustomization comment claimed `monolith` could not start because `monolith-database` was absent. `dystopia/monolith/kubernetes/overlays/production/external-secret.yaml` now supplies it, so the note is misleading.

## Verification

- `kustomize build kubernetes/components/cilium/production/kustomization` renders the Gateway with `allowedRoutes.namespaces.from: All`
- `python3 -c 'yaml.safe_load_all(...)'` on `monorepo.yaml` still parses three documents (`GitRepository`, `Kustomization`, `ExternalSecret`)

## Related

- panicboat/monorepo#1007 — depends on this PR being applied first, otherwise its HTTPRoute in `dystopia` cannot attach to the Gateway (`NotAllowedByListeners`)