### PR TITLE
refactor(aws/secrets-manager): drop pennyworth-only secret containers

### DIFF
--- a/aws/secrets-manager/modules/main.tf
+++ b/aws/secrets-manager/modules/main.tf
@@ -14,13 +14,11 @@
 locals {
   secrets = {
     fluxcd-bot             = { name = "github-app/fluxcd-bot" }
-    holmes-bot             = { name = "github-app/holmes-bot" }
     alertmanager-slack     = { name = "eks/alertmanager/slack" }
     grafana-admin          = { name = "eks/grafana/admin" }
     keycloak-admin         = { name = "eks/keycloak/admin" }
     oauth2-proxy-google    = { name = "eks/oauth2-proxy/google" }
     holmesgpt-alertmanager = { name = "eks/holmesgpt/alertmanager" }
-    holmesgpt-slack        = { name = "eks/holmesgpt/slack" }
   }
 }
 


### PR DESCRIPTION
## Summary
- `github-app/holmes-bot` and `eks/holmesgpt/slack` are only ever consumed by `panicboat/monorepo`'s `pennyworth` ExternalSecret — nothing in `panicboat/platform` reads them (unlike `eks/holmesgpt/alertmanager`, which platform's own Alertmanager notification config also uses). Declaring their containers in this shared stack was incidental.
- `pennyworth` is moving to its own Terraform-managed, pennyworth-branded secrets: `system-components/pennyworth/slack` and `github-app/holmesgpt-bot`. Real values have already been copied over (verified key structure matches, no data loss).
- This PR removes the two now-unused entries from `local.secrets`.

## ⚠️ Do not merge yet
Merging (and the resulting `terragrunt apply`) destroys `github-app/holmes-bot` and `eks/holmesgpt/slack`. Only merge after confirming pennyworth's ExternalSecret has cut over to the new paths and is `SecretSynced: True` in production — see the companion `panicboat/monorepo` PR.

## Test plan
- [x] `terragrunt plan` (against the real production account) — `Plan: 0 to add, 0 to change, 2 to destroy`, exactly the two removed entries