### PR TITLE
chore(kubernetes/components): right-size idle-state over-provisioned resource requests

### DIFF
--- a/kubernetes/components/beyla/production/values.yaml.gotmpl
+++ b/kubernetes/components/beyla/production/values.yaml.gotmpl
@@ -114,10 +114,12 @@ config:
 # =============================================================================
 # Resources (= small DaemonSet、~5-7 Pods total per cluster)
 # =============================================================================
+# 2026-09-04 recreate 直後 (アイドル状態) の実測 (概ね 1-2m / 21-26Mi) に対し
+# 50m/128Mi は過大。right-size。実トラフィック投入後に再計測して見直すこと。
 resources:
   requests:
-    cpu: 50m
-    memory: 128Mi
+    cpu: 15m
+    memory: 48Mi
   limits:
     cpu: 200m
     memory: 384Mi

--- a/kubernetes/components/keda/production/values.yaml
+++ b/kubernetes/components/keda/production/values.yaml
@@ -3,5 +3,29 @@
 # =============================================================================
 # Resources / Replicas
 # =============================================================================
-# chart default を採用 (HA / resource tuning は現状不要、AWS scaler の IRSA も
-# 利用が顕在化していないため未設定)。
+# cpu/memory request: chart default (各 100m/100Mi) は 2026-09-04 recreate
+# 直後 (アイドル状態) の実測 (operator 1-4m/22-28Mi、metricServer 4m/28Mi、
+# webhooks 1m/8Mi) に対し過大。right-size。実トラフィック投入後に再計測して
+# 見直すこと。
+resources:
+  operator:
+    requests:
+      cpu: 15m
+      memory: 48Mi
+    limits:
+      cpu: 500m
+      memory: 256Mi
+  metricServer:
+    requests:
+      cpu: 15m
+      memory: 48Mi
+    limits:
+      cpu: 500m
+      memory: 256Mi
+  webhooks:
+    requests:
+      cpu: 10m
+      memory: 24Mi
+    limits:
+      cpu: 200m
+      memory: 128Mi

--- a/kubernetes/components/loki/production/values.yaml.gotmpl
+++ b/kubernetes/components/loki/production/values.yaml.gotmpl
@@ -132,10 +132,12 @@ singleBinary:
   # Resources (small production)
   # cpu: 実測平均 32m に対し 500m は過大。ingest burst 用に headroom は残しつつ
   # right-size。
+  # memory: 2026-09-04 recreate 直後 (アイドル状態) の実測 76Mi に対し 1Gi は
+  # 過大。実トラフィック投入後に再計測して見直すこと。
   resources:
     requests:
       cpu: 100m
-      memory: 1Gi
+      memory: 256Mi
     limits:
       cpu: 1
       memory: 2Gi

--- a/kubernetes/components/metrics-server/production/values.yaml
+++ b/kubernetes/components/metrics-server/production/values.yaml
@@ -18,10 +18,12 @@ defaultArgs:
 # Resources
 # =============================================================================
 # cpu request: 実測平均 4m に対し 100m は過大。right-size。
+# memory: 2026-09-04 recreate 直後 (アイドル状態) の実測 25Mi に対し 200Mi は
+# 過大。実トラフィック投入後に再計測して見直すこと。
 resources:
   requests:
     cpu: 25m
-    memory: 200Mi
+    memory: 64Mi
   limits:
     cpu: 1000m
     memory: 1Gi

--- a/kubernetes/components/mimir/production/values.yaml.gotmpl
+++ b/kubernetes/components/mimir/production/values.yaml.gotmpl
@@ -109,6 +109,14 @@ overrides_exporter:
 # cpu request は実測平均 (avg over 6h) に対して余裕を持たせた right-size 値。
 # chart default の 100m は各 component の実使用 (概ね 0-25m) に対し過大で
 # Karpenter の bin-packing を圧迫していた。
+#
+# memory request は 2026-09-04 recreate 直後 (= 実トラフィックほぼ無いアイドル
+# 状態) の実測値に対して headroom を持たせた right-size 値。chart default 由来
+# の 256Mi-512Mi は各 component の実使用 (概ね 12-30Mi) に対し過大だった。
+# ingester のみ実測 (605Mi) が旧 request (512Mi) を超えていたため増量。
+# 実トラフィック投入後に再計測して見直すこと。chunks-cache は memcached の
+# `allocatedMemory: 512` (= キャッシュ本体の割当サイズ) に合わせているため
+# 対象外 (キャッシュが埋まるまでは実測値が低いだけで過大ではない)。
 
 # gateway: chart の HTTP API entry point (nginx-based reverse proxy)
 gateway:
@@ -117,7 +125,7 @@ gateway:
   resources:
     requests:
       cpu: 25m
-      memory: 128Mi
+      memory: 64Mi
     limits:
       cpu: 200m
       memory: 256Mi
@@ -127,7 +135,7 @@ distributor:
   resources:
     requests:
       cpu: 50m
-      memory: 256Mi
+      memory: 128Mi
     limits:
       cpu: 500m
       memory: 1Gi
