### PR TITLE
fix(github/branch): let fluxcd-bot bypass monorepo's pull_request rule

### DIFF
--- a/github/branch/master/monorepo.hcl
+++ b/github/branch/master/monorepo.hcl
@@ -12,10 +12,9 @@ locals {
             "Validate PR title",
             "Ensure actions are pinned to SHAs",
           ]
-          # panicboat App (1371999) bypasses the pull_request rule for direct
-          # push from Flux ImageUpdateAutomation (= release-driven image bump
-          # commits to overlays/production/deployment.yaml).
-          bypass_app_ids = [1371999]
+          # 1371999 = panicboat-github-workflow-bot (general CI, e.g. release-please)
+          # 4671042 = panicboat-fluxcd-bot (Flux ImageUpdateAutomation direct push)
+          bypass_app_ids = [1371999, 4671042]
         }
       )
     }


### PR DESCRIPTION
## Summary
- `panicboat/monorepo`'s `monorepo-main` ruleset only listed the general CI workflow bot (App ID `1371999`, `panicboat-github-workflow-bot`) as a `pull_request` rule bypass actor.
- Flux's `ImageUpdateAutomation` in `eks-production` pushes release-driven image-bump commits directly to `main` (no PR), using credentials for `panicboat-fluxcd-bot` (App ID `4671042`) — wired into `flux-system`'s `panicboat-github-app` secret from `github-app/fluxcd-bot` in Secrets Manager.
- Since `4671042` wasn't in the bypass list, every such push has been rejected with `push declined due to repository rule violations`. Verified this affects not just the newly-deployed `pennyworth` but also `frontend` and `monolith` — none had their Deployment manifest's image tag advanced by Flux despite `ImagePolicy` correctly resolving newer versions.
- Adds `4671042` to `bypass_app_ids` alongside the existing `1371999`.

## Test plan
- [x] `terragrunt validate` — clean
- [x] `terragrunt plan` — `Plan: 0 to add, 1 to change, 0 to destroy`, diff is exactly the new `bypass_actors` block for App `4671042`
- [ ] Post-merge (apply): confirm Flux's `ImageUpdateAutomation` for `pennyworth` succeeds and the Deployment manifest is updated to `v1.0.0`