### PR TITLE
chore(workflow-config): enable production for CI-driven deploy automation

### DIFF
--- a/workflow-config.yaml
+++ b/workflow-config.yaml
@@ -13,12 +13,12 @@ environments:
   #       iam_role_plan: arn:aws:iam::270242382571:role/github-oidc-auth-develop-github-actions-plan-role
   #       iam_role_apply: arn:aws:iam::270242382571:role/github-oidc-auth-develop-github-actions-apply-role
 
-  # - environment: production
-  #   stacks:
-  #     terragrunt:
-  #       aws_region: ap-northeast-1
-  #       iam_role_plan: arn:aws:iam::337169763788:role/github-oidc-auth-production-github-actions-plan-role
-  #       iam_role_apply: arn:aws:iam::337169763788:role/github-oidc-auth-production-github-actions-apply-role
+  - environment: production
+    stacks:
+      terragrunt:
+        aws_region: ap-northeast-1
+        iam_role_plan: arn:aws:iam::337169763788:role/github-oidc-auth-production-github-actions-plan-role
+        iam_role_apply: arn:aws:iam::337169763788:role/github-oidc-auth-production-github-actions-apply-role
 
 stack_conventions:
   - root: "aws/{service}"


### PR DESCRIPTION
## Summary
- `workflow-config.yaml`'s `environments:` list has `production` fully commented out, so `panicboat/deploy-actions`' label-resolver resolves **zero** deployment targets for any `kubernetes/components/**/production/**` or `aws/**/production/**` change, regardless of the `deploy:*` label applied.
- This is why #881 (dashboard consolidation) never got auto-hydrated and needed #882 as a manual follow-up, and is presumably why terragrunt production changes have been applied by hand too.
- Uncommented the `production` entry. The AWS account id (`337169763788`) and both `github-oidc-auth-production-github-actions-{plan,apply}-role` ARNs already match the dedicated production account and the roles provisioned by `aws/github-oidc-auth/production` — this only wires up routing, it does not mint new credentials.
- **Behavior change to be aware of**: the `environments:` schema has no way to scope an environment to a single stack, so this enables both the kubernetes hydrate/diff automation *and* terragrunt auto-apply for production. After this merges, a PR touching `aws/{service}/production/` with a matching `deploy:{service}` label will run `terragrunt apply` on merge to main, not just plan — today it silently does neither.

## Test plan
- [x] Cloned `panicboat/deploy-actions` at the SHA pinned in `.github/workflows/auto-label--deploy-trigger.yaml` (`0f0a02d87678cf779217ca2056218e2315bc1c61`) and ran `config-manager validate` against the edited file: passes (`environments: 2 configured`)
- [x] Ran `label-resolver resolve 881 production` against this repo with the edited config: correctly resolves `dashboard:kubernetes -> kubernetes/components/dashboard/production`
- [ ] Watch the next labeled `aws/**/production/**` PR to confirm `deploy-terragrunt` actually runs (expected, but not exercised by this PR's own diff)

https://claude.ai/code/session_01ATZmXFKkyfCC7TF9WWmAt1