### PR TITLE
fix(kubernetes/components/dashboard): fix Grafana investigability gaps

### DIFF
--- a/kubernetes/components/dashboard/production/kustomization/grafana/app-monitoring.json
+++ b/kubernetes/components/dashboard/production/kustomization/grafana/app-monitoring.json
@@ -8,7 +8,7 @@
           "uid": "-- Grafana --"
         },
         "enable": true,
-        "hide": true,
+        "hide": false,
         "iconColor": "rgba(0, 211, 255, 1)",
         "name": "Annotations & Alerts",
         "type": "dashboard"
@@ -37,6 +37,7 @@
         "type": "prometheus",
         "uid": "mimir"
       },
+      "description": "Includes Succeeded (completed Job) pods, so this will not equal Running + Unhealthy below.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -57,7 +58,7 @@
       },
       "gridPos": {
         "h": 4,
-        "w": 6,
+        "w": 4,
         "x": 0,
         "y": 1
       },
@@ -94,6 +95,7 @@
         "type": "prometheus",
         "uid": "mimir"
       },
+      "description": "Counts pods by phase only. A pod stuck in CrashLoopBackOff or ImagePullBackOff still reports phase=Running and will NOT be counted here.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -118,8 +120,8 @@
       },
       "gridPos": {
         "h": 4,
-        "w": 6,
-        "x": 6,
+        "w": 4,
+        "x": 4,
         "y": 1
       },
       "id": 3,
@@ -175,8 +177,8 @@
       },
       "gridPos": {
         "h": 4,
-        "w": 6,
-        "x": 12,
+        "w": 4,
+        "x": 8,
         "y": 1
       },
       "id": 4,
@@ -200,7 +202,7 @@
             "type": "prometheus",
             "uid": "mimir"
           },
-          "expr": "sum(rate(http_server_request_duration_seconds_count{service_name=~\"$service\"}[5m]))",
+          "expr": "sum(rate(http_server_request_duration_seconds_count{service_name=~\"$service\", k8s_namespace_name=~\"$namespace\"}[$__rate_interval]))",
           "refId": "A"
         }
       ],
@@ -212,6 +214,7 @@
         "type": "prometheus",
         "uid": "mimir"
       },
+      "description": "Current p95 latency (last data point), not an average over the selected time range.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -240,8 +243,8 @@
       },
       "gridPos": {
         "h": 4,
-        "w": 6,
-        "x": 18,
+        "w": 4,
+        "x": 12,
         "y": 1
       },
       "id": 5,
@@ -252,7 +255,7 @@
         "orientation": "auto",
         "reduceOptions": {
           "calcs": [
-            "mean"
+            "lastNotNull"
           ],
           "fields": "",
           "values": false
@@ -265,7 +268,7 @@
             "type": "prometheus",
             "uid": "mimir"
           },
-          "expr": "histogram_quantile(0.95, sum(rate(http_server_request_duration_seconds_bucket{service_name=~\"$service\"}[5m])) by (le))",
+          "expr": "histogram_quantile(0.95, sum(rate(http_server_request_duration_seconds_bucket{service_name=~\"$service\", k8s_namespace_name=~\"$namespace\"}[$__rate_interval])) by (le))",
           "refId": "A"
         }
       ],
@@ -298,6 +301,13 @@
             },
             "inspect": false
           },
+          "links": [
+            {
+              "targetBlank": false,
+              "title": "View Trace",
+              "url": "/d/app-monitoring/application-monitoring?var-traceId=${__data.fields.traceID}&${__url_time_range}"
+            }
+          ],
           "mappings": [],
           "thresholds": {
             "mode": "absolute",
@@ -307,14 +317,7 @@
                 "value": null
               }
             ]
-          },
-          "links": [
-            {
-              "title": "View Trace",
-              "url": "/d/app-monitoring/application-monitoring?var-traceId=${__data.fields.traceID}&${__url_time_range}",
-              "targetBlank": false
-            }
-          ]
+          }
         },
         "overrides": [
           {
@@ -351,7 +354,7 @@
         "h": 8,
         "w": 24,
         "x": 0,
-        "y": 6
+        "y": 12
       },
       "id": 7,
       "options": {
@@ -379,8 +382,8 @@
             "uid": "tempo"
           },
           "limit": 20,
-          "queryType": "traceql",
           "query": "{resource.service.name =~ \"${service:regex}\" && resource.k8s.namespace.name =~ \"${namespace:regex}\"}",
+          "queryType": "traceql",
           "refId": "A",
           "tableType": "traces"
         }
@@ -398,7 +401,7 @@
         "h": 12,
         "w": 24,
         "x": 0,
-        "y": 14
+        "y": 20
       },
       "id": 13,
       "options": {},
@@ -421,20 +424,20 @@
         "type": "tempo",
         "uid": "tempo"
       },
-      "description": "Service dependencies based on trace data",
+      "description": "Cluster-wide service map for the selected time range. The Namespace/Service variables above do not filter this panel.",
       "gridPos": {
         "h": 12,
         "w": 24,
         "x": 0,
-        "y": 26
+        "y": 32
       },
       "id": 14,
       "options": {
-        "nodes": {
-          "mainStatUnit": "ms"
-        },
         "edges": {
           "mainStatUnit": "r/sec"
+        },
+        "nodes": {
+          "mainStatUnit": "ms"
         }
       },
       "targets": [
@@ -455,7 +458,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 38
+        "y": 44
       },
       "id": 8,
       "title": "Logs",
@@ -470,15 +473,15 @@
         "h": 10,
         "w": 24,
         "x": 0,
-        "y": 39
+        "y": 45
       },
       "id": 9,
       "options": {
         "dedupStrategy": "none",
         "enableLogDetails": true,
         "prettifyLogMessage": false,
-        "showCommonLabels": false,
-        "showLabels": false,
+        "showCommonLabels": true,
+        "showLabels": true,
         "showTime": true,
         "sortOrder": "Descending",
         "wrapLogMessage": false
@@ -501,7 +504,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 49
+        "y": 55
       },
       "id": 10,
       "title": "Metrics",
@@ -566,7 +569,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 50
+        "y": 56
       },
       "id": 11,
       "options": {
@@ -587,7 +590,7 @@
             "type": "prometheus",
             "uid": "mimir"
           },
-          "expr": "sum(rate(http_server_request_duration_seconds_count{service_name=~\"$service\"}[1m])) by (http_route)",
+          "expr": "sum(rate(http_server_request_duration_seconds_count{service_name=~\"$service\", k8s_namespace_name=~\"$namespace\"}[$__rate_interval])) by (http_route)",
           "legendFormat": "{{http_route}}",
           "refId": "A"
         }
@@ -654,7 +657,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 50
+        "y": 56
       },
       "id": 12,
       "options": {
@@ -675,15 +678,116 @@
             "type": "prometheus",
             "uid": "mimir"
           },
-          "expr": "histogram_quantile(0.95, sum(rate(http_server_request_duration_seconds_bucket{service_name=~\"$service\"}[1m])) by (le, http_route))",
+          "expr": "histogram_quantile(0.95, sum(rate(http_server_request_duration_seconds_bucket{service_name=~\"$service\", k8s_namespace_name=~\"$namespace\"}[$__rate_interval])) by (le, http_route))",
           "legendFormat": "{{http_route}}",
           "refId": "A"
         }
       ],
       "title": "P95 Latency by Route",
       "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "mimir"
+      },
+      "description": "Verify the http_response_status_code label exists on http_server_request_duration_seconds_count in Mimir before relying on this (checked against live traffic pending; monolith/frontend are currently scaled to 0).",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 1
+              },
+              {
+                "color": "red",
+                "value": 5
+              }
+            ]
+          },
+          "unit": "percent"
+        }
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 16,
+        "y": 1
+      },
+      "id": 15,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "mimir"
+          },
+          "expr": "100 * sum(rate(http_server_request_duration_seconds_count{service_name=~\"$service\", k8s_namespace_name=~\"$namespace\", http_response_status_code=~\"5..\"}[$__rate_interval])) / clamp_min(sum(rate(http_server_request_duration_seconds_count{service_name=~\"$service\", k8s_namespace_name=~\"$namespace\"}[$__rate_interval])), 0.001)",
+          "refId": "A"
+        }
+      ],
+      "title": "5xx Rate",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "tempo",
+        "uid": "tempo"
+      },
+      "description": "Failed traces for the selected namespace/service \u2014 narrower than the general Trace Search Results below.",
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 24,
+        "x": 0,
+        "y": 6
+      },
+      "id": 16,
+      "options": {},
+      "targets": [
+        {
+          "datasource": {
+            "type": "tempo",
+            "uid": "tempo"
+          },
+          "limit": 50,
+          "query": "{ resource.service.name =~ \"${service:regex}\" && resource.k8s.namespace.name =~ \"${namespace:regex}\" && status = error }",
+          "queryType": "traceql",
+          "refId": "A",
+          "tableType": "traces"
+        }
+      ],
+      "title": "Error Traces",
+      "type": "table"
     }
   ],
