### PR TITLE
refactor: detach the EKS module cluster security group

### DIFF
--- a/aws/eks-karpenter/modules/tests/security_group_attachments.tftest.hcl
+++ b/aws/eks-karpenter/modules/tests/security_group_attachments.tftest.hcl
@@ -49,9 +49,7 @@ override_module {
       certificate_authority_data        = "Y2E="
       service_cidr                      = "10.100.0.0/16"
       ip_family                         = "ipv4"
-      cluster_security_group_id         = "sg-primary"
       cluster_primary_security_group_id = "sg-primary"
-      node_security_group_id            = "sg-module-node"
     }
   }
 }

--- a/aws/eks/lookup/main.tf
+++ b/aws/eks/lookup/main.tf
@@ -5,20 +5,3 @@ data "aws_eks_cluster" "this" {
 }
 
 data "aws_caller_identity" "current" {}
-
-# Node security group created by terraform-aws-modules/eks parent module.
-# Naming pattern: `eks-${cluster_name}-node-${random_suffix}` (terraform-aws-
-# modules/eks v21 default). This SG allows node-to-node pod-network traffic
-# and must be attached to MNGs (parent module auto-wires it for in-module
-# MNGs, but standalone eks-managed-node-group submodule requires explicit
-# pass-through via `vpc_security_group_ids`).
-data "aws_security_group" "node" {
-  vpc_id = data.aws_eks_cluster.this.vpc_config[0].vpc_id
-
-  # terraform-aws-modules/eks v21 sets the Name tag to `eks-${cluster_name}-node`
-  # (no random suffix; the suffix is only on the SG's `GroupName` attribute).
-  filter {
-    name   = "tag:Name"
-    values = ["eks-${var.environment}-node"]
-  }
-}

