### PR TITLE
fix(kubernetes/components/beyla): instrument the application namespaces

### DIFF
--- a/kubernetes/components/beyla/production/values.yaml.gotmpl
+++ b/kubernetes/components/beyla/production/values.yaml.gotmpl
@@ -1,5 +1,5 @@
 # Beyla eBPF Auto-Instrumentation Configuration for production
-# default namespace の application Pod を eBPF auto-instrumentation で観測、
+# application namespace の Pod を eBPF auto-instrumentation で観測、
 # traces を OTel Collector 経由 Tempo に、metrics を /metrics + ServiceMonitor
 # 経由 Prometheus → Mimir に送る。
 
@@ -40,10 +40,10 @@ config:
       path: /metrics
 
     # -------------------------------------------------------------------------
-    # Service Discovery (= default namespace の application Pod、open_ports 省略で
+    # Service Discovery (= application namespace の Pod、open_ports 省略で
     # 全 listening port auto-discover)
     # -------------------------------------------------------------------------
-    # NOTE: open_ports は明示的に省略。default namespace は application 専用想定
+    # NOTE: open_ports は明示的に省略。列挙した namespace は application 専用
     # (= infra Pod 不在)、全 listening port auto-discover で運用 friction 最小。
     # microservice 追加時に Beyla config 更新不要 (= 新 service の任意 port が
     # 自動 trace 対象)。
@@ -59,6 +59,8 @@ config:
     discovery:
       instrument:
         - k8s_namespace: default
+        - k8s_namespace: dystopia
+        - k8s_namespace: system-components
       exclude_instrument:
         - k8s_deployment_name: monolith
 

--- a/kubernetes/manifests/production/beyla/manifest.yaml
+++ b/kubernetes/manifests/production/beyla/manifest.yaml
@@ -48,6 +48,8 @@ data:
       - k8s_deployment_name: monolith
       instrument:
       - k8s_namespace: default
+      - k8s_namespace: dystopia
+      - k8s_namespace: system-components
     filter:
       network:
         k8s_dst_owner_name:
@@ -158,7 +160,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: f8c9d53f070247ba91e5492b8da3c95b975e8693257f6e8931bccdcf1fb1d814
+        checksum/config: 98083d164f429657410576306091c68ab75c265c4a7fa175b29dacb48b9ab2b3
       labels:
         helm.sh/chart: beyla-1.16.11
         app.kubernetes.io/name: beyla


### PR DESCRIPTION
## Why

Grafana の Application Monitoring dashboard に trace が 1 件も出ない状態を調査した結果、Beyla が何も instrument していなかった。`discovery.instrument` に `default` だけが載っていたが、`default` は Pod ゼロ。実際の workload は他の namespace に居る。

| namespace | Pod |
|---|---|
| `default` | なし |
| `dystopia` | `frontend`, `monolith` |
| `system-components` | `pennyworth-alertmanager`, `pennyworth-slack` |

### 変更前の production cluster の実測

| 観測点 | 結果 |
|---|---|
| `monitoring/beyla` ConfigMap | `instrument: [{k8s_namespace: default}]` |
| Beyla logs (2 node) | `instrumenting process` 0 件 |
| Mimir | `http_server_*` / `traces_service_graph_*` ともに series 0 |
| Tempo `/api/search?q={}` (24h) | `{"traces":[]}` |
| OTel Collector (4 pod) | span counter の series 自体が不在 = 一度も span 未受信 |

`http_server_request_duration_seconds_count` が空だったため dashboard の `$service` 変数も空になり、Traces row だけでなく Request Rate / P95 Latency / 5xx Rate panel も同時に空になっていた。

## What

- `discovery.instrument` に `dystopia` と `system-components` を追加。`default` は置き換えず残し、そこに Pod が戻っても対象から外れないようにした
- 周辺コメントを namespace 列挙に依存しない記述に変更（値は config 側が source of truth）
- `exclude_instrument: monolith` は据え置き。Beyla の Ruby prober は HTTP only で gruf gRPC を capture できない状態が続いているため

## Verification

- `scripts/kubernetes-hydrate/hydrate-component.sh beyla production` を実行し、hydrate 出力の ConfigMap が 3 namespace になること、`checksum/config` annotation の更新で DaemonSet が rollout されることを確認 (VERIFIED)
- apply 後の確認項目: Beyla log に `instrumenting process` が出ること / Tempo に frontend・pennyworth の trace が入ること

## Out of scope

同じ調査で判明した残り 2 件は本 PR では扱わない。

- `frontend` (Next.js 16): OTel Operator の nodejs auto-instrumentation は注入済みだが span を出さない。実験で HTTP 200 × 5 回に対し span 0 件を確認。standalone build に `instrumentation.js` も `@vercel/otel` も無く、Next.js の instrumentation hook が未登録
- `monolith` (Ruby): `inject-ruby` annotation はあるが init container が付かない。operator 0.156.0 は Ruby auto-instrumentation 未サポート