+  "refresh": "30s",
   "schemaVersion": 39,
   "tags": [
     "application",
@@ -692,6 +796,7 @@
   "templating": {
     "list": [
       {
+        "allValue": ".+",
         "current": {
           "selected": false,
           "text": "All",
@@ -705,7 +810,7 @@
         "hide": 0,
         "includeAll": true,
         "label": "Namespace",
-        "multi": false,
+        "multi": true,
         "name": "namespace",
         "options": [],
         "query": {
@@ -717,10 +822,10 @@
         "regex": "",
         "skipUrlSync": false,
         "sort": 1,
-        "type": "query",
-        "allValue": ".+"
+        "type": "query"
       },
       {
+        "allValue": ".+",
         "current": {
           "selected": false,
           "text": "All",
@@ -730,26 +835,26 @@
           "type": "prometheus",
           "uid": "mimir"
         },
-        "definition": "label_values(http_server_request_duration_seconds_count, service_name)",
+        "definition": "label_values(http_server_request_duration_seconds_count{k8s_namespace_name=~\"$namespace\"}, service_name)",
         "hide": 0,
         "includeAll": true,
         "label": "Service",
-        "multi": false,
+        "multi": true,
         "name": "service",
         "options": [],
         "query": {
           "qryType": 1,
-          "query": "label_values(http_server_request_duration_seconds_count, service_name)",
+          "query": "label_values(http_server_request_duration_seconds_count{k8s_namespace_name=~\"$namespace\"}, service_name)",
           "refId": "PrometheusVariableQueryEditor-VariableQuery"
         },
         "refresh": 2,
         "regex": "",
         "skipUrlSync": false,
         "sort": 1,
-        "type": "query",
-        "allValue": ".+"
+        "type": "query"
       },
       {
+        "allValue": ".+",
         "current": {
           "selected": false,
           "text": "All",
@@ -763,7 +868,7 @@
         "hide": 0,
         "includeAll": true,
         "label": "Pod",
-        "multi": false,
+        "multi": true,
         "name": "pod",
         "options": [],
         "query": {
@@ -776,8 +881,7 @@
         "regex": "",
         "skipUrlSync": false,
         "sort": 1,
-        "type": "query",
-        "allValue": ".+"
+        "type": "query"
       },
       {
         "current": {
@@ -826,7 +930,14 @@
     "from": "now-1h",
     "to": "now"
   },
-  "timepicker": {},
+  "timepicker": {
+    "refresh_intervals": [
+      "10s",
+      "30s",
+      "1m",
+      "5m"
+    ]
+  },
   "timezone": "browser",
   "title": "Application Monitoring",
   "uid": "app-monitoring",

--- a/kubernetes/components/dashboard/production/kustomization/grafana/infra-monitoring.json
+++ b/kubernetes/components/dashboard/production/kustomization/grafana/infra-monitoring.json
@@ -8,7 +8,7 @@
           "uid": "-- Grafana --"
         },
         "enable": true,
-        "hide": true,
+        "hide": false,
         "iconColor": "rgba(0, 211, 255, 1)",
         "name": "Annotations & Alerts",
         "type": "dashboard"
@@ -220,10 +220,6 @@
               {
                 "color": "green",
                 "value": null
-              },
-              {
-                "color": "red",
-                "value": 1
               }
             ]
           },
@@ -269,6 +265,7 @@
         "type": "prometheus",
         "uid": "mimir"
       },
+      "description": "Counts pods by phase only. A pod stuck in CrashLoopBackOff or ImagePullBackOff still reports phase=Running and will NOT be counted here \u2014 see \"Pods Waiting by Reason\" below.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -330,6 +327,7 @@
         "type": "prometheus",
         "uid": "mimir"
       },
+      "description": "Container restarts in the last 15m (not lifetime cumulative count).",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -379,11 +377,11 @@
             "type": "prometheus",
             "uid": "mimir"
           },
-          "expr": "sum(kube_pod_container_status_restarts_total{namespace=~\"$namespace\", pod=~\"$pod\"})",
+          "expr": "sum(increase(kube_pod_container_status_restarts_total{namespace=~\"$namespace\", pod=~\"$pod\"}[15m]))",
           "refId": "A"
         }
       ],
-      "title": "Container Restarts",
+      "title": "Restarts (15m)",
       "type": "stat"
     },
     {
@@ -391,7 +389,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 5
+        "y": 14
       },
       "id": 8,
       "title": "Resource Usage",
@@ -456,7 +454,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 6
+        "y": 15
       },
       "id": 9,
       "options": {
@@ -544,7 +542,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 6
+        "y": 15
       },
       "id": 10,
       "options": {
@@ -578,7 +576,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 14
+        "y": 29
       },
       "id": 11,
       "title": "Network",
@@ -643,7 +641,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 15
+        "y": 30
       },
       "id": 12,
       "options": {
@@ -686,6 +684,7 @@
         "type": "prometheus",
         "uid": "mimir"
       },
+      "description": "Egress (source_namespace) and inbound (destination_namespace) drops shown separately \u2014 previously only egress was visible.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -740,7 +739,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 15
+        "y": 30
       },
       "id": 13,
       "options": {
@@ -762,8 +761,17 @@
             "uid": "mimir"
           },
           "expr": "sum(rate(hubble_drop_total{source_namespace=~\"$namespace\"}[5m])) by (reason)",
-          "legendFormat": "{{reason}}",
+          "legendFormat": "egress {{reason}}",
           "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "mimir"
+          },
+          "expr": "sum(rate(hubble_drop_total{destination_namespace=~\"$namespace\"}[5m])) by (reason)",
+          "legendFormat": "inbound {{reason}}",
+          "refId": "B"
         }
       ],
       "title": "Network Drops (Hubble)",
@@ -774,7 +782,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 23
+        "y": 38
       },
       "id": 14,
       "title": "Pod Status",
@@ -845,7 +853,7 @@
         "h": 10,
         "w": 24,
         "x": 0,
-        "y": 24
+        "y": 39
       },
       "id": 15,
       "options": {
@@ -899,7 +907,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 34
+        "y": 55
       },
       "id": 16,
       "title": "Events & Logs",
@@ -914,15 +922,15 @@
         "h": 10,
         "w": 24,
         "x": 0,
-        "y": 35
+        "y": 56
       },
       "id": 17,
       "options": {
         "dedupStrategy": "none",
         "enableLogDetails": true,
         "prettifyLogMessage": false,
-        "showCommonLabels": false,
-        "showLabels": false,
+        "showCommonLabels": true,
+        "showLabels": true,
         "showTime": true,
         "sortOrder": "Descending",
         "wrapLogMessage": false
@@ -933,14 +941,241 @@
             "type": "loki",
             "uid": "loki"
           },
-          "expr": "{k8s_namespace_name=~\"$namespace\", k8s_pod_name=~\"$pod\"} |~ \"error|warn|fail|crash|panic|oom|kill\"",
+          "expr": "{k8s_namespace_name=~\"$namespace\", k8s_pod_name=~\"$pod\"} |~ \"(?i)(error|exception|panic|fatal|oom|killed|crash|warn|5[0-9]{2})\"",
           "refId": "A"
         }
       ],
       "title": "Error Logs",
       "type": "logs"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "mimir"
+      },
+      "description": "Node count over time \u2014 catches fast Karpenter scale-out/in events that an instant stat cannot.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 1,
+            "pointSize": 5,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            }
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 6
+      },
+      "id": 18,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "mimir"
+          },
+          "expr": "sum(kube_node_status_condition{condition=\"Ready\",status=\"true\"} == 1)",
+          "legendFormat": "Ready",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "mimir"
+          },
+          "expr": "sum(kube_node_status_condition{condition=\"Ready\",status=~\"false|unknown\"} == 1)",
+          "legendFormat": "Not Ready",
+          "refId": "B"
+        }
+      ],
+      "title": "Node Ready State",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "loki",
+        "uid": "loki"
+      },
+      "description": "Karpenter controller log lines mentioning node lifecycle actions \u2014 read alongside Node Ready State during a churn event.",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 6
+      },
+      "id": 19,
+      "options": {
+        "dedupStrategy": "none",
+        "enableLogDetails": true,
+        "prettifyLogMessage": false,
+        "showCommonLabels": false,
+        "showLabels": true,
+        "showTime": true,
+        "sortOrder": "Descending",
+        "wrapLogMessage": false
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "loki",
+            "uid": "loki"
+          },
+          "expr": "{k8s_namespace_name=\"karpenter\"} |~ \"(?i)(nodeclaim|nodepool|launch|disrupt|consolidat|drain|terminat)\"",
+          "refId": "A"
+        }
+      ],
+      "title": "Karpenter Events",
+      "type": "logs"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 5
+      },
+      "id": 23,
+      "panels": [],
+      "title": "Node Lifecycle",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "mimir"
+      },
+      "description": "Which container is restarting right now, not just the aggregate count.",
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 12,
+        "x": 12,
+        "y": 23
+      },
+      "id": 20,
+      "options": {
+        "cellHeight": "sm",
+        "showHeader": true
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "mimir"
+          },
+          "expr": "sum by (namespace,pod,container) (increase(kube_pod_container_status_restarts_total{namespace=~\"$namespace\", pod=~\"$pod\"}[15m])) > 0",
+          "format": "table",
+          "instant": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Restarting Containers (15m)",
+      "type": "table"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "mimir"
+      },
+      "description": "Pods with no CPU request set are invisible on the \"% of Request\" panels above regardless of actual usage.",
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 12,
+        "x": 0,
+        "y": 23
+      },
+      "id": 21,
+      "options": {
+        "cellHeight": "sm",
+        "showHeader": true
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "mimir"
+          },
+          "expr": "sum by (namespace,pod) (kube_pod_info{namespace=~\"$namespace\",pod=~\"$pod\"}) unless on (namespace,pod) (sum by (namespace,pod) (kube_pod_container_resource_requests{namespace=~\"$namespace\",pod=~\"$pod\",resource=\"cpu\"}) > 0)",
+          "format": "table",
+          "instant": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Pods without CPU Requests",
+      "type": "table"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "mimir"
+      },
+      "description": "Containers currently waiting (CrashLoopBackOff, ImagePullBackOff, etc.) \u2014 the blind spot in the Unhealthy Pods stat above.",
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 24,
+        "x": 0,
+        "y": 49
+      },
+      "id": 22,
+      "options": {
+        "cellHeight": "sm",
+        "showHeader": true
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "mimir"
+          },
+          "expr": "sum by (namespace,pod,container,reason) (kube_pod_container_status_waiting_reason{namespace=~\"$namespace\",pod=~\"$pod\"} == 1)",
+          "format": "table",
+          "instant": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Pods Waiting by Reason",
+      "type": "table"
     }
   ],