@@ -141,7 +149,7 @@ ingester:
   resources:
     requests:
       cpu: 75m
-      memory: 512Mi
+      memory: 768Mi
     limits:
       cpu: 1
       memory: 2Gi
@@ -155,7 +163,7 @@ querier:
   resources:
     requests:
       cpu: 25m
-      memory: 256Mi
+      memory: 96Mi
     limits:
       cpu: 500m
       memory: 1Gi
@@ -165,7 +173,7 @@ query_frontend:
   resources:
     requests:
       cpu: 25m
-      memory: 256Mi
+      memory: 64Mi
     limits:
       cpu: 500m
       memory: 512Mi
@@ -179,7 +187,7 @@ store_gateway:
   resources:
     requests:
       cpu: 25m
-      memory: 512Mi
+      memory: 96Mi
     limits:
       cpu: 500m
       memory: 2Gi
@@ -193,7 +201,7 @@ compactor:
   resources:
     requests:
       cpu: 25m
-      memory: 512Mi
+      memory: 96Mi
     limits:
       cpu: 500m
       memory: 2Gi
@@ -203,6 +211,8 @@ compactor:
     size: 10Gi
 
 # memcached (chunks-cache) — querier の S3 query 高速化
+# NOTE: request/limit は allocatedMemory (= memcached -m フラグ) に合わせて
+# あるため他 component と異なり right-size 対象外 (上記 NOTE 参照)。
 chunks-cache:
   enabled: true
   replicas: 1
@@ -224,10 +234,10 @@ query_scheduler:
   resources:
     requests:
       cpu: 25m
-      memory: 128Mi
+      memory: 32Mi
 
 rollout_operator:
   resources:
     requests:
       cpu: 25m
-      memory: 100Mi
+      memory: 32Mi

--- a/kubernetes/components/tempo/production/values.yaml.gotmpl
+++ b/kubernetes/components/tempo/production/values.yaml.gotmpl
@@ -13,10 +13,12 @@ tempo:
   # -------------------------------------------------------------------------
   # cpu: 実測平均 2m に対し 200m は過大。trace ingest burst 用に headroom は
   # 残しつつ right-size。
+  # memory: 2026-09-04 recreate 直後 (アイドル状態) の実測 47Mi に対し 512Mi は
+  # 過大。実トラフィック投入後に再計測して見直すこと。
   resources:
     requests:
       cpu: 50m
-      memory: 512Mi
+      memory: 128Mi
     limits:
       cpu: 1
       memory: 2Gi

--- a/kubernetes/manifests/production/beyla/manifest.yaml
+++ b/kubernetes/manifests/production/beyla/manifest.yaml
@@ -188,8 +188,8 @@ spec:
               cpu: 200m
               memory: 384Mi
             requests:
-              cpu: 50m
-              memory: 128Mi
+              cpu: 15m
+              memory: 48Mi
           env:
             - name: BEYLA_CONFIG_PATH
               value: "/etc/beyla/config/beyla-config.yml"

--- a/kubernetes/manifests/production/keda/manifest.yaml
+++ b/kubernetes/manifests/production/keda/manifest.yaml
@@ -12097,11 +12097,11 @@ spec:
             readOnly: true
           resources:
             limits:
-              cpu: 1
-              memory: 1000Mi
+              cpu: 500m
+              memory: 256Mi
             requests:
-              cpu: 100m
-              memory: 100Mi
+              cpu: 15m
+              memory: 48Mi
       volumes:
       - name: certificates
         secret:
@@ -12230,11 +12230,11 @@ spec:
             readOnly: true
           resources:
             limits:
-              cpu: 1
-              memory: 1000Mi
+              cpu: 500m
+              memory: 256Mi
             requests:
-              cpu: 100m
-              memory: 100Mi
+              cpu: 15m
+              memory: 48Mi
       volumes:
       - name: certificates
         secret:
@@ -12345,11 +12345,11 @@ spec:
             readOnly: true
           resources:
             limits:
-              cpu: 1
-              memory: 1000Mi
+              cpu: 200m
+              memory: 128Mi
             requests:
-              cpu: 100m
-              memory: 100Mi
+              cpu: 10m
+              memory: 24Mi
       volumes:
       - name: certificates
         secret:

--- a/kubernetes/manifests/production/loki/manifest.yaml
+++ b/kubernetes/manifests/production/loki/manifest.yaml
@@ -1099,7 +1099,7 @@ spec:
               memory: 2Gi
             requests:
               cpu: 100m
-              memory: 1Gi
+              memory: 256Mi
         - name: loki-sc-rules
           image: docker.io/kiwigrid/k8s-sidecar:2.10.3
           imagePullPolicy: IfNotPresent

--- a/kubernetes/manifests/production/metrics-server/manifest.yaml
+++ b/kubernetes/manifests/production/metrics-server/manifest.yaml
@@ -227,7 +227,7 @@ spec:
               memory: 1Gi
             requests:
               cpu: 25m
-              memory: 200Mi
+              memory: 64Mi
       volumes:
         - name: tmp
           emptyDir: {}

