### PR TITLE
refactor: attach private trust security group to Karpenter nodes

### DIFF
--- a/kubernetes/components/karpenter/production/kustomization/ec2nodeclass.yaml
+++ b/kubernetes/components/karpenter/production/kustomization/ec2nodeclass.yaml
@@ -5,7 +5,7 @@
 # - AMI: AL2023 ARM64 (latest)
 # - Subnet: VPC private subnets (Tier=private tag で discover)
 # - SecurityGroup: cluster SG (aws:eks:cluster-name tag) + private trust SG
-#   (Name=private-trust-production tag で discover)
+#   (discover by the Name=private-trust-production tag)
 # - Role: aws/eks-karpenter/ stack が provision した Node IAM role
 #   (aws/eks-karpenter/production terragrunt output `node_role_name` の値)
 # - EBS: gp3 30 GiB (Karpenter-managed node 用 sizing、Plan 1c-β L2 学び参照)

--- a/kubernetes/components/karpenter/production/kustomization/ec2nodeclass.yaml
+++ b/kubernetes/components/karpenter/production/kustomization/ec2nodeclass.yaml
@@ -4,7 +4,8 @@
 # Karpenter が node を起動する際の AWS-side configuration:
 # - AMI: AL2023 ARM64 (latest)
 # - Subnet: VPC private subnets (Tier=private tag で discover)
-# - SecurityGroup: cluster SG (aws:eks:cluster-name tag で discover)
+# - SecurityGroup: cluster SG (aws:eks:cluster-name tag) + private trust SG
+#   (Name=private-trust-production tag で discover)
 # - Role: aws/eks-karpenter/ stack が provision した Node IAM role
 #   (aws/eks-karpenter/production terragrunt output `node_role_name` の値)
 # - EBS: gp3 30 GiB (Karpenter-managed node 用 sizing、Plan 1c-β L2 学び参照)
@@ -24,6 +25,8 @@ spec:
   securityGroupSelectorTerms:
     - tags:
         "aws:eks:cluster-name": eks-production
+    - tags:
+        Name: private-trust-production
   # STABLE: aws/eks-karpenter/modules/main.tf で node_iam_role_use_name_prefix = false +
   # node_iam_role_name = "Karpenter-eks-${var.environment}" に固定済、recreate でも変化しない
   role: Karpenter-eks-production

--- a/kubernetes/components/karpenter/tests/security-group-selectors.sh
+++ b/kubernetes/components/karpenter/tests/security-group-selectors.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repository_root="$(git rev-parse --show-toplevel)"
+rendered_file="$(mktemp)"
+selector_file="$(mktemp)"
+trap 'rm -f "$rendered_file" "$selector_file"' EXIT
+
+kustomize build \
+  "$repository_root/kubernetes/components/karpenter/production/kustomization" \
+  >"$rendered_file"
+
+awk '
+  /^  securityGroupSelectorTerms:$/ { capture = 1; next }
+  capture && /^  [A-Za-z]/ { exit }
+  capture { print }
+' "$rendered_file" >"$selector_file"
+
+test "$(grep -c '^  - tags:$' "$selector_file")" -eq 2
+grep -Fxq '      aws:eks:cluster-name: eks-production' "$selector_file"
+grep -Fxq '      Name: private-trust-production' "$selector_file"
+
+if grep -Fq 'kubernetes.io/cluster/' "$selector_file"; then
+  echo "The private trust selector must not use a Kubernetes cluster tag." >&2
+  exit 1
+fi
+
+echo "Security group selector contract passed."

--- a/kubernetes/components/karpenter/tests/security-group-selectors.sh
+++ b/kubernetes/components/karpenter/tests/security-group-selectors.sh
@@ -3,26 +3,38 @@ set -euo pipefail
 
 repository_root="$(git rev-parse --show-toplevel)"
 rendered_file="$(mktemp)"
-selector_file="$(mktemp)"
-trap 'rm -f "$rendered_file" "$selector_file"' EXIT
+resource_file="$(mktemp)"
+trap 'rm -f "$rendered_file" "$resource_file"' EXIT
 
 kustomize build \
   "$repository_root/kubernetes/components/karpenter/production/kustomization" \
   >"$rendered_file"
 
-awk '
+target_count="$(awk -v output="$resource_file" '
+  BEGIN { RS = "---\\n" }
+  /(^|\n)kind: EC2NodeClass\n/ && /(^|\n)metadata:\n  name: system-components\n/ {
+    count++
+    print > output
+  }
+  END { print count + 0 }
+' "$rendered_file" | tail -n 1)"
+test "$target_count" -eq 1
+
+selector_count="$(awk '/^  securityGroupSelectorTerms:$/ { count++ } END { print count + 0 }' "$resource_file")"
+test "$selector_count" -eq 1
+
+actual_selectors="$(awk '
   /^  securityGroupSelectorTerms:$/ { capture = 1; next }
   capture && /^  [A-Za-z]/ { exit }
   capture { print }
-' "$rendered_file" >"$selector_file"
-
-test "$(grep -c '^  - tags:$' "$selector_file")" -eq 2
-grep -Fxq '      aws:eks:cluster-name: eks-production' "$selector_file"
-grep -Fxq '      Name: private-trust-production' "$selector_file"
-
-if grep -Fq 'kubernetes.io/cluster/' "$selector_file"; then
-  echo "The private trust selector must not use a Kubernetes cluster tag." >&2
-  exit 1
-fi
+' "$resource_file")"
+expected_selectors="$(
+  printf '%s\n' \
+    '  - tags:' \
+    '      aws:eks:cluster-name: eks-production' \
+    '  - tags:' \
+    '      Name: private-trust-production'
+)"
+test "$actual_selectors" = "$expected_selectors"
 
 echo "Security group selector contract passed."

--- a/kubernetes/manifests/production/karpenter/manifest.yaml
+++ b/kubernetes/manifests/production/karpenter/manifest.yaml
@@ -2902,6 +2902,8 @@ spec:
   securityGroupSelectorTerms:
   - tags:
       aws:eks:cluster-name: eks-production
+  - tags:
+      Name: private-trust-production
   subnetSelectorTerms:
   - tags:
       Tier: private


### PR DESCRIPTION
Karpenter-launched nodes need to join the VPC private trust boundary before any legacy security group detachment. Keeping the EKS primary selector alongside the VPC-owned trust security group preserves EKS networking and provides a rollback path during replacement.