+  "refresh": "30s",
   "schemaVersion": 39,
   "tags": [
     "infrastructure",
@@ -949,6 +1184,7 @@
   "templating": {
     "list": [
       {
+        "allValue": ".+",
         "current": {
           "selected": false,
           "text": "All",
@@ -962,7 +1198,7 @@
         "hide": 0,
         "includeAll": true,
         "label": "Namespace",
-        "multi": false,
+        "multi": true,
         "name": "namespace",
         "options": [],
         "query": {
@@ -974,10 +1210,10 @@
         "regex": "",
         "skipUrlSync": false,
         "sort": 1,
-        "type": "query",
-        "allValue": ".+"
+        "type": "query"
       },
       {
+        "allValue": ".+",
         "current": {
           "selected": false,
           "text": "All",
@@ -991,7 +1227,7 @@
         "hide": 0,
         "includeAll": true,
         "label": "Pod",
-        "multi": false,
+        "multi": true,
         "name": "pod",
         "options": [],
         "query": {
@@ -1003,8 +1239,7 @@
         "regex": "",
         "skipUrlSync": false,
         "sort": 1,
-        "type": "query",
-        "allValue": ".+"
+        "type": "query"
       }
     ]
   },
@@ -1012,7 +1247,14 @@
     "from": "now-1h",
     "to": "now"
   },
-  "timepicker": {},
+  "timepicker": {
+    "refresh_intervals": [
+      "10s",
+      "30s",
+      "1m",
+      "5m"
+    ]
+  },
   "timezone": "browser",
   "title": "Infrastructure Monitoring",
   "uid": "infra-monitoring",

--- a/kubernetes/components/dashboard/production/kustomization/grafana/unified-monitoring.json
+++ b/kubernetes/components/dashboard/production/kustomization/grafana/unified-monitoring.json
@@ -8,7 +8,7 @@
           "uid": "-- Grafana --"
         },
         "enable": true,
-        "hide": true,
+        "hide": false,
         "iconColor": "rgba(0, 211, 255, 1)",
         "name": "Annotations & Alerts",
         "type": "dashboard"
@@ -37,6 +37,7 @@
         "type": "prometheus",
         "uid": "mimir"
       },
+      "description": "Includes Succeeded (completed Job) pods.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -56,7 +57,7 @@
         }
       },
       "gridPos": {
-        "h": 3,
+        "h": 4,
         "w": 4,
         "x": 0,
         "y": 1
@@ -64,7 +65,7 @@
       "id": 2,
       "options": {
         "colorMode": "value",
-        "graphMode": "none",
+        "graphMode": "area",
         "justifyMode": "auto",
         "orientation": "auto",
         "reduceOptions": {
@@ -94,6 +95,7 @@
         "type": "prometheus",
         "uid": "mimir"
       },
+      "description": "Counts pods by phase only. A pod stuck in CrashLoopBackOff or ImagePullBackOff still reports phase=Running and will NOT be counted here.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -117,7 +119,7 @@
         }
       },
       "gridPos": {
-        "h": 3,
+        "h": 4,
         "w": 4,
         "x": 4,
         "y": 1
@@ -125,7 +127,7 @@
       "id": 3,
       "options": {
         "colorMode": "value",
-        "graphMode": "none",
+        "graphMode": "area",
         "justifyMode": "auto",
         "orientation": "auto",
         "reduceOptions": {
@@ -174,7 +176,7 @@
         }
       },
       "gridPos": {
-        "h": 3,
+        "h": 4,
         "w": 4,
         "x": 8,
         "y": 1
@@ -182,7 +184,7 @@
       "id": 4,
       "options": {
         "colorMode": "value",
-        "graphMode": "none",
+        "graphMode": "area",
         "justifyMode": "auto",
         "orientation": "auto",
         "reduceOptions": {
@@ -200,7 +202,7 @@
             "type": "prometheus",
             "uid": "mimir"
           },
-          "expr": "sum(rate(http_server_request_duration_seconds_count{service_name=~\"$service\"}[5m]))",
+          "expr": "sum(rate(http_server_request_duration_seconds_count{service_name=~\"$service\", k8s_namespace_name=~\"$namespace\"}[$__rate_interval]))",
           "refId": "A"
         }
       ],
@@ -212,6 +214,7 @@
         "type": "prometheus",
         "uid": "mimir"
       },
+      "description": "Current p95 latency (last data point), not an average over the selected time range.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -239,7 +242,7 @@
         }
       },
       "gridPos": {
-        "h": 3,
+        "h": 4,
         "w": 4,
         "x": 12,
         "y": 1
@@ -247,12 +250,12 @@
       "id": 5,
       "options": {
         "colorMode": "value",
-        "graphMode": "none",
+        "graphMode": "area",
         "justifyMode": "auto",
         "orientation": "auto",
         "reduceOptions": {
           "calcs": [
-            "mean"
+            "lastNotNull"
           ],
           "fields": "",
           "values": false
@@ -265,7 +268,7 @@
             "type": "prometheus",
             "uid": "mimir"
           },
-          "expr": "histogram_quantile(0.95, sum(rate(http_server_request_duration_seconds_bucket{service_name=~\"$service\"}[5m])) by (le))",
+          "expr": "histogram_quantile(0.95, sum(rate(http_server_request_duration_seconds_bucket{service_name=~\"$service\", k8s_namespace_name=~\"$namespace\"}[$__rate_interval])) by (le))",
           "refId": "A"
         }
       ],
@@ -277,6 +280,7 @@
         "type": "prometheus",
         "uid": "mimir"
       },
+      "description": "Container restarts in the last 15m (not lifetime cumulative count).",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -300,7 +304,7 @@
         }
       },
       "gridPos": {
-        "h": 3,
+        "h": 4,
         "w": 4,
         "x": 16,
         "y": 1
@@ -308,7 +312,7 @@
       "id": 6,
       "options": {
         "colorMode": "value",
-        "graphMode": "none",
+        "graphMode": "area",
         "justifyMode": "auto",
         "orientation": "auto",
         "reduceOptions": {
@@ -326,11 +330,11 @@
             "type": "prometheus",
             "uid": "mimir"
           },
-          "expr": "sum(kube_pod_container_status_restarts_total{namespace=~\"$namespace\", pod=~\"$pod\"})",
+          "expr": "sum(increase(kube_pod_container_status_restarts_total{namespace=~\"$namespace\", pod=~\"$pod\"}[15m]))",
           "refId": "A"
         }
       ],
-      "title": "Restarts",
+      "title": "Restarts (15m)",
       "type": "stat"
     },
     {
@@ -357,7 +361,7 @@
         }
       },
       "gridPos": {
-        "h": 3,
+        "h": 4,
         "w": 4,
         "x": 20,
         "y": 1
@@ -365,7 +369,7 @@
       "id": 7,
       "options": {
         "colorMode": "value",
-        "graphMode": "none",
+        "graphMode": "area",
         "justifyMode": "auto",
         "orientation": "auto",
         "reduceOptions": {
@@ -395,7 +399,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 4
+        "y": 16
       },
       "id": 8,
       "title": "Traces",
@@ -416,6 +420,13 @@
             },
             "inspect": false
           },
+          "links": [
+            {
+              "targetBlank": false,
+              "title": "View Trace",
+              "url": "/d/unified-monitoring/unified-monitoring?var-traceId=${__data.fields.traceID}&${__url_time_range}"
+            }
+          ],
           "mappings": [],
           "thresholds": {
             "mode": "absolute",
@@ -425,14 +436,7 @@
                 "value": null
               }
             ]
-          },
-          "links": [
-            {
-              "title": "View Trace",
-              "url": "/d/unified-monitoring/unified-monitoring?var-traceId=${__data.fields.traceID}&${__url_time_range}",
-              "targetBlank": false
-            }
-          ]
+          }
         },
         "overrides": [
           {
@@ -469,7 +473,7 @@
         "h": 8,
         "w": 24,
         "x": 0,
-        "y": 5
+        "y": 17
       },
       "id": 9,
       "options": {
@@ -497,8 +501,8 @@
             "uid": "tempo"
           },
           "limit": 20,
-          "queryType": "traceql",
           "query": "{resource.service.name =~ \"${service:regex}\" && resource.k8s.namespace.name =~ \"${namespace:regex}\"}",
+          "queryType": "traceql",
           "refId": "A",
           "tableType": "traces"
         }
@@ -516,7 +520,7 @@
         "h": 12,
         "w": 24,
         "x": 0,
-        "y": 13
+        "y": 25
       },
       "id": 21,
       "options": {},
@@ -539,20 +543,20 @@
         "type": "tempo",
         "uid": "tempo"
       },
-      "description": "Service dependencies based on trace data",
+      "description": "Cluster-wide service map for the selected time range. The Namespace/Service variables above do not filter this panel.",
       "gridPos": {
         "h": 12,
         "w": 24,
         "x": 0,
-        "y": 25
+        "y": 37
       },
       "id": 22,
       "options": {
-        "nodes": {
-          "mainStatUnit": "ms"
-        },
         "edges": {
           "mainStatUnit": "r/sec"
+        },
+        "nodes": {
+          "mainStatUnit": "ms"
         }
       },
       "targets": [
@@ -573,7 +577,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 37
+        "y": 49
       },
       "id": 10,
       "title": "Application Metrics",
@@ -638,7 +642,7 @@
         "h": 6,
         "w": 12,
         "x": 0,
-        "y": 38
+        "y": 50
       },
       "id": 11,
       "options": {
@@ -659,7 +663,7 @@
             "type": "prometheus",
             "uid": "mimir"
           },
-          "expr": "sum(rate(http_server_request_duration_seconds_count{service_name=~\"$service\"}[1m])) by (http_route)",
+          "expr": "sum(rate(http_server_request_duration_seconds_count{service_name=~\"$service\", k8s_namespace_name=~\"$namespace\"}[$__rate_interval])) by (http_route)",
           "legendFormat": "{{http_route}}",
           "refId": "A"
         }
@@ -726,7 +730,7 @@
         "h": 6,
         "w": 12,
         "x": 12,
-        "y": 38
+        "y": 50
       },
       "id": 12,
       "options": {
@@ -747,7 +751,7 @@
             "type": "prometheus",
             "uid": "mimir"
           },
