### PR TITLE
fix(kubernetes/components/opentelemetry): point Node.js exporter at the OTLP/HTTP port

### DIFF
--- a/kubernetes/components/opentelemetry/production/kustomization/instrumentation.yaml
+++ b/kubernetes/components/opentelemetry/production/kustomization/instrumentation.yaml
@@ -1,18 +1,19 @@
 # =============================================================================
 # OpenTelemetry Instrumentation CR (= L2 auto-injection)
 # =============================================================================
-# namespace default に 1 つ deploy で全 application Pod (= monolith / frontend)
-# が instrumentation.opentelemetry.io/inject-{ruby,nodejs} annotation で
-# auto-injection を受ける。
+# namespace default に 1 つ deploy で application Pod が
+# instrumentation.opentelemetry.io/inject-nodejs annotation で auto-injection
+# を受ける。 ruby は chart 0.156.0 でも未 support (= CR に ruby block を持たない)
+# ため monolith は対象外、 monolith 自身の OTel SDK 設定 (dystopia/monolith 側)
+# で計装している。
 #
 # Operator が Pod の init container で OTel SDK auto-instrumentation library
 # を inject、 application container の env vars (= OTEL_EXPORTER_OTLP_ENDPOINT
-# 等) を設定。 L1 (= application code 側 OpenTelemetry::SDK.configure /
-# NodeSDK) がそれらを detect + use する pattern。
+# 等) を設定。 L1 (= application code 側の NodeSDK) がそれらを detect + use する
+# pattern。
 #
 # auto-instrumentation image version は chart 同梱の binary verify で固定、
 # specific version (= nodejs 0.62.0) を pin (= :latest 不採用)。
-# ruby は chart 0.112.1 で未 support。
 # =============================================================================
 apiVersion: opentelemetry.io/v1alpha1
 kind: Instrumentation
@@ -21,7 +22,16 @@ metadata:
   namespace: default
 spec:
   exporter:
-    endpoint: http://opentelemetry-collector.monitoring.svc.cluster.local:4317
+    # Node.js の auto-instrumentation は OTEL_EXPORTER_OTLP_PROTOCOL 未指定時
+    # http/protobuf を既定にする (= gRPC ではない)。 gRPC 専用の 4317 を指すと
+    # SDK は plain HTTP/1.1 で接続し、 collector は HTTP/2 の SETTINGS frame で
+    # 応答するため "Parse Error: Expected HTTP/, RTSP/ or ICE/" で export が
+    # 毎回失敗する。 診断ロガー既定 (OTEL_LOG_LEVEL 未設定) は no-op のため
+    # このエラーはどこにもログされず、SDK 起動・計装・span 生成は正常に見える。
+    # collector 側は 4317/4318 とも同じ otlp receiver → 同一 pipeline のため
+    # port 以外の差分は無い (kubernetes/components/opentelemetry-collector/
+    # production/values.yaml.gotmpl の receivers.otlp 参照)。
+    endpoint: http://opentelemetry-collector.monitoring.svc.cluster.local:4318
   propagators:
     - tracecontext
     - baggage

--- a/kubernetes/manifests/production/opentelemetry/manifest.yaml
+++ b/kubernetes/manifests/production/opentelemetry/manifest.yaml
@@ -18933,7 +18933,7 @@ metadata:
   namespace: default
 spec:
   exporter:
-    endpoint: http://opentelemetry-collector.monitoring.svc.cluster.local:4317
+    endpoint: http://opentelemetry-collector.monitoring.svc.cluster.local:4318
   nodejs:
     image: ghcr.io/open-telemetry/opentelemetry-operator/autoinstrumentation-nodejs:0.62.0
   propagators:


### PR DESCRIPTION
## Why

frontend の OTel Operator auto-instrumentation は injection まで正常なのに、Tempo に SDK 由来の trace が 1 件も入っていませんでした。production の frontend Pod 内で実際の `server.js` を `OTEL_LOG_LEVEL=debug` 付きで動かして再現・特定しました。

`sdk.start()` は成功、`instrumentation-http` は正しく patch されリクエストに対して span も生成される。しかし export のたびに以下で失敗していました。

```
Error: Parse Error: Expected HTTP/, RTSP/ or ICE/
rawPacket: <Buffer 00 00 06 04 00 00 00 00 00 00 05 00 00 40 00>
```

この `rawPacket` は HTTP/2 の SETTINGS フレームです。Node の auto-instrumentation は `OTEL_EXPORTER_OTLP_PROTOCOL` 未指定時に `http/protobuf` を既定にします（monolith の Ruby exporter が最初から port 4318 を使っているのと同じ挙動）。ところが Instrumentation CR の `exporter.endpoint` は collector の **gRPC 専用ポート `4317`** を指していたため、SDK は plain HTTP/1.1 で接続し、collector が HTTP/2 で応答してパースエラーになっていました。

`OTEL_LOG_LEVEL` が未設定だと診断ロガーは既定で no-op のため、このエラーはどこにもログされません。SDK は起動・計装・span 生成まで完全に正常に見え、最後の送信 1 箇所だけが黙って失敗する状態でした。

## What

`spec.exporter.endpoint` のポートを `4317` → `4318` に変更しました。collector 側は `receivers.otlp.protocols.grpc`（4317）と `.http`（4318）のどちらも同じ `otlp` receiver → 同一 pipeline に繋がるため、port 以外の差分はありません。

CR は現在 Node.js にしか使われていません（Ruby は operator 未対応で PR #1093 により `inject-ruby` annotation を削除済み、monolith は自前の env で port 4318 を指定）。将来 gRPC を前提にする言語が増えたら `spec.<language>.env` での override を検討します。

ついでにファイル冒頭のコメントも直しました。`monolith / frontend` の 2 language 対象という記述が PR #1093 以降古くなっていたため、Node.js 専用である現状に合わせています。

## Verification

production の frontend Pod 内（container exec、実トラフィックには非干渉）で検証しました。

- 修正前の endpoint（`:4317`）で `server.js` を起動 → リクエストに対する span は生成されるが、shutdown 時に上記 Parse Error で export 失敗
- endpoint を `:4318` に変えて再実行 → Parse Error 消失、`OTLPExportDelegate shutdown` → `OpenTelemetry SDK terminated` がクリーンに完了
- Tempo に `resource.service.name` でクエリし、**実際に span が届いていることを確認**（`GET /` を含む 5 spans）
- `scripts/kubernetes-hydrate/hydrate-component.sh opentelemetry production` で描画し、diff が意図した 1 行のみであることを確認
- 検証用の一時プロセスは production Pod 内で `kill` 済み。本番トラフィックへの影響は無い（`curl` で 200 を確認）

## Deploy 後に確認すること

1. Tempo に `resource.service.name = "frontend"` かつ `telemetry.sdk.name = "opentelemetry"` の trace が入る
2. frontend → monolith の trace が連結するか（Beyla が eBPF レベルで `traceparent` を注入していない可能性が高いという以前の調査結果があるため、繋がらなければ Connect-ES interceptor の追加作業が必要）

## Out of scope

- Connect-ES interceptor（frontend → monolith の trace 連結）
- frontend を Beyla の instrument 対象から外す判断（SDK が確実に動くと確認できてから）
- `nodejs` version pin (0.62.0) の見直し（今回 0.62.0 のままで span 生成に成功したため優先度低下）