### PR TITLE
refactor: attach private trust security group to system nodes

### DIFF
--- a/aws/eks-karpenter/modules/main.tf
+++ b/aws/eks-karpenter/modules/main.tf
@@ -91,16 +91,14 @@ module "system_critical" {
 
   subnet_ids = module.vpc.subnets.private.ids
 
-  # Cluster primary SG must be attached to nodes for cluster API access
-  cluster_primary_security_group_id = module.eks.cluster.cluster_security_group_id
+  # The standalone module does not inherit cluster SG attachments, so every migration SG remains explicit during rollout.
+  cluster_primary_security_group_id = module.eks.cluster.cluster_primary_security_group_id
 
-  # Node SG (from parent module "eks") required for node-to-node pod-network
-  # traffic. Standalone eks-managed-node-group submodule does NOT attach this
-  # automatically (unlike when MNGs live inside `module "eks"`), causing
-  # cross-node pod traffic (e.g., bootstrap-host pod → CoreDNS on the same
-  # MNG) to be silently dropped. Sourced from aws/eks/lookup via tag-based
-  # discovery.
-  vpc_security_group_ids = [module.eks.cluster.node_security_group_id]
+  // TODO: Remove the module node SG after every system-critical node carries the private trust SG.
+  vpc_security_group_ids = [
+    module.eks.cluster.node_security_group_id,
+    module.vpc.security_groups.private_trust.id,
+  ]
 
   ami_type       = "AL2023_ARM_64_STANDARD"
   instance_types = var.system_critical_instance_types
@@ -158,19 +156,9 @@ module "system_critical" {
   # 必要はない。
   iam_role_attach_cni_policy = false
 
-  # Use fixed IAM role name (not name_prefix) because the auto-generated
-  # name_prefix would exceed the AWS IAM name_prefix 38-chars limit when
-  # combined with the MNG name. With use_name_prefix=false, the sub-module
-  # assigns a deterministic role name `eks-${var.environment}-system-critical-eks-node-group`
-  # (within the 64-chars IAM role name limit).
-  #
-  # The AWS physical name `eks-${var.environment}-system-critical` is fixed
-  # by external contract (eks-login script / dashboard references), so a
-  # deterministic role name is used.
-  #
-  # Side effect: a fixed IAM role name is immutable, so a future rename of
-  # this MNG would make create_before_destroy fail with a role-name conflict.
-  # If renamed, destroy the old role first, then apply (a 2-step operation).
+  # The MNG base name is an external contract. `use_name_prefix` remains at
+  # the module default to avoid replacing the existing MNG, so runtime tooling
+  # resolves the generated physical name by its stable prefix.
   iam_role_use_name_prefix = false
 
   tags = var.common_tags

--- a/aws/eks-karpenter/modules/tests/security_group_attachments.tftest.hcl
+++ b/aws/eks-karpenter/modules/tests/security_group_attachments.tftest.hcl
@@ -1,0 +1,85 @@
+mock_provider "aws" {
+  mock_data "aws_partition" {
+    defaults = {
+      partition  = "aws"
+      dns_suffix = "amazonaws.com"
+    }
+  }
+
+  mock_data "aws_caller_identity" {
+    defaults = {
+      account_id = "337169763788"
+    }
+  }
+
+  mock_data "aws_ssm_parameter" {
+    defaults = {
+      value = "1.33.7-20250920"
+    }
+  }
+
+  mock_data "aws_iam_policy_document" {
+    defaults = {
+      json = "{}"
+    }
+  }
+  mock_resource "aws_launch_template" {
+    defaults = {
+      id = "lt-test"
+    }
+  }
+}
+
+mock_provider "cloudinit" {}
+
+override_module {
+  target = module.karpenter
+  outputs = {
+    node_iam_role_name = "Karpenter-eks-production"
+    queue_name         = "Karpenter-eks-production"
+  }
+}
+
+override_module {
+  target = module.eks
+  outputs = {
+    cluster = {
+      name                              = "eks-production"
+      endpoint                          = "https://eks.example.test"
+      certificate_authority_data        = "Y2E="
+      service_cidr                      = "10.100.0.0/16"
+      ip_family                         = "ipv4"
+      cluster_security_group_id         = "sg-primary"
+      cluster_primary_security_group_id = "sg-primary"
+      node_security_group_id            = "sg-module-node"
+    }
+  }
+}
+
+override_module {
+  target = module.vpc
+  outputs = {
+    subnets = {
+      private = {
+        ids = ["subnet-a", "subnet-b"]
+      }
+    }
+    security_groups = {
+      private_trust = {
+        id = "sg-private-trust"
+      }
+    }
+  }
+}
+
+variables {
+  environment = "production"
+  aws_region  = "ap-northeast-1"
+  common_tags = {
+    Environment = "production"
+  }
+}
+
+run "plans_three_security_groups_for_system_nodes" {
+  command = plan
+}

--- a/aws/eks-karpenter/tests/security-group-contract.sh
+++ b/aws/eks-karpenter/tests/security-group-contract.sh
@@ -14,8 +14,10 @@ plan_output="$(
 
 actual_security_groups="$(
   awk '
-    /^[[:space:]]+[+~]?[[:space:]]*vpc_security_group_ids[[:space:]]*=[[:space:]]*\[/ { capture = 1; next }
-    capture && /]/ { exit }
+    /^  # module\.system_critical\.aws_launch_template\.this\[0\] / { target = 1; next }
+    /^  # .* will be / { target = 0; capture = 0; next }
+    target && /^[[:space:]]+[+~]?[[:space:]]*vpc_security_group_ids[[:space:]]*=[[:space:]]*\[/ { capture = 1; next }
+    capture && /^[[:space:]]+\]/ { capture = 0; target = 0; next }
     capture {
       gsub(/[+~ ",]/, "")
       if (length > 0) print

--- a/aws/eks-karpenter/tests/security-group-contract.sh
+++ b/aws/eks-karpenter/tests/security-group-contract.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repository_root="$(git rev-parse --show-toplevel)"
+module_dir="$repository_root/aws/eks-karpenter/modules"
+
+plan_output="$(
+  cd "$module_dir"
+  aqua exec -- tofu test \
+    -no-color \
+    -verbose \
+    -filter=tests/security_group_attachments.tftest.hcl
+)"
+
+actual_security_groups="$(
+  awk '
+    /^[[:space:]]+[+~]?[[:space:]]*vpc_security_group_ids[[:space:]]*=[[:space:]]*\[/ { capture = 1; next }
+    capture && /]/ { exit }
+    capture {
+      gsub(/[+~ ",]/, "")
+      if (length > 0) print
+    }
+  ' <<<"$plan_output" | sort
+)"
+
+expected_security_groups="$(
+  printf '%s\n' \
+    sg-module-node \
+    sg-primary \
+    sg-private-trust \
+    | sort
+)"
+
+if test "$actual_security_groups" != "$expected_security_groups"; then
+  printf 'expected security groups:\n%s\n' "$expected_security_groups" >&2
+  printf 'planned security groups:\n%s\n' "$actual_security_groups" >&2
+  exit 1
+fi
+
+echo "MNG security group contract passed."


### PR DESCRIPTION
## Why

system-critical managed node group を private trust boundary へ段階移行するため、既存 module node SG を維持したまま common SG を追加します。EKS primary SG も明示的な compatibility fieldから渡し、standalone MNGのattachment contractを曖昧にしません。

旧 SG のdetachは、更新後の全system-critical nodeが3 SGを持ち、runtime healthが確認できた後の別phaseに分離します。MNG physical nameを変えるinputには触れず、node group replacementを避けます。

## Verification

- module test: 1 passed, 0 failed
- scoped MNG launch template contract: passed
- validate / format / git diff checks: exit 0
- independent review: initial parser scope findingを修正し、re-reviewで全finding解消
- CI plan: 0 add, 2 change, 0 destroy
- changed resources: launch template versionとmanaged node groupのin-place updateのみ
- common SG `sg-08a0721ec0e1cef05`を追加し、既存2 SGを維持
- MNG、IAM role、EKS cluster、Karpenter queue、module node SGのreplace/destroy: なし

VPC lookupの既存pass-through outputからdeprecated attribute warningが出ますが、この差分によるwarningではありません。