-          "expr": "histogram_quantile(0.95, sum(rate(http_server_request_duration_seconds_bucket{service_name=~\"$service\"}[1m])) by (le, http_route))",
+          "expr": "histogram_quantile(0.95, sum(rate(http_server_request_duration_seconds_bucket{service_name=~\"$service\", k8s_namespace_name=~\"$namespace\"}[$__rate_interval])) by (le, http_route))",
           "legendFormat": "{{http_route}}",
           "refId": "A"
         }
@@ -760,7 +764,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 44
+        "y": 56
       },
       "id": 13,
       "title": "Resource Usage",
@@ -825,7 +829,7 @@
         "h": 6,
         "w": 12,
         "x": 0,
-        "y": 45
+        "y": 57
       },
       "id": 14,
       "options": {
@@ -913,7 +917,7 @@
         "h": 6,
         "w": 12,
         "x": 12,
-        "y": 45
+        "y": 57
       },
       "id": 15,
       "options": {
@@ -947,7 +951,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 51
+        "y": 63
       },
       "id": 16,
       "title": "Network",
@@ -1012,7 +1016,7 @@
         "h": 6,
         "w": 12,
         "x": 0,
-        "y": 52
+        "y": 64
       },
       "id": 17,
       "options": {
@@ -1055,6 +1059,7 @@
         "type": "prometheus",
         "uid": "mimir"
       },
+      "description": "Egress (source_namespace) and inbound (destination_namespace) drops shown separately.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1109,7 +1114,7 @@
         "h": 6,
         "w": 12,
         "x": 12,
-        "y": 52
+        "y": 64
       },
       "id": 18,
       "options": {
@@ -1131,8 +1136,17 @@
             "uid": "mimir"
           },
           "expr": "sum(rate(hubble_drop_total{source_namespace=~\"$namespace\"}[5m])) by (reason)",
-          "legendFormat": "{{reason}}",
+          "legendFormat": "egress {{reason}}",
           "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "mimir"
+          },
+          "expr": "sum(rate(hubble_drop_total{destination_namespace=~\"$namespace\"}[5m])) by (reason)",
+          "legendFormat": "inbound {{reason}}",
+          "refId": "B"
         }
       ],
       "title": "Network Drops (Hubble)",
@@ -1143,7 +1157,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 58
+        "y": 70
       },
       "id": 19,
       "title": "Logs",
@@ -1158,15 +1172,15 @@
         "h": 10,
         "w": 24,
         "x": 0,
-        "y": 59
+        "y": 71
       },
       "id": 20,
       "options": {
         "dedupStrategy": "none",
         "enableLogDetails": true,
         "prettifyLogMessage": false,
-        "showCommonLabels": false,
-        "showLabels": false,
+        "showCommonLabels": true,
+        "showLabels": true,
         "showTime": true,
         "sortOrder": "Descending",
         "wrapLogMessage": false
@@ -1183,8 +1197,157 @@
       ],
       "title": "Application Logs",
       "type": "logs"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "mimir"
+      },
+      "description": "Verify the http_response_status_code label exists on http_server_request_duration_seconds_count in Mimir before relying on this (checked against live traffic pending; monolith/frontend are currently scaled to 0).",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 1
+              },
+              {
+                "color": "red",
+                "value": 5
+              }
+            ]
+          },
+          "unit": "percent"
+        }
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 0,
+        "y": 5
+      },
+      "id": 23,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "mimir"
+          },
+          "expr": "100 * sum(rate(http_server_request_duration_seconds_count{service_name=~\"$service\", k8s_namespace_name=~\"$namespace\", http_response_status_code=~\"5..\"}[$__rate_interval])) / clamp_min(sum(rate(http_server_request_duration_seconds_count{service_name=~\"$service\", k8s_namespace_name=~\"$namespace\"}[$__rate_interval])), 0.001)",
+          "refId": "A"
+        }
+      ],
+      "title": "5xx Rate",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "mimir"
+      },
+      "description": "Node count over time \u2014 catches fast Karpenter scale-out/in events an instant stat cannot. See Infrastructure Monitoring for Karpenter event logs.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 1,
+            "pointSize": 5,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            }
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 24,
+        "x": 0,
+        "y": 10
+      },
+      "id": 24,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "mimir"
+          },
+          "expr": "sum(kube_node_status_condition{condition=\"Ready\",status=\"true\"} == 1)",
+          "legendFormat": "Ready",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "mimir"
+          },
+          "expr": "sum(kube_node_status_condition{condition=\"Ready\",status=~\"false|unknown\"} == 1)",
+          "legendFormat": "Not Ready",
+          "refId": "B"
+        }
+      ],
+      "title": "Node Ready State",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 9
+      },
+      "id": 25,
+      "panels": [],
+      "title": "Node Health",
+      "type": "row"
     }
   ],
+  "refresh": "30s",
   "schemaVersion": 39,
   "tags": [
     "unified",
@@ -1194,6 +1357,7 @@
   "templating": {
     "list": [
       {
+        "allValue": ".+",
         "current": {
           "selected": false,
           "text": "All",
@@ -1207,7 +1371,7 @@
         "hide": 0,
         "includeAll": true,
         "label": "Namespace",
-        "multi": false,
+        "multi": true,
         "name": "namespace",
         "options": [],
         "query": {
@@ -1219,10 +1383,10 @@
         "regex": "",
         "skipUrlSync": false,
         "sort": 1,
-        "type": "query",
-        "allValue": ".+"
+        "type": "query"
       },
       {
+        "allValue": ".+",
         "current": {
           "selected": false,
           "text": "All",
@@ -1232,26 +1396,26 @@
           "type": "prometheus",
           "uid": "mimir"
         },
-        "definition": "label_values(http_server_request_duration_seconds_count, service_name)",
+        "definition": "label_values(http_server_request_duration_seconds_count{k8s_namespace_name=~\"$namespace\"}, service_name)",
         "hide": 0,
         "includeAll": true,
         "label": "Service",
-        "multi": false,
+        "multi": true,
         "name": "service",
         "options": [],
         "query": {
           "qryType": 1,
-          "query": "label_values(http_server_request_duration_seconds_count, service_name)",
+          "query": "label_values(http_server_request_duration_seconds_count{k8s_namespace_name=~\"$namespace\"}, service_name)",
           "refId": "PrometheusVariableQueryEditor-VariableQuery"
         },
         "refresh": 2,
         "regex": "",
         "skipUrlSync": false,
         "sort": 1,
-        "type": "query",
-        "allValue": ".+"
+        "type": "query"
       },
       {
+        "allValue": ".+",
         "current": {
           "selected": false,
           "text": "All",
@@ -1265,7 +1429,7 @@
         "hide": 0,
         "includeAll": true,
         "label": "Pod",
-        "multi": false,
+        "multi": true,
         "name": "pod",
         "options": [],
         "query": {
@@ -1278,8 +1442,7 @@
         "regex": "",
         "skipUrlSync": false,
         "sort": 1,
-        "type": "query",
-        "allValue": ".+"
+        "type": "query"
       },
       {
         "current": {
@@ -1328,7 +1491,14 @@
     "from": "now-1h",
     "to": "now"
   },
-  "timepicker": {},
+  "timepicker": {
+    "refresh_intervals": [
+      "10s",
+      "30s",
+      "1m",
+      "5m"
+    ]
+  },
   "timezone": "browser",
   "title": "Unified Monitoring",
   "uid": "unified-monitoring",

--- a/kubernetes/manifests/production/dashboard/manifest.yaml
+++ b/kubernetes/manifests/production/dashboard/manifest.yaml
@@ -12,7 +12,7 @@ data:
               "uid": "-- Grafana --"
             },
             "enable": true,
-            "hide": true,
+            "hide": false,
             "iconColor": "rgba(0, 211, 255, 1)",
             "name": "Annotations & Alerts",
             "type": "dashboard"
@@ -41,6 +41,7 @@ data:
             "type": "prometheus",
             "uid": "mimir"
           },
+          "description": "Includes Succeeded (completed Job) pods, so this will not equal Running + Unhealthy below.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -61,7 +62,7 @@ data:
           },
           "gridPos": {
             "h": 4,
-            "w": 6,
+            "w": 4,
             "x": 0,
             "y": 1
           },
@@ -98,6 +99,7 @@ data:
             "type": "prometheus",
             "uid": "mimir"
           },
+          "description": "Counts pods by phase only. A pod stuck in CrashLoopBackOff or ImagePullBackOff still reports phase=Running and will NOT be counted here.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -122,8 +124,8 @@ data:
           },
           "gridPos": {
             "h": 4,
-            "w": 6,
-            "x": 6,
+            "w": 4,
+            "x": 4,
             "y": 1
           },
           "id": 3,
@@ -179,8 +181,8 @@ data:
           },
           "gridPos": {
             "h": 4,
-            "w": 6,
-            "x": 12,
+            "w": 4,
+            "x": 8,
             "y": 1
           },
           "id": 4,
@@ -204,7 +206,7 @@ data:
                 "type": "prometheus",
                 "uid": "mimir"
               },
-              "expr": "sum(rate(http_server_request_duration_seconds_count{service_name=~\"$service\"}[5m]))",
+              "expr": "sum(rate(http_server_request_duration_seconds_count{service_name=~\"$service\", k8s_namespace_name=~\"$namespace\"}[$__rate_interval]))",
               "refId": "A"
             }
           ],
@@ -216,6 +218,7 @@ data:
             "type": "prometheus",
             "uid": "mimir"
           },
+          "description": "Current p95 latency (last data point), not an average over the selected time range.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -244,8 +247,8 @@ data:
           },
           "gridPos": {
             "h": 4,
-            "w": 6,
-            "x": 18,
+            "w": 4,
+            "x": 12,
             "y": 1
           },
           "id": 5,
@@ -256,7 +259,7 @@ data:
             "orientation": "auto",
             "reduceOptions": {
               "calcs": [
-                "mean"
+                "lastNotNull"
               ],
               "fields": "",
               "values": false
@@ -269,7 +272,7 @@ data:
                 "type": "prometheus",
                 "uid": "mimir"
               },
