### PR TITLE
feat(ci): release-please phase 2 — production deploy trigger

### DIFF
--- a/.github/workflows/auto-label--deploy-trigger.yaml
+++ b/.github/workflows/auto-label--deploy-trigger.yaml
@@ -23,8 +23,8 @@ jobs:
     name: 'Deployment Trigger'
     runs-on: ubuntu-latest
     outputs:
-      targets: ${{ steps.resolver.outputs.targets }}
-      has-targets: ${{ steps.resolver.outputs.has-targets }}
+      targets: ${{ steps.filter.outputs.targets }}
+      has-targets: ${{ steps.filter.outputs.has-targets }}
     steps:
       - name: Generate GitHub App token
         id: app-token
@@ -50,7 +50,20 @@ jobs:
           pr-number: ${{ steps.pr-info.outputs.number }}
           github-token: ${{ steps.app-token.outputs.token }}
           config-path: 'workflow-config.yaml'
-          environments: 'master'
+
+      - name: Filter out production targets
+        id: filter
+        env:
+          TARGETS: ${{ steps.resolver.outputs.targets }}
+        run: |
+          set -euo pipefail
+          filtered=$(echo "$TARGETS" | jq -c '[.[] | select(.environment != "production")]')
+          if [ "$(echo "$filtered" | jq 'length')" -gt 0 ]; then
+            echo "has-targets=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "has-targets=false" >> "$GITHUB_OUTPUT"
+          fi
+          echo "targets=$filtered" >> "$GITHUB_OUTPUT"
 
   kubernetes-targets-group:
     name: 'Group Kubernetes Targets by Environment'

--- a/.github/workflows/auto-label--deploy-trigger.yaml
+++ b/.github/workflows/auto-label--deploy-trigger.yaml
@@ -50,6 +50,7 @@ jobs:
           pr-number: ${{ steps.pr-info.outputs.number }}
           github-token: ${{ steps.app-token.outputs.token }}
           config-path: 'workflow-config.yaml'
+          environments: 'master'
 
   kubernetes-targets-group:
     name: 'Group Kubernetes Targets by Environment'

--- a/.github/workflows/release-deploy.yml
+++ b/.github/workflows/release-deploy.yml
@@ -64,7 +64,7 @@ jobs:
           ref: ${{ github.event.release.tag_name }}
 
       - name: Setup aqua
-        uses: aquaproj/aqua-installer@96a9bc20066c5bf5e275b41019cfc165b25f4e2e # v2.48.2
+        uses: aquaproj/aqua-installer@96a9bc20066c5bf5e275b41019cfc165b25f4e2e # v4.0.5
         with:
           aqua_version: v2.48.2
 
@@ -114,8 +114,6 @@ jobs:
           fetch-depth: 0
 
       - name: Force-update kubernetes-production tag
-        env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           set -euo pipefail
           git tag -f kubernetes-production "${{ github.event.release.tag_name }}"

--- a/.github/workflows/release-deploy.yml
+++ b/.github/workflows/release-deploy.yml
@@ -1,0 +1,93 @@
+name: Release Deploy
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  id-token: write
+  contents: write
+
+jobs:
+  parse-tag:
+    name: 'Parse Release Tag'
+    runs-on: ubuntu-latest
+    outputs:
+      component: ${{ steps.parse.outputs.component }}
+      is-aws: ${{ steps.parse.outputs.is-aws }}
+      is-kubernetes: ${{ steps.parse.outputs.is-kubernetes }}
+    steps:
+      - name: Parse component from tag
+        id: parse
+        env:
+          TAG_NAME: ${{ github.event.release.tag_name }}
+        run: |
+          set -euo pipefail
+          if [[ "$TAG_NAME" =~ ^([a-z0-9-]+)-v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            component="${BASH_REMATCH[1]}"
+          else
+            echo "Tag '$TAG_NAME' does not match <component>-vX.Y.Z, skipping"
+            echo "component=" >> "$GITHUB_OUTPUT"
+            echo "is-aws=false" >> "$GITHUB_OUTPUT"
+            echo "is-kubernetes=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "component=$component" >> "$GITHUB_OUTPUT"
+          case "$component" in
+            alb|eks|eks-holmesgpt|eks-karpenter|eks-logs|eks-metrics|eks-secrets|eks-traces|github-oidc-auth|iam-service-linked-roles|secrets-manager|vpc)
+              echo "is-aws=true" >> "$GITHUB_OUTPUT"
+              echo "is-kubernetes=false" >> "$GITHUB_OUTPUT"
+              ;;
+            kubernetes)
+              echo "is-aws=false" >> "$GITHUB_OUTPUT"
+              echo "is-kubernetes=true" >> "$GITHUB_OUTPUT"
+              ;;
+            *)
+              echo "Unknown component '$component', skipping"
+              echo "is-aws=false" >> "$GITHUB_OUTPUT"
+              echo "is-kubernetes=false" >> "$GITHUB_OUTPUT"
+              ;;
+          esac
+
+  resolve-aws-config:
+    name: 'Resolve Production AWS Config'
+    needs: parse-tag
+    if: needs.parse-tag.outputs.is-aws == 'true'
+    runs-on: ubuntu-latest
+    outputs:
+      aws-region: ${{ steps.config.outputs.aws-region }}
+      iam-role-apply: ${{ steps.config.outputs.iam-role-apply }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.event.release.tag_name }}
+
+      - name: Setup aqua
+        uses: aquaproj/aqua-installer@96a9bc20066c5bf5e275b41019cfc165b25f4e2e # v2.48.2
+        with:
+          aqua_version: v2.48.2
+
+      - name: Resolve production config
+        id: config
+        run: |
+          set -euo pipefail
+          aws_region=$(yq '.environments[] | select(.environment == "production") | .stacks.terragrunt.aws_region' workflow-config.yaml)
+          iam_role_apply=$(yq '.environments[] | select(.environment == "production") | .stacks.terragrunt.iam_role_apply' workflow-config.yaml)
+          echo "aws-region=$aws_region" >> "$GITHUB_OUTPUT"
+          echo "iam-role-apply=$iam_role_apply" >> "$GITHUB_OUTPUT"
+
+  deploy-aws:
+    name: 'Deploy AWS (${{ needs.parse-tag.outputs.component }})'
+    needs: [parse-tag, resolve-aws-config]
+    uses: ./.github/workflows/reusable--terragrunt-executor.yaml
+    with:
+      service-name: ${{ needs.parse-tag.outputs.component }}
+      environment: production
+      action-type: apply
+      iam-role: ${{ needs.resolve-aws-config.outputs.iam-role-apply }}
+      aws-region: ${{ needs.resolve-aws-config.outputs.aws-region }}
+      working-directory: aws/${{ needs.parse-tag.outputs.component }}/production
+      app-id: ${{ vars.APP_ID }}
+    secrets:
+      private-key: ${{ secrets.APP_PRIVATE_KEY }}

--- a/.github/workflows/release-deploy.yml
+++ b/.github/workflows/release-deploy.yml
@@ -91,3 +91,32 @@ jobs:
       app-id: ${{ vars.APP_ID }}
     secrets:
       private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
+  deploy-kubernetes:
+    name: 'Advance Flux Production Tag'
+    needs: parse-tag
+    if: needs.parse-tag.outputs.is-kubernetes == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ vars.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+          ref: ${{ github.event.release.tag_name }}
+          fetch-depth: 0
+
+      - name: Force-update kubernetes-production tag
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          set -euo pipefail
+          git tag -f kubernetes-production "${{ github.event.release.tag_name }}"
+          git push origin kubernetes-production --force

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,4 +22,3 @@ jobs:
         id: release
         with:
           token: ${{ steps.app-token.outputs.token }}
-          release-type: simple

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,0 +1,15 @@
+{
+  "aws/alb": "0.1.0",
+  "aws/eks": "0.1.0",
+  "aws/eks-holmesgpt": "0.1.0",
+  "aws/eks-karpenter": "0.1.0",
+  "aws/eks-logs": "0.1.0",
+  "aws/eks-metrics": "0.1.0",
+  "aws/eks-secrets": "0.1.0",
+  "aws/eks-traces": "0.1.0",
+  "aws/github-oidc-auth": "0.1.0",
+  "aws/iam-service-linked-roles": "0.1.0",
+  "aws/secrets-manager": "0.1.0",
+  "aws/vpc": "0.1.0",
+  "kubernetes": "0.1.0"
+}

--- a/aqua.yaml
+++ b/aqua.yaml
@@ -18,3 +18,4 @@ packages:
   - name: rhysd/actionlint@v1.7.7
   - name: opentofu/opentofu@v1.12.0
   - name: gruntwork-io/terragrunt@v1.0.2
+  - name: mikefarah/yq@v4.44.3

