### PR TITLE
refactor: remove the empty EKS cluster security group

### DIFF
--- a/aws/eks/modules/main.tf
+++ b/aws/eks/modules/main.tf
@@ -56,24 +56,3 @@ module "eks" {
 
   tags = var.common_tags
 }
-
-// TODO: Remove after EKS uses only the private trust security group and this SG has no ENI attachments.
-resource "aws_security_group" "cluster" {
-  name_prefix = "eks-${var.environment}-cluster-"
-  description = "EKS cluster security group"
-  vpc_id      = module.vpc.vpc.id
-
-  tags = merge(
-    var.common_tags,
-    { Name = "eks-${var.environment}-cluster" },
-  )
-
-  lifecycle {
-    create_before_destroy = true
-  }
-}
-
-moved {
-  from = module.eks.aws_security_group.cluster[0]
-  to   = aws_security_group.cluster
-}

--- a/aws/eks/modules/tests/private_trust_security_group.tftest.hcl
+++ b/aws/eks/modules/tests/private_trust_security_group.tftest.hcl
@@ -103,8 +103,4 @@ run "uses_private_trust_for_cluster_and_node_security_groups" {
     error_message = "The EKS module must not create a node security group."
   }
 
-  assert {
-    condition     = aws_security_group.cluster.name_prefix == "eks-production-cluster-" && aws_security_group.cluster.description == "EKS cluster security group" && aws_security_group.cluster.vpc_id == "vpc-test"
-    error_message = "The retained cluster security group must preserve its physical identity configuration."
-  }
 }

--- a/aws/eks/tests/security-group-contract.sh
+++ b/aws/eks/tests/security-group-contract.sh
@@ -5,6 +5,32 @@ repository_root="$(git rev-parse --show-toplevel)"
 module_dir="$repository_root/aws/eks/modules"
 module_source="$module_dir/main.tf"
 
+for module_file in "$module_dir"/*.tf; do
+  if grep -Eq '^[[:space:]]*resource[[:space:]]+"aws_security_group"[[:space:]]+"cluster"' "$module_file"; then
+    printf 'root cluster security group resource must not be configured: %s\n' "$module_file" >&2
+    exit 1
+  fi
+done
+
+module_eks_configuration="$(
+  awk '
+    /^module "eks" \{/ {
+      in_module = 1
+    }
+    in_module {
+      print
+    }
+    in_module && /^}/ {
+      exit
+    }
+  ' "$module_source"
+)"
+
+if test -z "$module_eks_configuration"; then
+  echo 'module "eks" block must be configured.' >&2
+  exit 1
+fi
+
 required_configuration=(
   '  create_security_group      = false'
   '  security_group_id          = module.vpc.security_groups.private_trust.id'
@@ -13,7 +39,7 @@ required_configuration=(
 )
 
 for expected_line in "${required_configuration[@]}"; do
-  if ! grep -Fxq "$expected_line" "$module_source"; then
+  if ! grep -Fxq "$expected_line" <<<"$module_eks_configuration"; then
     printf 'missing EKS security group configuration: %s\n' "$expected_line" >&2
     exit 1
   fi


### PR DESCRIPTION
## Why

Task 9AでEKS control planeから旧module cluster SGを先にdetachし、requester-managed ENIとの削除競合を分離した。apply後にretained SGのENI attachment、自身のrule、他SGからのreferenceがすべてゼロになったため、不要になったempty SGをTerraformで削除する。

## What

- root `aws_security_group.cluster`を削除する
- 完了済みの`// TODO:`とstate移行用`moved` blockを削除する
- module-created cluster/node SGの非作成とprivate trust existing-SG contractを維持する
- module root全`.tf`でroot cluster SGの再導入を拒否するcontractを追加する

## Verification

- EKS focused/full tests、contract、validate、fmt、diff check: pass
- mutation tests: 別`.tf`のSG再導入とmodule外の同名inputをreject
- scoped code review: Approved
- production plan: `0 to add, 0 to change, 1 to destroy`
- only action: empty `aws_security_group.cluster` (`sg-0a68a4bec4a21b262`) destroy
- EKS/Karpenter/primary/private trust action and replacement: none

## Rollout

apply前baselineはtarget SGのENI 0、自身のingress/egress 0、他SGからのreference 0。apply後にSGの不在、Terraform stateの不在、EKS common-only、cluster/node/application/database healthを再確認する。