-              "expr": "histogram_quantile(0.95, sum(rate(http_server_request_duration_seconds_bucket{service_name=~\"$service\"}[5m])) by (le))",
+              "expr": "histogram_quantile(0.95, sum(rate(http_server_request_duration_seconds_bucket{service_name=~\"$service\", k8s_namespace_name=~\"$namespace\"}[$__rate_interval])) by (le))",
               "refId": "A"
             }
           ],
@@ -302,6 +305,13 @@ data:
                 },
                 "inspect": false
               },
+              "links": [
+                {
+                  "targetBlank": false,
+                  "title": "View Trace",
+                  "url": "/d/app-monitoring/application-monitoring?var-traceId=${__data.fields.traceID}&${__url_time_range}"
+                }
+              ],
               "mappings": [],
               "thresholds": {
                 "mode": "absolute",
@@ -311,14 +321,7 @@ data:
                     "value": null
                   }
                 ]
-              },
-              "links": [
-                {
-                  "title": "View Trace",
-                  "url": "/d/app-monitoring/application-monitoring?var-traceId=${__data.fields.traceID}&${__url_time_range}",
-                  "targetBlank": false
-                }
-              ]
+              }
             },
             "overrides": [
               {
@@ -355,7 +358,7 @@ data:
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 6
+            "y": 12
           },
           "id": 7,
           "options": {
@@ -383,8 +386,8 @@ data:
                 "uid": "tempo"
               },
               "limit": 20,
-              "queryType": "traceql",
               "query": "{resource.service.name =~ \"${service:regex}\" && resource.k8s.namespace.name =~ \"${namespace:regex}\"}",
+              "queryType": "traceql",
               "refId": "A",
               "tableType": "traces"
             }
@@ -402,7 +405,7 @@ data:
             "h": 12,
             "w": 24,
             "x": 0,
-            "y": 14
+            "y": 20
           },
           "id": 13,
           "options": {},
@@ -425,20 +428,20 @@ data:
             "type": "tempo",
             "uid": "tempo"
           },
-          "description": "Service dependencies based on trace data",
+          "description": "Cluster-wide service map for the selected time range. The Namespace/Service variables above do not filter this panel.",
           "gridPos": {
             "h": 12,
             "w": 24,
             "x": 0,
-            "y": 26
+            "y": 32
           },
           "id": 14,
           "options": {
-            "nodes": {
-              "mainStatUnit": "ms"
-            },
             "edges": {
               "mainStatUnit": "r/sec"
+            },
+            "nodes": {
+              "mainStatUnit": "ms"
             }
           },
           "targets": [
@@ -459,7 +462,7 @@ data:
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 38
+            "y": 44
           },
           "id": 8,
           "title": "Logs",
@@ -474,15 +477,15 @@ data:
             "h": 10,
             "w": 24,
             "x": 0,
-            "y": 39
+            "y": 45
           },
           "id": 9,
           "options": {
             "dedupStrategy": "none",
             "enableLogDetails": true,
             "prettifyLogMessage": false,
-            "showCommonLabels": false,
-            "showLabels": false,
+            "showCommonLabels": true,
+            "showLabels": true,
             "showTime": true,
             "sortOrder": "Descending",
             "wrapLogMessage": false
@@ -505,7 +508,7 @@ data:
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 49
+            "y": 55
           },
           "id": 10,
           "title": "Metrics",
@@ -570,7 +573,7 @@ data:
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 50
+            "y": 56
           },
           "id": 11,
           "options": {
@@ -591,7 +594,7 @@ data:
                 "type": "prometheus",
                 "uid": "mimir"
               },
-              "expr": "sum(rate(http_server_request_duration_seconds_count{service_name=~\"$service\"}[1m])) by (http_route)",
+              "expr": "sum(rate(http_server_request_duration_seconds_count{service_name=~\"$service\", k8s_namespace_name=~\"$namespace\"}[$__rate_interval])) by (http_route)",
               "legendFormat": "{{http_route}}",
               "refId": "A"
             }
@@ -658,7 +661,7 @@ data:
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 50
+            "y": 56
           },
           "id": 12,
           "options": {
@@ -679,15 +682,116 @@ data:
                 "type": "prometheus",
                 "uid": "mimir"
               },
-              "expr": "histogram_quantile(0.95, sum(rate(http_server_request_duration_seconds_bucket{service_name=~\"$service\"}[1m])) by (le, http_route))",
+              "expr": "histogram_quantile(0.95, sum(rate(http_server_request_duration_seconds_bucket{service_name=~\"$service\", k8s_namespace_name=~\"$namespace\"}[$__rate_interval])) by (le, http_route))",
               "legendFormat": "{{http_route}}",
               "refId": "A"
             }
           ],
           "title": "P95 Latency by Route",
           "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "mimir"
+          },
+          "description": "Verify the http_response_status_code label exists on http_server_request_duration_seconds_count in Mimir before relying on this (checked against live traffic pending; monolith/frontend are currently scaled to 0).",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "yellow",
+                    "value": 1
+                  },
+                  {
+                    "color": "red",
+                    "value": 5
+                  }
+                ]
+              },
+              "unit": "percent"
+            }
+          },
+          "gridPos": {
+            "h": 4,
+            "w": 4,
+            "x": 16,
+            "y": 1
+          },
+          "id": 15,
+          "options": {
+            "colorMode": "value",
+            "graphMode": "area",
+            "justifyMode": "auto",
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "textMode": "auto"
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "mimir"
+              },
+              "expr": "100 * sum(rate(http_server_request_duration_seconds_count{service_name=~\"$service\", k8s_namespace_name=~\"$namespace\", http_response_status_code=~\"5..\"}[$__rate_interval])) / clamp_min(sum(rate(http_server_request_duration_seconds_count{service_name=~\"$service\", k8s_namespace_name=~\"$namespace\"}[$__rate_interval])), 0.001)",
+              "refId": "A"
+            }
+          ],
+          "title": "5xx Rate",
+          "type": "stat"
+        },
+        {
+          "datasource": {
+            "type": "tempo",
+            "uid": "tempo"
+          },
+          "description": "Failed traces for the selected namespace/service \u2014 narrower than the general Trace Search Results below.",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 6,
+            "w": 24,
+            "x": 0,
+            "y": 6
+          },
+          "id": 16,
+          "options": {},
+          "targets": [
+            {
+              "datasource": {
+                "type": "tempo",
+                "uid": "tempo"
+              },
+              "limit": 50,
+              "query": "{ resource.service.name =~ \"${service:regex}\" && resource.k8s.namespace.name =~ \"${namespace:regex}\" && status = error }",
+              "queryType": "traceql",
+              "refId": "A",
+              "tableType": "traces"
+            }
+          ],
+          "title": "Error Traces",
+          "type": "table"
         }
       ],
+      "refresh": "30s",
       "schemaVersion": 39,
       "tags": [
         "application",
@@ -696,6 +800,7 @@ data:
       "templating": {
         "list": [
           {
+            "allValue": ".+",
             "current": {
               "selected": false,
               "text": "All",
@@ -709,7 +814,7 @@ data:
             "hide": 0,
             "includeAll": true,
             "label": "Namespace",
-            "multi": false,
+            "multi": true,
             "name": "namespace",
             "options": [],
             "query": {
@@ -721,10 +826,10 @@ data:
             "regex": "",
             "skipUrlSync": false,
             "sort": 1,
-            "type": "query",
-            "allValue": ".+"
+            "type": "query"
           },
           {
+            "allValue": ".+",
             "current": {
               "selected": false,
               "text": "All",
@@ -734,26 +839,26 @@ data:
               "type": "prometheus",
               "uid": "mimir"
             },
-            "definition": "label_values(http_server_request_duration_seconds_count, service_name)",
+            "definition": "label_values(http_server_request_duration_seconds_count{k8s_namespace_name=~\"$namespace\"}, service_name)",
             "hide": 0,
             "includeAll": true,
             "label": "Service",
-            "multi": false,
+            "multi": true,
             "name": "service",
             "options": [],
             "query": {
               "qryType": 1,
-              "query": "label_values(http_server_request_duration_seconds_count, service_name)",
+              "query": "label_values(http_server_request_duration_seconds_count{k8s_namespace_name=~\"$namespace\"}, service_name)",
               "refId": "PrometheusVariableQueryEditor-VariableQuery"
             },
             "refresh": 2,
             "regex": "",
             "skipUrlSync": false,
             "sort": 1,
-            "type": "query",
-            "allValue": ".+"
+            "type": "query"
           },
           {
+            "allValue": ".+",
             "current": {
               "selected": false,
               "text": "All",
@@ -767,7 +872,7 @@ data:
             "hide": 0,
             "includeAll": true,
             "label": "Pod",
-            "multi": false,
+            "multi": true,
             "name": "pod",
             "options": [],
             "query": {
@@ -780,8 +885,7 @@ data:
             "regex": "",
             "skipUrlSync": false,
             "sort": 1,
-            "type": "query",
-            "allValue": ".+"
+            "type": "query"
           },
           {
             "current": {
@@ -830,7 +934,14 @@ data:
         "from": "now-1h",
         "to": "now"
       },
-      "timepicker": {},
+      "timepicker": {
+        "refresh_intervals": [
+          "10s",
+          "30s",
+          "1m",
+          "5m"
+        ]
+      },
       "timezone": "browser",
       "title": "Application Monitoring",
       "uid": "app-monitoring",
@@ -857,7 +968,7 @@ data:
               "uid": "-- Grafana --"
             },
             "enable": true,
-            "hide": true,
+            "hide": false,
             "iconColor": "rgba(0, 211, 255, 1)",
             "name": "Annotations & Alerts",
             "type": "dashboard"
@@ -1069,10 +1180,6 @@ data:
                   {
                     "color": "green",
                     "value": null
-                  },
-                  {
-                    "color": "red",
-                    "value": 1
                   }
                 ]
               },
@@ -1118,6 +1225,7 @@ data:
             "type": "prometheus",
             "uid": "mimir"
           },
+          "description": "Counts pods by phase only. A pod stuck in CrashLoopBackOff or ImagePullBackOff still reports phase=Running and will NOT be counted here \u2014 see \"Pods Waiting by Reason\" below.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -1179,6 +1287,7 @@ data:
             "type": "prometheus",
             "uid": "mimir"
           },
+          "description": "Container restarts in the last 15m (not lifetime cumulative count).",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -1228,11 +1337,11 @@ data:
                 "type": "prometheus",
                 "uid": "mimir"
               },
-              "expr": "sum(kube_pod_container_status_restarts_total{namespace=~\"$namespace\", pod=~\"$pod\"})",
+              "expr": "sum(increase(kube_pod_container_status_restarts_total{namespace=~\"$namespace\", pod=~\"$pod\"}[15m]))",
               "refId": "A"
             }
           ],