--- a/docs/superpowers/plans/2026-09-06-release-please-phase2-deploy.md
+++ b/docs/superpowers/plans/2026-09-06-release-please-phase2-deploy.md
@@ -1,0 +1,801 @@
+# release-please Phase 2 Deploy Trigger Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** production への deploy を release-please の `release: published` イベント起点に切り替える(aws は component ごとの terragrunt apply、kubernetes は Flux の追従先タグ切り替え)。あわせて #884 以降ライブになっている production 誤爆リスクを止める。
+
+**Architecture:** `release-please-config.json` を manifest mode に切り替え、`aws/{service}` 11 component + `kubernetes` 1 component を管理する。新規 workflow `release-deploy.yml`(`on: release: types: [published]`)が tag 名から component を特定し、aws component は label-resolver を経由せず直接 `reusable--terragrunt-executor.yaml` を呼び出し、kubernetes component は `kubernetes-production` タグを force-update して Flux の追従先を進める。既存の自動 push トリガー(`auto-label--deploy-trigger.yaml`)は `environments: master` を明示して production を対象外にする。
+
+**Tech Stack:**
+- `googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7` (v5、既存 pin を継続使用)
+- `mikefarah/yq`(aqua 経由、新規追加)
+- 既存 GitHub App(`vars.APP_ID` / `secrets.APP_PRIVATE_KEY`)
+- 既存 `reusable--terragrunt-executor.yaml`
+
+**Spec:** `docs/superpowers/specs/2026-09-06-release-please-phase2-deploy-design.md`
+
+## Global Constraints
+
+- production 環境のみが対象。`develop` は out of scope(常時起動していないため)
+- `github/{service}` は対象外(`master` 専用、`production` ディレクトリを持たない)
+- 既存の `master` 向け自動パイプラインの挙動は変更しない(production のみ切り離す)
+- GitHub Actions の `uses:` は SHA-pin する(このリポジトリ全体の既存方針)
+- commit は Conventional Commits + `-s`(sign-off)
+- 初回 push は `git push -u origin HEAD`
+- PR は `gh pr create --draft` で作成
+- `Co-Authored-By` は付けない
+- worktree: `.claude/worktrees/feat-release-please-phase2-deploy`(作成済み)、branch: `feat/release-please-phase2-deploy`(作成済み、`origin/main` の `83d44bfe1f5840da0fe6b9834f5d7d727d68cb4a` から分岐)
+
+---
+
+## File Structure
+
+| File | 種別 | 役割 |
+|---|---|---|
+| `.github/workflows/auto-label--deploy-trigger.yaml` | Modify | Label Resolver 呼び出しに `environments: master` を明示し、production を対象外にする |
+| `aqua.yaml` | Modify | `mikefarah/yq` を追加(workflow-config.yaml の値取得に使う) |
+| `release-please-config.json` | Create | manifest mode の component 定義(aws 11 + kubernetes 1) |
+| `.release-please-manifest.json` | Create | 各 component の現在バージョン state |
+| `.github/workflows/release.yml` | Modify | non-manifest(`release-type: simple`)から manifest mode 呼び出しに変更 |
+| `.github/workflows/release-deploy.yml` | Create | `release: published` 起点で aws component は terragrunt apply、kubernetes component は追従タグを force-update |
+| `kubernetes/clusters/production/flux-system/gotk-sync.yaml` | Modify | `GitRepository.spec.ref` を `branch: main` から `tag: kubernetes-production` に切り替え |
+
+既存ファイルへの変更はなし(`workflow-config.yaml` の `production` エントリは #884 で既に有効化済み、本 plan での変更は不要)。
+
+---
+
+## Task 1: production 誤爆リスクの解消(最優先)
+
+**Files:**
+- Modify: `.github/workflows/auto-label--deploy-trigger.yaml`
+
+**Interfaces:**
+- 変更なし(既存の label-resolver composite action の呼び出しに input を1つ追加するのみ)
+
+### Setup
+
+- [ ] **Step 1.1: 現状を確認**
+
+Run:
+```bash
+cd /Users/takanokenichi/GitHub/panicboat/platform/.claude/worktrees/feat-release-please-phase2-deploy
+grep -n "environments:" .github/workflows/auto-label--deploy-trigger.yaml
+```
+
+Expected: no output(`environments:` input がまだ存在しないことを確認)
+
+### Implementation
+
+- [ ] **Step 1.2: `environments: master` を追加**
+
+`.github/workflows/auto-label--deploy-trigger.yaml` の Label Resolver ステップを以下のように変更する。
+
+変更前:
+```yaml
+      - name: Label Resolver
+        id: resolver
+        uses: panicboat/deploy-actions/label-resolver@0f0a02d87678cf779217ca2056218e2315bc1c61 # refactor/infrastructure-layout (panicboat/deploy-actions#307) — re-point to the v1.3.0 release SHA before merge
+        with:
+          repository: ${{ github.repository }}
+          pr-number: ${{ steps.pr-info.outputs.number }}
+          github-token: ${{ steps.app-token.outputs.token }}
+          config-path: 'workflow-config.yaml'
+```
+
+変更後:
+```yaml
+      - name: Label Resolver
+        id: resolver
+        uses: panicboat/deploy-actions/label-resolver@0f0a02d87678cf779217ca2056218e2315bc1c61 # refactor/infrastructure-layout (panicboat/deploy-actions#307) — re-point to the v1.3.0 release SHA before merge
+        with:
+          repository: ${{ github.repository }}
+          pr-number: ${{ steps.pr-info.outputs.number }}
+          github-token: ${{ steps.app-token.outputs.token }}
+          config-path: 'workflow-config.yaml'
+          environments: 'master'
+```
+
+- [ ] **Step 1.3: actionlint で検証**
+
+Run:
+```bash
+cd /Users/takanokenichi/GitHub/panicboat/platform/.claude/worktrees/feat-release-please-phase2-deploy
+docker run --rm -v "$(pwd):/repo" -w /repo rhysd/actionlint:latest -color .github/workflows/auto-label--deploy-trigger.yaml
+```
+
+Expected: no output(exit 0)
+
+### Commit
+
+- [ ] **Step 1.4: commit**
+
+```bash
+cd /Users/takanokenichi/GitHub/panicboat/platform/.claude/worktrees/feat-release-please-phase2-deploy
+git add .github/workflows/auto-label--deploy-trigger.yaml
+git commit -s -m "$(cat <<'EOF'
+fix(ci): pin auto deploy-trigger to master environment only
+
+#884 で workflow-config.yaml の production を有効化したことにより、
+label-resolver が environments 未指定時に production も対象にしてしまい、
+master のみの変更でも production へ apply されうる状態になっていた。
+production 配下しか持たない service では既に実害はないが、master と
+production の両方を持つ github-oidc-auth は誤爆しうるため明示的に固定する。
+
+Spec: docs/superpowers/specs/2026-09-06-release-please-phase2-deploy-design.md
+EOF
+)"
+```
+
+Expected: 1 file changed
+
+> **Note:** この Task は独立して安全にマージ可能。他の Task を待たず先に PR 化・マージしたい場合は、ここで一旦 push して単独 PR にしてよい(Task 2 以降とは無関係)。
+
+---
+
+## Task 2: yq を CI ツールチェーンに追加
+
+**Files:**
+- Modify: `aqua.yaml`
+
+**Interfaces:**
+- Produces: CI 上で `yq` コマンドが使えるようになる(Task 6 で使用)
+
+### Implementation
+
+- [ ] **Step 2.1: `aqua.yaml` に `mikefarah/yq` を追加**
+
+`aqua.yaml` の `packages:` に以下を追加する(既存エントリの並びの末尾に追加、renovate が追跡できるよう aqua 標準の書式に合わせる)。
+
+```yaml
+  - name: mikefarah/yq@v4.44.3
+```
+
+追加後の `packages:` セクション全体は以下のようになる。
+
+```yaml
+packages:
+  - name: helmfile/helmfile@v0.169.2
+  - name: helm/helm@v3.17.3
+  - name: kubernetes-sigs/kustomize@kustomize/v5.6.0
+  - name: nektos/act@v0.2.87
+  - name: rhysd/actionlint@v1.7.7
+  - name: opentofu/opentofu@v1.12.0
+  - name: gruntwork-io/terragrunt@v1.0.2
+  - name: mikefarah/yq@v4.44.3
+```
+
+- [ ] **Step 2.2: aqua.yaml の構文を検証**
+
+Run:
+```bash
+cd /Users/takanokenichi/GitHub/panicboat/platform/.claude/worktrees/feat-release-please-phase2-deploy
+python3 -c "import yaml,sys; yaml.safe_load(open('aqua.yaml'))" && echo "aqua.yaml OK"
+```
+
+Expected: `aqua.yaml OK`
+
+### Commit
+
+- [ ] **Step 2.3: commit**
+
+```bash
+cd /Users/takanokenichi/GitHub/panicboat/platform/.claude/worktrees/feat-release-please-phase2-deploy
+git add aqua.yaml
+git commit -s -m "$(cat <<'EOF'
+chore(aqua): add yq for workflow-config.yaml value extraction
+
+release-deploy.yml が production の iam_role_apply / aws_region を
+workflow-config.yaml から取得するために使う。
+
+Spec: docs/superpowers/specs/2026-09-06-release-please-phase2-deploy-design.md
+EOF
+)"
+```
+
+Expected: 1 file changed
+
+---
+
+## Task 3: release-please を manifest mode に切り替える(設定ファイル)
+
+**Files:**
+- Create: `release-please-config.json`
+- Create: `.release-please-manifest.json`
+
+**Interfaces:**
+- Produces: 12 個の release-please component(`aws/alb` ... `aws/vpc`、`kubernetes`)。tag 形式は `{component}-vX.Y.Z`
+
+### Implementation
+
+- [ ] **Step 3.1: 対象 aws service を実ディレクトリで再確認**
+
+Run:
+```bash
+cd /Users/takanokenichi/GitHub/panicboat/platform/.claude/worktrees/feat-release-please-phase2-deploy
+for d in aws/*/; do
+  svc=$(basename "$d")
+  [ -d "${d}production" ] && echo "$svc: production あり"
+done
+```
+
+Expected: 以下11行が出力される(spec のスナップショットと一致することを確認)
+```
+alb: production あり
+eks: production あり
+eks-holmesgpt: production あり
+eks-karpenter: production あり
+eks-logs: production あり
+eks-metrics: production あり
+eks-secrets: production あり
+eks-traces: production あり
+github-oidc-auth: production あり
+iam-service-linked-roles: production あり
+vpc: production あり
+```
+
+差分があれば(directory が増減していれば)後続の JSON の component 一覧をこの実測結果に合わせる。
+
+- [ ] **Step 3.2: `release-please-config.json` を作成**
+
+Files: `release-please-config.json`
+
+```json
+{
+  "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
+  "bootstrap-sha": "83d44bfe1f5840da0fe6b9834f5d7d727d68cb4a",
+  "separate-pull-requests": true,
+  "packages": {
+    "aws/alb": { "release-type": "simple", "component": "alb", "include-component-in-tag": true },
+    "aws/eks": { "release-type": "simple", "component": "eks", "include-component-in-tag": true },
+    "aws/eks-holmesgpt": { "release-type": "simple", "component": "eks-holmesgpt", "include-component-in-tag": true },
+    "aws/eks-karpenter": { "release-type": "simple", "component": "eks-karpenter", "include-component-in-tag": true },
+    "aws/eks-logs": { "release-type": "simple", "component": "eks-logs", "include-component-in-tag": true },
+    "aws/eks-metrics": { "release-type": "simple", "component": "eks-metrics", "include-component-in-tag": true },
+    "aws/eks-secrets": { "release-type": "simple", "component": "eks-secrets", "include-component-in-tag": true },
+    "aws/eks-traces": { "release-type": "simple", "component": "eks-traces", "include-component-in-tag": true },
+    "aws/github-oidc-auth": { "release-type": "simple", "component": "github-oidc-auth", "include-component-in-tag": true },
+    "aws/iam-service-linked-roles": { "release-type": "simple", "component": "iam-service-linked-roles", "include-component-in-tag": true },
+    "aws/vpc": { "release-type": "simple", "component": "vpc", "include-component-in-tag": true },
+    "kubernetes": { "release-type": "simple", "component": "kubernetes", "include-component-in-tag": true }
+  }
+}
+```
+
+- [ ] **Step 3.3: `.release-please-manifest.json` を作成**
+
+Files: `.release-please-manifest.json`
+
+```json
+{
+  "aws/alb": "0.1.0",
+  "aws/eks": "0.1.0",
+  "aws/eks-holmesgpt": "0.1.0",
+  "aws/eks-karpenter": "0.1.0",
+  "aws/eks-logs": "0.1.0",
+  "aws/eks-metrics": "0.1.0",
+  "aws/eks-secrets": "0.1.0",
+  "aws/eks-traces": "0.1.0",
+  "aws/github-oidc-auth": "0.1.0",
+  "aws/iam-service-linked-roles": "0.1.0",
+  "aws/vpc": "0.1.0",
+  "kubernetes": "0.1.0"
+}
+```
+
+- [ ] **Step 3.4: JSON 構文と整合性を検証**
+
+Run:
+```bash
+cd /Users/takanokenichi/GitHub/panicboat/platform/.claude/worktrees/feat-release-please-phase2-deploy
+jq empty release-please-config.json && echo "config OK"
+jq empty .release-please-manifest.json && echo "manifest OK"
+echo "--- config packages ---"
+jq -r '.packages | keys[]' release-please-config.json | sort
+echo "--- manifest packages ---"
+jq -r 'keys[]' .release-please-manifest.json | sort
+```
+
+Expected:
+- `config OK` / `manifest OK`
+- 2つの package 一覧(12件ずつ)が完全に一致する
+
+### Commit
+
+- [ ] **Step 3.5: commit**
+
+```bash
+cd /Users/takanokenichi/GitHub/panicboat/platform/.claude/worktrees/feat-release-please-phase2-deploy
+git add release-please-config.json .release-please-manifest.json
+git commit -s -m "$(cat <<'EOF'
+feat(ci): switch release-please to manifest mode
+
+aws/{service}(production ディレクトリを持つ11 service)と kubernetes を
+それぞれ独立 component として管理する。tag は {component}-vX.Y.Z 形式
+(include-component-in-tag: true)。bootstrap-sha は本ブランチの分岐元
+main HEAD に固定し、既存 CHANGELOG.md の履歴とは独立した起点にする。
+
+Spec: docs/superpowers/specs/2026-09-06-release-please-phase2-deploy-design.md
+EOF
+)"
+```
+
+Expected: 2 files changed
+
+---
+
+## Task 4: release.yml を manifest mode 呼び出しに変更
+
+**Files:**
+- Modify: `.github/workflows/release.yml`
+
+**Interfaces:**
+- Consumes: Task 3 で作成した `release-please-config.json` / `.release-please-manifest.json`
+
+### Implementation
+
+- [ ] **Step 4.1: `release-type: simple` を削除し manifest mode 呼び出しにする**
+
+変更前:
+```yaml
+      - uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5
+        id: release
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+          release-type: simple
+```
+
+変更後:
+```yaml
+      - uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5
+        id: release
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+```
+
+(`release-please-config.json` / `.release-please-manifest.json` が存在するため `release-type` の指定は不要。Phase 1 の monorepo 展開時と同じパターン。)
+
+- [ ] **Step 4.2: actionlint で検証**
+
+Run:
+```bash
+cd /Users/takanokenichi/GitHub/panicboat/platform/.claude/worktrees/feat-release-please-phase2-deploy
+docker run --rm -v "$(pwd):/repo" -w /repo rhysd/actionlint:latest -color .github/workflows/release.yml
+```
+
+Expected: no output(exit 0)
+
+### Commit
+
+- [ ] **Step 4.3: commit**
+
+```bash
+cd /Users/takanokenichi/GitHub/panicboat/platform/.claude/worktrees/feat-release-please-phase2-deploy
+git add .github/workflows/release.yml
+git commit -s -m "$(cat <<'EOF'
+feat(ci): drive release.yml from manifest config
+
+release-please-config.json / .release-please-manifest.json の追加に伴い、
+with: の release-type 指定を削除し manifest mode に委譲する。
+
+Spec: docs/superpowers/specs/2026-09-06-release-please-phase2-deploy-design.md
+EOF
+)"
+```
+
+Expected: 1 file changed
+
+---
+
+## Task 5: 旧 release PR #422 を close する
+
+**Files:** なし(GitHub 上の操作)
+
+manifest mode への切り替えにより、非 manifest 時代の単一 component release PR(#422, `chore(main): release 1.0.0`)は成立しなくなる。
+
+- [ ] **Step 5.1: #422 の現状を確認**
+
+Run:
+```bash
+cd /Users/takanokenichi/GitHub/panicboat/platform
+gh pr view 422 --json number,title,state,headRefName
+```
+
+Expected: `"state": "OPEN"`, `"headRefName": "release-please--branches--main"`
+
+- [ ] **Step 5.2: close する(ユーザー確認推奨)**
+
+Run:
+```bash
+cd /Users/takanokenichi/GitHub/panicboat/platform
+gh pr close 422 --comment "release-please を manifest mode に切り替えるため close します。以降は component ごとに release PR が生成されます。Spec: docs/superpowers/specs/2026-09-06-release-please-phase2-deploy-design.md"
+```
+
+Expected: `Closed pull request #422 ...`
+
+> **Note:** #422 の4ヶ月分の変更履歴は CHANGELOG.md(`v0.1.0` リリース以降の commit)としては失われるが、Git の commit history 自体には残るため追跡は可能。close は破壊的操作(GitHub 上で他者に見える状態変更)のため、実行前にユーザーに確認する。
+
+---
+
+## Task 6: release-deploy.yml(aws 経路)を作成
+
+**Files:**
+- Create: `.github/workflows/release-deploy.yml`
+
+**Interfaces:**
+- Consumes: `workflow-config.yaml` の `environments[] | select(.environment == "production")`、`reusable--terragrunt-executor.yaml` の `workflow_call` インターフェース(`service-name`, `environment`, `action-type`, `iam-role`, `aws-region`, `working-directory`, `app-id`, `secrets.private-key`)
+- Produces: `parse-tag` job の outputs `component` / `is-aws` / `is-kubernetes`(Task 7 で kubernetes job から参照)
+
+### Implementation
+
+- [ ] **Step 6.1: `release-deploy.yml` を作成(parse-tag + resolve-aws-config + deploy-aws)**
+
+Files: `.github/workflows/release-deploy.yml`
+
+```yaml
+name: Release Deploy
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  id-token: write
+  contents: write
+
+jobs:
+  parse-tag:
+    name: 'Parse Release Tag'
+    runs-on: ubuntu-latest
+    outputs:
+      component: ${{ steps.parse.outputs.component }}
+      is-aws: ${{ steps.parse.outputs.is-aws }}
+      is-kubernetes: ${{ steps.parse.outputs.is-kubernetes }}
+    steps:
+      - name: Parse component from tag
+        id: parse
+        env:
+          TAG_NAME: ${{ github.event.release.tag_name }}
+        run: |
+          set -euo pipefail
+          if [[ "$TAG_NAME" =~ ^([a-z0-9-]+)-v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            component="${BASH_REMATCH[1]}"
+          else
+            echo "Tag '$TAG_NAME' does not match <component>-vX.Y.Z, skipping"
+            echo "component=" >> "$GITHUB_OUTPUT"
+            echo "is-aws=false" >> "$GITHUB_OUTPUT"
+            echo "is-kubernetes=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "component=$component" >> "$GITHUB_OUTPUT"
+          case "$component" in
+            alb|eks|eks-holmesgpt|eks-karpenter|eks-logs|eks-metrics|eks-secrets|eks-traces|github-oidc-auth|iam-service-linked-roles|vpc)
+              echo "is-aws=true" >> "$GITHUB_OUTPUT"
+              echo "is-kubernetes=false" >> "$GITHUB_OUTPUT"
+              ;;
+            kubernetes)
+              echo "is-aws=false" >> "$GITHUB_OUTPUT"
+              echo "is-kubernetes=true" >> "$GITHUB_OUTPUT"
+              ;;
+            *)
+              echo "Unknown component '$component', skipping"
+              echo "is-aws=false" >> "$GITHUB_OUTPUT"
+              echo "is-kubernetes=false" >> "$GITHUB_OUTPUT"
+              ;;
+          esac
+
+  resolve-aws-config:
+    name: 'Resolve Production AWS Config'
+    needs: parse-tag
+    if: needs.parse-tag.outputs.is-aws == 'true'
+    runs-on: ubuntu-latest
+    outputs:
+      aws-region: ${{ steps.config.outputs.aws-region }}
+      iam-role-apply: ${{ steps.config.outputs.iam-role-apply }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.event.release.tag_name }}
+
+      - name: Setup aqua
+        uses: aquaproj/aqua-installer@96a9bc20066c5bf5e275b41019cfc165b25f4e2e # v2.48.2
+        with:
+          aqua_version: v2.48.2
+
+      - name: Resolve production config
+        id: config
+        run: |
+          set -euo pipefail
+          aws_region=$(yq '.environments[] | select(.environment == "production") | .stacks.terragrunt.aws_region' workflow-config.yaml)
+          iam_role_apply=$(yq '.environments[] | select(.environment == "production") | .stacks.terragrunt.iam_role_apply' workflow-config.yaml)
+          echo "aws-region=$aws_region" >> "$GITHUB_OUTPUT"
+          echo "iam-role-apply=$iam_role_apply" >> "$GITHUB_OUTPUT"
+
+  deploy-aws:
+    name: 'Deploy AWS (${{ needs.parse-tag.outputs.component }})'
+    needs: [parse-tag, resolve-aws-config]
+    uses: ./.github/workflows/reusable--terragrunt-executor.yaml
+    with:
+      service-name: ${{ needs.parse-tag.outputs.component }}
+      environment: production
+      action-type: apply
+      iam-role: ${{ needs.resolve-aws-config.outputs.iam-role-apply }}
+      aws-region: ${{ needs.resolve-aws-config.outputs.aws-region }}
+      working-directory: aws/${{ needs.parse-tag.outputs.component }}/production
+      app-id: ${{ vars.APP_ID }}
+    secrets:
+      private-key: ${{ secrets.APP_PRIVATE_KEY }}
+```
+
+- [ ] **Step 6.2: actionlint で検証**
+
+Run:
+```bash
+cd /Users/takanokenichi/GitHub/panicboat/platform/.claude/worktrees/feat-release-please-phase2-deploy
+docker run --rm -v "$(pwd):/repo" -w /repo rhysd/actionlint:latest -color .github/workflows/release-deploy.yml
+```
+
+Expected: no output(exit 0)
+
+### Commit
+
+- [ ] **Step 6.3: commit**
+
+```bash
+cd /Users/takanokenichi/GitHub/panicboat/platform/.claude/worktrees/feat-release-please-phase2-deploy
+git add .github/workflows/release-deploy.yml
+git commit -s -m "$(cat <<'EOF'
+feat(ci): deploy aws components to production on release published
+
+release タグ名(<component>-vX.Y.Z)から component を直接特定し、
+label-resolver / label-dispatcher を経由せず reusable--terragrunt-executor
+を直接呼び出す。production への apply は release published イベントのみが
+唯一の経路になる。
+
+Spec: docs/superpowers/specs/2026-09-06-release-please-phase2-deploy-design.md
+EOF
+)"
+```
+
+Expected: 1 file changed
+
+---
+
+## Task 7: release-deploy.yml(kubernetes 経路)を追加
+
+**Files:**
+- Modify: `.github/workflows/release-deploy.yml`
+
+**Interfaces:**
+- Consumes: Task 6 の `parse-tag` job の `is-kubernetes` output
+
+### Implementation
+
+- [ ] **Step 7.1: `deploy-kubernetes` job を追加**
+
+`.github/workflows/release-deploy.yml` の末尾(`deploy-aws` job の後)に以下を追加する。
+
+```yaml
+
+  deploy-kubernetes:
+    name: 'Advance Flux Production Tag'
+    needs: parse-tag
+    if: needs.parse-tag.outputs.is-kubernetes == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ vars.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+          ref: ${{ github.event.release.tag_name }}
+          fetch-depth: 0
+
+      - name: Force-update kubernetes-production tag
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          set -euo pipefail
+          git tag -f kubernetes-production "${{ github.event.release.tag_name }}"
+          git push origin kubernetes-production --force
+```
+
+- [ ] **Step 7.2: actionlint で検証**
+
+Run:
+```bash
+cd /Users/takanokenichi/GitHub/panicboat/platform/.claude/worktrees/feat-release-please-phase2-deploy
+docker run --rm -v "$(pwd):/repo" -w /repo rhysd/actionlint:latest -color .github/workflows/release-deploy.yml
+```
+
+Expected: no output(exit 0)
+
+### Commit
+
+- [ ] **Step 7.3: commit**
+
+```bash
+cd /Users/takanokenichi/GitHub/panicboat/platform/.claude/worktrees/feat-release-please-phase2-deploy
+git add .github/workflows/release-deploy.yml
+git commit -s -m "$(cat <<'EOF'
+feat(ci): advance Flux production tag on kubernetes release published
+
+panicboat-actions の v0 major tag force-update と同じパターンで、
+kubernetes component の release published を kubernetes-production タグの
+force-update に変換する。Flux はこのタグを追従先にする(Task 8)。
+
+Spec: docs/superpowers/specs/2026-09-06-release-please-phase2-deploy-design.md
+EOF
+)"
+```
+
+Expected: 1 file changed
+
+---
+
+## Task 8: kubernetes-production タグの初期作成と Flux 追従先の切り替え
+
+**Files:**
+- Modify: `kubernetes/clusters/production/flux-system/gotk-sync.yaml`
+
+**Interfaces:** なし
+
+`kubernetes-production` タグが存在しない状態で `gotk-sync.yaml` の `ref` を切り替えると Flux が解決できなくなるため、**タグの作成を先に行う**。
+
+### Setup
+
+- [ ] **Step 8.1: 現在の main HEAD に `kubernetes-production` タグを作成して push**
+
+Run:
+```bash
+cd /Users/takanokenichi/GitHub/panicboat/platform/.claude/worktrees/feat-release-please-phase2-deploy
+git fetch origin main --quiet
+git tag kubernetes-production origin/main
+git push origin kubernetes-production
+```
+
+Expected: `* [new tag]         kubernetes-production -> kubernetes-production`
+
+> **Note:** タグの push は他者から見える共有状態への変更。実行前にユーザーに確認する。
+
+### Implementation
+
+- [ ] **Step 8.2: `gotk-sync.yaml` の `ref` を切り替え**
+
+変更前:
+```yaml
+spec:
+  interval: 1m
+  url: https://github.com/panicboat/platform.git
+  ref:
+    branch: main
+```
+
+変更後:
+```yaml
+spec:
+  interval: 1m
+  url: https://github.com/panicboat/platform.git
+  ref:
+    tag: kubernetes-production
+```
+
+(`kubernetes/clusters/production/flux-system/gotk-sync.yaml` の `GitRepository` リソースのみを変更する。同ファイル内の `Kustomization` リソースは変更しない。)
+
+- [ ] **Step 8.3: YAML 構文を検証**
+
+Run:
+```bash
+cd /Users/takanokenichi/GitHub/panicboat/platform/.claude/worktrees/feat-release-please-phase2-deploy
+python3 -c "import yaml,sys; list(yaml.safe_load_all(open('kubernetes/clusters/production/flux-system/gotk-sync.yaml')))" && echo "gotk-sync.yaml OK"
+```
+
+Expected: `gotk-sync.yaml OK`
+
+### Commit
+
+- [ ] **Step 8.4: commit**
+
+```bash
+cd /Users/takanokenichi/GitHub/panicboat/platform/.claude/worktrees/feat-release-please-phase2-deploy
+git add kubernetes/clusters/production/flux-system/gotk-sync.yaml
+git commit -s -m "$(cat <<'EOF'
+feat(kubernetes): track kubernetes-production tag instead of main branch
+
+Flux の GitRepository が main を継続追従する状態から、release published
+のたびに Task 7 が force-update する kubernetes-production タグを追従する
+状態に切り替える。切り替え時点でタグは main の現在地を指しているため、
+反映内容に差分は発生しない。
+
+Spec: docs/superpowers/specs/2026-09-06-release-please-phase2-deploy-design.md
+EOF
+)"
+```
+
+Expected: 1 file changed
+
+---
+
+## Merge and Verification
+
+- [ ] **Step 9.1: push と PR(draft)作成**
+
+```bash
+cd /Users/takanokenichi/GitHub/panicboat/platform/.claude/worktrees/feat-release-please-phase2-deploy
+git push -u origin HEAD
+gh pr create --draft --title "feat(ci): release-please phase 2 — production deploy trigger" --body "$(cat <<'EOF'
+## Summary
+
+- `auto-label--deploy-trigger.yaml` を `environments: master` に固定し、#884 以降ライブになっていた production 誤爆リスクを解消
+- release-please を manifest mode に切り替え、aws 11 component + kubernetes 1 component を管理
+- `release-deploy.yml` を新規追加。release published イベントで aws component は terragrunt apply、kubernetes component は `kubernetes-production` タグを force-update
+- `gotk-sync.yaml` の Flux 追従先を `main` ブランチから `kubernetes-production` タグに変更
+
+## Spec
+
+`docs/superpowers/specs/2026-09-06-release-please-phase2-deploy-design.md`
+
+## Test plan
+
+- [ ] CI(lint-actions / semantic-pull-request)が通る
+- [ ] マージ後、旧 release PR #422 が close 済みであることを確認
+- [ ] 11 component + kubernetes の release PR が個別に生成される
+- [ ] いずれかの aws component の release PR をマージすると、その component だけ production に terragrunt apply される(他 component・master には影響しない)
+- [ ] kubernetes component の release PR をマージすると `kubernetes-production` タグが移動し、Flux が新しい manifest を反映する
+EOF
+)"
+```
+
+Expected: PR URL が出力される
+
+- [ ] **Step 9.2: PR をマージ(ユーザー操作)**
+
+完了の判断: `gh pr view --json state -q .state` が `MERGED` を返す。
+
+- [ ] **Step 9.3: release-please PR が component ごとに生成されたことを確認**
+
+マージ完了から1〜2分待ち、以下を実行:
+
+```bash
+cd /Users/takanokenichi/GitHub/panicboat/platform
+gh pr list --search "in:title release-please" --json number,title,headRefName --jq '.[]'
+```
+
+Expected: 最大12件(その時点で pending commits がある component の分だけ)、タイトルは `chore(<component>): release 0.1.0` 形式
+
+- [ ] **Step 9.4: いずれかの aws component をマージして deploy を検証(ユーザー操作)**
+
+component の release PR を1つマージし、release published を待つ(数分):
+
+```bash
+cd /Users/takanokenichi/GitHub/panicboat/platform
+gh run list --workflow=release-deploy.yml --limit 3
+```
+
+Expected: 対象 component の `deploy-aws` job が `success` で完了し、他の component・master には影響が出ていないこと(`gh run view <id> --log` で `working_directory: aws/<component>/production` を確認)
+
+- [ ] **Step 9.5: kubernetes component をマージして Flux 反映を検証(ユーザー操作、任意タイミング)**
+
+```bash
+cd /Users/takanokenichi/GitHub/panicboat/platform
+git fetch origin --tags --quiet
+git rev-parse kubernetes-production
+git rev-parse origin/main
+```
+
+Expected: kubernetes の release PR マージ直後は両者が一致(タグが最新コミットに追従したことを確認)
+
+---
+
+## Notes
+
+- Task 1 は他の Task と独立してマージ可能。#884 由来の誤爆リスクを早く止めたい場合は Task 1 単体を先に PR 化してよい
+- Task 5(#422 close)と Task 8.1(タグ push)は GitHub 上の共有状態を変える操作のため、実行前にユーザー確認を挟む
+- release-please PR のレビュー・マージ頻度をどう改善するか(auto-merge 導入など)は本 spec の out of scope。今回の設計は「レビューが定期的に回る」ことを前提にしている

--- a/docs/superpowers/plans/2026-09-06-release-please-phase2-deploy.md
+++ b/docs/superpowers/plans/2026-09-06-release-please-phase2-deploy.md
@@ -4,7 +4,7 @@
 
 **Goal:** production への deploy を release-please の `release: published` イベント起点に切り替える(aws は component ごとの terragrunt apply、kubernetes は Flux の追従先タグ切り替え)。あわせて #884 以降ライブになっている production 誤爆リスクを止める。
 
-**Architecture:** `release-please-config.json` を manifest mode に切り替え、`aws/{service}` 11 component + `kubernetes` 1 component を管理する。新規 workflow `release-deploy.yml`(`on: release: types: [published]`)が tag 名から component を特定し、aws component は label-resolver を経由せず直接 `reusable--terragrunt-executor.yaml` を呼び出し、kubernetes component は `kubernetes-production` タグを force-update して Flux の追従先を進める。既存の自動 push トリガー(`auto-label--deploy-trigger.yaml`)は `environments: master` を明示して production を対象外にする。
+**Architecture:** `release-please-config.json` を manifest mode に切り替え、`aws/{service}` 12 component + `kubernetes` 1 component を管理する。新規 workflow `release-deploy.yml`(`on: release: types: [published]`)が tag 名から component を特定し、aws component は label-resolver を経由せず直接 `reusable--terragrunt-executor.yaml` を呼び出し、kubernetes component は `kubernetes-production` タグを force-update して Flux の追従先を進める。既存の自動 push トリガー(`auto-label--deploy-trigger.yaml`)は `environments: master` を明示して production を対象外にする。
 
 **Tech Stack:**
 - `googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7` (v5、既存 pin を継続使用)
@@ -34,7 +34,7 @@
 |---|---|---|
 | `.github/workflows/auto-label--deploy-trigger.yaml` | Modify | Label Resolver 呼び出しに `environments: master` を明示し、production を対象外にする |
 | `aqua.yaml` | Modify | `mikefarah/yq` を追加(workflow-config.yaml の値取得に使う) |
-| `release-please-config.json` | Create | manifest mode の component 定義(aws 11 + kubernetes 1) |
+| `release-please-config.json` | Create | manifest mode の component 定義(aws 12 + kubernetes 1、secrets-manager は Task 3 実行時に実測で追加) |
 | `.release-please-manifest.json` | Create | 各 component の現在バージョン state |
 | `.github/workflows/release.yml` | Modify | non-manifest(`release-type: simple`)から manifest mode 呼び出しに変更 |
 | `.github/workflows/release-deploy.yml` | Create | `release: published` 起点で aws component は terragrunt apply、kubernetes component は追従タグを force-update |
@@ -203,7 +203,7 @@ Expected: 1 file changed
 - Create: `.release-please-manifest.json`
 
 **Interfaces:**
-- Produces: 12 個の release-please component(`aws/alb` ... `aws/vpc`、`kubernetes`)。tag 形式は `{component}-vX.Y.Z`
+- Produces: 13 個の release-please component(`aws/alb` ... `aws/vpc`, `aws/secrets-manager`、`kubernetes`)。tag 形式は `{component}-vX.Y.Z`
 
 ### Implementation
 
@@ -309,7 +309,7 @@ git add release-please-config.json .release-please-manifest.json
 git commit -s -m "$(cat <<'EOF'
 feat(ci): switch release-please to manifest mode
 
-aws/{service}(production ディレクトリを持つ11 service)と kubernetes を
+aws/{service}(production ディレクトリを持つ12 service)と kubernetes を
 それぞれ独立 component として管理する。tag は {component}-vX.Y.Z 形式
 (include-component-in-tag: true)。bootstrap-sha は本ブランチの分岐元
 main HEAD に固定し、既存 CHANGELOG.md の履歴とは独立した起点にする。
@@ -468,7 +468,7 @@ jobs:
           fi
           echo "component=$component" >> "$GITHUB_OUTPUT"
           case "$component" in
-            alb|eks|eks-holmesgpt|eks-karpenter|eks-logs|eks-metrics|eks-secrets|eks-traces|github-oidc-auth|iam-service-linked-roles|vpc)
+            alb|eks|eks-holmesgpt|eks-karpenter|eks-logs|eks-metrics|eks-secrets|eks-traces|github-oidc-auth|iam-service-linked-roles|secrets-manager|vpc)
               echo "is-aws=true" >> "$GITHUB_OUTPUT"
               echo "is-kubernetes=false" >> "$GITHUB_OUTPUT"
               ;;
@@ -734,7 +734,7 @@ gh pr create --draft --title "feat(ci): release-please phase 2 — production de
 ## Summary
 
 - `auto-label--deploy-trigger.yaml` を `environments: master` に固定し、#884 以降ライブになっていた production 誤爆リスクを解消
-- release-please を manifest mode に切り替え、aws 11 component + kubernetes 1 component を管理
+- release-please を manifest mode に切り替え、aws 12 component + kubernetes 1 component を管理
 - `release-deploy.yml` を新規追加。release published イベントで aws component は terragrunt apply、kubernetes component は `kubernetes-production` タグを force-update
 - `gotk-sync.yaml` の Flux 追従先を `main` ブランチから `kubernetes-production` タグに変更
 
@@ -746,7 +746,7 @@ gh pr create --draft --title "feat(ci): release-please phase 2 — production de
 
 - [ ] CI(lint-actions / semantic-pull-request)が通る
 - [ ] マージ後、旧 release PR #422 が close 済みであることを確認
-- [ ] 11 component + kubernetes の release PR が個別に生成される
+- [ ] 13 component(aws 12 + kubernetes 1)の release PR が個別に生成される
 - [ ] いずれかの aws component の release PR をマージすると、その component だけ production に terragrunt apply される(他 component・master には影響しない)
 - [ ] kubernetes component の release PR をマージすると `kubernetes-production` タグが移動し、Flux が新しい manifest を反映する
 EOF

--- a/docs/superpowers/specs/2026-09-06-release-please-phase2-deploy-design.md
+++ b/docs/superpowers/specs/2026-09-06-release-please-phase2-deploy-design.md
@@ -161,16 +161,20 @@ git push origin kubernetes-production --force
 
 3. hydrate/build(`reusable--kubernetes-hydrator.yaml` / `reusable--kubernetes-builder.yaml`)は無変更。これらは PR マージ時点で `kubernetes/manifests/production/` を確定させる工程であり、Flux が「いつ」その状態を読むかとは独立している。release tag が指すコミットの時点で、hydrate は release を待たずに既に完了している
 
-## 既存自動パイプラインとの分離
+## 既存自動パイプラインとの分離(緊急度高)
 
-`auto-label--deploy-trigger.yaml` の Label Resolver ステップは、現在 `environments:` を指定しておらず `workflow-config.yaml` の `environments` 全キーがデフォルトになる(`label-resolver/bin/resolver` の `parse_environments(nil)` 参照)。本設計で `production` を `workflow-config.yaml` に追加すると、このデフォルト動作により自動パイプラインが production も対象にしてしまう(意図しない誤爆)。
+`workflow-config.yaml` の `production` は本 spec 検討中に #884(`chore(workflow-config): enable production for CI-driven deploy automation`)で**既に有効化済み**。しかし `auto-label--deploy-trigger.yaml` の Label Resolver ステップは `environments:` を指定しておらず `workflow-config.yaml` の `environments` 全キーがデフォルトになる(`label-resolver/bin/resolver` の `parse_environments(nil)` 参照)。そのため #884 以降、**既存の自動パイプライン(push トリガー・PR ラベルベース)が production も対象にしてしまっている**。
 
-これを防ぐため、`auto-label--deploy-trigger.yaml` の Label Resolver 呼び出しに `environments: master` を明示的に指定する。これにより:
+`master` と `production` を両方定義しているのは現時点で `github-oidc-auth` のみ(他 service は production か master の一方のみ定義)。`deploy:{service}` ラベルは environment を区別しないため、`aws/github-oidc-auth/master/` だけを変更した PR でも resolver は `master`・`production` 両方をターゲットに含めてしまい、**変更していない production にも terragrunt apply が実行されている可能性がある**。`github-oidc-auth` は直近6ヶ月で47コミットと変更頻度が高く、影響は無視できない。
 
-- 自動パイプライン(push トリガー・PR ラベルベース)は `master` のみを対象にし続ける
-- production は本設計の release-published トリガーのみが唯一の deploy 経路になる
+このため `auto-label--deploy-trigger.yaml` の Label Resolver 呼び出しに `environments: master` を明示的に指定する修正は、**本設計の実装の中で最優先(他のタスクより先)に対応する**。これにより:
 
-## workflow-config.yaml の変更
+- 自動パイプライン(push トリガー・PR ラベルベース)は `master` のみを対象にし続ける(#884 以前の意図された挙動に戻す)
+- production は本設計の release-published トリガーのみが唯一の deploy 経路になる(継続的パイプラインと release-gated パイプラインが同じ production を二重に扱う状態を解消する)
+
+## workflow-config.yaml
+
+`production` エントリは #884 で既に有効化済み(本設計側での追加作業は不要)。IAM role / region はこの値を新規 workflow(`release-deploy.yml`)が参照する。
 
 ```yaml
 environments:
@@ -204,10 +208,9 @@ Phase 1 と同じ(`actions/create-github-app-token`、`googleapis/release-please
 
 ## Verification
 
+- [ ] **(最優先)** `auto-label--deploy-trigger.yaml` の Label Resolver 呼び出しに `environments: master` が明示され、#884 以降の production 誤爆リスク(`github-oidc-auth` 等)が解消されている
 - [ ] `release-please-config.json` / `.release-please-manifest.json` が manifest mode で追加され、対象 component(aws 11 + kubernetes 1)が定義されている
 - [ ] 既存の release PR #422 が close されている(manifest mode 移行に伴い）
-- [ ] `workflow-config.yaml` に `production` 環境が正しい IAM role で追加されている
-- [ ] `auto-label--deploy-trigger.yaml` の Label Resolver 呼び出しに `environments: master` が明示されている
 - [ ] `aws/{service}` の release PR をマージ・release published すると、対応する service だけ production に terragrunt apply される(他 service・他 environment に影響しない)
 - [ ] `kubernetes` の release PR をマージ・release published すると、`kubernetes-production` タグが移動し、Flux が新しい manifest を反映する
 - [ ] `gotk-sync.yaml` の `ref` が `tag: kubernetes-production` に切り替わっている

--- a/docs/superpowers/specs/2026-09-06-release-please-phase2-deploy-design.md
+++ b/docs/superpowers/specs/2026-09-06-release-please-phase2-deploy-design.md
@@ -213,7 +213,7 @@ Phase 1 と同じ(`actions/create-github-app-token`、`googleapis/release-please
 ## Verification
 
 - [ ] **(最優先)** `auto-label--deploy-trigger.yaml` の Label Resolver 呼び出しに `environments: master` が明示され、#884 以降の production 誤爆リスク(`github-oidc-auth` 等)が解消されている
-- [ ] `release-please-config.json` / `.release-please-manifest.json` が manifest mode で追加され、対象 component(aws 11 + kubernetes 1)が定義されている
+- [ ] `release-please-config.json` / `.release-please-manifest.json` が manifest mode で追加され、対象 component(aws 12 + kubernetes 1)が定義されている
 - [ ] 既存の release PR #422 が close されている(manifest mode 移行に伴い）
 - [ ] `aws/{service}` の release PR をマージ・release published すると、対応する service だけ production に terragrunt apply される(他 service・他 environment に影響しない)
 - [ ] `kubernetes` の release PR をマージ・release published すると、`kubernetes-production` タグが移動し、Flux が新しい manifest を反映する

--- a/docs/superpowers/specs/2026-09-06-release-please-phase2-deploy-design.md
+++ b/docs/superpowers/specs/2026-09-06-release-please-phase2-deploy-design.md
@@ -1,0 +1,214 @@
+# release-please Phase 2: Production Deploy Trigger Design
+
+## Overview
+
+Phase 1([2026-05-16-release-please-rollout-design.md](2026-05-16-release-please-rollout-design.md))で `platform` に導入した release-please を、production への deploy トリガーとして活用する。
+
+現状、production への自動 deploy は aws (terragrunt) 側が完全に存在せず(`workflow-config.yaml` の `environments.production` が開発フェーズのコスト最適化のため意図的にコメントアウトされている)、手動デプロイに頼っている。kubernetes (Flux) 側は逆に `main` ブランチを継続的に追従しており、ゲートが一切ない。
+
+本 spec は、release-please の `release: published` イベントを「production に対して明示的に行われた deploy 判断」の起点とし、aws・kubernetes 双方の production 反映を release 起点で揃える設計を定める。
+
+## Scope
+
+### In scope
+
+- production 環境のみ
+- aws (`aws/{service}`) のうち `production/` ディレクトリを持つ service を release-please manifest mode の component として管理し、release published を terragrunt apply の起点にする
+- kubernetes を release-please manifest mode の component として管理し、release published を Flux の追従先切り替えの起点にする
+- `workflow-config.yaml` への `production` 環境定義の追加(IAM role / region)
+- 既存の自動 push トリガー pipeline(`auto-label--deploy-trigger.yaml`)が production を誤って巻き込まないための明示的な environment 固定
+
+### Out of scope
+
+- `develop` 環境(常時起動していないため deploy トリガーの対象にしない)
+- `github/{service}`(`master` 専用で `production` ディレクトリを持たないため対象外)
+- release-please PR のレビュー・マージ運用そのものの改善(auto-merge 導入など)。本設計は「レビュー速度が改善される」ことを前提にしているが、その改善策自体は別途検討する
+- Renovate の `semanticCommitType` 変更、CHANGELOG の `chore` セクション可視化(検討したが採用しない、後述)
+
+## 検討して採用しなかった案(Why not)
+
+設計の背景として、検討済みで不採用にした案を残す。
+
+- **GitHub Environments の Required reviewers による承認ゲート**: production 用の `environment:` を job に追加し、承認待ちにする案。しかし現状 `workflow-config.yaml` の `environments.production` がコメントアウトされているのは「開発フェーズ中は production に対して CI を極力動かしたくない」という意図的な選択であり、この案は push のたびに CI が解決処理を実行してしまうため、その意図と逆行する。release published という「稀にしか起きない、人が明示的に起こす」イベントの方が意図に合致する
+- **既存の label-resolver / label-dispatcher パイプラインをそのまま production に拡張する**: `deploy-actions` の実装を確認したところ、`deploy:{service}` ラベルは `{environment}` 情報を破棄しており(`label-dispatcher/use_cases/detect_changed_services.rb` 参照)、resolver 側は呼び出し時に渡された `environments:` を(未指定ならconfig全キーに)ループしてディレクトリ存在だけで target を作る。つまりラベルの仕組みは構造的に「どの environment が実際に変更されたか」を見ていない。`production` を有効化すると、`master` だけを変更した PR でも `production` に(何も変更していないのに)apply が走りかねない。この経路には手を入れず、production は完全に独立した経路にする
+- **Renovate の `semanticCommitType` を `fix` に変更する**: release-please に `chore` コミットを拾わせる目的で検討したが、実際に release-please のソース(`src/versioning-strategies/default.ts`)を確認した結果、**`feat`/breaking 以外のコミットは既定で patch bump される**ことが判明した(`chore` かどうかは version bump の判定に影響しない)。影響するのは CHANGELOG 本文への表示可否のみ(`src/util/filter-commits.ts` の `DEFAULT_CHANGELOG_SECTIONS` で `chore` は `hidden: true`)。よって `semanticCommitType` の変更は不要と判断し、Renovate 側の設定は一切変更しない
+- **CHANGELOG の `chore` セクションを可視化する**(`changelog-sections` で `hidden: false` にする): 技術的には可能だが、今回は既定の非表示のままとする
+
+## Component 構成
+
+`release-please-config.json` を manifest mode に切り替え、以下の component を管理する。
+
+### aws (terragrunt) — production ディレクトリを持つ service のみ
+
+`aws/{service}/production/` が存在する service を対象にする(存在しない service は master/org 専用のため対象外)。2026-09-06 時点のスナップショット:
+
+| component | 対象 |
+|---|---|
+| alb | ✅ |
+| eks | ✅ |
+| eks-holmesgpt | ✅ |
+| eks-karpenter | ✅ |
+| eks-logs | ✅ |
+| eks-metrics | ✅ |
+| eks-secrets | ✅ |
+| eks-traces | ✅ |
+| github-oidc-auth | ✅ |
+| iam-service-linked-roles | ✅ |
+| vpc | ✅ |
+| cost-management | ❌ (master 専用、production ディレクトリなし) |
+| karpenter | ❌ (production ディレクトリなし、`eks-karpenter` に統合済みの可能性) |
+| route53 | ❌ (master 専用、production ディレクトリなし) |
+
+実装時は `aws/*/production/` の実在チェックで対象を再確認し、上記スナップショットとの差分があれば実態を優先する。
+
+各 component:
+
+```json
+"aws/{service}": {
+  "release-type": "simple",
+  "component": "{service}",
+  "include-component-in-tag": true
+}
+```
+
+tag は `{service}-vX.Y.Z` 形式(例: `eks-v1.2.0`)。バージョンファイルの同期先はない(Phase 1 と同じ理由、terragrunt に version.rb 相当のファイルがない)。
+
+### kubernetes — 1 component
+
+```json
+"kubernetes": {
+  "release-type": "simple",
+  "component": "kubernetes",
+  "include-component-in-tag": true
+}
+```
+
+root は `kubernetes/` 配下全体(`kubernetes/components/`、`kubernetes/clusters/`)。Flux の `GitRepository` は cluster 全体に対して1本の ref しか持てず、per-service に分割しても deploy 粒度が上がらないため、component は1つに集約する。
+
+### release-please-config.json (全体像)
+
+```json
+{
+  "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
+  "bootstrap-sha": "<導入 PR のベース main HEAD SHA>",
+  "separate-pull-requests": true,
+  "packages": {
+    "aws/alb": { "release-type": "simple", "component": "alb", "include-component-in-tag": true },
+    "aws/eks": { "release-type": "simple", "component": "eks", "include-component-in-tag": true },
+    "aws/eks-holmesgpt": { "release-type": "simple", "component": "eks-holmesgpt", "include-component-in-tag": true },
+    "aws/eks-karpenter": { "release-type": "simple", "component": "eks-karpenter", "include-component-in-tag": true },
+    "aws/eks-logs": { "release-type": "simple", "component": "eks-logs", "include-component-in-tag": true },
+    "aws/eks-metrics": { "release-type": "simple", "component": "eks-metrics", "include-component-in-tag": true },
+    "aws/eks-secrets": { "release-type": "simple", "component": "eks-secrets", "include-component-in-tag": true },
+    "aws/eks-traces": { "release-type": "simple", "component": "eks-traces", "include-component-in-tag": true },
+    "aws/github-oidc-auth": { "release-type": "simple", "component": "github-oidc-auth", "include-component-in-tag": true },
+    "aws/iam-service-linked-roles": { "release-type": "simple", "component": "iam-service-linked-roles", "include-component-in-tag": true },
+    "aws/vpc": { "release-type": "simple", "component": "vpc", "include-component-in-tag": true },
+    "kubernetes": { "release-type": "simple", "component": "kubernetes", "include-component-in-tag": true }
+  }
+}
+```
+
+`.release-please-manifest.json` は各 component の現在バージョン(state)。既存の Phase 1 tag(`v0.1.0`)は non-manifest 時代のものなので、manifest 移行後の各 component は改めて `0.1.0` から開始する。
+
+```json
+{
+  "aws/alb": "0.1.0",
+  "aws/eks": "0.1.0",
+  "aws/eks-holmesgpt": "0.1.0",
+  "aws/eks-karpenter": "0.1.0",
+  "aws/eks-logs": "0.1.0",
+  "aws/eks-metrics": "0.1.0",
+  "aws/eks-secrets": "0.1.0",
+  "aws/eks-traces": "0.1.0",
+  "aws/github-oidc-auth": "0.1.0",
+  "aws/iam-service-linked-roles": "0.1.0",
+  "aws/vpc": "0.1.0",
+  "kubernetes": "0.1.0"
+}
+```
+
+### 既存 Phase 1 設定からの移行
+
+現行の `release.yml` は non-manifest(`release-type: simple` を `with:` に直書き)。Phase 2 で manifest mode に切り替えるため、既存の `with:` 設定は `release-please-config.json` / `.release-please-manifest.json` に置き換わる。
+
+現在 open している release PR(#422, `chore(main): release 1.0.0`)は非 manifest 時代の1コンポーネント構成を前提にしており、manifest mode 切り替え後は成立しない。**実装時にこの PR は merge せず close する**(4ヶ月分の CHANGELOG が失われるが、Phase 1 の CHANGELOG.md 自体は残るため履歴は追える)。
+
+## Deploy Flow
+
+### aws: release published → terragrunt apply
+
+label-resolver / label-dispatcher は経由しない。新規 workflow(例: `release-deploy.yml`、`on: release: types: [published]`)で以下を行う。
+
+1. `github.event.release.tag_name` を `^(?<component>[a-z0-9-]+)-v\d+\.\d+\.\d+$` でパースし `component` を取得
+2. `component` が aws component 一覧に含まれる場合、`workflow-config.yaml` の `production` エントリから `iam_role_apply` / `aws_region` を(`yq` 等で直接)取得
+3. `reusable--terragrunt-executor.yaml` を `service-name: {component}`, `environment: production`, `action-type: apply`, `working-directory: aws/{component}/production` で呼び出す
+
+tag 名から component を直接特定できるため、Phase 1 で検討した「release PR に `deploy:all` ラベルを付けて `jwalton/gh-find-current-pr` で辿る」という間接的な方式は不要。
+
+### kubernetes: release published → Flux 追従先の切り替え
+
+1. `component` が `kubernetes` の場合、GitHub App token で固定タグ(例 `kubernetes-production`)を release の対象コミットへ force-update する
+
+```bash
+git tag -f kubernetes-production ${{ github.sha }}
+git push origin kubernetes-production --force
+```
+
+(`panicboat-actions` の `v0` major tag force-update と同じパターン)
+
+2. `kubernetes/clusters/production/flux-system/gotk-sync.yaml` の `GitRepository.spec.ref` を、本設計の導入時に一度だけ `branch: main` → `tag: kubernetes-production` に変更する。以降はタグが動くだけで、このファイルへの変更は不要
+
+3. hydrate/build(`reusable--kubernetes-hydrator.yaml` / `reusable--kubernetes-builder.yaml`)は無変更。これらは PR マージ時点で `kubernetes/manifests/production/` を確定させる工程であり、Flux が「いつ」その状態を読むかとは独立している。release tag が指すコミットの時点で、hydrate は release を待たずに既に完了している
+
+## 既存自動パイプラインとの分離
+
+`auto-label--deploy-trigger.yaml` の Label Resolver ステップは、現在 `environments:` を指定しておらず `workflow-config.yaml` の `environments` 全キーがデフォルトになる(`label-resolver/bin/resolver` の `parse_environments(nil)` 参照)。本設計で `production` を `workflow-config.yaml` に追加すると、このデフォルト動作により自動パイプラインが production も対象にしてしまう(意図しない誤爆)。
+
+これを防ぐため、`auto-label--deploy-trigger.yaml` の Label Resolver 呼び出しに `environments: master` を明示的に指定する。これにより:
+
+- 自動パイプライン(push トリガー・PR ラベルベース)は `master` のみを対象にし続ける
+- production は本設計の release-published トリガーのみが唯一の deploy 経路になる
+
+## workflow-config.yaml の変更
+
+```yaml
+environments:
+  - environment: master
+    stacks:
+      terragrunt:
+        aws_region: ap-northeast-1
+        iam_role_plan: arn:aws:iam::559744160976:role/github-oidc-auth-master-github-actions-plan-role
+        iam_role_apply: arn:aws:iam::559744160976:role/github-oidc-auth-master-github-actions-apply-role
+
+  - environment: production
+    stacks:
+      terragrunt:
+        aws_region: ap-northeast-1
+        iam_role_plan: arn:aws:iam::337169763788:role/github-oidc-auth-production-github-actions-plan-role
+        iam_role_apply: arn:aws:iam::337169763788:role/github-oidc-auth-production-github-actions-apply-role
+```
+
+(`develop` は out of scope のためコメントアウトのまま維持する。account ID / role 名は既存のコメントアウト済み記述を踏襲、実装時に実在する role であることを確認する。)
+
+## Renovate との関係
+
+`renovate.json` は変更しない。
+
+- `production/** ` は既に `automerge: false` になっており、Renovate PR も人が merge するまで main に入らない(既存の deliberate gate)
+- merge された commit(`chore:` 含む)は release-please の既定動作により patch bump 対象になり、release PR に積まれる。CHANGELOG 上は `chore` セクションが非表示のままなので見た目は変わらないが、release / deploy トリガーとしては機能する
+
+## SHA Pinning / GitHub App
+
+Phase 1 と同じ(`actions/create-github-app-token`、`googleapis/release-please-action`、既存 GitHub App)。新規追加する `release-deploy.yml` の `actions/checkout` 等も同一の SHA-pinning 方針に従う。
+
+## Verification
+
+- [ ] `release-please-config.json` / `.release-please-manifest.json` が manifest mode で追加され、対象 component(aws 11 + kubernetes 1)が定義されている
+- [ ] 既存の release PR #422 が close されている(manifest mode 移行に伴い）
+- [ ] `workflow-config.yaml` に `production` 環境が正しい IAM role で追加されている
+- [ ] `auto-label--deploy-trigger.yaml` の Label Resolver 呼び出しに `environments: master` が明示されている
+- [ ] `aws/{service}` の release PR をマージ・release published すると、対応する service だけ production に terragrunt apply される(他 service・他 environment に影響しない)
+- [ ] `kubernetes` の release PR をマージ・release published すると、`kubernetes-production` タグが移動し、Flux が新しい manifest を反映する
+- [ ] `gotk-sync.yaml` の `ref` が `tag: kubernetes-production` に切り替わっている
+- [ ] master 向けの既存自動パイプラインが従来通り動作し、production に影響しない

--- a/docs/superpowers/specs/2026-09-06-release-please-phase2-deploy-design.md
+++ b/docs/superpowers/specs/2026-09-06-release-please-phase2-deploy-design.md
@@ -61,6 +61,8 @@ Phase 1([2026-05-16-release-please-rollout-design.md](2026-05-16-release-please-
 
 実装時は `aws/*/production/` の実在チェックで対象を再確認し、上記スナップショットとの差分があれば実態を優先する。
 
+**実装時の追記:** 実装時点で `aws/secrets-manager/production/` が新規に存在していた(このスナップショット作成後にマージされた PR #885 由来)。実測に合わせて `secrets-manager` を component に追加し、対象は 12 service になった。
+
 各 component:
 
 ```json
@@ -103,6 +105,7 @@ root は `kubernetes/` 配下全体(`kubernetes/components/`、`kubernetes/clust
     "aws/eks-traces": { "release-type": "simple", "component": "eks-traces", "include-component-in-tag": true },
     "aws/github-oidc-auth": { "release-type": "simple", "component": "github-oidc-auth", "include-component-in-tag": true },
     "aws/iam-service-linked-roles": { "release-type": "simple", "component": "iam-service-linked-roles", "include-component-in-tag": true },
+    "aws/secrets-manager": { "release-type": "simple", "component": "secrets-manager", "include-component-in-tag": true },
     "aws/vpc": { "release-type": "simple", "component": "vpc", "include-component-in-tag": true },
     "kubernetes": { "release-type": "simple", "component": "kubernetes", "include-component-in-tag": true }
   }
@@ -123,6 +126,7 @@ root は `kubernetes/` 配下全体(`kubernetes/components/`、`kubernetes/clust
   "aws/eks-traces": "0.1.0",
   "aws/github-oidc-auth": "0.1.0",
   "aws/iam-service-linked-roles": "0.1.0",
+  "aws/secrets-manager": "0.1.0",
   "aws/vpc": "0.1.0",
   "kubernetes": "0.1.0"
 }

--- a/kubernetes/clusters/production/flux-system/gotk-sync.yaml
+++ b/kubernetes/clusters/production/flux-system/gotk-sync.yaml
@@ -13,7 +13,7 @@ spec:
   interval: 1m
   url: https://github.com/panicboat/platform.git
   ref:
-    branch: main
+    tag: kubernetes-production
 ---
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
+  "bootstrap-sha": "83d44bfe1f5840da0fe6b9834f5d7d727d68cb4a",
+  "separate-pull-requests": true,
+  "packages": {
+    "aws/alb": { "release-type": "simple", "component": "alb", "include-component-in-tag": true },
+    "aws/eks": { "release-type": "simple", "component": "eks", "include-component-in-tag": true },
+    "aws/eks-holmesgpt": { "release-type": "simple", "component": "eks-holmesgpt", "include-component-in-tag": true },
+    "aws/eks-karpenter": { "release-type": "simple", "component": "eks-karpenter", "include-component-in-tag": true },
+    "aws/eks-logs": { "release-type": "simple", "component": "eks-logs", "include-component-in-tag": true },
+    "aws/eks-metrics": { "release-type": "simple", "component": "eks-metrics", "include-component-in-tag": true },
+    "aws/eks-secrets": { "release-type": "simple", "component": "eks-secrets", "include-component-in-tag": true },
+    "aws/eks-traces": { "release-type": "simple", "component": "eks-traces", "include-component-in-tag": true },
+    "aws/github-oidc-auth": { "release-type": "simple", "component": "github-oidc-auth", "include-component-in-tag": true },
+    "aws/iam-service-linked-roles": { "release-type": "simple", "component": "iam-service-linked-roles", "include-component-in-tag": true },
+    "aws/secrets-manager": { "release-type": "simple", "component": "secrets-manager", "include-component-in-tag": true },
+    "aws/vpc": { "release-type": "simple", "component": "vpc", "include-component-in-tag": true },
+    "kubernetes": { "release-type": "simple", "component": "kubernetes", "include-component-in-tag": true }
+  }
+}


### PR DESCRIPTION
## Summary

- `auto-label--deploy-trigger.yaml` を `environments: master` に固定し、#884 以降ライブになっていた production 誤爆リスクを解消
- release-please を manifest mode に切り替え、aws 12 component(`production/` ディレクトリを持つ全 service、実装時に `secrets-manager` を実測で追加)+ kubernetes 1 component を管理
- `release-deploy.yml` を新規追加。release published イベントで aws component は terragrunt apply、kubernetes component は `kubernetes-production` タグを force-update
- `gotk-sync.yaml` の Flux 追従先を `main` ブランチから `kubernetes-production` タグに変更
- 旧 non-manifest 時代の release PR #422 は close 済み

## Spec / Plan

- `docs/superpowers/specs/2026-09-06-release-please-phase2-deploy-design.md`
- `docs/superpowers/plans/2026-09-06-release-please-phase2-deploy.md`

## ⚠️ マージ直前に必ず確認すること

`kubernetes-production` タグは準備時点の `main` HEAD を指すよう作成済みです。**このタグ作成後に kubernetes 関連の変更が main にマージされている場合、このPRのマージと同時に Flux が古い状態に固定されてしまいます。** マージ実行の直前に以下を確認してください。

```bash
git fetch origin main --tags
git rev-parse kubernetes-production origin/main
```

両者が一致していなければ、マージ前に `git tag -f kubernetes-production origin/main && git push origin kubernetes-production --force` でタグを最新化してください。

## Test plan

- [ ] CI(lint-actions / semantic-pull-request)が通る
- [ ] マージ後、旧 release PR #422 が close 済みであることを確認(済み)
- [ ] 12 component + kubernetes の release PR が個別に生成される
- [ ] いずれかの aws component の release PR をマージすると、その component だけ production に terragrunt apply される(他 component・master には影響しない)
- [ ] kubernetes component の release PR をマージすると `kubernetes-production` タグが移動し、Flux が新しい manifest を反映する