### PR TITLE
refactor: attach private trust security group to EKS

### DIFF
--- a/aws/eks/lookup/outputs.tf
+++ b/aws/eks/lookup/outputs.tf
@@ -3,10 +3,11 @@
 output "cluster" {
   description = "EKS cluster information (pass-through of aws_eks_cluster data source)."
   value = {
-    name                      = data.aws_eks_cluster.this.name
-    arn                       = data.aws_eks_cluster.this.arn
-    endpoint                  = data.aws_eks_cluster.this.endpoint
-    cluster_security_group_id = data.aws_eks_cluster.this.vpc_config[0].cluster_security_group_id
+    name                              = data.aws_eks_cluster.this.name
+    arn                               = data.aws_eks_cluster.this.arn
+    endpoint                          = data.aws_eks_cluster.this.endpoint
+    cluster_security_group_id         = data.aws_eks_cluster.this.vpc_config[0].cluster_security_group_id
+    cluster_primary_security_group_id = data.aws_eks_cluster.this.vpc_config[0].cluster_security_group_id
 
     # Node security group (created by terraform-aws-modules/eks parent module).
     # Required by standalone `eks-managed-node-group` submodule for node-to-node

--- a/aws/eks/lookup/tests/security_groups.tftest.hcl
+++ b/aws/eks/lookup/tests/security_groups.tftest.hcl
@@ -1,0 +1,72 @@
+mock_provider "aws" {}
+
+override_data {
+  target = data.aws_eks_cluster.this
+  values = {
+    arn      = "arn:aws:eks:ap-northeast-1:337169763788:cluster/eks-production"
+    endpoint = "https://eks.example.test"
+    vpc_config = [{
+      vpc_id                    = "vpc-test"
+      cluster_security_group_id = "sg-primary"
+      control_plane_egress_mode = "PRIVATE"
+      endpoint_private_access   = true
+      endpoint_public_access    = true
+      public_access_cidrs       = ["0.0.0.0/0"]
+      security_group_ids        = ["sg-primary"]
+      subnet_ids                = ["subnet-a"]
+    }]
+    certificate_authority = [{
+      data = "Y2E="
+    }]
+    kubernetes_network_config = [{
+      elastic_load_balancing = [{
+        enabled = false
+      }]
+      service_ipv4_cidr = "10.100.0.0/16"
+      service_ipv6_cidr = null
+      ip_family         = "ipv4"
+    }]
+    identity = [{
+      oidc = [{
+        issuer = "https://oidc.eks.ap-northeast-1.amazonaws.com/id/test"
+      }]
+    }]
+  }
+}
+
+override_data {
+  target = data.aws_security_group.node
+  values = {
+    id = "sg-module-node"
+  }
+}
+
+override_data {
+  target = data.aws_caller_identity.current
+  values = {
+    account_id = "337169763788"
+  }
+}
+
+variables {
+  environment = "production"
+}
+
+run "exposes_cluster_primary_security_group_id" {
+  command = plan
+
+  assert {
+    condition     = output.cluster.cluster_primary_security_group_id == "sg-primary"
+    error_message = "The lookup must identify the EKS-owned primary security group explicitly."
+  }
+
+  assert {
+    condition     = output.cluster.cluster_security_group_id == output.cluster.cluster_primary_security_group_id
+    error_message = "The compatibility field must keep its current value until consumers migrate."
+  }
+
+  assert {
+    condition     = output.cluster.node_security_group_id == "sg-module-node"
+    error_message = "The module node security group lookup must remain during the attachment phase."
+  }
+}

--- a/aws/eks/modules/main.tf
+++ b/aws/eks/modules/main.tf
@@ -49,6 +49,9 @@ module "eks" {
   access_entries = local.access_entries
   addons         = local.cluster_addons
 
+  // TODO: Replace the module cluster SG with the private trust SG after every consumer carries the private trust SG.
+  additional_security_group_ids = [module.vpc.security_groups.private_trust.id]
+
   tags = var.common_tags
 }
 

--- a/aws/eks/modules/outputs.tf
+++ b/aws/eks/modules/outputs.tf
@@ -31,6 +31,11 @@ output "cluster_security_group_id" {
   value       = module.eks.cluster_security_group_id
 }
 
+output "cluster_primary_security_group_id" {
+  description = "EKS-owned primary cluster security group ID"
+  value       = module.eks.cluster_primary_security_group_id
+}
+
 output "node_security_group_id" {
   description = "Node security group"
   value       = module.eks.node_security_group_id

--- a/aws/eks/modules/tests/private_trust_security_group.tftest.hcl
+++ b/aws/eks/modules/tests/private_trust_security_group.tftest.hcl
@@ -1,0 +1,95 @@
+mock_provider "aws" {
+  mock_data "aws_iam_policy_document" {
+    defaults = {
+      json = "{}"
+    }
+  }
+
+  mock_data "aws_caller_identity" {
+    defaults = {
+      account_id = "337169763788"
+      arn        = "arn:aws:iam::337169763788:user/test"
+    }
+  }
+
+  mock_data "aws_partition" {
+    defaults = {
+      partition = "aws"
+    }
+  }
+
+  mock_resource "aws_iam_role" {
+    defaults = {
+      arn = "arn:aws:iam::337169763788:role/eks-test"
+    }
+  }
+
+  mock_resource "aws_eks_cluster" {
+    defaults = {
+      identity = [{
+        oidc = [{
+          issuer = "https://oidc.eks.ap-northeast-1.amazonaws.com/id/test"
+        }]
+      }]
+      certificate_authority = [{
+        data = "Y2E="
+      }]
+    }
+  }
+
+  mock_resource "aws_iam_policy" {
+    defaults = {
+      arn = "arn:aws:iam::337169763788:policy/test"
+    }
+  }
+}
+
+mock_provider "time" {}
+mock_provider "tls" {}
+
+override_module {
+  target = module.vpc
+  outputs = {
+    vpc = {
+      id = "vpc-test"
+    }
+    subnets = {
+      private = {
+        ids = ["subnet-a", "subnet-b"]
+      }
+    }
+    security_groups = {
+      private_trust = {
+        id = "sg-private-trust"
+      }
+    }
+  }
+}
+
+override_data {
+  target = data.aws_iam_roles.sso_admin
+  values = {
+    arns = ["arn:aws:iam::337169763788:role/aws-reserved/sso.amazonaws.com/AWSReservedSSO_AdministratorAccess_test"]
+  }
+}
+
+override_data {
+  target = data.aws_caller_identity.current
+  values = {
+    account_id = "337169763788"
+  }
+}
+
+variables {
+  environment           = "production"
+  aws_region            = "ap-northeast-1"
+  cluster_version       = "1.33"
+  route53_zone_role_arn = "arn:aws:iam::559744160976:role/route53-zone-access"
+  common_tags = {
+    Environment = "production"
+  }
+}
+
+run "plans_private_trust_as_additional_control_plane_security_group" {
+  command = plan
+}

--- a/aws/eks/tests/security-group-contract.sh
+++ b/aws/eks/tests/security-group-contract.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repository_root="$(git rev-parse --show-toplevel)"
+module_dir="$repository_root/aws/eks/modules"
+
+plan_output="$(
+  cd "$module_dir"
+  aqua exec -- tofu test \
+    -no-color \
+    -verbose \
+    -filter=tests/private_trust_security_group.tftest.hcl
+)"
+
+control_plane_security_groups="$(
+  awk '
+    /resource "aws_eks_cluster" "this"/ { in_cluster = 1 }
+    in_cluster && /^[[:space:]]+[+~]?[[:space:]]*security_group_ids[[:space:]]*=[[:space:]]*\[/ { capture = 1; next }
+    capture && /]/ { exit }
+    capture {
+      gsub(/[+~ \",]/, "")
+      if (length > 0) print
+    }
+  ' <<<"$plan_output"
+)"
+
+if ! grep -Fxq sg-private-trust <<<"$control_plane_security_groups"; then
+  printf 'planned control plane security groups:\n%s\n' "$control_plane_security_groups" >&2
+  exit 1
+fi
+
+echo "EKS security group contract passed."


### PR DESCRIPTION
## Why

EKS control plane を VPC owner の private trust boundary へ段階移行するため、既存 module cluster SG と共通 SG を併用 attach します。この段階では既存 SG と compatibility output を残し、接続性と rollback path を維持します。

EKS-owned primary SG を明示的な output 名でも公開し、後続の MNG / Karpenter migration が primary SG と module-created SG を混同しない contract にします。

## Verification

- EKS modules test: 1 passed, 0 failed
- EKS lookup test: 1 passed, 0 failed
- control-plane plan contract: passed
- modules / lookup validate and format checks: exit 0
- git diff check: exit 0
- CI plan: EKS cluster in-place updateで private trust SG を追加、既存 SG を維持
- EKS cluster replacement、module cluster/node SG resource destroy: なし

## Plan Constraints

EKS cluster の変更により、most-recent add-on version と OIDC thumbprint は apply 時に再取得されます。また、terraform-aws-modules/eks が node SG の cluster discovery tag を再付与するため、既存 terraform_data workaround が置換され、local-exec で同 tag を再削除します。これは今回追加した挙動ではなく、現行 EKS stack の apply contract です。

VPC lookup の既存 pass-through output から deprecated attribute warning が出ますが、この差分による warning ではありません。