-          "title": "Container Restarts",
+          "title": "Restarts (15m)",
           "type": "stat"
         },
         {
@@ -1240,7 +1349,7 @@ data:
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 5
+            "y": 14
           },
           "id": 8,
           "title": "Resource Usage",
@@ -1305,7 +1414,7 @@ data:
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 6
+            "y": 15
           },
           "id": 9,
           "options": {
@@ -1393,7 +1502,7 @@ data:
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 6
+            "y": 15
           },
           "id": 10,
           "options": {
@@ -1427,7 +1536,7 @@ data:
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 14
+            "y": 29
           },
           "id": 11,
           "title": "Network",
@@ -1492,7 +1601,7 @@ data:
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 15
+            "y": 30
           },
           "id": 12,
           "options": {
@@ -1535,6 +1644,7 @@ data:
             "type": "prometheus",
             "uid": "mimir"
           },
+          "description": "Egress (source_namespace) and inbound (destination_namespace) drops shown separately \u2014 previously only egress was visible.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -1589,7 +1699,7 @@ data:
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 15
+            "y": 30
           },
           "id": 13,
           "options": {
@@ -1611,8 +1721,17 @@ data:
                 "uid": "mimir"
               },
               "expr": "sum(rate(hubble_drop_total{source_namespace=~\"$namespace\"}[5m])) by (reason)",
-              "legendFormat": "{{reason}}",
+              "legendFormat": "egress {{reason}}",
               "refId": "A"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "mimir"
+              },
+              "expr": "sum(rate(hubble_drop_total{destination_namespace=~\"$namespace\"}[5m])) by (reason)",
+              "legendFormat": "inbound {{reason}}",
+              "refId": "B"
             }
           ],
           "title": "Network Drops (Hubble)",
@@ -1623,7 +1742,7 @@ data:
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 23
+            "y": 38
           },
           "id": 14,
           "title": "Pod Status",
@@ -1694,7 +1813,7 @@ data:
             "h": 10,
             "w": 24,
             "x": 0,
-            "y": 24
+            "y": 39
           },
           "id": 15,
           "options": {
@@ -1748,7 +1867,7 @@ data:
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 34
+            "y": 55
           },
           "id": 16,
           "title": "Events & Logs",
@@ -1763,15 +1882,15 @@ data:
             "h": 10,
             "w": 24,
             "x": 0,
-            "y": 35
+            "y": 56
           },
           "id": 17,
           "options": {
             "dedupStrategy": "none",
             "enableLogDetails": true,
             "prettifyLogMessage": false,
-            "showCommonLabels": false,
-            "showLabels": false,
+            "showCommonLabels": true,
+            "showLabels": true,
             "showTime": true,
             "sortOrder": "Descending",
             "wrapLogMessage": false
@@ -1782,14 +1901,241 @@ data:
                 "type": "loki",
                 "uid": "loki"
               },
-              "expr": "{k8s_namespace_name=~\"$namespace\", k8s_pod_name=~\"$pod\"} |~ \"error|warn|fail|crash|panic|oom|kill\"",
+              "expr": "{k8s_namespace_name=~\"$namespace\", k8s_pod_name=~\"$pod\"} |~ \"(?i)(error|exception|panic|fatal|oom|killed|crash|warn|5[0-9]{2})\"",
               "refId": "A"
             }
           ],
           "title": "Error Logs",
           "type": "logs"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "mimir"
+          },
+          "description": "Node count over time \u2014 catches fast Karpenter scale-out/in events that an instant stat cannot.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "drawStyle": "line",
+                "fillOpacity": 10,
+                "lineWidth": 1,
+                "pointSize": 5,
+                "showPoints": "never",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                }
+              },
+              "unit": "short"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 6
+          },
+          "id": 18,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "mimir"
+              },
+              "expr": "sum(kube_node_status_condition{condition=\"Ready\",status=\"true\"} == 1)",
+              "legendFormat": "Ready",
+              "refId": "A"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "mimir"
+              },
+              "expr": "sum(kube_node_status_condition{condition=\"Ready\",status=~\"false|unknown\"} == 1)",
+              "legendFormat": "Not Ready",
+              "refId": "B"
+            }
+          ],
+          "title": "Node Ready State",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "loki",
+            "uid": "loki"
+          },
+          "description": "Karpenter controller log lines mentioning node lifecycle actions \u2014 read alongside Node Ready State during a churn event.",
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 6
+          },
+          "id": 19,
+          "options": {
+            "dedupStrategy": "none",
+            "enableLogDetails": true,
+            "prettifyLogMessage": false,
+            "showCommonLabels": false,
+            "showLabels": true,
+            "showTime": true,
+            "sortOrder": "Descending",
+            "wrapLogMessage": false
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "loki",
+                "uid": "loki"
+              },
+              "expr": "{k8s_namespace_name=\"karpenter\"} |~ \"(?i)(nodeclaim|nodepool|launch|disrupt|consolidat|drain|terminat)\"",
+              "refId": "A"
+            }
+          ],
+          "title": "Karpenter Events",
+          "type": "logs"
+        },
+        {
+          "collapsed": false,
+          "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 5
+          },
+          "id": 23,
+          "panels": [],
+          "title": "Node Lifecycle",
+          "type": "row"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "mimir"
+          },
+          "description": "Which container is restarting right now, not just the aggregate count.",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 6,
+            "w": 12,
+            "x": 12,
+            "y": 23
+          },
+          "id": 20,
+          "options": {
+            "cellHeight": "sm",
+            "showHeader": true
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "mimir"
+              },
+              "expr": "sum by (namespace,pod,container) (increase(kube_pod_container_status_restarts_total{namespace=~\"$namespace\", pod=~\"$pod\"}[15m])) > 0",
+              "format": "table",
+              "instant": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Restarting Containers (15m)",
+          "type": "table"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "mimir"
+          },
+          "description": "Pods with no CPU request set are invisible on the \"% of Request\" panels above regardless of actual usage.",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 6,
+            "w": 12,
+            "x": 0,
+            "y": 23
+          },
+          "id": 21,
+          "options": {
+            "cellHeight": "sm",
+            "showHeader": true
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "mimir"
+              },
+              "expr": "sum by (namespace,pod) (kube_pod_info{namespace=~\"$namespace\",pod=~\"$pod\"}) unless on (namespace,pod) (sum by (namespace,pod) (kube_pod_container_resource_requests{namespace=~\"$namespace\",pod=~\"$pod\",resource=\"cpu\"}) > 0)",
+              "format": "table",
+              "instant": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Pods without CPU Requests",
+          "type": "table"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "mimir"
+          },
+          "description": "Containers currently waiting (CrashLoopBackOff, ImagePullBackOff, etc.) \u2014 the blind spot in the Unhealthy Pods stat above.",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 6,
+            "w": 24,
+            "x": 0,
+            "y": 49
+          },
+          "id": 22,
+          "options": {
+            "cellHeight": "sm",
+            "showHeader": true
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "mimir"
+              },
+              "expr": "sum by (namespace,pod,container,reason) (kube_pod_container_status_waiting_reason{namespace=~\"$namespace\",pod=~\"$pod\"} == 1)",
+              "format": "table",
+              "instant": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Pods Waiting by Reason",
+          "type": "table"
         }
       ],
