### PR TITLE
feat: add the private trust security group

### DIFF
--- a/aqua.yaml
+++ b/aqua.yaml
@@ -16,5 +16,5 @@ packages:
   - name: kubernetes-sigs/kustomize@kustomize/v5.6.0
   - name: nektos/act@v0.2.87
   - name: rhysd/actionlint@v1.7.7
-  - name: opentofu/opentofu@v1.12.0
+  - name: opentofu/opentofu@v1.12.6
   - name: gruntwork-io/terragrunt@v1.0.2

--- a/aws/vpc/lookup/main.tf
+++ b/aws/vpc/lookup/main.tf
@@ -33,3 +33,11 @@ data "aws_subnets" "database" {
 data "aws_db_subnet_group" "this" {
   name = "vpc-${var.environment}"
 }
+
+data "aws_security_group" "private_trust" {
+  vpc_id = data.aws_vpc.this.id
+
+  tags = {
+    Name = "private-trust-${var.environment}"
+  }
+}

--- a/aws/vpc/lookup/outputs.tf
+++ b/aws/vpc/lookup/outputs.tf
@@ -18,3 +18,10 @@ output "db_subnet_group" {
   description = "DB subnet group data source (pass-through). See AWS provider docs for aws_db_subnet_group."
   value       = data.aws_db_subnet_group.this
 }
+
+output "security_groups" {
+  description = "Security groups owned by the VPC stack."
+  value = {
+    private_trust = data.aws_security_group.private_trust
+  }
+}

--- a/aws/vpc/lookup/tests/private_trust.tftest.hcl
+++ b/aws/vpc/lookup/tests/private_trust.tftest.hcl
@@ -1,0 +1,34 @@
+mock_provider "aws" {}
+
+override_data {
+  target = data.aws_vpc.this
+  values = {
+    id = "vpc-test"
+  }
+}
+
+override_data {
+  target = data.aws_security_group.private_trust
+  values = {
+    id   = "sg-private-trust"
+    name = "private-trust-production"
+  }
+}
+
+variables {
+  environment = "production"
+}
+
+run "finds_private_trust_security_group" {
+  command = plan
+
+  assert {
+    condition     = data.aws_security_group.private_trust.vpc_id == data.aws_vpc.this.id
+    error_message = "The lookup must constrain the private trust security group to the selected VPC."
+  }
+
+  assert {
+    condition     = output.security_groups.private_trust.id == "sg-private-trust"
+    error_message = "The lookup output must expose the private trust security group data source."
+  }
+}

--- a/aws/vpc/modules/main.tf
+++ b/aws/vpc/modules/main.tf
@@ -60,3 +60,27 @@ resource "aws_vpc_endpoint" "s3" {
     Name = "vpce-s3-${var.environment}"
   })
 }
+
+resource "aws_security_group" "private_trust" {
+  name        = "private-trust-${var.environment}"
+  description = "Private trust boundary for VPC resources"
+  vpc_id      = module.vpc.vpc_id
+
+  tags = merge(var.common_tags, {
+    Name = "private-trust-${var.environment}"
+  })
+}
+
+resource "aws_vpc_security_group_ingress_rule" "private_trust_self" {
+  security_group_id            = aws_security_group.private_trust.id
+  referenced_security_group_id = aws_security_group.private_trust.id
+  ip_protocol                  = "-1"
+  description                  = "Allow traffic within the private trust boundary"
+}
+
+resource "aws_vpc_security_group_egress_rule" "private_trust_ipv4" {
+  security_group_id = aws_security_group.private_trust.id
+  cidr_ipv4         = "0.0.0.0/0"
+  ip_protocol       = "-1"
+  description       = "Allow all IPv4 egress"
+}

--- a/aws/vpc/modules/outputs.tf
+++ b/aws/vpc/modules/outputs.tf
@@ -54,3 +54,8 @@ output "availability_zones" {
   description = "Availability zones used by the VPC"
   value       = module.vpc.azs
 }
+
+output "private_trust_security_group_id" {
+  description = "ID of the private trust security group"
+  value       = aws_security_group.private_trust.id
+}

--- a/aws/vpc/modules/tests/private_trust.tftest.hcl
+++ b/aws/vpc/modules/tests/private_trust.tftest.hcl
@@ -1,0 +1,57 @@
+mock_provider "aws" {}
+
+override_module {
+  target = module.vpc
+  outputs = {
+    vpc_id                       = "vpc-test"
+    vpc_cidr_block               = "10.0.0.0/16"
+    public_subnets               = ["subnet-public"]
+    private_subnets              = ["subnet-private"]
+    database_subnets             = ["subnet-database"]
+    public_subnets_cidr_blocks   = ["10.0.0.0/24"]
+    private_subnets_cidr_blocks  = ["10.0.32.0/19"]
+    database_subnets_cidr_blocks = ["10.0.10.0/24"]
+    database_subnet_group_name   = "vpc-production"
+    nat_public_ips               = ["203.0.113.10"]
+    azs                          = ["ap-northeast-1a"]
+    private_route_table_ids      = ["rtb-private"]
+  }
+}
+
+variables {
+  environment = "production"
+  aws_region  = "ap-northeast-1"
+  common_tags = {
+    Environment = "production"
+    ManagedBy   = "terraform"
+  }
+}
+
+run "creates_private_trust_security_group" {
+  command = plan
+
+  assert {
+    condition     = aws_security_group.private_trust.name == "private-trust-production"
+    error_message = "The private trust security group must use the stable production name."
+  }
+
+  assert {
+    condition     = (aws_vpc_security_group_ingress_rule.private_trust_self.ip_protocol == "-1" && aws_vpc_security_group_ingress_rule.private_trust_self.referenced_security_group_id == aws_security_group.private_trust.id)
+    error_message = "The private trust ingress rule must allow every protocol from itself."
+  }
+
+  assert {
+    condition     = (aws_vpc_security_group_egress_rule.private_trust_ipv4.ip_protocol == "-1" && aws_vpc_security_group_egress_rule.private_trust_ipv4.cidr_ipv4 == "0.0.0.0/0")
+    error_message = "The private trust egress rule must allow all IPv4 destinations."
+  }
+
+  assert {
+    condition     = output.private_trust_security_group_id == aws_security_group.private_trust.id
+    error_message = "The producer output must expose the private trust security group ID."
+  }
+
+  assert {
+    condition     = (!contains(keys(aws_security_group.private_trust.tags), "aws:eks:cluster-name") && alltrue([for key in keys(aws_security_group.private_trust.tags) : !startswith(key, "kubernetes.io/cluster/")]))
+    error_message = "The private trust security group must not carry EKS discovery tags."
+  }
+}


### PR DESCRIPTION
## Why

VPC 内の EKS、node、Pod ENI、RDS を段階的に同じ trust boundary へ移行できるようにするため、locked default SG とは別に VPC stack 所有の Security Group を追加します。既存 attachment はこの PR では変更せず、後続 PR の安全な attach-first rollout に備えます。

単数 lookup に VPC ID と安定した Name tag を指定し、候補がゼロ件または複数件の場合は任意選択せず失敗させます。private trust SG には EKS discovery tag を付けず、EKS primary SG と Load Balancer Controller 管理 SG の責務を維持します。

## Verification

- OpenTofu 1.12.6
- producer test: 1 passed, 0 failed
- lookup test: 1 passed, 0 failed
- modules / lookup validate and format checks: exit 0
- Terragrunt HCL format and git diff check: exit 0

lookup の既存 VPC pass-through output から deprecated attribute warning が出ますが、この差分による warning ではありません。