--- a/kubernetes/manifests/production/mimir/manifest.yaml
+++ b/kubernetes/manifests/production/mimir/manifest.yaml
@@ -1315,7 +1315,7 @@ spec:
               memory: 200Mi
             requests:
               cpu: 25m
-              memory: 100Mi
+              memory: 32Mi
 ---
 # Source: mimir-distributed/templates/distributor/distributor-dep.yaml
 apiVersion: apps/v1
@@ -1415,7 +1415,7 @@ spec:
               memory: 1Gi
             requests:
               cpu: 50m
-              memory: 256Mi
+              memory: 128Mi
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:
@@ -1526,7 +1526,7 @@ spec:
               memory: 256Mi
             requests:
               cpu: 25m
-              memory: 128Mi
+              memory: 64Mi
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:
@@ -1652,7 +1652,7 @@ spec:
               memory: 1Gi
             requests:
               cpu: 25m
-              memory: 256Mi
+              memory: 96Mi
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:
@@ -1776,7 +1776,7 @@ spec:
               memory: 512Mi
             requests:
               cpu: 25m
-              memory: 256Mi
+              memory: 64Mi
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:
@@ -1891,7 +1891,7 @@ spec:
           resources:
             requests:
               cpu: 25m
-              memory: 128Mi
+              memory: 32Mi
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:
@@ -2149,7 +2149,7 @@ spec:
               memory: 2Gi
             requests:
               cpu: 25m
-              memory: 512Mi
+              memory: 96Mi
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:
@@ -2285,7 +2285,7 @@ spec:
               memory: 2Gi
             requests:
               cpu: 75m
-              memory: 512Mi
+              memory: 768Mi
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:
@@ -2420,7 +2420,7 @@ spec:
               memory: 2Gi
             requests:
               cpu: 25m
-              memory: 512Mi
+              memory: 96Mi
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:
@@ -2431,7 +2431,7 @@ spec:
             - name: GOMAXPROCS
               value: "5"
             - name: GOMEMLIMIT
-              value: "536870912"
+              value: "100663296"
 ---
 # Source: mimir-distributed/charts/rollout_operator/templates/prepare-downscale-webhook.yaml
 apiVersion: admissionregistration.k8s.io/v1

--- a/kubernetes/manifests/production/tempo/manifest.yaml
+++ b/kubernetes/manifests/production/tempo/manifest.yaml
@@ -242,7 +242,7 @@ spec:
             memory: 2Gi
           requests:
             cpu: 50m
-            memory: 512Mi
+            memory: 128Mi
         env:
         volumeMounts:
         - mountPath: /conf


### PR DESCRIPTION
## Summary
ユーザー依頼で HolmesGPT と協力して cluster 全体の resource requests 過大設定を調査。HolmesGPT の分析結果は自分でも `kubectl top pods --containers` + 各 Pod の requests を突き合わせて検証し、over-provisioning 側の指摘は概ね裏付けが取れた（under-provisioning 側の指摘＝mimir-ingester -176%、prometheus -73% は誤りと判明、本PRには含めていない）。

- **mimir**: 各 component の memory を実測 (12-30Mi) に対して right-size。CPU は既に別途 right-size 済みのため維持。`ingester` は実測 605Mi が旧 request 512Mi を超えていたため 768Mi に増量。`chunks-cache` は memcached の `allocatedMemory: 512` に合わせた意図的な設定のため対象外
- **loki / tempo**: memory を right-size（CPU は既に right-size 済みのため維持）
- **keda**: chart default (`resources.{operator,metricServer,webhooks}` 各 100m/100Mi) から初めて right-size
- **metrics-server**: memory を right-size（CPU は既に right-size 済み）
- **beyla**: cpu/memory とも初めて right-size

**対象外にしたもの:**
- **falco**: 「security agent を CPU throttling / OOM に晒すと検知を取り逃す」という既存の明示的な設計判断（コメント記載済み）があり、実測も他 component ほど極端でないため変更なし
- **holmesgpt**: 実測 memory (352Mi) が既存 request (512Mi) に近く、CPU はバースト特性のあるLLMエージェントのため idle 実測での判断を避けた
- **oauth2-proxy / opentelemetry-collector**: 既に right-size 済みで実測との乖離が小さい
- **coredns / ebs-csi-driver**: EKS managed addon（terraform 側の configuration_values 管轄）で本 PR のメカニズムと異なるため別途要検討
- **flux-system controllers**: `gotk-components.yaml`（生成済み静的 manifest、PR #407）側の管轄で、hand-edit すると生成元との一貫性が崩れるため別途検討

## Test plan
- [x] `kubectl top pods -A --containers` の実測値と `kubectl get pods -o json` の requests を突き合わせて over-provisioning 候補を検証
- [x] hydrate diff は各 component の requests (主に memory) の変更のみで、image/chart version 等の意図しない変更が無いことを確認
- [ ] merge 後、Flux reconcile で反映され `kubectl top` の余剰が縮小することを確認
- [ ] 実トラフィック投入後に再計測し、特に mimir/loki/tempo の値を見直す