+      "refresh": "30s",
       "schemaVersion": 39,
       "tags": [
         "infrastructure",
@@ -1798,6 +2144,7 @@ data:
       "templating": {
         "list": [
           {
+            "allValue": ".+",
             "current": {
               "selected": false,
               "text": "All",
@@ -1811,7 +2158,7 @@ data:
             "hide": 0,
             "includeAll": true,
             "label": "Namespace",
-            "multi": false,
+            "multi": true,
             "name": "namespace",
             "options": [],
             "query": {
@@ -1823,10 +2170,10 @@ data:
             "regex": "",
             "skipUrlSync": false,
             "sort": 1,
-            "type": "query",
-            "allValue": ".+"
+            "type": "query"
           },
           {
+            "allValue": ".+",
             "current": {
               "selected": false,
               "text": "All",
@@ -1840,7 +2187,7 @@ data:
             "hide": 0,
             "includeAll": true,
             "label": "Pod",
-            "multi": false,
+            "multi": true,
             "name": "pod",
             "options": [],
             "query": {
@@ -1852,8 +2199,7 @@ data:
             "regex": "",
             "skipUrlSync": false,
             "sort": 1,
-            "type": "query",
-            "allValue": ".+"
+            "type": "query"
           }
         ]
       },
@@ -1861,7 +2207,14 @@ data:
         "from": "now-1h",
         "to": "now"
       },
-      "timepicker": {},
+      "timepicker": {
+        "refresh_intervals": [
+          "10s",
+          "30s",
+          "1m",
+          "5m"
+        ]
+      },
       "timezone": "browser",
       "title": "Infrastructure Monitoring",
       "uid": "infra-monitoring",
@@ -1888,7 +2241,7 @@ data:
               "uid": "-- Grafana --"
             },
             "enable": true,
-            "hide": true,
+            "hide": false,
             "iconColor": "rgba(0, 211, 255, 1)",
             "name": "Annotations & Alerts",
             "type": "dashboard"
@@ -1917,6 +2270,7 @@ data:
             "type": "prometheus",
             "uid": "mimir"
           },
+          "description": "Includes Succeeded (completed Job) pods.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -1936,7 +2290,7 @@ data:
             }
           },
           "gridPos": {
-            "h": 3,
+            "h": 4,
             "w": 4,
             "x": 0,
             "y": 1
@@ -1944,7 +2298,7 @@ data:
           "id": 2,
           "options": {
             "colorMode": "value",
-            "graphMode": "none",
+            "graphMode": "area",
             "justifyMode": "auto",
             "orientation": "auto",
             "reduceOptions": {
@@ -1974,6 +2328,7 @@ data:
             "type": "prometheus",
             "uid": "mimir"
           },
+          "description": "Counts pods by phase only. A pod stuck in CrashLoopBackOff or ImagePullBackOff still reports phase=Running and will NOT be counted here.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -1997,7 +2352,7 @@ data:
             }
           },
           "gridPos": {
-            "h": 3,
+            "h": 4,
             "w": 4,
             "x": 4,
             "y": 1
@@ -2005,7 +2360,7 @@ data:
           "id": 3,
           "options": {
             "colorMode": "value",
-            "graphMode": "none",
+            "graphMode": "area",
             "justifyMode": "auto",
             "orientation": "auto",
             "reduceOptions": {
@@ -2054,7 +2409,7 @@ data:
             }
           },
           "gridPos": {
-            "h": 3,
+            "h": 4,
             "w": 4,
             "x": 8,
             "y": 1
@@ -2062,7 +2417,7 @@ data:
           "id": 4,
           "options": {
             "colorMode": "value",
-            "graphMode": "none",
+            "graphMode": "area",
             "justifyMode": "auto",
             "orientation": "auto",
             "reduceOptions": {
@@ -2080,7 +2435,7 @@ data:
                 "type": "prometheus",
                 "uid": "mimir"
               },
-              "expr": "sum(rate(http_server_request_duration_seconds_count{service_name=~\"$service\"}[5m]))",
+              "expr": "sum(rate(http_server_request_duration_seconds_count{service_name=~\"$service\", k8s_namespace_name=~\"$namespace\"}[$__rate_interval]))",
               "refId": "A"
             }
           ],
@@ -2092,6 +2447,7 @@ data:
             "type": "prometheus",
             "uid": "mimir"
           },
+          "description": "Current p95 latency (last data point), not an average over the selected time range.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -2119,7 +2475,7 @@ data:
             }
           },
           "gridPos": {
-            "h": 3,
+            "h": 4,
             "w": 4,
             "x": 12,
             "y": 1
@@ -2127,12 +2483,12 @@ data:
           "id": 5,
           "options": {
             "colorMode": "value",
-            "graphMode": "none",
+            "graphMode": "area",
             "justifyMode": "auto",
             "orientation": "auto",
             "reduceOptions": {
               "calcs": [
-                "mean"
+                "lastNotNull"
               ],
               "fields": "",
               "values": false
@@ -2145,7 +2501,7 @@ data:
                 "type": "prometheus",
                 "uid": "mimir"
               },
-              "expr": "histogram_quantile(0.95, sum(rate(http_server_request_duration_seconds_bucket{service_name=~\"$service\"}[5m])) by (le))",
+              "expr": "histogram_quantile(0.95, sum(rate(http_server_request_duration_seconds_bucket{service_name=~\"$service\", k8s_namespace_name=~\"$namespace\"}[$__rate_interval])) by (le))",
               "refId": "A"
             }
           ],
@@ -2157,6 +2513,7 @@ data:
             "type": "prometheus",
             "uid": "mimir"
           },
+          "description": "Container restarts in the last 15m (not lifetime cumulative count).",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -2180,7 +2537,7 @@ data:
             }
           },
           "gridPos": {
-            "h": 3,
+            "h": 4,
             "w": 4,
             "x": 16,
             "y": 1
@@ -2188,7 +2545,7 @@ data:
           "id": 6,
           "options": {
             "colorMode": "value",
-            "graphMode": "none",
+            "graphMode": "area",
             "justifyMode": "auto",
             "orientation": "auto",
             "reduceOptions": {
@@ -2206,11 +2563,11 @@ data:
                 "type": "prometheus",
                 "uid": "mimir"
               },
-              "expr": "sum(kube_pod_container_status_restarts_total{namespace=~\"$namespace\", pod=~\"$pod\"})",
+              "expr": "sum(increase(kube_pod_container_status_restarts_total{namespace=~\"$namespace\", pod=~\"$pod\"}[15m]))",
               "refId": "A"
             }
           ],
-          "title": "Restarts",
+          "title": "Restarts (15m)",
           "type": "stat"
         },
         {
@@ -2237,7 +2594,7 @@ data:
             }
           },
           "gridPos": {
-            "h": 3,
+            "h": 4,
             "w": 4,
             "x": 20,
             "y": 1
@@ -2245,7 +2602,7 @@ data:
           "id": 7,
           "options": {
             "colorMode": "value",
-            "graphMode": "none",
+            "graphMode": "area",
             "justifyMode": "auto",
             "orientation": "auto",
             "reduceOptions": {
@@ -2275,7 +2632,7 @@ data:
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 4
+            "y": 16
           },
           "id": 8,
           "title": "Traces",
@@ -2296,6 +2653,13 @@ data:
                 },
                 "inspect": false
               },
+              "links": [
+                {
+                  "targetBlank": false,
+                  "title": "View Trace",
+                  "url": "/d/unified-monitoring/unified-monitoring?var-traceId=${__data.fields.traceID}&${__url_time_range}"
+                }
+              ],
               "mappings": [],
               "thresholds": {
                 "mode": "absolute",
@@ -2305,14 +2669,7 @@ data:
                     "value": null
                   }
                 ]
-              },
-              "links": [
-                {
-                  "title": "View Trace",
-                  "url": "/d/unified-monitoring/unified-monitoring?var-traceId=${__data.fields.traceID}&${__url_time_range}",
-                  "targetBlank": false
-                }
-              ]
+              }
             },
             "overrides": [
               {
@@ -2349,7 +2706,7 @@ data:
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 5
+            "y": 17
           },
           "id": 9,
           "options": {
@@ -2377,8 +2734,8 @@ data:
                 "uid": "tempo"
               },
               "limit": 20,
-              "queryType": "traceql",
               "query": "{resource.service.name =~ \"${service:regex}\" && resource.k8s.namespace.name =~ \"${namespace:regex}\"}",
+              "queryType": "traceql",
               "refId": "A",
               "tableType": "traces"
             }
@@ -2396,7 +2753,7 @@ data:
             "h": 12,
             "w": 24,
             "x": 0,
-            "y": 13
+            "y": 25
           },
           "id": 21,
           "options": {},
@@ -2419,20 +2776,20 @@ data:
             "type": "tempo",
             "uid": "tempo"
           },
-          "description": "Service dependencies based on trace data",
+          "description": "Cluster-wide service map for the selected time range. The Namespace/Service variables above do not filter this panel.",
           "gridPos": {
             "h": 12,
             "w": 24,
             "x": 0,
-            "y": 25
+            "y": 37
           },
           "id": 22,
           "options": {
-            "nodes": {
-              "mainStatUnit": "ms"
-            },
             "edges": {
               "mainStatUnit": "r/sec"
+            },
+            "nodes": {
+              "mainStatUnit": "ms"
             }
           },
           "targets": [
@@ -2453,7 +2810,7 @@ data:
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 37
+            "y": 49
           },
           "id": 10,
           "title": "Application Metrics",
@@ -2518,7 +2875,7 @@ data:
             "h": 6,
             "w": 12,
             "x": 0,
-            "y": 38
+            "y": 50
           },
           "id": 11,
           "options": {
@@ -2539,7 +2896,7 @@ data:
                 "type": "prometheus",
                 "uid": "mimir"
               },
-              "expr": "sum(rate(http_server_request_duration_seconds_count{service_name=~\"$service\"}[1m])) by (http_route)",
+              "expr": "sum(rate(http_server_request_duration_seconds_count{service_name=~\"$service\", k8s_namespace_name=~\"$namespace\"}[$__rate_interval])) by (http_route)",
               "legendFormat": "{{http_route}}",
               "refId": "A"
             }
@@ -2606,7 +2963,7 @@ data:
             "h": 6,
             "w": 12,
             "x": 12,
-            "y": 38
+            "y": 50
           },
           "id": 12,
           "options": {
@@ -2627,7 +2984,7 @@ data:
                 "type": "prometheus",
                 "uid": "mimir"
               },
-              "expr": "histogram_quantile(0.95, sum(rate(http_server_request_duration_seconds_bucket{service_name=~\"$service\"}[1m])) by (le, http_route))",
+              "expr": "histogram_quantile(0.95, sum(rate(http_server_request_duration_seconds_bucket{service_name=~\"$service\", k8s_namespace_name=~\"$namespace\"}[$__rate_interval])) by (le, http_route))",
               "legendFormat": "{{http_route}}",
               "refId": "A"
             }
@@ -2640,7 +2997,7 @@ data:
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 44
+            "y": 56
           },
           "id": 13,
           "title": "Resource Usage",
@@ -2705,7 +3062,7 @@ data:
             "h": 6,
             "w": 12,
             "x": 0,
-            "y": 45
+            "y": 57
           },
           "id": 14,
           "options": {
@@ -2793,7 +3150,7 @@ data:
             "h": 6,
             "w": 12,
             "x": 12,
-            "y": 45
+            "y": 57
           },
           "id": 15,
           "options": {
@@ -2827,7 +3184,7 @@ data:
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 51
+            "y": 63
           },
           "id": 16,
           "title": "Network",
@@ -2892,7 +3249,7 @@ data:
             "h": 6,
             "w": 12,
             "x": 0,