--- a/aws/eks/lookup/outputs.tf
+++ b/aws/eks/lookup/outputs.tf
@@ -6,14 +6,7 @@ output "cluster" {
     name                              = data.aws_eks_cluster.this.name
     arn                               = data.aws_eks_cluster.this.arn
     endpoint                          = data.aws_eks_cluster.this.endpoint
-    cluster_security_group_id         = data.aws_eks_cluster.this.vpc_config[0].cluster_security_group_id
     cluster_primary_security_group_id = data.aws_eks_cluster.this.vpc_config[0].cluster_security_group_id
-
-    # Node security group (created by terraform-aws-modules/eks parent module).
-    # Required by standalone `eks-managed-node-group` submodule for node-to-node
-    # pod-network traffic (cluster_primary_security_group_id alone allows only
-    # control plane → node, not node-to-node).
-    node_security_group_id = data.aws_security_group.node.id
 
     # Cluster info needed by the standalone `eks-managed-node-group` submodule's
     # AL2023 user data generator (auto-wired when MNGs live inside `module "eks"`,

--- a/aws/eks/lookup/tests/security_groups.tftest.hcl
+++ b/aws/eks/lookup/tests/security_groups.tftest.hcl
@@ -35,13 +35,6 @@ override_data {
 }
 
 override_data {
-  target = data.aws_security_group.node
-  values = {
-    id = "sg-module-node"
-  }
-}
-
-override_data {
   target = data.aws_caller_identity.current
   values = {
     account_id = "337169763788"
@@ -60,13 +53,4 @@ run "exposes_cluster_primary_security_group_id" {
     error_message = "The lookup must identify the EKS-owned primary security group explicitly."
   }
 
-  assert {
-    condition     = output.cluster.cluster_security_group_id == output.cluster.cluster_primary_security_group_id
-    error_message = "The compatibility field must keep its current value until consumers migrate."
-  }
-
-  assert {
-    condition     = output.cluster.node_security_group_id == "sg-module-node"
-    error_message = "The module node security group lookup must remain during the attachment phase."
-  }
 }

--- a/aws/eks/modules/main.tf
+++ b/aws/eks/modules/main.tf
@@ -49,39 +49,31 @@ module "eks" {
   access_entries = local.access_entries
   addons         = local.cluster_addons
 
-  // TODO: Replace the module cluster SG with the private trust SG after every consumer carries the private trust SG.
-  additional_security_group_ids = [module.vpc.security_groups.private_trust.id]
+  create_security_group      = false
+  security_group_id          = module.vpc.security_groups.private_trust.id
+  create_node_security_group = false
+  node_security_group_id     = module.vpc.security_groups.private_trust.id
 
   tags = var.common_tags
 }
 
-# Read the node SG state after module apply to detect the cluster tag.
-# depends_on = [module.eks] ensures this runs after the module applies the tag,
-# so triggers_replace captures the "owned" value and triggers local-exec cleanup.
-data "aws_security_group" "node_sg" {
-  id = module.eks.node_security_group_id
+// TODO: Remove after EKS uses only the private trust security group and this SG has no ENI attachments.
+resource "aws_security_group" "cluster" {
+  name_prefix = "eks-${var.environment}-cluster-"
+  description = "EKS cluster security group"
+  vpc_id      = module.vpc.vpc.id
 
-  depends_on = [module.eks]
+  tags = merge(
+    var.common_tags,
+    { Name = "eks-${var.environment}-cluster" },
+  )
+
+  lifecycle {
+    create_before_destroy = true
+  }
 }
 
-# Remove the cluster tag from the node SG after every apply.
-# terraform-aws-modules/eks/aws hardcodes kubernetes.io/cluster/<name>=owned on
-# the node SG (node_groups.tf merge block), and node_security_group_tags only
-# supports map(string) so null-value key removal is not possible via variable.
-# AWS LB Controller identifies the target endpoint SG by checking if the tag key
-# exists (value-independent check, pkg/networking/networking_manager.go line 561),
-# so both the EKS cluster SG (eks-cluster-sg-*) and the node SG would match,
-# causing "expected exactly one securityGroup" panic.
-# The data source re-reads the SG after module.eks applies "owned", changing the
-# trigger and causing local-exec to delete the tag on the same apply run.
-resource "terraform_data" "node_sg_cluster_tag_removal" {
-  triggers_replace = [
-    try(data.aws_security_group.node_sg.tags["kubernetes.io/cluster/eks-${var.environment}"], "")
-  ]
-
-  depends_on = [data.aws_security_group.node_sg]
-
-  provisioner "local-exec" {
-    command = "aws ec2 delete-tags --region ${var.aws_region} --resources ${module.eks.node_security_group_id} --tags Key=kubernetes.io/cluster/eks-${var.environment} 2>/dev/null || true"
-  }
+moved {
+  from = module.eks.aws_security_group.cluster[0]
+  to   = aws_security_group.cluster
 }

--- a/aws/eks/modules/outputs.tf
+++ b/aws/eks/modules/outputs.tf
@@ -26,19 +26,9 @@ output "cluster_certificate_authority_data" {
   sensitive   = true
 }
 
-output "cluster_security_group_id" {
-  description = "Cluster security group created by EKS"
-  value       = module.eks.cluster_security_group_id
-}
-
 output "cluster_primary_security_group_id" {
   description = "EKS-owned primary cluster security group ID"
   value       = module.eks.cluster_primary_security_group_id
-}
-
-output "node_security_group_id" {
-  description = "Node security group"
-  value       = module.eks.node_security_group_id
 }
 
 output "oidc_provider_arn" {

--- a/aws/eks/modules/tests/private_trust_security_group.tftest.hcl
+++ b/aws/eks/modules/tests/private_trust_security_group.tftest.hcl
@@ -90,6 +90,21 @@ variables {
   }
 }
 
-run "plans_private_trust_as_additional_control_plane_security_group" {
+run "uses_private_trust_for_cluster_and_node_security_groups" {
   command = plan
+
+  assert {
+    condition     = module.eks.cluster_security_group_id == null
+    error_message = "The EKS module must not create a cluster security group."
+  }
+
+  assert {
+    condition     = module.eks.node_security_group_id == null
+    error_message = "The EKS module must not create a node security group."
+  }
+
+  assert {
+    condition     = aws_security_group.cluster.name_prefix == "eks-production-cluster-" && aws_security_group.cluster.description == "EKS cluster security group" && aws_security_group.cluster.vpc_id == "vpc-test"
+    error_message = "The retained cluster security group must preserve its physical identity configuration."
+  }
 }

--- a/aws/eks/tests/security-group-contract.sh
+++ b/aws/eks/tests/security-group-contract.sh
@@ -3,6 +3,26 @@ set -euo pipefail
 
 repository_root="$(git rev-parse --show-toplevel)"
 module_dir="$repository_root/aws/eks/modules"
+module_source="$module_dir/main.tf"
+
+required_configuration=(
+  '  create_security_group      = false'
+  '  security_group_id          = module.vpc.security_groups.private_trust.id'
+  '  create_node_security_group = false'
+  '  node_security_group_id     = module.vpc.security_groups.private_trust.id'
+)
+
+for expected_line in "${required_configuration[@]}"; do
+  if ! grep -Fxq "$expected_line" "$module_source"; then
+    printf 'missing EKS security group configuration: %s\n' "$expected_line" >&2
+    exit 1
+  fi
+done
+
+if grep -Eq '^[[:space:]]*additional_security_group_ids[[:space:]]*=' "$module_source"; then
+  echo 'additional_security_group_ids must not be configured.' >&2
+  exit 1
+fi
 
 plan_output="$(
   cd "$module_dir"
@@ -14,9 +34,10 @@ plan_output="$(
 
 control_plane_security_groups="$(
   awk '
-    /resource "aws_eks_cluster" "this"/ { in_cluster = 1 }
+    /^  # module\.eks\.aws_eks_cluster\.this/ { in_cluster = 1; next }
+    /^  # / { in_cluster = 0; capture = 0; next }
     in_cluster && /^[[:space:]]+[+~]?[[:space:]]*security_group_ids[[:space:]]*=[[:space:]]*\[/ { capture = 1; next }
-    capture && /]/ { exit }
+    capture && /^[[:space:]]+\]/ { exit }
     capture {
       gsub(/[+~ \",]/, "")
       if (length > 0) print
@@ -24,7 +45,8 @@ control_plane_security_groups="$(
   ' <<<"$plan_output"
 )"
 
-if ! grep -Fxq sg-private-trust <<<"$control_plane_security_groups"; then
+expected_security_groups="sg-private-trust"
+if test "$control_plane_security_groups" != "$expected_security_groups"; then
   printf 'planned control plane security groups:\n%s\n' "$control_plane_security_groups" >&2
   exit 1
 fi


### PR DESCRIPTION
## Why

EKS の control plane を private trust SG 一件へ収束させる。cluster SG の detach と destroy を同一 apply にすると、requester-managed ENI の更新完了と Security Group 削除の `DependencyViolation` retry に依存するため、この PR では既存 cluster SG を root resource へ state move して保持する。

## What

- EKS module の cluster/node SG 作成を無効化し、private trust SG を既存 SG として渡す
- module cluster SG を root resource へ declarative move し、物理 SG を保持する
- attachment がゼロの module node SG、関連 rules、tag workaround を削除する
- legacy cluster/node SG outputs と lookup interface を削除する
- module 非作成、existing-SG inputs、control-plane SG exact set の contract test を追加する

## Verification

- EKS、lookup、Karpenter の focused/full tests、validate、fmt、diff check: pass
- scoped code review: Approved
- production plan: `0 to add, 5 to change, 14 to destroy`
- cluster SG `sg-0a68a4bec4a21b262`: root への state move のみで resource action なし
- EKS cluster: in-place update、replacement なし
- module node SG: ENI attachment 0 件

## Rollout

apply 後に EKS が private trust SG 一件だけを additional SG として保持し、retained cluster SG の ENI attachment がゼロであることを確認する。その runtime gate 後、別 PR で empty cluster SG を削除する。