### PR TITLE
refactor: detach the EKS module node SG

### DIFF
--- a/aws/eks-karpenter/modules/main.tf
+++ b/aws/eks-karpenter/modules/main.tf
@@ -91,14 +91,10 @@ module "system_critical" {
 
   subnet_ids = module.vpc.subnets.private.ids
 
-  # The standalone module does not inherit cluster SG attachments, so every migration SG remains explicit during rollout.
+  # The standalone module does not inherit cluster SG attachments, so both final SGs remain explicit.
   cluster_primary_security_group_id = module.eks.cluster.cluster_primary_security_group_id
 
-  // TODO: Remove the module node SG after every system-critical node carries the private trust SG.
-  vpc_security_group_ids = [
-    module.eks.cluster.node_security_group_id,
-    module.vpc.security_groups.private_trust.id,
-  ]
+  vpc_security_group_ids = [module.vpc.security_groups.private_trust.id]
 
   ami_type       = "AL2023_ARM_64_STANDARD"
   instance_types = var.system_critical_instance_types

--- a/aws/eks-karpenter/modules/tests/security_group_attachments.tftest.hcl
+++ b/aws/eks-karpenter/modules/tests/security_group_attachments.tftest.hcl
@@ -80,6 +80,6 @@ variables {
   }
 }
 
-run "plans_three_security_groups_for_system_nodes" {
+run "plans_primary_and_private_trust_security_groups_for_system_nodes" {
   command = plan
 }

--- a/aws/eks-karpenter/tests/security-group-contract.sh
+++ b/aws/eks-karpenter/tests/security-group-contract.sh
@@ -27,7 +27,6 @@ actual_security_groups="$(
 
 expected_security_groups="$(
   printf '%s\n' \
-    sg-module-node \
     sg-primary \
     sg-private-trust \
     | sort


### PR DESCRIPTION
Removes the obsolete EKS module node security group from system-critical nodes after the private trust runtime checkpoint passed. Keeps the EKS primary and private trust security groups attached. The production plan must contain only a launch template version and managed node group in-place update; it must not destroy a security group or replace the node group.