-            "y": 52
+            "y": 64
           },
           "id": 17,
           "options": {
@@ -2935,6 +3292,7 @@ data:
             "type": "prometheus",
             "uid": "mimir"
           },
+          "description": "Egress (source_namespace) and inbound (destination_namespace) drops shown separately.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -2989,7 +3347,7 @@ data:
             "h": 6,
             "w": 12,
             "x": 12,
-            "y": 52
+            "y": 64
           },
           "id": 18,
           "options": {
@@ -3011,8 +3369,17 @@ data:
                 "uid": "mimir"
               },
               "expr": "sum(rate(hubble_drop_total{source_namespace=~\"$namespace\"}[5m])) by (reason)",
-              "legendFormat": "{{reason}}",
+              "legendFormat": "egress {{reason}}",
               "refId": "A"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "mimir"
+              },
+              "expr": "sum(rate(hubble_drop_total{destination_namespace=~\"$namespace\"}[5m])) by (reason)",
+              "legendFormat": "inbound {{reason}}",
+              "refId": "B"
             }
           ],
           "title": "Network Drops (Hubble)",
@@ -3023,7 +3390,7 @@ data:
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 58
+            "y": 70
           },
           "id": 19,
           "title": "Logs",
@@ -3038,15 +3405,15 @@ data:
             "h": 10,
             "w": 24,
             "x": 0,
-            "y": 59
+            "y": 71
           },
           "id": 20,
           "options": {
             "dedupStrategy": "none",
             "enableLogDetails": true,
             "prettifyLogMessage": false,
-            "showCommonLabels": false,
-            "showLabels": false,
+            "showCommonLabels": true,
+            "showLabels": true,
             "showTime": true,
             "sortOrder": "Descending",
             "wrapLogMessage": false
@@ -3063,8 +3430,157 @@ data:
           ],
           "title": "Application Logs",
           "type": "logs"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "mimir"
+          },
+          "description": "Verify the http_response_status_code label exists on http_server_request_duration_seconds_count in Mimir before relying on this (checked against live traffic pending; monolith/frontend are currently scaled to 0).",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "yellow",
+                    "value": 1
+                  },
+                  {
+                    "color": "red",
+                    "value": 5
+                  }
+                ]
+              },
+              "unit": "percent"
+            }
+          },
+          "gridPos": {
+            "h": 4,
+            "w": 4,
+            "x": 0,
+            "y": 5
+          },
+          "id": 23,
+          "options": {
+            "colorMode": "value",
+            "graphMode": "area",
+            "justifyMode": "auto",
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "textMode": "auto"
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "mimir"
+              },
+              "expr": "100 * sum(rate(http_server_request_duration_seconds_count{service_name=~\"$service\", k8s_namespace_name=~\"$namespace\", http_response_status_code=~\"5..\"}[$__rate_interval])) / clamp_min(sum(rate(http_server_request_duration_seconds_count{service_name=~\"$service\", k8s_namespace_name=~\"$namespace\"}[$__rate_interval])), 0.001)",
+              "refId": "A"
+            }
+          ],
+          "title": "5xx Rate",
+          "type": "stat"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "mimir"
+          },
+          "description": "Node count over time \u2014 catches fast Karpenter scale-out/in events an instant stat cannot. See Infrastructure Monitoring for Karpenter event logs.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "drawStyle": "line",
+                "fillOpacity": 10,
+                "lineWidth": 1,
+                "pointSize": 5,
+                "showPoints": "never",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                }
+              },
+              "unit": "short"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 6,
+            "w": 24,
+            "x": 0,
+            "y": 10
+          },
+          "id": 24,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "mimir"
+              },
+              "expr": "sum(kube_node_status_condition{condition=\"Ready\",status=\"true\"} == 1)",
+              "legendFormat": "Ready",
+              "refId": "A"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "mimir"
+              },
+              "expr": "sum(kube_node_status_condition{condition=\"Ready\",status=~\"false|unknown\"} == 1)",
+              "legendFormat": "Not Ready",
+              "refId": "B"
+            }
+          ],
+          "title": "Node Ready State",
+          "type": "timeseries"
+        },
+        {
+          "collapsed": false,
+          "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 9
+          },
+          "id": 25,
+          "panels": [],
+          "title": "Node Health",
+          "type": "row"
         }
       ],
+      "refresh": "30s",
       "schemaVersion": 39,
       "tags": [
         "unified",
@@ -3074,6 +3590,7 @@ data:
       "templating": {
         "list": [
           {
+            "allValue": ".+",
             "current": {
               "selected": false,
               "text": "All",
@@ -3087,7 +3604,7 @@ data:
             "hide": 0,
             "includeAll": true,
             "label": "Namespace",
-            "multi": false,
+            "multi": true,
             "name": "namespace",
             "options": [],
             "query": {
@@ -3099,10 +3616,10 @@ data:
             "regex": "",
             "skipUrlSync": false,
             "sort": 1,
-            "type": "query",
-            "allValue": ".+"
+            "type": "query"
           },
           {
+            "allValue": ".+",
             "current": {
               "selected": false,
               "text": "All",
@@ -3112,26 +3629,26 @@ data:
               "type": "prometheus",
               "uid": "mimir"
             },
-            "definition": "label_values(http_server_request_duration_seconds_count, service_name)",
+            "definition": "label_values(http_server_request_duration_seconds_count{k8s_namespace_name=~\"$namespace\"}, service_name)",
             "hide": 0,
             "includeAll": true,
             "label": "Service",
-            "multi": false,
+            "multi": true,
             "name": "service",
             "options": [],
             "query": {
               "qryType": 1,
-              "query": "label_values(http_server_request_duration_seconds_count, service_name)",
+              "query": "label_values(http_server_request_duration_seconds_count{k8s_namespace_name=~\"$namespace\"}, service_name)",
               "refId": "PrometheusVariableQueryEditor-VariableQuery"
             },
             "refresh": 2,
             "regex": "",
             "skipUrlSync": false,
             "sort": 1,
-            "type": "query",
-            "allValue": ".+"
+            "type": "query"
           },
           {
+            "allValue": ".+",
             "current": {
               "selected": false,
               "text": "All",
@@ -3145,7 +3662,7 @@ data:
             "hide": 0,
             "includeAll": true,
             "label": "Pod",
-            "multi": false,
+            "multi": true,
             "name": "pod",
             "options": [],
             "query": {
@@ -3158,8 +3675,7 @@ data:
             "regex": "",
             "skipUrlSync": false,
             "sort": 1,
-            "type": "query",
-            "allValue": ".+"
+            "type": "query"
           },
           {
             "current": {
@@ -3208,7 +3724,14 @@ data:
         "from": "now-1h",
         "to": "now"
       },
-      "timepicker": {},
+      "timepicker": {
+        "refresh_intervals": [
+          "10s",
+          "30s",
+          "1m",
+          "5m"
+        ]
+      },
       "timezone": "browser",
       "title": "Unified Monitoring",
       "uid": "unified-monitoring",


### PR DESCRIPTION
## Summary
「Total Pods / Unhealthy Podsが瞬間値だけで時系列の変化が分かりにくい」という指摘を発端に、Codex (`codex:codex-rescue`) と Claude Opus の2エージェントに独立レビューを依頼。重複を除いて優先度付けし、実クラスタ (Mimirへの直接PromQLクエリ) と repo 設定 (Beylaのlabel保持設定) で裏取りした上で反映しました。

### 確実なバグ
- `unified-monitoring.json` のみ `graphMode:"none"` だった（app/infraは既に`area`設定済み — 当初の認識を訂正）
- `infra-monitoring.json` "Running Pods" の threshold が `value>=1` で赤になる逆転バグ
- "P95 Latency" stat が `reduceOptions.calcs=mean`（期間平均）になっており `lastNotNull`（現在値）が正しい
- "Container Restarts"/"Restarts" が累積カウンタのままで、`increase(...[15m])` に変更（「今起きている」障害かどうかを表せるように）
- "Unhealthy Pods" が pod phase のみ判定のため CrashLoopBackOff 中でも `phase=Running` なら検知漏れ（description明記 + 新設panelで補完）
- `namespace` 変数が `service` 変数・app系メトリクスクエリに一切効いていなかった（Beylaが `k8s_namespace_name` label を保持する設定を確認した上で全クエリに追加）

### 新規panel
- **5xx Rate**（app/unified）— 成功率だけでは holmesgpt/Bedrock 500 のような障害が見えない
- **Node Ready State timeseries**（infra/unified）— 瞬間値のみだったKarpenter node churnを推移で追えるように
- **Karpenter Events / Restarting Containers / Pods without CPU Requests / Pods Waiting by Reason**（infra）— 各stat panelのblind spotを補完

### その他
- 3ファイルとも `refresh` 未設定 → `30s`
- 組み込みannotationを可視化（`hide:false`）
- `namespace`/`pod`/`service` 変数を `multi:true`
- Hubble dropがsource（egress）のみだったのをdestination（inbound）も追加
- Error Logsのregex拡張 + `showLabels`有効化
- Service Graphに「namespace/service filterは効かない」description追加（誤認防止）

### 対象外にしたもの
- deploy/scalingイベントのannotation自動投入（別途CI連携が必要、範囲外）
- trace panelの並び順の大幅変更（影響範囲が広いため保留、appのみError Traces panelを追加）

## Test plan
- [x] 3ファイルともJSON構文妥当、panel id重複なし、gridPos overflow なし
- [x] hydrate後のConfigMap manifest.yamlがYAMLとして妥当
- [x] live clusterに一時適用し、Grafana API (`/api/search`, `/api/dashboards/uid/*`) 経由で全panelがschemaエラーなく読み込まれることを確認（panel数: app=16, infra=23, unified=25 で一致）
- [x] 新規PromQLクエリ（`unless on(...)`含む）を実際にMimirへ実行しエラーなしを確認
- [ ] `http_response_status_code` labelは現在アプリ実トラフィックが無く未検証（5xx Rate panelのdescriptionに明記、monolith/frontendのsuspend解除後に確認要）